### PR TITLE
Temporarily disable intermittent drawer test

### DIFF
--- a/change/@ni-nimble-components-49e37a85-7c90-4500-b535-55640060fba1.json
+++ b/change/@ni-nimble-components-49e37a85-7c90-4500-b535-55640060fba1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Temporarily disable intermittent drawer test",
+  "packageName": "@ni/nimble-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/drawer/tests/drawer.spec.ts
+++ b/packages/nimble-components/src/drawer/tests/drawer.spec.ts
@@ -126,7 +126,8 @@ describe('Drawer', () => {
             await expectAsync(promise).toBePending();
         });
 
-        it('should resolve promise if drawer completely opens before being closed', async () => {
+        // Temporarily disabled due to https://github.com/ni/nimble/issues/816
+        xit('should resolve promise if drawer completely opens before being closed', async () => {
             const promise = element.show();
             await completeAnimationAsync(element);
             element.close();


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The test is failing frequently on the pipeline, blocking unrelated PRs from being submitted. Fixing it is tracked by #816. @mollykreis has a potential fix but it won't be ready until Monday.

## 👩‍💻 Implementation

Comment out test.

## 🧪 Testing

Relying on pipeline

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
