### PR TITLE
Fix storybook mdx plugin

### DIFF
--- a/change/@ni-nimble-components-2aca898c-e7e9-4b3c-a84b-cf13e15f6b39.json
+++ b/change/@ni-nimble-components-2aca898c-e7e9-4b3c-a84b-cf13e15f6b39.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update storybook devDependencies",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5050,23 +5050,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@mdx-js/react": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.1.5.tgz",
-      "integrity": "sha512-3Az1I6SAWA9R38rYjz5rXBrGKeZhq96CSSyQtqY+maPj8stBsoUH5pNcmIixuGkufYsh8F5+ka2CVPo2fycWZw==",
-      "dev": true,
-      "dependencies": {
-        "@types/mdx": "^2.0.0",
-        "@types/react": ">=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      },
-      "peerDependencies": {
-        "react": ">=16"
-      }
-    },
     "node_modules/@mdx-js/util": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.22.tgz",
@@ -13013,12 +12996,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/@types/mdx": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.3.tgz",
-      "integrity": "sha512-IgHxcT3RC8LzFLhKwP3gbMPeaK7BM9eBH46OdapPA7yvuIUJ8H6zHZV53J8hGZcTSnt95jANt+rTBNUUc22ACQ==",
-      "dev": true
-    },
     "node_modules/@types/mime": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
@@ -13093,7 +13070,8 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/q": {
       "version": "1.5.5",
@@ -13118,6 +13096,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.25.tgz",
       "integrity": "sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -13143,7 +13122,8 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -19026,7 +19006,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/cuint": {
       "version": "0.2.2",
@@ -42623,7 +42604,7 @@
         "@babel/cli": "^7.13.16",
         "@babel/core": "^7.14.6",
         "@babel/preset-env": "^7.13.15",
-        "@mdx-js/react": "*",
+        "@mdx-js/react": "^1.6.22",
         "@ni/eslint-config-javascript": "^4.0.0",
         "@ni/eslint-config-typescript": "^4.1.0",
         "@rollup/plugin-commonjs": "^21.0.2",
@@ -42672,6 +42653,33 @@
         "webpack": "^5.37.0",
         "webpack-cli": "^4.6.0",
         "webpack-dev-middleware": "^5.0.0"
+      }
+    },
+    "packages/nimble-components/node_modules/@mdx-js/react": {
+      "version": "1.6.22",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
+      "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.0"
+      }
+    },
+    "packages/nimble-components/node_modules/react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "packages/nimble-tokens": {
@@ -46517,16 +46525,6 @@
         }
       }
     },
-    "@mdx-js/react": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.1.5.tgz",
-      "integrity": "sha512-3Az1I6SAWA9R38rYjz5rXBrGKeZhq96CSSyQtqY+maPj8stBsoUH5pNcmIixuGkufYsh8F5+ka2CVPo2fycWZw==",
-      "dev": true,
-      "requires": {
-        "@types/mdx": "^2.0.0",
-        "@types/react": ">=16"
-      }
-    },
     "@mdx-js/util": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.22.tgz",
@@ -46701,7 +46699,7 @@
         "@babel/cli": "^7.13.16",
         "@babel/core": "^7.14.6",
         "@babel/preset-env": "^7.13.15",
-        "@mdx-js/react": "*",
+        "@mdx-js/react": "^1.6.22",
         "@microsoft/fast-colors": "^5.3.1",
         "@microsoft/fast-element": "^1.10.1",
         "@microsoft/fast-foundation": "^2.46.11",
@@ -46762,6 +46760,26 @@
         "webpack": "^5.37.0",
         "webpack-cli": "^4.6.0",
         "webpack-dev-middleware": "^5.0.0"
+      },
+      "dependencies": {
+        "@mdx-js/react": {
+          "version": "1.6.22",
+          "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
+          "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
+          "dev": true,
+          "requires": {}
+        },
+        "react": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+          "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "@ni/nimble-tokens": {
@@ -53079,12 +53097,6 @@
         "@types/unist": "*"
       }
     },
-    "@types/mdx": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.3.tgz",
-      "integrity": "sha512-IgHxcT3RC8LzFLhKwP3gbMPeaK7BM9eBH46OdapPA7yvuIUJ8H6zHZV53J8hGZcTSnt95jANt+rTBNUUc22ACQ==",
-      "dev": true
-    },
     "@types/mime": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
@@ -53159,7 +53171,8 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@types/q": {
       "version": "1.5.5",
@@ -53184,6 +53197,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.25.tgz",
       "integrity": "sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -53209,7 +53223,8 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -57798,7 +57813,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "cuint": {
       "version": "0.2.2",

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -63,7 +63,7 @@
     "@babel/cli": "^7.13.16",
     "@babel/core": "^7.14.6",
     "@babel/preset-env": "^7.13.15",
-    "@mdx-js/react": "*",
+    "@mdx-js/react": "^1.6.22",
     "@ni/eslint-config-javascript": "^4.0.0",
     "@ni/eslint-config-typescript": "^4.1.0",
     "@rollup/plugin-commonjs": "^21.0.2",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Found that the current "@mdx-js/react": "*" version was resolving in package-lock.json to the latest "@mdx-js/react" at v2 which is an actual breaking change for storybook.

## 👩‍💻 Implementation

Instead matched the version specifier with the one in the [storybook package version](https://github.com/storybookjs/storybook/blob/9bc627d9b364d2ea915470dfd08cfe5cb3716dee/addons/docs/package.json#L61) and verified that the package-lock only shows one version.


## 🧪 Testing

Built locally 

## ✅ Checklist


- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
