### PR TITLE
Create CNAME file for pages site

### DIFF
--- a/packages/site/root/CNAME
+++ b/packages/site/root/CNAME
@@ -1,0 +1,1 @@
+nimble.ni.dev


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Adds a CNAME file to the site build so that the subdomain is preserved when new GitHub Pages site changes are published. This is required until we move to the new publishing format discussed in https://github.com/ni/nimble/issues/679#issuecomment-1282823786

## 👩‍💻 Implementation

Adds the file to the site root.

## 🧪 Testing

Manually added it to the GitHub Pages branch to verify it re-enabled support for nimble.ni.dev

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
