### PR TITLE
Consistent private package configuration

### DIFF
--- a/angular-workspace/package.json
+++ b/angular-workspace/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "angular-workspace",
-  "version": "0.0.0",
+  "name": "@ni-private/angular-workspace",
+  "version": "1.0.0",
+  "private": true,
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -18,7 +19,6 @@
     "lint": "ng lint",
     "format": "ng lint --fix"
   },
-  "private": true,
   "dependencies": {
     "@angular/animations": "^14.2.0",
     "@angular/common": "^14.2.0",

--- a/angular-workspace/projects/example-client-app/build-assets/package.json
+++ b/angular-workspace/projects/example-client-app/build-assets/package.json
@@ -1,7 +1,7 @@
 {
     "description": "Dummy package.json for build deployment. DO NOT MODIFY",
-    "name": "example-client-app",
-    "version": "0.0.0",
+    "name": "@ni-private/example-client-app",
+    "version": "1.0.0",
     "private":true,
     "files": [
         "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@ni/nimble",
-  "version": "0.0.0",
+  "name": "@ni-private/nimble",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ni/nimble",
-      "version": "0.0.0",
+      "name": "@ni-private/nimble",
+      "version": "1.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -28,7 +28,8 @@
       }
     },
     "angular-workspace": {
-      "version": "0.0.0",
+      "name": "@ni-private/angular-workspace",
+      "version": "1.0.0",
       "dependencies": {
         "@angular/animations": "^14.2.0",
         "@angular/common": "^14.2.0",
@@ -5124,6 +5125,14 @@
         "webpack": "^5.54.0"
       }
     },
+    "node_modules/@ni-private/angular-workspace": {
+      "resolved": "angular-workspace",
+      "link": true
+    },
+    "node_modules/@ni-private/site": {
+      "resolved": "packages/site",
+      "link": true
+    },
     "node_modules/@ni/eslint-config-angular": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@ni/eslint-config-angular/-/eslint-config-angular-5.0.1.tgz",
@@ -5180,10 +5189,6 @@
     },
     "node_modules/@ni/nimble-tokens": {
       "resolved": "packages/nimble-tokens",
-      "link": true
-    },
-    "node_modules/@ni/site": {
-      "resolved": "packages/site",
       "link": true
     },
     "node_modules/@ni/xliff-to-json-converter": {
@@ -14126,10 +14131,6 @@
       "peerDependencies": {
         "ajv": "^8.8.2"
       }
-    },
-    "node_modules/angular-workspace": {
-      "resolved": "angular-workspace",
-      "link": true
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
@@ -42040,8 +42041,8 @@
       }
     },
     "packages/site": {
-      "name": "@ni/site",
-      "version": "1.0.0-beta.0",
+      "name": "@ni-private/site",
+      "version": "1.0.0",
       "devDependencies": {
         "@11ty/eleventy": "^1.0.2"
       }
@@ -45763,6 +45764,59 @@
       "dev": true,
       "requires": {}
     },
+    "@ni-private/angular-workspace": {
+      "version": "file:angular-workspace",
+      "requires": {
+        "@angular-devkit/build-angular": "^14.2.0",
+        "@angular/animations": "^14.2.0",
+        "@angular/cli": "^14.2.0",
+        "@angular/common": "^14.2.0",
+        "@angular/compiler": "^14.2.0",
+        "@angular/compiler-cli": "^14.2.0",
+        "@angular/core": "^14.2.0",
+        "@angular/forms": "^14.2.0",
+        "@angular/platform-browser": "^14.2.0",
+        "@angular/platform-browser-dynamic": "^14.2.0",
+        "@angular/router": "^14.2.0",
+        "@microsoft/fast-web-utilities": "^5.4.1",
+        "@ni/eslint-config-angular": "^5.0.1",
+        "@ni/eslint-config-javascript": "^4.0.0",
+        "@ni/eslint-config-typescript": "^4.1.0",
+        "@ni/nimble-components": "*",
+        "@ni/nimble-tokens": "*",
+        "@rollup/plugin-node-resolve": "^13.1.3",
+        "@types/jasmine": "^3.6.0",
+        "@types/node": "^12.11.1",
+        "eslint-plugin-jsdoc": "^37.9.7",
+        "jasmine-core": "^3.7.0",
+        "karma": "^6.3.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-coverage": "^2.0.3",
+        "karma-jasmine": "^4.0.0",
+        "karma-jasmine-html-reporter": "^1.5.0",
+        "ng-packagr": "^14.1.0",
+        "puppeteer": "^10.1.0",
+        "rollup": "^2.61.1",
+        "rxjs": "^7.3.0",
+        "tslib": "^2.2.0",
+        "typescript": "~4.6.4",
+        "zone.js": "^0.11.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.55",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+          "dev": true
+        }
+      }
+    },
+    "@ni-private/site": {
+      "version": "file:packages/site",
+      "requires": {
+        "@11ty/eleventy": "^1.0.2"
+      }
+    },
     "@ni/eslint-config-angular": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@ni/eslint-config-angular/-/eslint-config-angular-5.0.1.tgz",
@@ -45998,12 +46052,6 @@
             "has-flag": "^4.0.0"
           }
         }
-      }
-    },
-    "@ni/site": {
-      "version": "file:packages/site",
-      "requires": {
-        "@11ty/eleventy": "^1.0.2"
       }
     },
     "@ni/xliff-to-json-converter": {
@@ -53054,53 +53102,6 @@
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.3"
-      }
-    },
-    "angular-workspace": {
-      "version": "file:angular-workspace",
-      "requires": {
-        "@angular-devkit/build-angular": "^14.2.0",
-        "@angular/animations": "^14.2.0",
-        "@angular/cli": "^14.2.0",
-        "@angular/common": "^14.2.0",
-        "@angular/compiler": "^14.2.0",
-        "@angular/compiler-cli": "^14.2.0",
-        "@angular/core": "^14.2.0",
-        "@angular/forms": "^14.2.0",
-        "@angular/platform-browser": "^14.2.0",
-        "@angular/platform-browser-dynamic": "^14.2.0",
-        "@angular/router": "^14.2.0",
-        "@microsoft/fast-web-utilities": "^5.4.1",
-        "@ni/eslint-config-angular": "^5.0.1",
-        "@ni/eslint-config-javascript": "^4.0.0",
-        "@ni/eslint-config-typescript": "^4.1.0",
-        "@ni/nimble-components": "*",
-        "@ni/nimble-tokens": "*",
-        "@rollup/plugin-node-resolve": "^13.1.3",
-        "@types/jasmine": "^3.6.0",
-        "@types/node": "^12.11.1",
-        "eslint-plugin-jsdoc": "^37.9.7",
-        "jasmine-core": "^3.7.0",
-        "karma": "^6.3.0",
-        "karma-chrome-launcher": "^3.1.0",
-        "karma-coverage": "^2.0.3",
-        "karma-jasmine": "^4.0.0",
-        "karma-jasmine-html-reporter": "^1.5.0",
-        "ng-packagr": "^14.1.0",
-        "puppeteer": "^10.1.0",
-        "rollup": "^2.61.1",
-        "rxjs": "^7.3.0",
-        "tslib": "^2.2.0",
-        "typescript": "~4.6.4",
-        "zone.js": "^0.11.4"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.20.55",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-          "dev": true
-        }
       }
     },
     "ansi-align": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@ni/nimble",
-  "version": "0.0.0",
+  "name": "@ni-private/nimble",
+  "version": "1.0.0",
   "private": true,
   "description": "The NI Nimble Design System Monorepo",
   "scripts": {

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,8 +1,8 @@
 {
-    "name": "@ni/site",
-    "version": "1.0.0-beta.0",
-    "description": "A meta package used for creating GitHub pages site contents",
+    "name": "@ni-private/site",
+    "version": "1.0.0",
     "private": true,
+    "description": "A meta package used for creating GitHub pages site contents",
     "scripts": {
         "build": "eleventy",
         "pack": "npm pack",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Our private unpublished packages were using either the scope `@ni` or not using a scope at all. They also had inconsistent versions numbers.

## 👩‍💻 Implementation

- Updated all the private unpublished packages to use the `@ni-private` scoped owned by the `ni-webapps-ops` account.
- Updated the version number for private unpublished packages to `1.0.0`

## 🧪 Testing

Rely on CI build

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
