### PR TITLE
Change code owners for nimble-angular

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,8 @@
 # More info: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
 
 # These owners will be the default owners for everything in the repo.
-*                           @rajsite @jattasNI @fredvisser
+* @rajsite @jattasNI @fredvisser
 
 # Owners of specific locations or file patterns in the repo. Locations are relative to the root of the repo.
 # Order is important. The last matching pattern has the most precedence.
-
-/angular-workspace/projects/ni/nimble-angular                           @brianehenry @rajsite
+/angular-workspace/projects/ni/nimble-angular @brianehenry @rajsite


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

I realized when reviewing #135 that @brianehenry knew more about Angular integrations than me (since he basically came up with all the patterns we're using), so I thought he should be an owner for the `nimble-angular` package.

## 👩‍💻 Implementation

Override default owners for the `nimble-angular`package to be @brianehenry and @rajsite. I'm happy to change that list, but figured we should have at least 2 owners and that @rajsite was better positioned than me or @fredvisser.

## 🧪 Testing

N/A. We'll see if I got the syntax right the next time someone creates a PR :-P.

## ✅ Checklist


- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
