### PR TITLE
Temporarily disable 'npm audit' on non-production dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,9 @@ jobs:
       - run: npm ci
 
       # Audit
-      - run: npm audit --only=prod
-      # - run: npm audit --audit-level=critical https://github.com/ni/nimble/issues/581
+      # https://github.com/ni/nimble/issues/581
+      # - run: npm audit --only=prod
+      # - run: npm audit --audit-level=critical
 
       # Build
       - run: npm run build


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Workaround for #581 to get the pipeline unblocked while we wait for beachball to publish a fix (or try out updating the transitive dependency on `workspace-tools` ourselves within this repo).

## 👩‍💻 Implementation

Comment out the steps which run `npm audit` in `main.yml`.

I thought we could get away with only disabling the non-production configuration of `npm audit`. But `beachball` (and by extension `workspace-tools`) is listed in `peerDependencies` of our `beackball-lock-update` package and it seems that `audit` includes those when running `--only=prod`.

## 🧪 Testing

Relying on pipeline.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
