### PR TITLE
useHash: true for example app

### DIFF
--- a/angular-workspace/projects/example-client-app/src/app/app.module.ts
+++ b/angular-workspace/projects/example-client-app/src/app/app.module.ts
@@ -18,7 +18,8 @@ import { LoginComponent } from './login/login.component';
         RouterModule.forRoot([
             { path: '', redirectTo: '/login', pathMatch: 'full' },
             { path: 'login', component: LoginComponent }
-        ])
+        ],
+        { useHash: true })
     ],
     providers: [],
     bootstrap: [AppComponent],


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The GitHub-hosted example app currently routes to https://ni.github.io/nimble/example-client-app/example-client-app/ and then complains that example-client-app isn't a valid route. We think hash-based routing will resolve this problem.

## 👩‍💻 Implementation

Add `useHash: true` to the RouterModule configuration.

## 🧪 Testing

The desired routing behavior continues to work locally.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
