### PR TITLE
Disable npm audit step in PR builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
       - run: npm ci
 
       # Audit
+      # https://github.com/ni/nimble/issues/625
       #- run: npm audit --only=prod
       #- run: npm audit --audit-level=critical
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

PR builds have begun failing recently due to the npm audit step. It is catching vulnerabilities reported on the parse-path and parse-url packages, which are indirect dependencies of Beachball.

## 👩‍💻 Implementation

I tried:
1. updating to the latest Beachball version
2. updating the parse-path and parse-url packages directly

Neither resolved the issue, so I'm disabling the npm audit step of our build until a fix is available for the vulnerabilities. I created issue #625 to track the vulnerabilities.

## 🧪 Testing

None

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
