### PR TITLE
Make NI.CSharp.Analyzers to private dependency

### DIFF
--- a/packages/nimble-blazor/NimbleBlazor/NimbleBlazor.csproj
+++ b/packages/nimble-blazor/NimbleBlazor/NimbleBlazor.csproj
@@ -40,7 +40,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.1" />
-    <PackageReference Include="NI.CSharp.Analyzers" Version="2.0.4" />
+    <PackageReference Include="NI.CSharp.Analyzers" Version="2.0.4" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Currently the NimbleBlazor nuget is exposing the `NI.CSharp.Analyzers` (version 2.0.4) dependency to projects that reference it.  This causes some trouble to projects that using a different version of `NI.CSharp.Analyzers`.

I think NimbleBlazor is using `NI.CSharp.Analyzers` more as a development harness and might not want to expose it to projects that will consume NimbleBlazor.

## 👩‍💻 Implementation

Following the document [here](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets), use `PrivateAssets="all"` to make `NI.CSharp.Analyzers` private dependency, 

## 🧪 Testing

build and pack the nuget locally, the new nuget package does not expose the `NI.CSharp.Analyzers` dependency anymore.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
