### PR TITLE
Update ci deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Required for beachball changelog detection
           fetch-depth: 0
@@ -24,10 +24,10 @@ jobs:
           token: ${{ secrets.GITHUBPAGESDEPLOYTOKEN }}
 
       # Install dependencies
-      - uses: actions/setup-dotnet@v2
+      - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.x'
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
           registry-url: 'https://registry.npmjs.org'
@@ -44,7 +44,7 @@ jobs:
 
       # Pack
       - run: npm run pack
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: packages
           path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,10 @@ jobs:
             packages/**/*.nupkg
             angular-workspace/**/*.tgz
           if-no-files-found: error
+      # The actions/upload-pages-artifact@v1 results in unexpected warning messages, workaround for:
+      # https://github.com/actions/upload-pages-artifact/issues/45
+      - name: Pages file permission workaround
+        run: chmod -c -R +rX packages/site/dist
       - uses: actions/upload-pages-artifact@v1
         with:
           path: 'packages/site/dist'

--- a/change/@ni-nimble-tokens-8856d58c-6aa1-4fe1-b008-b10544d13034.json
+++ b/change/@ni-nimble-tokens-8856d58c-6aa1-4fe1-b008-b10544d13034.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update assembly to .net 6",
+  "packageName": "@ni/nimble-tokens",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-tokens-8856d58c-6aa1-4fe1-b008-b10544d13034.json
+++ b/change/@ni-nimble-tokens-8856d58c-6aa1-4fe1-b008-b10544d13034.json
@@ -3,5 +3,5 @@
   "comment": "Update assembly to .net 6",
   "packageName": "@ni/nimble-tokens",
   "email": "rajsite@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/packages/nimble-tokens/NimbleTokens/NimbleTokens.csproj
+++ b/packages/nimble-tokens/NimbleTokens/NimbleTokens.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeContentInPack>true</IncludeContentInPack>
     <Authors>NI</Authors>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #944 

Cleans up warnings related to:
- File permissions
- Node version and deprecated github actions commands used
- .net version used

## 👩‍💻 Implementation

Addressed the above by:
- Pre-running a file permissions update on CI to workaround: https://github.com/actions/upload-pages-artifact/issues/45 
- Update each of the actions used to the latest versions (which use a newer version of Node.js)
- Updated the nimble tokens package to .NET 6 to match our other packages

## 🧪 Testing

Validated warning removed from CI build

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
