### PR TITLE
Improve rendering speed and fix text alignment issue

### DIFF
--- a/change/@ni-nimble-components-330f85ba-9862-4e5a-8422-20d7a7143a1e.json
+++ b/change/@ni-nimble-components-330f85ba-9862-4e5a-8422-20d7a7143a1e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed issues with rendering",
+  "packageName": "@ni/nimble-components",
+  "email": "62277788+zszilagy@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/wafer-map/modules/rendering.ts
+++ b/packages/nimble-components/src/wafer-map/modules/rendering.ts
@@ -40,7 +40,7 @@ export class RenderingModule {
             return 0;
         });
 
-        let prev!: DieRenderInfo;
+        let prev: DieRenderInfo | undefined;
 
         for (const die of this.dies) {
             if (!prev) {

--- a/packages/nimble-components/src/wafer-map/modules/rendering.ts
+++ b/packages/nimble-components/src/wafer-map/modules/rendering.ts
@@ -40,7 +40,12 @@ export class RenderingModule {
                 this.context.fillStyle = die.fillStyle;
             }
             this.context?.beginPath();
-            this.context?.rect(die.x, die.y, this.dimensions.width, this.dimensions.height);
+            this.context?.rect(
+                die.x,
+                die.y,
+                this.dimensions.width,
+                this.dimensions.height
+            );
             this.context?.fill();
             prev = die;
         }
@@ -60,7 +65,9 @@ export class RenderingModule {
                 this.context.fillText(
                     die.text,
                     die.x + this.dimensions.width / 2,
-                    die.y + this.dimensions.height / 2 + aproxTextHeight.width / 2,
+                    die.y
+                        + this.dimensions.height / 2
+                        + aproxTextHeight.width / 2,
                     this.dimensions.width - (this.dimensions.width / 100) * 20
                 );
             }

--- a/packages/nimble-components/src/wafer-map/modules/rendering.ts
+++ b/packages/nimble-components/src/wafer-map/modules/rendering.ts
@@ -6,7 +6,7 @@ import type { DataManager } from './data-manager';
  */
 export class RenderingModule {
     private readonly context: CanvasRenderingContext2D;
-    private dieSize: number | undefined;
+    private dieSize?: number;
     private readonly dies: DieRenderInfo[];
     private readonly dimensions: Dimensions;
     private readonly labelFontSize: number;
@@ -29,7 +29,17 @@ export class RenderingModule {
 
     private renderDies(transform?: number): void {
         this.dieSize = this.dimensions.width * this.dimensions.height * (transform || 1);
-        this.dies.sort((a, b) => a.fillStyle.localeCompare(b.fillStyle));
+        this.dies.sort((a, b) => {
+            if (a.fillStyle > b.fillStyle) {
+                return 1;
+            }
+            if (b.fillStyle > a.fillStyle) {
+                return -1;
+            }
+
+            return 0;
+        });
+
         let prev!: DieRenderInfo;
 
         for (const die of this.dies) {
@@ -39,7 +49,7 @@ export class RenderingModule {
             if (prev && die.fillStyle !== prev.fillStyle && die.fillStyle) {
                 this.context.fillStyle = die.fillStyle;
             }
-            this.context?.fillRect(
+            this.context.fillRect(
                 die.x,
                 die.y,
                 this.dimensions.width,

--- a/packages/nimble-components/src/wafer-map/modules/rendering.ts
+++ b/packages/nimble-components/src/wafer-map/modules/rendering.ts
@@ -7,39 +7,61 @@ import type { DataManager } from './data-manager';
 export class RenderingModule {
     private readonly waferData: DataManager;
     private readonly context: CanvasRenderingContext2D;
+    private dieSize: number | undefined;
 
     public constructor(waferData: DataManager, canvas: HTMLCanvasElement) {
         this.waferData = waferData;
         this.context = canvas.getContext('2d')!;
     }
 
-    public drawWafer(): void {
+    public drawWafer(transform?: number): void {
+        this.renderDies(transform);
+        this.renderText(transform);
+    }
+
+    public clearCanvas(width: number, height: number): void {
+        this.context.clearRect(0, 0, width, height);
+    }
+
+    private renderDies(transform?: number): void {
         const dies: DieRenderInfo[] = this.waferData.diesRenderInfo;
         const dimensions: Dimensions = this.waferData.dieDimensions;
+        this.dieSize = dimensions.width * dimensions.height * (transform || 1);
+        dies.sort((a, b) => a.fillStyle.localeCompare(b.fillStyle));
+        let prev!: DieRenderInfo;
 
         for (const die of dies) {
-            this.context.fillStyle = die.fillStyle;
-            this.context?.fillRect(
-                die.x,
-                die.y,
-                dimensions.width,
-                dimensions.height
-            );
+            if (!prev) {
+                this.context.fillStyle = die.fillStyle;
+            }
+            if (prev && die.fillStyle !== prev.fillStyle && die.fillStyle) {
+                this.context.fillStyle = die.fillStyle;
+            }
+            this.context?.beginPath();
+            this.context?.rect(die.x, die.y, dimensions.width, dimensions.height);
+            this.context?.fill();
+            prev = die;
+        }
+    }
 
-            this.context.font = this.waferData.labelsFontSize.toString();
-            this.context.fillStyle = '#ffffff';
-            this.context.textAlign = 'center';
-            const aproxTextHeight = this.context.measureText('M');
+    private renderText(transform?: number): void {
+        debugger;
+        const dies: DieRenderInfo[] = this.waferData.diesRenderInfo;
+        const dimensions: Dimensions = this.waferData.dieDimensions;
+        this.dieSize = dimensions.width * dimensions.height * (transform || 1);
+        this.context.font = this.waferData.labelsFontSize.toString();
+        this.context.fillStyle = '#ffffff';
+        this.context.textAlign = 'center';
+        const aproxTextHeight = this.context.measureText('M');
 
+        // if (this.dieSize >= 50) {
+        for (const die of dies) {
             this.context.fillText(
                 die.text,
                 die.x + dimensions.width / 2,
                 die.y + dimensions.height / 2 + aproxTextHeight.width / 2
             );
         }
-    }
-
-    public clearCanvas(width: number, height: number): void {
-        this.context.clearRect(0, 0, width, height);
+        // }
     }
 }

--- a/packages/nimble-components/src/wafer-map/modules/rendering.ts
+++ b/packages/nimble-components/src/wafer-map/modules/rendering.ts
@@ -39,14 +39,12 @@ export class RenderingModule {
             if (prev && die.fillStyle !== prev.fillStyle && die.fillStyle) {
                 this.context.fillStyle = die.fillStyle;
             }
-            this.context?.beginPath();
-            this.context?.rect(
+            this.context?.fillRect(
                 die.x,
                 die.y,
                 this.dimensions.width,
                 this.dimensions.height
             );
-            this.context?.fill();
             prev = die;
         }
     }

--- a/packages/nimble-components/src/wafer-map/modules/rendering.ts
+++ b/packages/nimble-components/src/wafer-map/modules/rendering.ts
@@ -5,13 +5,17 @@ import type { DataManager } from './data-manager';
  * Responsible for drawing the dies inside the wafer map
  */
 export class RenderingModule {
-    private readonly waferData: DataManager;
     private readonly context: CanvasRenderingContext2D;
     private dieSize: number | undefined;
+    private readonly dies: DieRenderInfo[];
+    private readonly dimensions: Dimensions;
+    private readonly labelFontSize: number;
 
     public constructor(waferData: DataManager, canvas: HTMLCanvasElement) {
-        this.waferData = waferData;
         this.context = canvas.getContext('2d')!;
+        this.dies = waferData.diesRenderInfo;
+        this.dimensions = waferData.dieDimensions;
+        this.labelFontSize = waferData.labelsFontSize;
     }
 
     public drawWafer(transform?: number): void {
@@ -24,13 +28,11 @@ export class RenderingModule {
     }
 
     private renderDies(transform?: number): void {
-        const dies: DieRenderInfo[] = this.waferData.diesRenderInfo;
-        const dimensions: Dimensions = this.waferData.dieDimensions;
-        this.dieSize = dimensions.width * dimensions.height * (transform || 1);
-        dies.sort((a, b) => a.fillStyle.localeCompare(b.fillStyle));
+        this.dieSize = this.dimensions.width * this.dimensions.height * (transform || 1);
+        this.dies.sort((a, b) => a.fillStyle.localeCompare(b.fillStyle));
         let prev!: DieRenderInfo;
 
-        for (const die of dies) {
+        for (const die of this.dies) {
             if (!prev) {
                 this.context.fillStyle = die.fillStyle;
             }
@@ -38,30 +40,30 @@ export class RenderingModule {
                 this.context.fillStyle = die.fillStyle;
             }
             this.context?.beginPath();
-            this.context?.rect(die.x, die.y, dimensions.width, dimensions.height);
+            this.context?.rect(die.x, die.y, this.dimensions.width, this.dimensions.height);
             this.context?.fill();
             prev = die;
         }
     }
 
     private renderText(transform?: number): void {
-        debugger;
-        const dies: DieRenderInfo[] = this.waferData.diesRenderInfo;
-        const dimensions: Dimensions = this.waferData.dieDimensions;
-        this.dieSize = dimensions.width * dimensions.height * (transform || 1);
-        this.context.font = this.waferData.labelsFontSize.toString();
+        this.dieSize = this.dimensions.width * this.dimensions.height * (transform || 1);
+        const fontsize = this.labelFontSize;
+        this.context.font = `${fontsize.toString()}px sans-serif`;
         this.context.fillStyle = '#ffffff';
         this.context.textAlign = 'center';
+        this.context.lineCap = 'butt';
         const aproxTextHeight = this.context.measureText('M');
 
-        // if (this.dieSize >= 50) {
-        for (const die of dies) {
-            this.context.fillText(
-                die.text,
-                die.x + dimensions.width / 2,
-                die.y + dimensions.height / 2 + aproxTextHeight.width / 2
-            );
+        if (this.dieSize >= 50) {
+            for (const die of this.dies) {
+                this.context.fillText(
+                    die.text,
+                    die.x + this.dimensions.width / 2,
+                    die.y + this.dimensions.height / 2 + aproxTextHeight.width / 2,
+                    this.dimensions.width - (this.dimensions.width / 100) * 20
+                );
+            }
         }
-        // }
     }
 }

--- a/packages/nimble-components/src/wafer-map/modules/zoom-handler.ts
+++ b/packages/nimble-components/src/wafer-map/modules/zoom-handler.ts
@@ -45,7 +45,7 @@ export class ZoomHandler {
             zoomIdentity.y,
             zoomIdentity.k
         );
-        this.renderingModule.drawWafer();
+        this.renderingModule.drawWafer(this.zoomTransform.k);
         this.zoomBehavior?.transform(
             select(this.canvas as Element),
             zoomIdentity
@@ -93,7 +93,7 @@ export class ZoomHandler {
                         zoomIdentity.y,
                         zoomIdentity.k
                     );
-                    this.renderingModule.drawWafer();
+                    this.renderingModule.drawWafer(this.zoomTransform.k);
                     zoomBehavior.transform(
                         select(this.canvas as Element),
                         zoomIdentity
@@ -111,7 +111,7 @@ export class ZoomHandler {
                         transform.y,
                         transform.k
                     );
-                    this.renderingModule.drawWafer();
+                    this.renderingModule.drawWafer(this.zoomTransform.k);
                 }
                 canvasContext.restore();
                 this.zoomContainer.setAttribute(

--- a/packages/nimble-components/src/wafer-map/styles.ts
+++ b/packages/nimble-components/src/wafer-map/styles.ts
@@ -23,13 +23,6 @@ export const styles = css`
         position: absolute;
     }
 
-    .circle-base {
-        width: 100%;
-        height: 100%;
-        position: absolute;
-        fill: white;
-    }
-
     .notch {
         transform-origin: center center;
     }
@@ -60,7 +53,7 @@ export const styles = css`
         width: 100%;
         height: 100%;
         position: absolute;
-        fill: transparent;
+        fill: white;
     }
 
     .circle-drawing-path {

--- a/packages/nimble-components/src/wafer-map/template.ts
+++ b/packages/nimble-components/src/wafer-map/template.ts
@@ -11,11 +11,11 @@ export const template = html<WaferMap>`
                         version="1.1"
                         x="0px"
                         y="0px"
-                        viewBox="1 .45 20 21"
+                        viewBox="0 0 41 41"
                     >
                         <path
                             class="circle-drawing-path"
-                            d="m 21 12 a 10 10 330 1 1 0 -1.98 a 1 1 0 0 0 0 2"
+                            d="m 40.5 21 a 20 20 1 1 1 0 -1 a 0.5 0.5 0 0 0 0 1"
                         />
                     </svg>
                 </g>

--- a/packages/nimble-components/src/wafer-map/tests/wafer-map-matrix.stories.ts
+++ b/packages/nimble-components/src/wafer-map/tests/wafer-map-matrix.stories.ts
@@ -81,7 +81,7 @@ const waferMapDie = [
     { x: 3, y: 3, value: '30' }
 ];
 
-const waferMapSizes = [200, 300, 500];
+const waferMapSizes = [70, 200, 300, 400];
 
 const simpleWaferWithDies = (): ViewTemplate => html`<nimble-wafer-map
     :dies="${() => waferMapDie}"

--- a/packages/nimble-components/src/wafer-map/tests/wafer-map.stories.ts
+++ b/packages/nimble-components/src/wafer-map/tests/wafer-map.stories.ts
@@ -44,7 +44,7 @@ const getDiesSet = (
             returnedValue = sets[1]!;
             break;
         case 'largeGoodSet':
-            returnedValue = generateWaferData(100000, goodValueGenerator(seed))!;
+            returnedValue = generateWaferData(100, goodValueGenerator(seed))!;
             break;
         case 'largeBadSet':
             returnedValue = generateWaferData(100, badValueGenerator(seed))!;

--- a/packages/nimble-components/src/wafer-map/tests/wafer-map.stories.ts
+++ b/packages/nimble-components/src/wafer-map/tests/wafer-map.stories.ts
@@ -44,7 +44,7 @@ const getDiesSet = (
             returnedValue = sets[1]!;
             break;
         case 'largeGoodSet':
-            returnedValue = generateWaferData(100, goodValueGenerator(seed))!;
+            returnedValue = generateWaferData(100000, goodValueGenerator(seed))!;
             break;
         case 'largeBadSet':
             returnedValue = generateWaferData(100, badValueGenerator(seed))!;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The initial rendering module proved to cause significant slowdowns (10<= FPS) when it came to rendering high number of dies on the wafer area. This slowdown got even worse when the values were rendered on each individual die. This PR provides some improvement for that by:
- rendering text when the dies are of (or zoomed to) a certain size (this will prevent text from rendering when it's not of a legible size.
- use of `context.fillStyle` changes were reduced (MS recommends changing this as rarely as possible when drawing on the canvas as it causes slowdown).
- Split the drawWafer() functionality to two separate functions: `renderDies()` and `renderText()` 

This PR also contains a fix to align the rendered text to the middle of each die and always compress it so it always leaves 20% (10% each side) padding in the die.

Reduced the size of the notch.

## 👩‍💻 Implementation

Optimizations: 
- Sorted the the DieRenderInfo[] array by color (fillStyle) so we only swap the fillStyle of the canvas context when it's done rendering all the dies of a certain color.
-  Moved the text rendering into a separate function which is called after the plain dies (rectangles) are rendered as in the previous implementation, the fillStyle of the canvas context had to be swapped from color to white (and vice versa) every time we rendered a die with text. Without this split, the first optimization point is useless,
- Instead of rendering the text every time when the wafer map gets rendered, a new condition was introduced which allows the text to render only if the die has a certain size.

Updated the drawing path of the SVG so now the circle notch is proportional to the full circle. (also fixes the issue where the rendered dies cut into the notch)

Fixed issue which caused the text to exceed the limits of a die. Now the text can take up a maximum of 80% of the dies width and it's aligned to the center of the die leaving 10% padding on each side,

## 🧪 Testing

Performance:
Tested it manually using Chrome's dev tool to verify browser FPS.
Chromatic tests will be updated to match the current circle notch.

Performance test results

**Only Dies(no string with values):**

| Data Points  | Current Render Time (ms) | Improved Render Time (ms) |
| ------------- | ------------- |------------- |
| 1k  | 51.70  | 49.70 |
| 10k  | 92.20  | 82.80 |
| 100k  | 453.80 | 402.19 |
| 200k  | 835.40  | 764.59 |
| 500k  | 2278.19  | 1851.30 |

**Dies with value string:**

| Data Points  | Current Render Time (ms) | Improved Render Time (ms) |
| ------------- | ------------- |------------- |
| 1k  | 55.70  | 51.70 |
| 10k  | 153.19  | 126.09 |
| 100k  | 1412.90 | 812.80 |
| 200k  | 4496.80  | 1629.19 |
| 500k  | 11538.19  | 4227.69 |

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
