### PR TITLE
Fixing favicon in example Angular app

### DIFF
--- a/angular-workspace/angular.json
+++ b/angular-workspace/angular.json
@@ -104,6 +104,7 @@
               ],
               "outputHashing": "all",
               "assets": [
+                "projects/example-client-app/src/favicon.ico",
                 {
                   "glob": "package.json",
                   "input": "./projects/example-client-app/build-assets",


### PR DESCRIPTION
## 🤨 Rationale
The favicon was not being displayed in the angular example app because the image file was not being included in the build.

## 👩‍💻 Implementation
Updated the production build config in the angular.json file to include the image file.

## 🧪 Testing

- Dev site from `ng serve` works as expected. 
- Ran the build for the example app and confirmed the favicon was being added to the dist folder.
- Favicon displays correctly in the "Storybook Publish" check in this PR.

## ✅ Checklist
- [x ] I have updated the project documentation to reflect my changes or determined no changes are needed.
