### PR TITLE
Enforce lint and skip ci on publish

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,5 +30,4 @@ Include automated/manual test additions or modifications, testing done on a loca
 
 <!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->
 
-- [ ] I have included a change request file using `$ npm run change`
-- [ ] I have updated the project documentation to reflect my changes.
+- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,6 @@ jobs:
 
       # Lint
       - run: npm run lint
-        continue-on-error: true
 
       # Test
       - run: npm run test

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build-angular-example": "cd angular-workspace/dist && copyfiles -E \"example-client-app/**\" ../../site",
     "change": "beachball change",
     "check": "beachball check --changehint \"Run 'npm run change' to generate a change file\"",
-    "publish": "beachball publish",
+    "publish": "beachball publish  --message \"applying package updates [skip ci]\"",
     "publish-ci": "beachball publish --yes --access public"
   },
   "repository": {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

A collection of minor tweaks:
- Remove the continue on error for linting so linting can fail the CI
- Add [`[skip ci]`](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/) comment to beachball publish messages to avoid running the full pipeline for beachball publishing package.json and changelog updates (those changes are already in the published packages).
- Removed the checklist item in the PR template for running `npm run change` since it is automated and will already fail the CI. Also updated the wording of the documentation line so devs just have to acknowledge they thought about docs.

## 👩‍💻 Implementation

See above.

## 🧪 Testing

Doing it live!

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have included a change request file using `$ npm run change` - unneeded for this PR
- [x] I have updated the project documentation to reflect my changes. - none needed
