### PR TITLE
Add invalid styling to number field

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/CHANGELOG.json
+++ b/angular-workspace/projects/ni/nimble-angular/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@ni/nimble-angular",
   "entries": [
     {
+      "date": "Fri, 15 Jul 2022 21:12:50 GMT",
+      "tag": "@ni/nimble-angular_v7.3.1",
+      "version": "7.3.1",
+      "comments": {
+        "patch": [
+          {
+            "author": "beachball",
+            "package": "@ni/nimble-angular",
+            "comment": "Bump @ni/nimble-components to v11.4.1",
+            "commit": "aa729cc29ca4969f14f4ab9313c3abdac2c8b248"
+          }
+        ]
+      }
+    },
+    {
       "date": "Mon, 27 Jun 2022 18:59:58 GMT",
       "tag": "@ni/nimble-angular_v7.3.0",
       "version": "7.3.0",

--- a/angular-workspace/projects/ni/nimble-angular/CHANGELOG.md
+++ b/angular-workspace/projects/ni/nimble-angular/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @ni/nimble-angular
 
-This log was last generated on Mon, 27 Jun 2022 18:59:58 GMT and should not be manually modified.
+This log was last generated on Fri, 15 Jul 2022 21:12:50 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 7.3.1
+
+Fri, 15 Jul 2022 21:12:50 GMT
+
+### Patches
+
+- Bump @ni/nimble-components to v11.4.1
 
 ## 7.3.0
 

--- a/angular-workspace/projects/ni/nimble-angular/package.json
+++ b/angular-workspace/projects/ni/nimble-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ni/nimble-angular",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "Angular components for the NI Nimble Design System",
   "scripts": {
     "invoke-publish": "cd ../../../ && npm run build:library && cd dist/ni/nimble-angular && npm publish"
@@ -22,7 +22,7 @@
     "@angular/core": "^12.1.0",
     "@angular/forms": "^12.1.0",
     "@angular/router": "^12.1.0",
-    "@ni/nimble-components": "^11.4.0"
+    "@ni/nimble-components": "^11.4.1"
   },
   "dependencies": {
     "tslib": "^2.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
     },
     "angular-workspace/projects/ni/nimble-angular": {
       "name": "@ni/nimble-angular",
-      "version": "7.3.0",
+      "version": "7.3.1",
       "license": "UNLICENSED",
       "dependencies": {
         "tslib": "^2.2.0"
@@ -77,7 +77,7 @@
         "@angular/core": "^12.1.0",
         "@angular/forms": "^12.1.0",
         "@angular/router": "^12.1.0",
-        "@ni/nimble-components": "^11.4.0"
+        "@ni/nimble-components": "^11.4.1"
       }
     },
     "node_modules/@actions/core": {
@@ -42002,7 +42002,7 @@
     },
     "packages/nimble-blazor": {
       "name": "@ni/nimble-blazor",
-      "version": "5.1.4",
+      "version": "5.1.5",
       "license": "UNLICENSED",
       "devDependencies": {
         "@microsoft/fast-web-utilities": "^5.4.1",
@@ -42058,7 +42058,7 @@
     },
     "packages/nimble-components": {
       "name": "@ni/nimble-components",
-      "version": "11.4.0",
+      "version": "11.4.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@microsoft/fast-animation": "^4.2.2",

--- a/packages/nimble-blazor/package.json
+++ b/packages/nimble-blazor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ni/nimble-blazor",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "Blazor components for the NI Nimble Design System",
   "scripts": {
     "build": "npm run generate-icons && npm run build:release && npm run build:client",

--- a/packages/nimble-components/CHANGELOG.json
+++ b/packages/nimble-components/CHANGELOG.json
@@ -2,6 +2,36 @@
   "name": "@ni/nimble-components",
   "entries": [
     {
+      "date": "Fri, 15 Jul 2022 21:46:06 GMT",
+      "tag": "@ni/nimble-components_v11.4.1",
+      "version": "11.4.1",
+      "comments": {
+        "none": [
+          {
+            "author": "103057880+aidendk@users.noreply.github.com",
+            "package": "@ni/nimble-components",
+            "commit": "810c12e81ba735599efb53601a56499067728f9e",
+            "comment": "tooltip spec updates for states (#309)"
+          }
+        ]
+      }
+    },
+    {
+      "date": "Fri, 15 Jul 2022 21:12:50 GMT",
+      "tag": "@ni/nimble-components_v11.4.1",
+      "version": "11.4.1",
+      "comments": {
+        "patch": [
+          {
+            "author": "103057880+aidendk@users.noreply.github.com",
+            "package": "@ni/nimble-components",
+            "commit": "aa729cc29ca4969f14f4ab9313c3abdac2c8b248",
+            "comment": "Fix icon colors for the Color theme.(#629)"
+          }
+        ]
+      }
+    },
+    {
       "date": "Mon, 27 Jun 2022 17:17:28 GMT",
       "tag": "@ni/nimble-components_v11.4.0",
       "version": "11.4.0",

--- a/packages/nimble-components/CHANGELOG.md
+++ b/packages/nimble-components/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @ni/nimble-components
 
-This log was last generated on Mon, 27 Jun 2022 17:17:28 GMT and should not be manually modified.
+This log was last generated on Fri, 15 Jul 2022 21:12:50 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 11.4.1
+
+Fri, 15 Jul 2022 21:12:50 GMT
+
+### Patches
+
+- Fix icon colors for the Color theme.(#629) ([ni/nimble@aa729cc](https://github.com/ni/nimble/commit/aa729cc29ca4969f14f4ab9313c3abdac2c8b248))
 
 ## 11.4.0
 

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ni/nimble-components",
-  "version": "11.4.0",
+  "version": "11.4.1",
   "description": "Styled web components for the NI Nimble Design System",
   "scripts": {
     "build": "npm run generate-icons && npm run build-components && npm run bundle-components && npm run generate-scss && npm run build-storybook",

--- a/packages/nimble-components/src/theme-provider/design-tokens.ts
+++ b/packages/nimble-components/src/theme-provider/design-tokens.ts
@@ -646,26 +646,16 @@ function getWarningColorForTheme(element: HTMLElement): string {
         element,
         Warning100LightUi,
         Warning100DarkUi,
-        Warning100DarkUi
+        White
     );
 }
 
 function getFailColorForTheme(element: HTMLElement): string {
-    return getColorForTheme(
-        element,
-        Fail100LightUi,
-        Fail100DarkUi,
-        Fail100DarkUi
-    );
+    return getColorForTheme(element, Fail100LightUi, Fail100DarkUi, White);
 }
 
 function getPassColorForTheme(element: HTMLElement): string {
-    return getColorForTheme(
-        element,
-        Pass100LightUi,
-        Pass100DarkUi,
-        Pass100DarkUi
-    );
+    return getColorForTheme(element, Pass100LightUi, Pass100DarkUi, White);
 }
 
 function getDefaultLineColorForTheme(element: HTMLElement): string {

--- a/packages/nimble-components/src/tooltip/tooltip.spec.md
+++ b/packages/nimble-components/src/tooltip/tooltip.spec.md
@@ -20,23 +20,24 @@ The nimble-tooltip project will first be implemented as a prototype, open issues
 
 [FAST tooltip API](https://github.com/microsoft/fast/blob/de7f234ef871204fcac2b5df59433d919809341d/packages/web-components/fast-foundation/src/tooltip/tooltip.spec.md)
 
-Plan to extend API to support all cases shown in visual design XD document. Will add
-once tooltip is sucessfully implemented with one case.
+The state of the tooltip can be changed by setting the `error`, or `information` class. If neither of these classes are applied, the tooltip will use the `default` appearance- a state that does not require a CSS class. When the tooltip has the `error` or `information` class applied, an icon can optionally be visible in the tooltip by setting the `icon-visible` class. The `icon-visible` class will have no impact on the tooltip when it has the `default` appearance. This will allow clients to easily switch between `default` and `error` without also having to change whether or not the `icon-visible` class is applied.
 
-Plan to first implement the tooltip and let the client choose which type of tooltip (general, error, info) they want
-Additional changes to API expected in the future, but will not be included in first pass of implementation. Listed in Future Improvements and Open Issues
+Two local css variables will be created for the tooltips- one that controls the border color of the tooltip, and one that controls the background color of the tooltip. These variables will be changed based on the css classes described above.
+
+CSS constants for the `error`, `information`, and `default` states will be added to make configuring tooltip classes easier. `icon-visible` will not have constants, as it is easier to style the icon component itself.
+
+The tooltip will have a custom template based on FAST's template. In addition to the HTML that is in FAST's template, the template wll contain the two icons needed for the information and error states as shown in the XD spec. These icons will always be part of the template and their visibility will be controlled by a combination of the `icon-visible` class and the state classes.
 
 -   _Component Name:_ `nimble-tooltip`
 -   _Properties/Attributes:_ Unchanged
 -   _Methods:_ Unchanged
 -   _Events:_ Unchanged
--   _CSS Classes and Custom Properties that affect the component:_ None
+-   _CSS Classes and Custom Properties that affect the component:_ `icon-visible` and the special states of the tooltip (`error` and `information`)
 -   _Slots:_ Unchanged
 -   _Template:_ Unchanged
 
 ### Future Improvements
 
-Attribute for switching between error and info states of tooltip
 Easier integration with other nimble components
 
 ### Angular integration
@@ -52,15 +53,16 @@ A Blazor wrapper will be created for the component.
 -   _User interaction: Do the FAST component's behaviors match the visual design spec? When they differ, which approach is preferable and why?_
     -   No additional requirements
 -   _Styling: Does FAST provide APIs to achieve the styling in the visual design spec?_
-    -   FAST API most likely won't be sufficient for creating extra states in spec, will be adressed later on.
+    -   No additional requirements
+    -   Version of error / information tooltips with icons will also be included.
 -   _Testing: Is FAST's coverage sufficient? Should we write any tests beyond Chromatic visual tests?_
-    -   Will look at options as building, testing may be difficult because only displayed on hover.
+    -   No additional requirements
 -   _Documentation: Any requirements besides standard Storybook docs and updating the Example Client App demo?_
     -   No additional requirements
 -   _Tooling: Any new tools, updates to tools, code generation, etc?_
     -   No additional requirements
 -   _Accessibility: keyboard navigation/focus, form input, use with assistive technology, etc._
-    -   Aria-describedBy recommendation in storybook docs for tooltip for developers
+    -   aria-describedby implementation will eventually need to be fixed- currently only works when tooltip attribute is set to visible
 -   _Globalization: special RTL handling, swapping of icons/visuals, localization, etc._
     -   No additional requirements
 -   _Performance: does the FAST component meet Nimble's performance requirements?_
@@ -80,6 +82,10 @@ When user is using nimble tooltip and nimble components, is there an easier way 
 
 Can tooltip be found by screen reader?
 
-For testing, can we force the tooltip to be visible without hover? [Possible Ideas](https://stackoverflow.com/questions/62043424/mock-hover-state-in-storybook)
-
 Mobile tooltip is not very functional- have to click on button to show tooltip, and clicking away does not make it disappear
+
+aria-describedby only shows up when tooltip attribute is set to visible
+
+How can we give each tooltip a custom id?
+
+When should we use the tooltip vs. the title attribute? MDN [lists many issues with the title element](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title#accessibility_concerns). Needs to be discussed with team and designers.


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #615 

## 👩‍💻 Implementation

Using shared invalid styling from patterns/error/styles. Added common error text template and error icon to end slot. Set `display: contents` on the end slot and the `controls` div so that the error icon and +/- buttons are all children of the same flex container. This allowed me to put them in the right order, using the CSS `order` property. I had to tweak some padding values to get them to display properly.

Also updated the number-field Storybook stories and the Angular wrapper. Number field does not have Blazor support yet.

## 🧪 Testing

Tested in Storybook

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
