### PR TITLE
Update CODEOWNERS to catch sub files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,13 +10,13 @@
 # Order is important. The last matching pattern has the most precedence.
 
 # Specs
-/specs/* @rajsite @jattasNI @fredvisser @atmgrifter00
+/specs @rajsite @jattasNI @fredvisser @atmgrifter00
 *.spec.md @rajsite @jattasNI @fredvisser @atmgrifter00
 
 # Specific packages
-/angular-workspace/projects/ni/nimble-angular/* @rajsite @atmgrifter00
-/packages/beachball-lock-update/* @rajsite @jattasNI
-/packages/nimble-blazor/* @atmgrifter00 @msmithNI
+/angular-workspace/projects/ni/nimble-angular @rajsite @atmgrifter00
+/packages/beachball-lock-update @rajsite @jattasNI
+/packages/nimble-blazor @atmgrifter00 @msmithNI
 
 # Change files don't need explicit reviewers
-/change/*
+/change


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

CODEOWNERS uses git matching rules and the paths `/my-folder/*` only matches the files that are direct children of my-folder. Experimenting with updating the rules so that the match `/my-folder` which should match any path that has `/my-folder` in the path which includes all subdirectories.

## 👩‍💻 Implementation

See above.

## 🧪 Testing

Doing it line.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
