### PR TITLE
Update error size token

### DIFF
--- a/change/@ni-nimble-tokens-817d8aa1-77e4-4366-972b-60c8d4345866.json
+++ b/change/@ni-nimble-tokens-817d8aa1-77e4-4366-972b-60c8d4345866.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update error text size",
+  "packageName": "@ni/nimble-tokens",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-tokens/data/fonts.json
+++ b/packages/nimble-tokens/data/fonts.json
@@ -858,6 +858,8 @@
       "type": "font",
       "id": "3850253f-2169-4b7a-a7b2-3d7dc78c2997",
       "name": "Error_ColorUI",
+      "last_updated": "2022-10-20T19:56:47.845Z",
+      "last_updated_by": "",
       "tags": [],
       "related_entity_ids": [],
       "ext-com_adobe-cclib": {
@@ -868,21 +870,21 @@
       },
       "tokens": [
         {
-          "id": "9a9732b5-22c4-41e9-baa5-54f758d152ca",
+          "id": "Error_ColorUI-family",
           "type": "custom",
           "value": "Source Sans Pro",
           "key": "family"
         },
         {
-          "id": "9a9732b5-22c4-41e9-baa5-54f758d152ca",
+          "id": "Error_ColorUI-weight",
           "type": "custom",
           "value": "Regular",
           "key": "weight"
         },
         {
-          "id": "9a9732b5-22c4-41e9-baa5-54f758d152ca",
+          "id": "Error_ColorUI-size",
           "type": "size",
-          "value": "9",
+          "value": "11",
           "key": "size"
         }
       ]
@@ -926,6 +928,8 @@
       "type": "font",
       "id": "a0e02347-1124-4c8f-b5df-6111de871bac",
       "name": "Error_LightUI",
+      "last_updated": "2022-10-20T19:57:17.723Z",
+      "last_updated_by": "",
       "tags": [],
       "related_entity_ids": [],
       "ext-com_adobe-cclib": {
@@ -936,21 +940,21 @@
       },
       "tokens": [
         {
-          "id": "f55ade43-f3d8-407d-bdff-60d61fe632f9",
+          "id": "Error_LightUI-family",
           "type": "custom",
           "value": "Source Sans Pro",
           "key": "family"
         },
         {
-          "id": "f55ade43-f3d8-407d-bdff-60d61fe632f9",
+          "id": "Error_LightUI-weight",
           "type": "custom",
           "value": "Regular",
           "key": "weight"
         },
         {
-          "id": "f55ade43-f3d8-407d-bdff-60d61fe632f9",
+          "id": "Error_LightUI-size",
           "type": "size",
-          "value": "9",
+          "value": "11",
           "key": "size"
         }
       ]
@@ -960,6 +964,8 @@
       "type": "font",
       "id": "a749c62c-03ca-4b07-80cd-8418de8f7fac",
       "name": "Error_DarkUI",
+      "last_updated": "2022-10-20T19:57:08.052Z",
+      "last_updated_by": "",
       "tags": [],
       "related_entity_ids": [],
       "ext-com_adobe-cclib": {
@@ -970,21 +976,21 @@
       },
       "tokens": [
         {
-          "id": "941da48c-65b6-4325-a1b3-be3a548efb7a",
+          "id": "Error_DarkUI-family",
           "type": "custom",
           "value": "Source Sans Pro",
           "key": "family"
         },
         {
-          "id": "941da48c-65b6-4325-a1b3-be3a548efb7a",
+          "id": "Error_DarkUI-weight",
           "type": "custom",
           "value": "Regular",
           "key": "weight"
         },
         {
-          "id": "941da48c-65b6-4325-a1b3-be3a548efb7a",
+          "id": "Error_DarkUI-size",
           "type": "size",
-          "value": "9",
+          "value": "11",
           "key": "size"
         }
       ]

--- a/packages/nimble-tokens/dist/styledictionary/csharp/colors.cs
+++ b/packages/nimble-tokens/dist/styledictionary/csharp/colors.cs
@@ -2,7 +2,7 @@
 
 /**
     Do not edit directly
-    Generated on Thu, 26 May 2022 18:20:05 GMT
+    Generated on Thu, 20 Oct 2022 19:57:29 GMT
 **/
 
 using System.Windows.Media;

--- a/packages/nimble-tokens/dist/styledictionary/css/variables.css
+++ b/packages/nimble-tokens/dist/styledictionary/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 26 May 2022 18:20:05 GMT
+ * Generated on Thu, 20 Oct 2022 19:57:29 GMT
  */
 
 :root {
@@ -144,10 +144,10 @@
   --ni-nimble-base-control-label-1-chinese-mac-size: 11px;
   --ni-nimble-base-button-label-1-chinese-mac-size: 11px;
   --ni-nimble-base-body-chinese-mac-size: 13px;
-  --ni-nimble-base-error-color-ui-size: 9px;
+  --ni-nimble-base-error-color-ui-size: 11px;
   --ni-nimble-base-link-visited-light-ui-size: 14px;
-  --ni-nimble-base-error-light-ui-size: 9px;
-  --ni-nimble-base-error-dark-ui-size: 9px;
+  --ni-nimble-base-error-light-ui-size: 11px;
+  --ni-nimble-base-error-dark-ui-size: 11px;
   --ni-nimble-base-link-selection-100-light-ui-size: 14px;
   --ni-nimble-base-grid-header-size: 12.800000190734863px;
   --ni-nimble-base-group-label-expander-size: 14px;

--- a/packages/nimble-tokens/dist/styledictionary/js/tokens.d.ts
+++ b/packages/nimble-tokens/dist/styledictionary/js/tokens.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 26 May 2022 18:20:05 GMT
+ * Generated on Thu, 20 Oct 2022 19:57:29 GMT
  */
 
 export const SlLegacyBlue : string;

--- a/packages/nimble-tokens/dist/styledictionary/js/tokens.js
+++ b/packages/nimble-tokens/dist/styledictionary/js/tokens.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 26 May 2022 18:20:05 GMT
+ * Generated on Thu, 20 Oct 2022 19:57:29 GMT
  */
 
 export const SlLegacyBlue = "#009ff5";
@@ -143,10 +143,10 @@ export const Headline1Size = "25px";
 export const ControlLabel1ChineseMacSize = "11px";
 export const ButtonLabel1ChineseMacSize = "11px";
 export const BodyChineseMacSize = "13px";
-export const ErrorColorUiSize = "9px";
+export const ErrorColorUiSize = "11px";
 export const LinkVisitedLightUiSize = "14px";
-export const ErrorLightUiSize = "9px";
-export const ErrorDarkUiSize = "9px";
+export const ErrorLightUiSize = "11px";
+export const ErrorDarkUiSize = "11px";
 export const LinkSelection100LightUiSize = "14px";
 export const GridHeaderSize = "12.800000190734863px";
 export const GroupLabelExpanderSize = "14px";

--- a/packages/nimble-tokens/dist/styledictionary/properties/fonts.json
+++ b/packages/nimble-tokens/dist/styledictionary/properties/fonts.json
@@ -313,16 +313,16 @@
         "value": "13"
       },
       "Error_ColorUI": {
-        "value": "9"
+        "value": "11"
       },
       "Link_Visited_LightUI": {
         "value": "14"
       },
       "Error_LightUI": {
-        "value": "9"
+        "value": "11"
       },
       "Error_DarkUI": {
-        "value": "9"
+        "value": "11"
       },
       "Link_Selection100_LightUI": {
         "value": "14"

--- a/packages/nimble-tokens/dist/styledictionary/scss/variables.scss
+++ b/packages/nimble-tokens/dist/styledictionary/scss/variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 26 May 2022 18:20:05 GMT
+// Generated on Thu, 20 Oct 2022 19:57:29 GMT
 
 $ni-nimble-base-sl-legacy-blue: #009ff5;
 $ni-nimble-base-information-100-dark-ui: #a46eff;
@@ -142,10 +142,10 @@ $ni-nimble-base-headline-1-size: 25px;
 $ni-nimble-base-control-label-1-chinese-mac-size: 11px;
 $ni-nimble-base-button-label-1-chinese-mac-size: 11px;
 $ni-nimble-base-body-chinese-mac-size: 13px;
-$ni-nimble-base-error-color-ui-size: 9px;
+$ni-nimble-base-error-color-ui-size: 11px;
 $ni-nimble-base-link-visited-light-ui-size: 14px;
-$ni-nimble-base-error-light-ui-size: 9px;
-$ni-nimble-base-error-dark-ui-size: 9px;
+$ni-nimble-base-error-light-ui-size: 11px;
+$ni-nimble-base-error-dark-ui-size: 11px;
 $ni-nimble-base-link-selection-100-light-ui-size: 14px;
 $ni-nimble-base-grid-header-size: 12.800000190734863px;
 $ni-nimble-base-group-label-expander-size: 14px;

--- a/packages/nimble-tokens/dist/styledictionary/xaml/colors.xaml
+++ b/packages/nimble-tokens/dist/styledictionary/xaml/colors.xaml
@@ -5,7 +5,7 @@
 
 <!--
   Do not edit directly
-  Generated on Thu, 26 May 2022 18:20:05 GMT
+  Generated on Thu, 20 Oct 2022 19:57:29 GMT
 -->
     <Color x:Key="SL_LegacyBlue">#ff009ff5</Color>
     <Color x:Key="Information100_DarkUI">#ffa46eff</Color>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This fixes part of #781 by pulling in the new token value for the error text size (see #775).

## 👩‍💻 Implementation

I used the XD plugin to Visual Studio Code to update the values of the three error text size tokens (one token per theme).

## 🧪 Testing

Verified that the error text looks correct in storybook.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
