### PR TITLE
Fix broken link

### DIFF
--- a/change/@ni-nimble-components-f7186004-bae2-4fee-ab52-13b350faba7f.json
+++ b/change/@ni-nimble-components-f7186004-bae2-4fee-ab52-13b350faba7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix broken documentation link in storybook",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/docs/nimble-intro.stories.mdx
+++ b/packages/nimble-components/docs/nimble-intro.stories.mdx
@@ -33,7 +33,7 @@ styled components that can be used in any NI web application.
 Refer to the 
 [Nimble GitHub repository](https://github.com/ni/nimble) for documentation on using or 
 contributing to the component library. To add or update component design documentation, 
-refer to the [documentation guide](https://github.com/ni/nimble/tree/main/packages/nimble-components/docs/creating-storybook-component-documentation).
+refer to the [documentation guide](https://github.com/ni/nimble/tree/main/packages/nimble-components/docs/creating-storybook-component-documentation.md).
 
 <!-- The following links only works when published to Chomatic or GitHub Pages, not when running Storybook locally -->
 See the <a href="./example-client-app" target="_blank">example Angular app</a> or <a href="./blazor-client-app/wwwroot" target="_blank">example Blazor app</a> using the components!


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #788 

## 👩‍💻 Implementation

Add the file extension (`.md`) so that the github path would be valid.

## 🧪 Testing

Ran storybook locally and verified that the link now works.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
