### PR TITLE
Add Blazor support for table row IDs and validity

### DIFF
--- a/change/@ni-nimble-blazor-0705fce8-2223-4c2a-be66-de0ddb3991af.json
+++ b/change/@ni-nimble-blazor-0705fce8-2223-4c2a-be66-de0ddb3991af.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add table row ID and validity support to Blazor",
+  "packageName": "@ni/nimble-blazor",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleTable.razor
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleTable.razor
@@ -1,4 +1,7 @@
 ﻿@namespace NimbleBlazor
 @typeparam TData
-<nimble-table @ref="_table" @attributes="AdditionalAttributes">
+<nimble-table
+    @ref="_table"
+    id-field-name="@IdFieldName"
+    @attributes="AdditionalAttributes">
 </nimble-table>

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleTable.razor.cs
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleTable.razor.cs
@@ -16,9 +16,14 @@ public partial class NimbleTable<TData> : ComponentBase
     private bool _dataUpdated = false;
     private IEnumerable<TData> _data = Enumerable.Empty<TData>();
     internal static string SetTableDataMethodName = "NimbleBlazor.Table.setData";
+    internal static string CheckTableValidityMethodName = "NimbleBlazor.Table.checkValidity";
+    internal static string GetTableValidityMethodName = "NimbleBlazor.Table.getValidity";
 
     [Inject]
     private IJSRuntime? JSRuntime { get; set; }
+
+    [Parameter]
+    public string? IdFieldName { get; set; }
 
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
@@ -48,6 +53,22 @@ public partial class NimbleTable<TData> : ComponentBase
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    /// <summary>
+    /// Returns whether or not the table is valid.
+    /// </summary>
+    public async Task<bool> CheckValidityAsync()
+    {
+        return await JSRuntime!.InvokeAsync<bool>(CheckTableValidityMethodName, _table);
+    }
+
+    /// <summary>
+    /// Returns the validity state of the table.
+    /// </summary>
+    public async Task<ITableValidity> GetValidityAsync()
+    {
+        return await JSRuntime!.InvokeAsync<TableValidity>(GetTableValidityMethodName, _table);
+    }
 
     /// <inheritdoc/>
     /// <exception cref="JsonException"></exception>

--- a/packages/nimble-blazor/NimbleBlazor/TableValidity.cs
+++ b/packages/nimble-blazor/NimbleBlazor/TableValidity.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace NimbleBlazor;
+
+public interface ITableValidity
+{
+    public bool DuplicateRowId { get; }
+
+    public bool MissingRowId { get; }
+
+    public bool InvalidRowId { get; }
+}
+
+internal class TableValidity : ITableValidity
+{
+    [JsonPropertyName("duplicateRowId")]
+    public bool DuplicateRowId { get; set; }
+
+    [JsonPropertyName("missingRowId")]
+    public bool MissingRowId { get; set; }
+
+    [JsonPropertyName("invalidRowId")]
+    public bool InvalidRowId { get; set; }
+}

--- a/packages/nimble-blazor/NimbleBlazor/TableValidity.cs
+++ b/packages/nimble-blazor/NimbleBlazor/TableValidity.cs
@@ -4,21 +4,21 @@ namespace NimbleBlazor;
 
 public interface ITableValidity
 {
-    public bool DuplicateRowId { get; }
+    public bool DuplicateRecordId { get; }
 
-    public bool MissingRowId { get; }
+    public bool MissingRecordId { get; }
 
-    public bool InvalidRowId { get; }
+    public bool InvalidRecordId { get; }
 }
 
 internal class TableValidity : ITableValidity
 {
-    [JsonPropertyName("duplicateRowId")]
-    public bool DuplicateRowId { get; set; }
+    [JsonPropertyName("duplicateRecordId")]
+    public bool DuplicateRecordId { get; set; }
 
-    [JsonPropertyName("missingRowId")]
-    public bool MissingRowId { get; set; }
+    [JsonPropertyName("missingRecordId")]
+    public bool MissingRecordId { get; set; }
 
-    [JsonPropertyName("invalidRowId")]
-    public bool InvalidRowId { get; set; }
+    [JsonPropertyName("invalidRecordId")]
+    public bool InvalidRecordId { get; set; }
 }

--- a/packages/nimble-blazor/NimbleBlazor/wwwroot/NimbleBlazor.lib.module.js
+++ b/packages/nimble-blazor/NimbleBlazor/wwwroot/NimbleBlazor.lib.module.js
@@ -64,6 +64,12 @@ window.NimbleBlazor = {
         setData: async function (tableReference, data) {
             const dataObject = JSON.parse(data);
             tableReference.data = dataObject;
+        },
+        checkValidity: function (tableReference) {
+            return tableReference.checkValidity();
+        },
+        getValidity: function (tableReference) {
+            return tableReference.validity;
         }
     }
 };

--- a/packages/nimble-blazor/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableTests.cs
+++ b/packages/nimble-blazor/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableTests.cs
@@ -48,6 +48,15 @@ public class NimbleTableTests
     }
 
     [Fact]
+    public void NimbleTable_WithIdFieldNameAttribute_HasTableMarkup()
+    {
+        var table = RenderWithPropertySet<string, TableRowData>(x => x.IdFieldName!, "FirstName");
+
+        var expectedMarkup = @"id-field-name=""FirstName""";
+        Assert.Contains(expectedMarkup, table.Markup);
+    }
+
+    [Fact]
     public void NimbleTable_WithClassAttribute_HasTableMarkup()
     {
         IDictionary<string, object> classAttribute = new Dictionary<string, object>();


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Add Blazor support for changes made in #953, which includes:
- `id-field-name` attribute on the table
- `validity` property on the table, which is exposed through an async method because properties have to be retrieved through JS interop
- `checkValidity()` function on the table, which is exposed through an async method because it uses JS interop

## 👩‍💻 Implementation

- Add items listed above to the Blazor component
- Create an `ITableValidity` interface to expose the readonly table validity state.
- Create internal `TableValidity` class to provide the functionality needed to convert the javascript validity object to a C# object

## 🧪 Testing

- Write new auto test for `id-field-name`
- Manually tested that `CheckValidityAsync()` and `GetValidityAsync()` return the correct values

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
