### PR TITLE
Add Angular support for table row IDs and validity

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/src/directives/table/nimble-table.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/table/nimble-table.directive.ts
@@ -26,7 +26,7 @@ export class NimbleTableDirective<TData extends TableRecord = TableRecord> {
 
     // Renaming because property should have camel casing, but attribute should not
     // eslint-disable-next-line @angular-eslint/no-input-rename
-    @Input('id-field-name') public set idFieldName(value: string | null | undefined ) {
+    @Input('id-field-name') public set idFieldName(value: string | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'idFieldName', value);
     }
 

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/table/nimble-table.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/table/nimble-table.directive.ts
@@ -1,9 +1,9 @@
 import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
 import type { Table } from '@ni/nimble-components/dist/esm/table';
-import type { TableRecord, TableFieldName, TableFieldValue } from '@ni/nimble-components/dist/esm/table/types';
+import type { TableRecord, TableFieldName, TableFieldValue, TableValidity } from '@ni/nimble-components/dist/esm/table/types';
 
 export type { Table };
-export { TableRecord, TableFieldName, TableFieldValue };
+export { TableRecord, TableFieldName, TableFieldValue, TableValidity };
 
 /**
  * Directive to provide Angular integration for the table element.
@@ -20,5 +20,23 @@ export class NimbleTableDirective<TData extends TableRecord = TableRecord> {
         this.renderer.setProperty(this.elementRef.nativeElement, 'data', value);
     }
 
+    public get idFieldName(): string | null | undefined {
+        return this.elementRef.nativeElement.idFieldName;
+    }
+
+    // Renaming because property should have camel casing, but attribute should not
+    // eslint-disable-next-line @angular-eslint/no-input-rename
+    @Input('id-field-name') public set idFieldName(value: string | null | undefined ) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'idFieldName', value);
+    }
+
+    public get validity(): TableValidity {
+        return this.elementRef.nativeElement.validity;
+    }
+
     public constructor(private readonly renderer: Renderer2, private readonly elementRef: ElementRef<Table<TData>>) {}
+
+    public checkValidity(): boolean {
+        return this.elementRef.nativeElement.checkValidity();
+    }
 }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/table/tests/nimble-table.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/table/tests/nimble-table.directive.spec.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import type { Table, TableRecord } from '@ni/nimble-angular';
+import type { Table, TableRecord, TableValidity } from '@ni/nimble-angular';
 import { NimbleTableDirective } from '../nimble-table.directive';
 import { NimbleTableModule } from '../nimble-table.module';
 
@@ -14,6 +14,71 @@ describe('Nimble table', () => {
 
         it('custom element is defined', () => {
             expect(customElements.get('nimble-table')).not.toBeUndefined();
+        });
+    });
+
+    describe('validity', () => {
+        interface SimpleRecord extends TableRecord {
+            field1: string;
+            field2: string;
+        }
+
+        @Component({
+            template: `
+                <nimble-table #table [data]="data" [idFieldName]="idFieldName"></nimble-table>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('table', { read: NimbleTableDirective }) public directive: NimbleTableDirective<SimpleRecord>;
+            @ViewChild('table', { read: ElementRef }) public elementRef: ElementRef<Table<SimpleRecord>>;
+            public readonly originalData = [{
+                field1: 'hello world',
+                field2: 'foo'
+            }] as const;
+
+            public data: SimpleRecord[] = [...this.originalData];
+            public idFieldName = 'field1';
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleTableDirective<SimpleRecord>;
+        let nativeElement: Table<SimpleRecord>;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleTableModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('`checkValidity()` returns `true` when the table is valid', () => {
+            expect(directive.checkValidity()).toBeTrue();
+            expect(nativeElement.checkValidity()).toBeTrue();
+        });
+
+        it('`checkValidity()` returns `false` when the table is not valid', () => {
+            fixture.componentInstance.idFieldName = 'not-a-field';
+            fixture.detectChanges();
+
+            expect(directive.checkValidity()).toBeFalse();
+            expect(nativeElement.checkValidity()).toBeFalse();
+        });
+
+        it('`validity` property returns expected state', () => {
+            fixture.componentInstance.idFieldName = 'not-a-field';
+            fixture.detectChanges();
+
+            const expectedValidity: TableValidity = {
+                duplicateRowId: false,
+                invalidRowId: false,
+                missingRowId: true
+            };
+            expect(directive.validity).toEqual(expectedValidity);
+            expect(nativeElement.validity).toEqual(expectedValidity);
         });
     });
 
@@ -47,28 +112,34 @@ describe('Nimble table', () => {
             expect(directive.data).toEqual([]);
             expect(nativeElement.data).toEqual([]);
         });
+
+        it('has expected defaults for idFieldName', () => {
+            expect(directive.idFieldName).toEqual(undefined);
+            expect(nativeElement.idFieldName).toEqual(undefined);
+        });
     });
 
     describe('with property bound values', () => {
         interface SimpleRecord extends TableRecord {
-            myStr: string;
-            myNum: number;
+            field1: string;
+            field2: string;
         }
 
         @Component({
             template: `
-                <nimble-table #table [data]="data"></nimble-table>
+                <nimble-table #table [data]="data" [idFieldName]="idFieldName"></nimble-table>
             `
         })
         class TestHostComponent {
             @ViewChild('table', { read: NimbleTableDirective }) public directive: NimbleTableDirective<SimpleRecord>;
             @ViewChild('table', { read: ElementRef }) public elementRef: ElementRef<Table<SimpleRecord>>;
             public readonly originalData = [{
-                myStr: 'hello world',
-                myNum: 5
+                field1: 'hello world',
+                field2: 'foo'
             }] as const;
 
             public data: SimpleRecord[] = [...this.originalData];
+            public idFieldName = 'field1';
         }
 
         let fixture: ComponentFixture<TestHostComponent>;
@@ -91,20 +162,84 @@ describe('Nimble table', () => {
             expect(nativeElement.data).toEqual(fixture.componentInstance.originalData);
 
             const newData = [{
-                myStr: 'abc',
-                myNum: -6
+                field1: 'abc',
+                field2: 'xyz'
             }, {
-                myStr: 'hello world',
-                myNum: 7
+                field1: 'hello world',
+                field2: 'hola world'
             }, {
-                myStr: 'foo bar baz',
-                myNum: 999
+                field1: 'foo bar baz',
+                field2: 'fim fam foo'
             }] as const;
             fixture.componentInstance.data = [...newData];
             fixture.detectChanges();
 
             expect(directive.data).toEqual(newData);
             expect(nativeElement.data).toEqual(newData);
+        });
+
+        it('can be configured with property binding for idFieldName', () => {
+            expect(directive.idFieldName).toEqual(fixture.componentInstance.idFieldName);
+            expect(nativeElement.idFieldName).toEqual(fixture.componentInstance.idFieldName);
+
+            fixture.componentInstance.idFieldName = 'field2';
+            fixture.detectChanges();
+
+            expect(directive.idFieldName).toEqual('field2');
+            expect(nativeElement.idFieldName).toEqual('field2');
+        });
+    });
+
+    describe('with attribute bound values', () => {
+        interface SimpleRecord extends TableRecord {
+            field1: string;
+            field2: string;
+        }
+
+        @Component({
+            template: `
+                <nimble-table #table
+                    [data]="data"
+                    [attr.id-field-name]="idFieldName">
+                </nimble-table>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('table', { read: NimbleTableDirective }) public directive: NimbleTableDirective<SimpleRecord>;
+            @ViewChild('table', { read: ElementRef }) public elementRef: ElementRef<Table<SimpleRecord>>;
+            public readonly originalData = [{
+                field1: 'hello world',
+                field2: 'foo'
+            }] as const;
+
+            public data: SimpleRecord[] = [...this.originalData];
+            public idFieldName = 'field1';
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleTableDirective<SimpleRecord>;
+        let nativeElement: Table<SimpleRecord>;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleTableModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('can be configured with attribute binding for idFieldName', () => {
+            expect(directive.idFieldName).toEqual(fixture.componentInstance.idFieldName);
+            expect(nativeElement.idFieldName).toEqual(fixture.componentInstance.idFieldName);
+
+            fixture.componentInstance.idFieldName = 'field2';
+            fixture.detectChanges();
+
+            expect(directive.idFieldName).toEqual('field2');
+            expect(nativeElement.idFieldName).toEqual('field2');
         });
     });
 });

--- a/change/@ni-nimble-angular-6798e0f8-60e0-4bb2-b0b0-293f70ac7319.json
+++ b/change/@ni-nimble-angular-6798e0f8-60e0-4bb2-b0b0-293f70ac7319.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add Angular support for table row IDs and table validity",
+  "packageName": "@ni/nimble-angular",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Add Angular support for changes made in #953, which includes:
- `id-field-name` attribute on the table
- `validity` property on the table
- `checkValidity()` function on the table

## 👩‍💻 Implementation

- Add items listed above to the Angular directive for the table
- Export the `TableValidity` type from the directive

## 🧪 Testing

- Add unit tests for the directive changes
    - Note: I decided to add a `describe` section in the directive unit tests for "validity", which tests `validity` and `checkValidity()`. My expectation is that we won't attempt to write Angular tests for every case that could make the table invalid, but I wanted to put a few tests in that would sanity test that we are correctly calling into the native element to get the values for that property and function.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
