### PR TITLE
Fix tab keyboard focus style

### DIFF
--- a/change/@ni-nimble-components-8ed4d950-9ef7-42ca-8773-548203c0bc1f.json
+++ b/change/@ni-nimble-components-8ed4d950-9ef7-42ca-8773-548203c0bc1f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix tab keyboard focus style",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/tab/styles.ts
+++ b/packages/nimble-components/src/tab/styles.ts
@@ -29,6 +29,7 @@ export const styles = css`
         --ni-private-active-indicator-width: 2px;
         --ni-private-focus-indicator-width: 1px;
         --ni-private-indicator-lines-gap: 1px;
+        --ni-private-focus-indicator-inset-width: 3px;
     }
 
     :host(:hover) {
@@ -84,7 +85,7 @@ export const styles = css`
     }
 
     :host(${focusVisible})::before {
-        width: calc(100% - 6px);
+        width: calc(100% - 2 * var(--ni-private-focus-indicator-inset-width));
     }
 
     :host::after {

--- a/packages/nimble-components/src/tab/styles.ts
+++ b/packages/nimble-components/src/tab/styles.ts
@@ -84,7 +84,7 @@ export const styles = css`
     }
 
     :host(${focusVisible})::before {
-        width: 100%;
+        width: calc(100% - 6px);
     }
 
     :host::after {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #949.

The keyboard focused styling of the tab did not exactly match the design spec. Specifically, the extra thin line above the thicker selection line extended all the way to the edge of the tab instead of being 3px short on each side.

## 👩‍💻 Implementation

Changed the CSS width to subtract the 6 pixels.

## 🧪 Testing

Storybook

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
