### PR TITLE
Allow build to continue even if chromatic fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Publish to Chromatic
         if: github.event_name == 'push'
         uses: chromaui/action@v1
+        continue-on-error: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Chromatic is down and causing workflows to fail.

## 👩‍💻 Implementation

Continue workflow even if chromatic step errors.

## 🧪 Testing

Doing it live.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
