### PR TITLE
Capture contributing policies in docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_component.md
+++ b/.github/ISSUE_TEMPLATE/new_component.md
@@ -27,5 +27,7 @@ IBUTING](https://github.com/ni/nimble/blob/main/packages/nimble-components/CONTR
 - [ ] nimble-{name} Storybook tests
 - [ ] nimble-{name} Storybook docs
 - [ ] nimble-{name} Angular wrapper
+- [ ] nimble-{name} Blazor wrapper
 - [ ] Add to Angular example app
+- [ ] Add to Blazor example app
 - [ ] Update Component Status table in README

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ This repo generally follows the [NI JavaScript and TypeScript Styleguide](https:
 
 ## Pull request policies
 
+Each pull request should add a small increment of high-quality well-tested value to Nimble. To keep PRs small you can add functionality incrementally but each PR should contain appropriate tests for the functionality being added and shouldn't introduce technical debt to be fixed later.
+
 ### Beachball change file
 
 This repository uses [beachball](https://microsoft.github.io/beachball/) to automate publishing its packages to NPM. The basic workflow is as follows:
@@ -69,7 +71,7 @@ This repository uses [beachball](https://microsoft.github.io/beachball/) to auto
 3. A pipeline will run for each newly created git tag and invoke the `npm run publish` command for the associated package.
 
 When generating a change file, follow these guidelines:
-1. Follow [semantic versioning](https://semver.org) when choosing the change type.
+1. Follow [semantic versioning](https://semver.org) when choosing the change type. Components that are [marked as in-development](/packages/nimble-components/CONTRIBUTING.md/#Marking-a-component-as-in-development) may use `patch` version bumps even for breaking changes.
 2. Write a brief but useful description with Nimble clients in mind. If making a major (breaking) change, explain what clients need to do to adopt it. The description can be plain text or [markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax), with newlines specified via `\n` if needed.
 3. If you prefer not to expose your email address to the world, [configure GitHub to "Keep my email address private"](https://github.com/settings/emails) before generating the change file.
 

--- a/packages/nimble-components/CONTRIBUTING.md
+++ b/packages/nimble-components/CONTRIBUTING.md
@@ -63,13 +63,23 @@ Before building a new component, create a spec document to get agreement on the 
 
     See [Unit tests](#unit-tests) for additional available commands.
 
-5. Create changelists for your work by running the following from the `nimble` directory:
+5. Create change files for your work by running the following from the `nimble` directory:
 
     `npm run change`
 
 6. Update the [Component Status table](/README.md#component-status) to reflect the new component state.
 
 ## Develop new components
+
+### Marking a component as in development
+
+If a component will require multiple pull requests before having a complete and stable API, it should be marked as "in-development" to indicate to clients that they shouldn't start using it yet. To do this:
+
+1. In the component status table, set its status to ⚠️
+2. In the component Storybook documentation, add a red text banner to the page indicating that the component should not be used
+3. Consider placing the component implementation in a sub-folder named `experimental` so that it will be obvious when importing it that it is incomplete
+
+Be sure to remove these warnings when the component is complete!
 
 ### Folder structure
 
@@ -81,6 +91,8 @@ Create a new folder named after your component with some core files:
 | index.ts                               | Contains the component class definition and registration. All TypeScript logic contained in the component belongs here.                                                                                                                                                    |
 | styles.ts                              | Contains the styles relevant to this component. Note: Style property values that can be shared across components belong in [theme-provider/design-tokens.ts](/packages/nimble-components/src/theme-provider/design-tokens.ts).                                             |
 | template.ts                            | Contains the template definition for components that don't use a fast-foundation template.                                                                                                                                                                                 |
+| types.ts                               | Contains any enum-like types defined by the component                                                                                                                                                                                                                      |
+| models/                                | A folder containing any classes or interfaces that are part of the component API or implementation                                                                                                                                                                         |
 | tests/component-name.spec.ts           | Unit tests for this component. Covers behaviors added to components on top of existing Foundation behaviors or behavior of new components.                                                                                                                                 |
 | tests/component-name.stories.ts        | Contains the component hosted in Storybook. This provides a live component view for development and testing. In the future, this will also provide API documentation.                                                                                                      |
 | tests/component-name-matrix.stories.ts | Contains a story that shows all component states for all themes hosted in Storybook. This is used by Chromatic visual tests to verify styling changes across all themes and states.                                                                                        |

--- a/specs/templates/custom-component.md
+++ b/specs/templates/custom-component.md
@@ -41,7 +41,7 @@
 *The key elements of the component's public API surface:*
 
 - *Component Name*
-- *Props/Attrs*
+- *Props/Attrs: to match native element APIs, prefer primitive types rather than complex configuration objects and expose fields as both properties on the TypeScript class and attributes on the HTML element*
 - *Methods*
 - *Events*
 - *CSS Classes and CSS Custom Properties that affect the component*
@@ -61,11 +61,11 @@
 
 ### Angular integration 
 
-*Describe the plan for Angular support, including directives for attribute binding and ControlValueAccessor for form integration.*
+*Describe the plan for Angular support, including directives for attribute binding and ControlValueAccessor for form integration. Depending on the contributor's needs, implementing Angular integration may be deferred but the initial spec should still document what work will be needed.*
 
 ### Blazor integration 
 
-*Describe the plan for Blazor support. See the [nimble-blazor CONTRIBUTING.md](/packages/nimble-blazor/CONTRIBUTING.md) for details.*
+*Describe the plan for Blazor support. See the [nimble-blazor CONTRIBUTING.md](/packages/nimble-blazor/CONTRIBUTING.md) for details. Depending on the contributor's needs, implementing Angular integration may be deferred but the initial spec should still document what work will be needed.*
 
 ### Visual Appearance
 
@@ -79,6 +79,8 @@
 
 *Highlight any alternative implementations you considered in each section.*
 
+*If you think a section doesn't apply or don't know what to write, DO NOT delete it, just leave it blank and the Nimble team can help you fill it in.*
+
 ### States
 
 *Key component states, valid state transitions, and how interactions trigger a state transition.*
@@ -89,8 +91,10 @@
 
 - *Keyboard Navigation and Focus*
 - *Form Input*
-- *Use with Assistive Technology*
-  - e.g. The implications shadow dom might have on how roles and attributes are presented to the AT. Components which delegate focus require all global aria-* attributes to be enumerated.
+- *Use with Assistive Technology. For example:*
+  - *All components should define a role and label so that assistive technology can identify them*
+  - *The implications shadow dom might have on how roles and attributes are presented in the accessibility tree.*
+  - *Components which delegate focus require all global ARIA attributes to be enumerated.*
 
 ### Globalization
 

--- a/specs/templates/fast-based-component.md
+++ b/specs/templates/fast-based-component.md
@@ -31,11 +31,11 @@
 
 ### Angular integration 
 
-*Describe the plan for Angular support, including directives for attribute binding and ControlValueAccessor for form integration.*
+*Describe the plan for Angular support, including directives for attribute binding and ControlValueAccessor for form integration. Depending on the contributor's needs, implementing Angular integration may be deferred but the initial spec should still document what work will be needed.*
 
 ### Blazor integration 
 
-*Describe the plan for Blazor support. See the [nimble-blazor CONTRIBUTING.md](/packages/nimble-blazor/CONTRIBUTING.md) for details.*
+*Describe the plan for Blazor support. See the [nimble-blazor CONTRIBUTING.md](/packages/nimble-blazor/CONTRIBUTING.md) for details. Depending on the contributor's needs, implementing Angular integration may be deferred but the initial spec should still document what work will be needed.*
 
 ### Additional requirements
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

We want to clarify some contributing policies since we're happily receiving more external contributors.

## 👩‍💻 Implementation

Moved notes from [this brainstorming artifact](https://lucid.app/lucidspark/c8ad0840-c9aa-471b-a1da-c98794b004ca/edit?viewport_loc=-5%2C449%2C2063%2C1148%2C0_0&invitationId=inv_58630149-2d1b-46fc-9c4f-83a098613218) into various documents in the repo, including issue templates, spec templates, READMEs, and CONTRIBUTING documents.

## 🧪 Testing

N/A 
## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
