### PR TITLE
Fix intermittent drawer test

### DIFF
--- a/change/@ni-nimble-components-c605be0d-27fc-47ff-bf8e-c996c0fe7158.json
+++ b/change/@ni-nimble-components-c605be0d-27fc-47ff-bf8e-c996c0fe7158.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix intermittent drawer test",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-c605be0d-27fc-47ff-bf8e-c996c0fe7158.json
+++ b/change/@ni-nimble-components-c605be0d-27fc-47ff-bf8e-c996c0fe7158.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "none",
   "comment": "Fix intermittent drawer test",
   "packageName": "@ni/nimble-components",
   "email": "20542556+mollykreis@users.noreply.github.com",

--- a/packages/nimble-components/src/drawer/tests/drawer.spec.ts
+++ b/packages/nimble-components/src/drawer/tests/drawer.spec.ts
@@ -2,6 +2,7 @@ import { DOM, html } from '@microsoft/fast-element';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Drawer, UserDismissed } from '..';
 import { DrawerLocation } from '../types';
+import { eventAnimationEnd } from '@microsoft/fast-web-utilities';
 
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 async function setup<CloseReason = void>(
@@ -35,12 +36,14 @@ describe('Drawer', () => {
     async function completeAnimationAsync(
         nimbleDrawerElement: Drawer | Drawer<string>
     ): Promise<void> {
-        while (isDrawerAnimating(nimbleDrawerElement)) {
-            // eslint-disable-next-line no-await-in-loop
-            await DOM.nextUpdate();
-        }
-        // Ensure everything is updated appropriately after the animation completes.
-        await DOM.nextUpdate();
+        return new Promise(resolve => {
+            const dialogElement = nativeDialogElement(nimbleDrawerElement);
+            const handler = (): void => {
+                dialogElement.removeEventListener(eventAnimationEnd, handler);
+                resolve();
+            };
+            dialogElement.addEventListener(eventAnimationEnd, handler);
+        });
     }
 
     describe('with default setup', () => {

--- a/packages/nimble-components/src/drawer/tests/drawer.spec.ts
+++ b/packages/nimble-components/src/drawer/tests/drawer.spec.ts
@@ -1,8 +1,8 @@
 import { DOM, html } from '@microsoft/fast-element';
+import { eventAnimationEnd } from '@microsoft/fast-web-utilities';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Drawer, UserDismissed } from '..';
 import { DrawerLocation } from '../types';
-import { eventAnimationEnd } from '@microsoft/fast-web-utilities';
 
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 async function setup<CloseReason = void>(

--- a/packages/nimble-components/src/drawer/tests/drawer.spec.ts
+++ b/packages/nimble-components/src/drawer/tests/drawer.spec.ts
@@ -129,8 +129,7 @@ describe('Drawer', () => {
             await expectAsync(promise).toBePending();
         });
 
-        // Temporarily disabled due to https://github.com/ni/nimble/issues/816
-        xit('should resolve promise if drawer completely opens before being closed', async () => {
+        it('should resolve promise if drawer completely opens before being closed', async () => {
             const promise = element.show();
             await completeAnimationAsync(element);
             element.close();


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #816 

## 👩‍💻 Implementation

I wasn't able to determine why the previous implementation of `completeAnimationAsync` in the tests was causing intermittency, but I think the updated implementation is better regardless. Rather than polling for the `animating` CSS class to be removed from an element to know that the animation is complete, I am now adding an `animationend` event listener to know when the animation is complete.

## 🧪 Testing

- Ran the tests a number of times locally (although this always passed with the old implementation as well)
- Ran the pipeline a number of times

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
