### PR TITLE
Separate github-pages deploy job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,11 +107,11 @@ jobs:
 
   pages:
     needs: build
-    # if: startsWith(github.ref, 'refs/heads/main')
+    if: startsWith(github.ref, 'refs/heads/main')
     runs-on: ubuntu-22.04
     permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,9 @@ jobs:
             packages/**/*.nupkg
             angular-workspace/**/*.tgz
           if-no-files-found: error
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'packages/site/dist'
 
       # Publish to Chromatic (from any push)
       - name: Publish to Chromatic
@@ -94,19 +97,6 @@ jobs:
           git config --global user.name "${{ env.GITHUB_SERVICE_USER }}"
           git config --global user.email "${{ env.GITHUB_SERVICE_EMAIL }}"
 
-      # Publish site to GitHub Pages (only from main)
-      - name: Install ruby
-        if: startsWith(github.ref, 'refs/heads/main')
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: '2.6'
-      - name: Install dependencies
-        if: startsWith(github.ref, 'refs/heads/main')
-        run: gem install dpl
-      - name: Deploy to GitHub Pages
-        if: startsWith(github.ref, 'refs/heads/main')
-        run: dpl --provider=pages --repo=ni/nimble --local_dir=packages/site/dist --skip_cleanup --name="${{ env.GITHUB_SERVICE_USER }}" --email="${{ env.GITHUB_SERVICE_EMAIL }}" --github-token=${{ secrets.GITHUBPAGESDEPLOYTOKEN }}
-
       # Update package versions, tag, and publish to npm (only from main)
       - name: Beachball publish
         if: startsWith(github.ref, 'refs/heads/main')
@@ -114,3 +104,18 @@ jobs:
           NPM_SECRET_TOKEN: ${{ secrets.NPM_TOKEN }}
           NUGET_SECRET_TOKEN: ${{ secrets.NUGET_TOKEN }}
         run: npm run invoke-publish
+
+  pages:
+    needs: build
+    # if: startsWith(github.ref, 'refs/heads/main')
+    runs-on: ubuntu-22.04
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/packages/site/root/CNAME
+++ b/packages/site/root/CNAME
@@ -1,1 +1,0 @@
-nimble.ni.dev


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Changes the GitHub deploy step to use the new [GitHub Pages deploy actions](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#creating-a-custom-github-actions-workflow-to-publish-your-site). Fixes #679 

## 👩‍💻 Implementation

Removed the existing ruby-based approach and switched to the workflow actions.  Used a dedicated job as recommend in the [deploy pages usage](https://github.com/actions/deploy-pages#usage).

## 🧪 Testing

Doing it live

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
