### PR TITLE
Wafermap render after connectedCallback

### DIFF
--- a/change/@ni-nimble-components-23e94fa0-6939-4294-8166-781e262e178a.json
+++ b/change/@ni-nimble-components-23e94fa0-6939-4294-8166-781e262e178a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Wafermap ensure rendering only happens after template construction",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/wafer-map/index.ts
+++ b/packages/nimble-components/src/wafer-map/index.ts
@@ -71,6 +71,11 @@ export class WaferMap extends FoundationElement {
     private renderQueued = false;
     private dataManager: DataManager | undefined;
 
+    public override connectedCallback(): void {
+        super.connectedCallback();
+        this.queueRender();
+    }
+
     /**
      * @internal
      */
@@ -129,6 +134,9 @@ export class WaferMap extends FoundationElement {
     }
 
     private queueRender(): void {
+        if (!this.$fastController.isConnected) {
+            return;
+        }
         if (!this.renderQueued) {
             this.renderQueued = true;
             DOM.queueUpdate(() => this.render());


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

WaferMap tests have been intermittent in main showing an error about template content not being defined.

## 👩‍💻 Implementation

Updates the wafermap to only call render after the connected callback ensuring template content is available to reference (i.e. the canvas element).

## 🧪 Testing

Ran the unit tests locally 5 times and noticed intermittent failures before the change. After the change ran 20 times without failure.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
