### PR TITLE
Spinner size followup

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/src/directives/spinner/nimble-spinner.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/spinner/nimble-spinner.directive.ts
@@ -1,7 +1,9 @@
-import { Directive } from '@angular/core';
+import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
 import type { Spinner } from '@ni/nimble-components/dist/esm/spinner';
+import { SpinnerSize } from '@ni/nimble-components/dist/esm/spinner/types';
 
 export type { Spinner };
+export { SpinnerSize };
 
 /**
  * Directive to provide Angular integration for the spinner.
@@ -10,4 +12,13 @@ export type { Spinner };
     selector: 'nimble-spinner'
 })
 export class NimbleSpinnerDirective {
+    public get size(): SpinnerSize {
+        return this.elementRef.nativeElement.size;
+    }
+
+    @Input() public set size(value: SpinnerSize) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'size', value);
+    }
+
+    public constructor(private readonly renderer: Renderer2, private readonly elementRef: ElementRef<Spinner>) {}
 }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/spinner/tests/nimble-spinner.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/spinner/tests/nimble-spinner.directive.spec.ts
@@ -1,4 +1,6 @@
-import { TestBed } from '@angular/core/testing';
+import { Component, ElementRef, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Spinner, SpinnerSize, NimbleSpinnerDirective } from '../nimble-spinner.directive';
 import { NimbleSpinnerModule } from '../nimble-spinner.module';
 
 describe('Nimble Spinner', () => {
@@ -10,5 +12,155 @@ describe('Nimble Spinner', () => {
 
     it('custom element is defined', () => {
         expect(customElements.get('nimble-spinner')).not.toBeUndefined();
+    });
+
+    describe('with no values in template', () => {
+        @Component({
+            template: `
+                <nimble-spinner #target></nimble-spinner>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('target', { read: NimbleSpinnerDirective }) public directive: NimbleSpinnerDirective;
+            @ViewChild('target', { read: ElementRef }) public elementRef: ElementRef<Spinner>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleSpinnerDirective;
+        let nativeElement: Spinner;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleSpinnerModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('has expected defaults for size', () => {
+            expect(directive.size).toBe(SpinnerSize.default);
+            expect(nativeElement.size).toBe(SpinnerSize.default);
+        });
+    });
+
+    describe('with template string values', () => {
+        @Component({
+            template: `
+                <nimble-spinner #target
+                    size="large"
+                >
+                </nimble-spinner>`
+        })
+        class TestHostComponent {
+            @ViewChild('target', { read: NimbleSpinnerDirective }) public directive: NimbleSpinnerDirective;
+            @ViewChild('target', { read: ElementRef }) public elementRef: ElementRef<Spinner>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleSpinnerDirective;
+        let nativeElement: Spinner;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleSpinnerModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('will use template string values for size', () => {
+            expect(directive.size).toBe(SpinnerSize.large);
+            expect(nativeElement.size).toBe(SpinnerSize.large);
+        });
+    });
+
+    describe('with property bound values', () => {
+        @Component({
+            template: `
+                <nimble-spinner #target
+                    [size]="size"
+                >
+                </nimble-spinner>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('target', { read: NimbleSpinnerDirective }) public directive: NimbleSpinnerDirective;
+            @ViewChild('target', { read: ElementRef }) public elementRef: ElementRef<Spinner>;
+            public size: SpinnerSize;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleSpinnerDirective;
+        let nativeElement: Spinner;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleSpinnerModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('can be configured with property binding for size', () => {
+            expect(directive.size).toBe(SpinnerSize.default);
+            expect(nativeElement.size).toBe(SpinnerSize.default);
+
+            fixture.componentInstance.size = SpinnerSize.medium;
+            fixture.detectChanges();
+
+            expect(directive.size).toBe(SpinnerSize.medium);
+            expect(nativeElement.size).toBe(SpinnerSize.medium);
+        });
+    });
+
+    describe('with attribute bound values', () => {
+        @Component({
+            template: `
+                <nimble-spinner #target
+                    [attr.size]="size"
+                >
+                </nimble-spinner>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('target', { read: NimbleSpinnerDirective }) public directive: NimbleSpinnerDirective;
+            @ViewChild('target', { read: ElementRef }) public elementRef: ElementRef<Spinner>;
+            public size: SpinnerSize;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleSpinnerDirective;
+        let nativeElement: Spinner;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleSpinnerModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('can be configured with attribute binding for size', () => {
+            expect(directive.size).toBe(SpinnerSize.default);
+            expect(nativeElement.size).toBe(SpinnerSize.default);
+
+            fixture.componentInstance.size = SpinnerSize.large;
+            fixture.detectChanges();
+
+            expect(directive.size).toBe(SpinnerSize.large);
+            expect(nativeElement.size).toBe(SpinnerSize.large);
+        });
     });
 });

--- a/change/@ni-nimble-angular-7a92f17b-f381-4823-a5a8-2cef4eb079b5.json
+++ b/change/@ni-nimble-angular-7a92f17b-f381-4823-a5a8-2cef4eb079b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add size attribute to spinner",
+  "packageName": "@ni/nimble-angular",
+  "email": "20709258+msmithNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-blazor-39b607f8-6e6c-490a-9d66-33cf62ff6319.json
+++ b/change/@ni-nimble-blazor-39b607f8-6e6c-490a-9d66-33cf62ff6319.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add size property to spinner",
+  "packageName": "@ni/nimble-blazor",
+  "email": "20709258+msmithNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-391b7860-49c3-471c-8acc-144380464afb.json
+++ b/change/@ni-nimble-components-391b7860-49c3-471c-8acc-144380464afb.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add size attribute to spinner",
+  "packageName": "@ni/nimble-components",
+  "email": "20709258+msmithNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-blazor/Examples/Demo.Shared/Pages/ComponentsDemo.razor
+++ b/packages/nimble-blazor/Examples/Demo.Shared/Pages/ComponentsDemo.razor
@@ -184,7 +184,7 @@
         </div>
         <div class="sub-container">
             <div class="container-label">Spinner</div>
-            <NimbleSpinner></NimbleSpinner>
+            <NimbleSpinner Size="SpinnerSize.Medium"></NimbleSpinner>
         </div>
         <div class="sub-container">
             <div class="container-label">Switch</div>

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleSpinner.razor
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleSpinner.razor
@@ -1,4 +1,5 @@
 @namespace NimbleBlazor
 <nimble-spinner
+    size="@Size.ToAttributeValue()"
     @attributes="AdditionalAttributes">
 </nimble-spinner>

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleSpinner.razor.cs
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleSpinner.razor.cs
@@ -4,6 +4,15 @@ namespace NimbleBlazor;
 
 public partial class NimbleSpinner : ComponentBase
 {
+    /// <summary>
+    /// The size of the spinner.
+    /// </summary>
+    [Parameter]
+    public SpinnerSize? Size { get; set; }
+
+    /// <summary>
+    /// Any additional attributes that did not match known properties.
+    /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
 }

--- a/packages/nimble-blazor/NimbleBlazor/SpinnerSize.cs
+++ b/packages/nimble-blazor/NimbleBlazor/SpinnerSize.cs
@@ -1,0 +1,15 @@
+﻿namespace NimbleBlazor;
+
+public enum SpinnerSize
+{
+    Default,
+    Medium,
+    Large
+}
+
+internal static class SpinnerSizeExtensions
+{
+    private static readonly Dictionary<SpinnerSize, string> _enumValues = AttributeHelpers.GetEnumNamesAsKebabCaseValues<SpinnerSize>();
+
+    public static string? ToAttributeValue(this SpinnerSize? value) => (value == null || value == SpinnerSize.Default) ? null : _enumValues[value.Value];
+}

--- a/packages/nimble-components/src/spinner/index.ts
+++ b/packages/nimble-components/src/spinner/index.ts
@@ -1,6 +1,8 @@
 import { DesignSystem, FoundationElement } from '@microsoft/fast-foundation';
+import { attr } from '@microsoft/fast-element';
 import { styles } from './styles';
 import { template } from './template';
+import type { SpinnerSize } from './types';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -12,7 +14,18 @@ declare global {
  * A Nimble-styled spinner component.
  * A spinner is an animating indicator that can be placed in a particular region of a page to represent loading progress, or an ongoing operation, of an indeterminate / unknown duration.
  */
-export class Spinner extends FoundationElement {}
+export class Spinner extends FoundationElement {
+    /**
+     * Spinner size, defaults to 16x16.
+     * Can also be overridden via CSS width ahd height for custom sizes.
+     *
+     * @public
+     * @remarks
+     * HTML Attribute: size
+     */
+    @attr
+    public size: SpinnerSize;
+}
 
 const nimbleSpinner = Spinner.compose({
     baseName: 'spinner',

--- a/packages/nimble-components/src/spinner/styles.ts
+++ b/packages/nimble-components/src/spinner/styles.ts
@@ -16,6 +16,16 @@ export const styles = css`
         height: 16px;
     }
 
+    :host([size='medium']) {
+        width: 32px;
+        height: 32px;
+    }
+
+    :host([size='large']) {
+        width: 64px;
+        height: 64px;
+    }
+
     div.container {
         margin: max(2px, 6.25%);
         flex: 1;

--- a/packages/nimble-components/src/spinner/tests/spinner-matrix.stories.ts
+++ b/packages/nimble-components/src/spinner/tests/spinner-matrix.stories.ts
@@ -12,6 +12,7 @@ import {
 import { bodyFontColor } from '../../theme-provider/design-tokens';
 import { hiddenWrapper } from '../../utilities/tests/hidden';
 import '../../all-components';
+import { SpinnerSize } from '../types';
 
 const metadata: Meta = {
     title: 'Tests/Spinner',
@@ -27,17 +28,16 @@ const metadata: Meta = {
 
 export default metadata;
 
-const sizeStates = [
-    ['16x16', 'width: 16px; height: 16px'],
-    ['32x32', 'width: 32px; height: 32px']
-];
+const sizeStates: [string, string | undefined][] = Object.entries(
+    SpinnerSize
+).map(([key, value]) => [key, value]);
 type SizeState = typeof sizeStates[number];
 
 const component = ([stateName, state]: SizeState): ViewTemplate => html`
     <span style="color: var(${() => bodyFontColor.cssCustomProperty});">
         ${() => stateName}
     </span>
-    <nimble-spinner style="${() => state}"></nimble-spinner>
+    <nimble-spinner size="${() => state}"></nimble-spinner>
 `;
 
 export const spinnerThemeMatrix: Story = createMatrixThemeStory(

--- a/packages/nimble-components/src/spinner/tests/spinner.stories.ts
+++ b/packages/nimble-components/src/spinner/tests/spinner.stories.ts
@@ -3,12 +3,23 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { withXD } from 'storybook-addon-xd-designs';
 import { createUserSelectedThemeStory } from '../../utilities/tests/storybook';
 import '../../all-components';
+import { SpinnerSize } from '../types';
 
-const overviewText = 'The `nimble-spinner` is an animating indicator that can be placed in a particular region of a page to represent loading progress, or an ongoing operation, of an indeterminate / unknown duration.'
-    + '<p>The default spinner size is 16x16. Other sizes can be set via width/height CSS styles on the component, and it will scale appropriately.</p>'
-    + '<p>Other sizes suggested by the Nimble designers: 32x32, 48x48, 64x64, 96x96, 128x128.</p>';
+interface SpinnerArgs {
+    size: keyof typeof SpinnerSize;
+}
 
-const metadata: Meta = {
+const overviewText = '<p>The `nimble-spinner` is an animating indicator that can be placed in a particular region of a page to represent '
+    + 'loading progress, or an ongoing operation, of an indeterminate / unknown duration.</p>'
+    + '<p>Supported sizes:'
+    + '<ul>'
+    + '<li>16x16 (default). Example usages: Alongside inline text, or small controls like checkboxes; in a table control row/cell.</li>'
+    + '<li>32x32</li>'
+    + '<li>64x64. Example usage: For loading progress of components taking up a large percentage of a page.</li>'
+    + '</ul>'
+    + 'The spinner will also scale appropriately if its width/ height are overriden via CSS styles, for advanced use cases.';
+
+const metadata: Meta<SpinnerArgs> = {
     title: 'Spinner',
     decorators: [withXD],
     parameters: {
@@ -22,15 +33,33 @@ const metadata: Meta = {
                 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/dece308f-79e7-48ec-ab41-011f3376b49b/specs/'
         }
     },
-    argTypes: {},
+    argTypes: {
+        size: {
+            description: 'Size of the spinner',
+            options: Object.keys(SpinnerSize),
+            table: { defaultValue: { summary: '16x16' } },
+            control: {
+                type: 'radio',
+                labels: {
+                    default: '16x16 (small, default)',
+                    [SpinnerSize.medium]: '32x32 (medium)',
+                    [SpinnerSize.large]: '64x64 (large)'
+                }
+            }
+        }
+    },
     // prettier-ignore
     render: createUserSelectedThemeStory(html`
-        <nimble-spinner>
+        <nimble-spinner
+            size="${x => SpinnerSize[x.size]}"
+        >
         </nimble-spinner>
     `),
-    args: {}
+    args: {
+        size: 'default'
+    }
 };
 
 export default metadata;
 
-export const spinner: StoryObj = {};
+export const spinner: StoryObj<SpinnerArgs> = {};

--- a/packages/nimble-components/src/spinner/types.ts
+++ b/packages/nimble-components/src/spinner/types.ts
@@ -1,0 +1,6 @@
+export const SpinnerSize = {
+    default: undefined,
+    medium: 'medium',
+    large: 'large'
+} as const;
+export type SpinnerSize = typeof SpinnerSize[keyof typeof SpinnerSize];


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Associated feature 
- #346 

Nathan Mitchell, Fred Visser, Jesse Attas, and myself had a followup discussion about spinner sizes. The end result was that we wanted it to be easier for users to use the designer-prescribed spinner sizes, so we're adding the `size` attribute that was previously discussed (and that's in the spec). Nathan followed up with Brandon O'Keefe to confirm the 3 spinner sizes desired (they still went with 16/32/64, which also matches the spec).  
Separately I looked at the spinner usages in SystemLink Enterprise, and the vast majority are also 16x16, so I'm keeping 16x16 the default size as it was previously.

## 👩‍💻 Implementation

- Add `size` attribute - `default` is 16x16, `medium` is 32x32, `large` is 64x64
- Update Storybook docs to enumerate those sizes, and some examples of where they should be used in a page
- Update theme matrix story to have those 3 sizes

## 🧪 Testing

- Autotests
- Looked at updated stories

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
