### PR TITLE
Update table styles

### DIFF
--- a/change/@ni-nimble-components-621b5025-2de6-4432-b49d-cd73e0cff126.json
+++ b/change/@ni-nimble-components-621b5025-2de6-4432-b49d-cd73e0cff126.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update table row styles",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/components/header/styles.ts
+++ b/packages/nimble-components/src/table/components/header/styles.ts
@@ -1,7 +1,6 @@
 import { css } from '@microsoft/fast-element';
 import { display } from '@microsoft/fast-foundation';
 import {
-    applicationBackgroundColor,
     controlHeight,
     standardPadding,
     tableHeaderFont,
@@ -14,9 +13,9 @@ export const styles = css`
     :host {
         height: ${controlHeight};
         align-items: center;
-        background: ${applicationBackgroundColor};
         padding: 0px calc(${standardPadding} / 2);
         font: ${tableHeaderFont};
         color: ${tableHeaderFontColor};
+        text-transform: uppercase;
     }
 `;

--- a/packages/nimble-components/src/table/components/row/styles.ts
+++ b/packages/nimble-components/src/table/components/row/styles.ts
@@ -1,10 +1,8 @@
 import { css } from '@microsoft/fast-element';
 import { display } from '@microsoft/fast-foundation';
 import {
-    applicationBackgroundColor,
     borderWidth,
     controlHeight,
-    fillHoverColor,
     tableRowBorderColor
 } from '../../../theme-provider/design-tokens';
 
@@ -13,13 +11,8 @@ export const styles = css`
 
     :host {
         height: ${controlHeight};
-        background: ${applicationBackgroundColor};
         border-top: calc(2 * ${borderWidth}) solid ${tableRowBorderColor};
         grid-auto-flow: column;
         grid-auto-columns: 1fr;
-    }
-
-    :host(:hover) .cell {
-        background: ${fillHoverColor};
     }
 `;

--- a/packages/nimble-components/src/table/styles.ts
+++ b/packages/nimble-components/src/table/styles.ts
@@ -1,6 +1,10 @@
 import { css } from '@microsoft/fast-element';
 import { display } from '@microsoft/fast-foundation';
-import { bodyFont, bodyFontColor } from '../theme-provider/design-tokens';
+import { White } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
+import { applicationBackgroundColor, bodyFont, bodyFontColor, fillHoverColor } from '../theme-provider/design-tokens';
+import { Theme } from '../theme-provider/types';
+import { hexToRgbaCssColor } from '../utilities/style/colors';
+import { themeBehavior } from '../utilities/style/theme';
 
 export const styles = css`
     ${display('flex')}
@@ -22,9 +26,48 @@ export const styles = css`
     .header-row {
         display: flex;
         flex-direction: row;
+        background: ${applicationBackgroundColor};
+        position: relative;
     }
 
     .header {
         flex: 1;
     }
-`;
+
+    .row {
+        background: ${applicationBackgroundColor};
+        position: relative;
+    }
+
+    .row::before {
+        content: '';
+        width: 100%;
+        height: 100%;
+        position: absolute;
+    }
+
+    .row:hover::before {
+        background: ${fillHoverColor};
+    }
+`.withBehaviors(
+    themeBehavior(
+        Theme.color,
+        css`
+            .header-row::before {
+                content: '';
+                width: 100%;
+                height: 100%;
+                position: absolute;
+                background: ${fillHoverColor};                    
+            }
+
+            .row::before {
+                background: ${fillHoverColor};
+            }
+
+            .row:hover::before {
+                background: ${hexToRgbaCssColor(White, 0.15)};
+            }
+        `
+    )
+);

--- a/packages/nimble-components/src/table/styles.ts
+++ b/packages/nimble-components/src/table/styles.ts
@@ -1,7 +1,12 @@
 import { css } from '@microsoft/fast-element';
 import { display } from '@microsoft/fast-foundation';
 import { White } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
-import { applicationBackgroundColor, bodyFont, bodyFontColor, fillHoverColor } from '../theme-provider/design-tokens';
+import {
+    applicationBackgroundColor,
+    bodyFont,
+    bodyFontColor,
+    fillHoverColor
+} from '../theme-provider/design-tokens';
 import { Theme } from '../theme-provider/types';
 import { hexToRgbaCssColor } from '../utilities/style/colors';
 import { themeBehavior } from '../utilities/style/theme';
@@ -58,7 +63,7 @@ export const styles = css`
                 width: 100%;
                 height: 100%;
                 position: absolute;
-                background: ${fillHoverColor};                    
+                background: ${fillHoverColor};
             }
 
             .row::before {

--- a/packages/nimble-components/src/table/template.ts
+++ b/packages/nimble-components/src/table/template.ts
@@ -40,6 +40,7 @@ export const template = html<Table>`
             ${when(x => x.columns.length > 0, html<Table>`
                 ${repeat(x => x.tableData, html<TableRowState>`
                     <${DesignSystem.tagFor(TableRow)}
+                        class="row"
                         :dataRecord="${x => x.record}"
                         :columns="${(_, c) => (c.parent as Table).columns}"
                     >


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Update the styling of the table:
- Fix background color of rows on Color theme
- Use uppercase text transform on column headers

## 👩‍💻 Implementation

I moved the styling of the row background color from within the row styles into the table styles so that I could use a `::before` styling on the row without setting the `position` of the row's `:host` element (see discussion in [here](https://github.com/ni/nimble/pull/963#discussion_r1070174660)).

I added an `uppercase` text transform to the column headers since @nate-ni and @RickA-NI's research indicated that this would not cause an accessibility or localization issue.

## 🧪 Testing

- Looked at the table in all three themes in storybook.
- Performed basic testing with the Window's narrator that column headers were announced correctly

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
