### PR TITLE
GitHub workflow permissions test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,8 +6,12 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_SERVICE_USER: "rajsite"
   GITHUB_SERVICE_EMAIL: "rajsite@users.noreply.github.com"
 
@@ -18,7 +22,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Required for changelog detection
-          token: ${{ secrets.GITHUBPAGESDEPLOYTOKEN }}
 
       # Install dependencies
       - uses: actions/setup-dotnet@v2
@@ -55,7 +58,6 @@ jobs:
         if: github.event_name == 'push'
         uses: chromaui/action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: ./packages/nimble-components
           storybookBuildDir: ../../packages/site/dist/storybook

--- a/change/@ni-nimble-blazor-1e1c35d7-ed60-49fd-ba07-8a3d4f01ec25.json
+++ b/change/@ni-nimble-blazor-1e1c35d7-ed60-49fd-ba07-8a3d4f01ec25.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Patch change to test pipeline, no changes to uptake.",
+  "packageName": "@ni/nimble-blazor",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-blazor/README.md
+++ b/packages/nimble-blazor/README.md
@@ -57,6 +57,7 @@ Additional Resources: [Microsoft tutorial: Build a web app with Blazor](https://
 Additional Resources: [`dotnet add package` documentation](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-add-package)
 
 ### Use Nimble Blazor components
+
 For a simple modification to the Blazor template project: open `Index.razor` and add the following code at the bottom, to add a Nimble text field that updates when a Nimble button is clicked:
 ```cs
 <NimbleTextField Value="@ButtonClickStatus"></NimbleTextField>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This is a test to see if switching to workflow permissions (the permissions key in the workflow) from a personal access token (the previous secrets.GITHUBPAGESDEPLOYTOKEN) will work correctly with beachball publish.

## 👩‍💻 Implementation

Enabled the `contents: write` permission on the workflow.

## 🧪 Testing

Doing it live by publishing a patch change to blazor (fewer external users than components or angular). Will be prepared to revert if needed.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
