### PR TITLE
Change some Storybook urls from http to https

### DIFF
--- a/change/@ni-nimble-components-96df3d61-7cdc-4f21-827b-766425c85f07.json
+++ b/change/@ni-nimble-components-96df3d61-7cdc-4f21-827b-766425c85f07.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Change some urls in Storybook from http to https",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/anchor-button/tests/anchor-button-matrix.stories.ts
+++ b/packages/nimble-components/src/anchor-button/tests/anchor-button-matrix.stories.ts
@@ -61,7 +61,7 @@ const component = (
     [iconVisible, labelVisible, endIconVisible]: PartVisibilityState,
 ): ViewTemplate => html`
     <nimble-anchor-button
-        href="http://nimble.ni.dev"
+        href="https://nimble.ni.dev"
         appearance="${() => appearance}"
         appearance-variant="${() => appearanceVariant}"
         ?disabled=${() => disabled}

--- a/packages/nimble-components/src/anchor-button/tests/anchor-button.stories.ts
+++ b/packages/nimble-components/src/anchor-button/tests/anchor-button.stories.ts
@@ -90,7 +90,7 @@ const metadata: Meta<AnchorButtonArgs> = {
     },
     args: {
         label: 'Anchor Button',
-        href: 'http://nimble.ni.dev',
+        href: 'https://nimble.ni.dev',
         appearance: ButtonAppearance.outline,
         appearanceVariant: undefined,
         icon: false,

--- a/packages/nimble-components/src/anchor/tests/anchor-matrix.stories.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor-matrix.stories.ts
@@ -31,7 +31,7 @@ const metadata: Meta = {
 export default metadata;
 
 const disabledStates = [
-    ['', 'http://nimble.ni.dev'],
+    ['', 'https://nimble.ni.dev'],
     ['Disabled', null]
 ] as const;
 type DisabledState = typeof disabledStates[number];

--- a/packages/nimble-components/src/anchor/tests/anchor.stories.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor.stories.ts
@@ -64,7 +64,7 @@ const metadata: Meta<AnchorArgs> = {
     },
     args: {
         label: 'link',
-        href: 'http://nimble.ni.dev',
+        href: 'https://nimble.ni.dev',
         underlineHidden: false,
         appearance: 'default'
     }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Should use https://nimble.ni.dev instead of http://nimble.ni.dev.

## 👩‍💻 Implementation

Changed urls to https.

## 🧪 Testing

None

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
