### PR TITLE
Fix menu background color on Color theme

### DIFF
--- a/change/@ni-nimble-components-a6d50887-77fd-49db-b3ef-cd0904a88891.json
+++ b/change/@ni-nimble-components-a6d50887-77fd-49db-b3ef-cd0904a88891.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix menu background color on Color theme",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/menu/styles.ts
+++ b/packages/nimble-components/src/menu/styles.ts
@@ -24,7 +24,7 @@ export const styles = css`
         background: ${applicationBackgroundColor};
         border: ${borderWidth} solid ${popupBorderColor};
         margin: 0;
-        min-width: 168px;
+        min-width: 176px;
         width: max-content;
         box-shadow: ${elevation2BoxShadow};
     }

--- a/packages/nimble-components/src/menu/styles.ts
+++ b/packages/nimble-components/src/menu/styles.ts
@@ -24,11 +24,14 @@ export const styles = css`
         background: ${applicationBackgroundColor};
         border: ${borderWidth} solid ${popupBorderColor};
         margin: 0;
-        padding: 4px;
         min-width: 168px;
         width: max-content;
         box-shadow: ${elevation2BoxShadow};
-        position: relative;
+    }
+
+    slot {
+        padding: 4px;
+        display: block;
     }
 
     :host([slot='submenu']) {
@@ -61,11 +64,7 @@ export const styles = css`
     themeBehavior(
         Theme.color,
         css`
-            :host::before {
-                content: '';
-                width: 100%;
-                height: 100%;
-                position: absolute;
+            slot {
                 background: ${hexToRgbaCssColor(White, 0.15)};
             }
         `

--- a/packages/nimble-components/src/menu/styles.ts
+++ b/packages/nimble-components/src/menu/styles.ts
@@ -1,5 +1,6 @@
 import { css } from '@microsoft/fast-element';
 import { display } from '@microsoft/fast-foundation';
+import { White } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
 
 import {
     applicationBackgroundColor,
@@ -12,6 +13,9 @@ import {
     smallPadding,
     elevation2BoxShadow
 } from '../theme-provider/design-tokens';
+import { Theme } from '../theme-provider/types';
+import { hexToRgbaCssColor } from '../utilities/style/colors';
+import { themeBehavior } from '../utilities/style/theme';
 
 export const styles = css`
     ${display('grid')}
@@ -24,14 +28,18 @@ export const styles = css`
         min-width: 168px;
         width: max-content;
         box-shadow: ${elevation2BoxShadow};
+        position: relative;
     }
+
     :host([slot='submenu']) {
         margin: 0 calc(${smallPadding} * 2);
     }
+
     ::slotted(*) {
         padding-left: 8px;
         padding-right: 8px;
     }
+
     ::slotted(hr) {
         box-sizing: content-box;
         height: 2px;
@@ -40,6 +48,7 @@ export const styles = css`
         background: ${borderColor};
         opacity: 0.1;
     }
+
     ::slotted(header) {
         display: flex;
         font: ${groupHeaderFont};
@@ -48,4 +57,17 @@ export const styles = css`
         padding-top: ${smallPadding};
         padding-bottom: ${smallPadding};
     }
-`;
+`.withBehaviors(
+    themeBehavior(
+        Theme.color,
+        css`
+            :host::before {
+                content: '';
+                width: 100%;
+                height: 100%;
+                position: absolute;
+                background: ${hexToRgbaCssColor(White, 0.15)};
+            }
+        `
+    )
+);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #815

## 👩‍💻 Implementation

Style the `slot` of the menu to provide a background of White@15% in the Color theme.

## 🧪 Testing

Looked at the menu in storybook.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
