### PR TITLE
Disable dialog story

### DIFF
--- a/change/@ni-nimble-components-87ddfc72-597b-4ce5-b196-1be805885ca3.json
+++ b/change/@ni-nimble-components-87ddfc72-597b-4ce5-b196-1be805885ca3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Disable dialog stories to fix Chromatic build",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/dialog/tests/dialog-matrix.stories.ts
+++ b/packages/nimble-components/src/dialog/tests/dialog-matrix.stories.ts
@@ -15,7 +15,7 @@ const metadata: Meta = {
 };
 
 export default metadata;
-/*
+
 const component = html`
     <nimble-dialog>
         <h2
@@ -54,6 +54,10 @@ export const dialogLightThemeWhiteBackground: Story = createFixedThemeStory(
 );
 
 dialogLightThemeWhiteBackground.play = playFunction;
+// Disabling until Chromatic's Capture Cloud supports a version of Firefox that supports the dialog element
+dialogLightThemeWhiteBackground.parameters = {
+    chromatic: { disableSnapshot: true }
+};
 
 export const dialogColorThemeDarkGreenBackground: Story = createFixedThemeStory(
     component,
@@ -61,6 +65,10 @@ export const dialogColorThemeDarkGreenBackground: Story = createFixedThemeStory(
 );
 
 dialogColorThemeDarkGreenBackground.play = playFunction;
+// Disabling until Chromatic's Capture Cloud supports a version of Firefox that supports the dialog element
+dialogColorThemeDarkGreenBackground.parameters = {
+    chromatic: { disableSnapshot: true }
+};
 
 export const dialogDarkThemeBlackBackground: Story = createFixedThemeStory(
     component,
@@ -68,13 +76,7 @@ export const dialogDarkThemeBlackBackground: Story = createFixedThemeStory(
 );
 
 dialogDarkThemeBlackBackground.play = playFunction;
-*/
-
-const [lightThemeWhiteBackground] = backgroundStates;
-
-export const temporaryStandIn: Story = createFixedThemeStory(
-    html`This is a stand-in story for the dialog, because the real stories
-    started breaking Chromatic builds due to their Firefox version not
-    supporting the HTML dialog.`,
-    lightThemeWhiteBackground
-);
+// Disabling until Chromatic's Capture Cloud supports a version of Firefox that supports the dialog element
+dialogDarkThemeBlackBackground.parameters = {
+    chromatic: { disableSnapshot: true }
+};

--- a/packages/nimble-components/src/dialog/tests/dialog-matrix.stories.ts
+++ b/packages/nimble-components/src/dialog/tests/dialog-matrix.stories.ts
@@ -70,11 +70,11 @@ export const dialogDarkThemeBlackBackground: Story = createFixedThemeStory(
 dialogDarkThemeBlackBackground.play = playFunction;
 */
 
-const [
-    lightThemeWhiteBackground
-] = backgroundStates;
+const [lightThemeWhiteBackground] = backgroundStates;
 
 export const temporaryStandIn: Story = createFixedThemeStory(
-    html`This is a stand-in story for the dialog, because the real stories started breaking Chromatic builds due to their Firefox version not supporting the HTML dialog.`,
+    html`This is a stand-in story for the dialog, because the real stories
+    started breaking Chromatic builds due to their Firefox version not
+    supporting the HTML dialog.`,
     lightThemeWhiteBackground
 );

--- a/packages/nimble-components/src/dialog/tests/dialog-matrix.stories.ts
+++ b/packages/nimble-components/src/dialog/tests/dialog-matrix.stories.ts
@@ -45,7 +45,10 @@ if (remaining.length > 0) {
 }
 
 const playFunction = (): void => {
-    void document.querySelector('nimble-dialog')!.show();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    if ((window as any).HTMLDialogElement) {
+        void document.querySelector('nimble-dialog')!.show();
+    }
 };
 
 export const dialogLightThemeWhiteBackground: Story = createFixedThemeStory(
@@ -54,10 +57,6 @@ export const dialogLightThemeWhiteBackground: Story = createFixedThemeStory(
 );
 
 dialogLightThemeWhiteBackground.play = playFunction;
-// Disabling until Chromatic's Capture Cloud supports a version of Firefox that supports the dialog element
-dialogLightThemeWhiteBackground.parameters = {
-    chromatic: { disableSnapshot: true }
-};
 
 export const dialogColorThemeDarkGreenBackground: Story = createFixedThemeStory(
     component,
@@ -65,10 +64,6 @@ export const dialogColorThemeDarkGreenBackground: Story = createFixedThemeStory(
 );
 
 dialogColorThemeDarkGreenBackground.play = playFunction;
-// Disabling until Chromatic's Capture Cloud supports a version of Firefox that supports the dialog element
-dialogColorThemeDarkGreenBackground.parameters = {
-    chromatic: { disableSnapshot: true }
-};
 
 export const dialogDarkThemeBlackBackground: Story = createFixedThemeStory(
     component,
@@ -76,7 +71,3 @@ export const dialogDarkThemeBlackBackground: Story = createFixedThemeStory(
 );
 
 dialogDarkThemeBlackBackground.play = playFunction;
-// Disabling until Chromatic's Capture Cloud supports a version of Firefox that supports the dialog element
-dialogDarkThemeBlackBackground.parameters = {
-    chromatic: { disableSnapshot: true }
-};

--- a/packages/nimble-components/src/dialog/tests/dialog-matrix.stories.ts
+++ b/packages/nimble-components/src/dialog/tests/dialog-matrix.stories.ts
@@ -35,8 +35,8 @@ const component = html`
 
 const [
     lightThemeWhiteBackground,
-    colorThemeDarkGreenBackground,
-    darkThemeBlackBackground,
+    // colorThemeDarkGreenBackground,
+    // darkThemeBlackBackground,
     ...remaining
 ] = backgroundStates;
 
@@ -44,6 +44,11 @@ if (remaining.length > 0) {
     throw new Error('New backgrounds need to be supported');
 }
 
+export const temporaryStandIn: Story = createFixedThemeStory(
+    html`This is a stand-in story for the dialog, because the real stories started breaking Chromatic builds due to their Firefox version not supporting the HTML dialog.`,
+    lightThemeWhiteBackground
+);
+/*
 const playFunction = (): void => {
     void document.querySelector('nimble-dialog')!.show();
 };
@@ -68,3 +73,4 @@ export const dialogDarkThemeBlackBackground: Story = createFixedThemeStory(
 );
 
 dialogDarkThemeBlackBackground.play = playFunction;
+*/

--- a/packages/nimble-components/src/dialog/tests/dialog-matrix.stories.ts
+++ b/packages/nimble-components/src/dialog/tests/dialog-matrix.stories.ts
@@ -15,7 +15,7 @@ const metadata: Meta = {
 };
 
 export default metadata;
-
+/*
 const component = html`
     <nimble-dialog>
         <h2
@@ -35,8 +35,8 @@ const component = html`
 
 const [
     lightThemeWhiteBackground,
-    // colorThemeDarkGreenBackground,
-    // darkThemeBlackBackground,
+    colorThemeDarkGreenBackground,
+    darkThemeBlackBackground,
     ...remaining
 ] = backgroundStates;
 
@@ -44,11 +44,6 @@ if (remaining.length > 0) {
     throw new Error('New backgrounds need to be supported');
 }
 
-export const temporaryStandIn: Story = createFixedThemeStory(
-    html`This is a stand-in story for the dialog, because the real stories started breaking Chromatic builds due to their Firefox version not supporting the HTML dialog.`,
-    lightThemeWhiteBackground
-);
-/*
 const playFunction = (): void => {
     void document.querySelector('nimble-dialog')!.show();
 };
@@ -74,3 +69,12 @@ export const dialogDarkThemeBlackBackground: Story = createFixedThemeStory(
 
 dialogDarkThemeBlackBackground.play = playFunction;
 */
+
+const [
+    lightThemeWhiteBackground
+] = backgroundStates;
+
+export const temporaryStandIn: Story = createFixedThemeStory(
+    html`This is a stand-in story for the dialog, because the real stories started breaking Chromatic builds due to their Firefox version not supporting the HTML dialog.`,
+    lightThemeWhiteBackground
+);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

All our Chromatic builds have started failing.

## 👩‍💻 Implementation

I talked to one of their support team, and he let me know there was an error, `TypeError: this.dialogElement.showModal is not a function.` It was known that the version of Firefox they use is too old to support the HTML dialog element, but until now, it had just produced a blank Firefox snapshot without failing the build. They may have updated something on their end that caused this regression.

I've created a (temporary) stand-in story in `dialog-matrix.stories.ts` and commented out the stories that were there. I don't want to delete the whole file, and the file needs to have at least one story, or we get an error. I considered renaming the file (so it wouldn't be picked up by Storybook), but that wouldn't provide a good place to document why it was that way.

Note that we only had to disable the matrix stories, because those are the only ones that actually launch the dialog.

## 🧪 Testing

Build in PR

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
