### PR TITLE
Chromatic re-use storybook build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: ./packages/nimble-components
           storybookBuildDir: ./dist/storybook
-          exitOnceUploaded: true # Do not wait for test resuls
+          exitOnceUploaded: true # Do not wait for test results
           exitZeroOnChanges: true # Option to prevent the workflow from failing
 
       # Run Lighthouse audit


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The Chromatic GitHub Action has a parameter to re-use an existing storybook build. So let's use it!

## 👩‍💻 Implementation

Modified the action to point to the storybook build that is created during `npm run build`. Reduces total GitHub Action time by ~12% / 1 minute.

## 🧪 Testing

Tested monitoring GitHub Action build time.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
