### PR TITLE
Temporarily disable npm audit of dev dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,8 @@ jobs:
 
       # Audit
       - run: npm audit --only=prod
-      - run: npm audit --audit-level=critical
+      # https://github.com/ni/nimble/issues/801
+      # - run: npm audit --audit-level=critical
 
       # Build
       - run: npm run build


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As described in #801 we have a vulnerability that is causing `npm audit` to fail the PR build, preventing submissions.

## 👩‍💻 Implementation

Comment out the audit step that's failing. We'll use the bug linked above to track re-enabling it.

## 🧪 Testing

PR build

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
