### PR TITLE
Change "add package" wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ npm install five --save-peer --workspace=@ni/nimble-angular
 Example: Add a monorepo package `nimble-tokens` as a dependency to another monorepo package:
 
 ```
-npm install @ni/nimble-tokens --workspace=@ni/nimble-angular
+npm install @ni/nimble-tokens --workspace=@ni/nimble-components
 ```
 <!-- TODO this workflow doesn't seem to work
 ### Angular libraries


### PR DESCRIPTION
To me, "Add package" sounds like we're adding a new package such as `@ni/five`.

I've updated the wording to use "install".

I also updated the commands to use @ni instead of the absolute path, which is a little cleaner. I verified that each example command installs dependencies to the expected places.