### PR TITLE
Fix table row ids

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/src/directives/table/tests/nimble-table.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/table/tests/nimble-table.directive.spec.ts
@@ -73,9 +73,9 @@ describe('Nimble table', () => {
             fixture.detectChanges();
 
             const expectedValidity: TableValidity = {
-                duplicateRowId: false,
-                invalidRowId: false,
-                missingRowId: true
+                duplicateRecordId: false,
+                invalidRecordId: false,
+                missingRecordId: true
             };
             expect(directive.validity).toEqual(expectedValidity);
             expect(nativeElement.validity).toEqual(expectedValidity);

--- a/change/@ni-nimble-angular-a24614b5-d2a8-43eb-9746-855af6cca643.json
+++ b/change/@ni-nimble-angular-a24614b5-d2a8-43eb-9746-855af6cca643.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bug in table record ID logic",
+  "packageName": "@ni/nimble-angular",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-bf02f022-6b66-4dbf-849b-4586623e1c25.json
+++ b/change/@ni-nimble-components-bf02f022-6b66-4dbf-849b-4586623e1c25.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bug in table record ID logic",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/components/row/index.ts
+++ b/packages/nimble-components/src/table/components/row/index.ts
@@ -1,4 +1,4 @@
-import { observable } from '@microsoft/fast-element';
+import { attr, observable } from '@microsoft/fast-element';
 import { DesignSystem, FoundationElement } from '@microsoft/fast-foundation';
 import { styles } from './styles';
 import { template } from './template';
@@ -22,6 +22,9 @@ declare global {
 export class TableRow<
     TDataRecord extends TableDataRecord = TableDataRecord
 > extends FoundationElement {
+    @attr({ attribute: 'record-id' })
+    public recordId?: string;
+
     @observable
     public dataRecord?: TDataRecord;
 

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -101,7 +101,7 @@ export class Table<
     }
 
     private trySetData(newData: TData[]): void {
-        const areIdsValid = this.tableValidator.validateDataIds(
+        const areIdsValid = this.tableValidator.validateRecordIds(
             newData,
             this.idFieldName
         );

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -50,6 +50,7 @@ export class Table<
     private options: TanStackTableOptionsResolved<TData>;
     private readonly tableInitialized: boolean = false;
     private readonly tableValidator = new TableValidator();
+    private getRowIdFunction?: (originalRow: TData) => string;
 
     public constructor() {
         super();
@@ -71,11 +72,9 @@ export class Table<
         _next: string | undefined
     ): void {
         if (this.idFieldName == null) {
-            this.updateTableOptions({ getRowId: undefined });
+            this.getRowIdFunction = undefined;
         } else {
-            this.updateTableOptions({
-                getRowId: (record: TData) => record[this.idFieldName!] as string
-            });
+            this.getRowIdFunction = (record: TData) => record[this.idFieldName!] as string;
         }
         // Force TanStack to detect a data update because a row's ID is only
         // generated when creating a new row model.
@@ -106,9 +105,9 @@ export class Table<
             this.idFieldName
         );
         if (areIdsValid) {
-            this.updateTableOptions({ data: newData });
+            this.updateTableOptions({ data: newData, getRowId: this.getRowIdFunction });
         } else {
-            this.updateTableOptions({ data: [] });
+            this.updateTableOptions({ data: [], getRowId: this.getRowIdFunction });
         }
     }
 

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -50,7 +50,6 @@ export class Table<
     private options: TanStackTableOptionsResolved<TData>;
     private readonly tableInitialized: boolean = false;
     private readonly tableValidator = new TableValidator();
-    private getRowIdFunction?: (originalRow: TData) => string;
 
     public constructor() {
         super();
@@ -71,11 +70,6 @@ export class Table<
         _prev: string | undefined,
         _next: string | undefined
     ): void {
-        if (this.idFieldName == null) {
-            this.getRowIdFunction = undefined;
-        } else {
-            this.getRowIdFunction = (record: TData) => record[this.idFieldName!] as string;
-        }
         // Force TanStack to detect a data update because a row's ID is only
         // generated when creating a new row model.
         this.trySetData([...this.data]);
@@ -104,15 +98,19 @@ export class Table<
             newData,
             this.idFieldName
         );
+        const getRowIdFunction = this.idFieldName === null || this.idFieldName === undefined
+            ? undefined
+            : (record: TData) => record[this.idFieldName!] as string;
+
         if (areIdsValid) {
             this.updateTableOptions({
                 data: newData,
-                getRowId: this.getRowIdFunction
+                getRowId: getRowIdFunction
             });
         } else {
             this.updateTableOptions({
                 data: [],
-                getRowId: this.getRowIdFunction
+                getRowId: getRowIdFunction
             });
         }
     }

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -98,21 +98,14 @@ export class Table<
             newData,
             this.idFieldName
         );
+
         const getRowIdFunction = this.idFieldName === null || this.idFieldName === undefined
             ? undefined
             : (record: TData) => record[this.idFieldName!] as string;
-
-        if (areIdsValid) {
-            this.updateTableOptions({
-                data: newData,
-                getRowId: getRowIdFunction
-            });
-        } else {
-            this.updateTableOptions({
-                data: [],
-                getRowId: getRowIdFunction
-            });
-        }
+        this.updateTableOptions({
+            data: areIdsValid ? newData : [],
+            getRowId: getRowIdFunction
+        });
     }
 
     private refreshRows(): void {

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -57,13 +57,6 @@ export class Table<
             data: [],
             onStateChange: (_: TanStackUpdater<TanStackTableState>) => {},
             getCoreRowModel: tanStackGetCoreRowModel(),
-            getRowId: record => {
-                if (this.idFieldName) {
-                    return record[this.idFieldName] as string;
-                }
-                // Return a falsey value to use the default ID from TanStack.
-                return '';
-            },
             columns: [],
             state: {},
             renderFallbackValue: null,
@@ -77,6 +70,11 @@ export class Table<
         _prev: string | undefined,
         _next: string | undefined
     ): void {
+        if (this.idFieldName == null) {
+            this.updateTableOptions({ getRowId: undefined });
+        } else {
+            this.updateTableOptions({ getRowId: (record: TData) => record[this.idFieldName!] as string });
+        }
         // Force TanStack to detect a data update because a row's ID is only
         // generated when creating a new row model.
         this.trySetData([...this.data]);
@@ -115,7 +113,7 @@ export class Table<
     private refreshRows(): void {
         const rows = this.table.getRowModel().rows;
         this.tableData = rows.map(row => {
-            const rowState: TableRowState<TData> = { record: row.original };
+            const rowState: TableRowState<TData> = { record: row.original, id: row.id };
             return rowState;
         });
     }

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -105,9 +105,15 @@ export class Table<
             this.idFieldName
         );
         if (areIdsValid) {
-            this.updateTableOptions({ data: newData, getRowId: this.getRowIdFunction });
+            this.updateTableOptions({
+                data: newData,
+                getRowId: this.getRowIdFunction
+            });
         } else {
-            this.updateTableOptions({ data: [], getRowId: this.getRowIdFunction });
+            this.updateTableOptions({
+                data: [],
+                getRowId: this.getRowIdFunction
+            });
         }
     }
 

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -73,7 +73,9 @@ export class Table<
         if (this.idFieldName == null) {
             this.updateTableOptions({ getRowId: undefined });
         } else {
-            this.updateTableOptions({ getRowId: (record: TData) => record[this.idFieldName!] as string });
+            this.updateTableOptions({
+                getRowId: (record: TData) => record[this.idFieldName!] as string
+            });
         }
         // Force TanStack to detect a data update because a row's ID is only
         // generated when creating a new row model.
@@ -113,7 +115,10 @@ export class Table<
     private refreshRows(): void {
         const rows = this.table.getRowModel().rows;
         this.tableData = rows.map(row => {
-            const rowState: TableRowState<TData> = { record: row.original, id: row.id };
+            const rowState: TableRowState<TData> = {
+                record: row.original,
+                id: row.id
+            };
             return rowState;
         });
     }

--- a/packages/nimble-components/src/table/models/table-validator.spec.ts
+++ b/packages/nimble-components/src/table/models/table-validator.spec.ts
@@ -8,7 +8,7 @@ describe('TableValidator', () => {
         ];
         const validator = new TableValidator();
 
-        const isValid = validator.validateDataIds(data, 'stringField');
+        const isValid = validator.validateRecordIds(data, 'stringField');
         expect(isValid).toBeTrue();
         expect(validator.isValid()).toBeTrue();
         const validity = validator.getValidity();
@@ -24,7 +24,7 @@ describe('TableValidator', () => {
         ];
         const validator = new TableValidator();
 
-        const isValid = validator.validateDataIds(data, undefined);
+        const isValid = validator.validateRecordIds(data, undefined);
         expect(isValid).toBeTrue();
         expect(validator.isValid()).toBeTrue();
         const validity = validator.getValidity();
@@ -40,7 +40,7 @@ describe('TableValidator', () => {
         ];
         const validator = new TableValidator();
 
-        const isValid = validator.validateDataIds(data, null);
+        const isValid = validator.validateRecordIds(data, null);
         expect(isValid).toBeTrue();
         expect(validator.isValid()).toBeTrue();
         const validity = validator.getValidity();
@@ -56,7 +56,7 @@ describe('TableValidator', () => {
         ];
         const validator = new TableValidator();
 
-        const isValid = validator.validateDataIds(data, 'stringField');
+        const isValid = validator.validateRecordIds(data, 'stringField');
         expect(isValid).toBeFalse();
         expect(validator.isValid()).toBeFalse();
         const validity = validator.getValidity();
@@ -72,7 +72,7 @@ describe('TableValidator', () => {
         ];
         const validator = new TableValidator();
 
-        const isValid = validator.validateDataIds(data, 'numberField');
+        const isValid = validator.validateRecordIds(data, 'numberField');
         expect(isValid).toBeFalse();
         expect(validator.isValid()).toBeFalse();
         const validity = validator.getValidity();
@@ -88,7 +88,7 @@ describe('TableValidator', () => {
         ];
         const validator = new TableValidator();
 
-        const isValid = validator.validateDataIds(data, 'stringField');
+        const isValid = validator.validateRecordIds(data, 'stringField');
         expect(isValid).toBeTrue();
         expect(validator.isValid()).toBeTrue();
         const validity = validator.getValidity();
@@ -104,7 +104,7 @@ describe('TableValidator', () => {
         ];
         const validator = new TableValidator();
 
-        const isValid = validator.validateDataIds(data, 'stringField');
+        const isValid = validator.validateRecordIds(data, 'stringField');
         expect(isValid).toBeFalse();
         expect(validator.isValid()).toBeFalse();
         const validity = validator.getValidity();
@@ -120,7 +120,7 @@ describe('TableValidator', () => {
         ];
         const validator = new TableValidator();
 
-        const isValid = validator.validateDataIds(data, 'stringField');
+        const isValid = validator.validateRecordIds(data, 'stringField');
         expect(isValid).toBeFalse();
         expect(validator.isValid()).toBeFalse();
         const validity = validator.getValidity();
@@ -136,7 +136,7 @@ describe('TableValidator', () => {
         ];
         const validator = new TableValidator();
 
-        const isValid = validator.validateDataIds(data, 'missingField');
+        const isValid = validator.validateRecordIds(data, 'missingField');
         expect(isValid).toBeFalse();
         expect(validator.isValid()).toBeFalse();
         const validity = validator.getValidity();
@@ -155,7 +155,7 @@ describe('TableValidator', () => {
         ];
         const validator = new TableValidator();
 
-        const isValid = validator.validateDataIds(data, 'stringField');
+        const isValid = validator.validateRecordIds(data, 'stringField');
         expect(isValid).toBeFalse();
         expect(validator.isValid()).toBeFalse();
         const validity = validator.getValidity();
@@ -171,11 +171,11 @@ describe('TableValidator', () => {
         ];
         const validator = new TableValidator();
 
-        let isValid = validator.validateDataIds(data, 'missingField');
+        let isValid = validator.validateRecordIds(data, 'missingField');
         expect(isValid).toBeFalse();
         expect(validator.isValid()).toBeFalse();
 
-        isValid = validator.validateDataIds(data, undefined);
+        isValid = validator.validateRecordIds(data, undefined);
         expect(isValid).toBeTrue();
         expect(validator.isValid()).toBeTrue();
     });
@@ -187,11 +187,11 @@ describe('TableValidator', () => {
         ];
         const validator = new TableValidator();
 
-        let isValid = validator.validateDataIds(data, 'missingField');
+        let isValid = validator.validateRecordIds(data, 'missingField');
         expect(isValid).toBeFalse();
         expect(validator.isValid()).toBeFalse();
 
-        isValid = validator.validateDataIds(data, 'stringField');
+        isValid = validator.validateRecordIds(data, 'stringField');
         expect(isValid).toBeTrue();
         expect(validator.isValid()).toBeTrue();
     });
@@ -203,11 +203,11 @@ describe('TableValidator', () => {
         ];
         const validator = new TableValidator();
 
-        let isValid = validator.validateDataIds(data, 'stringField');
+        let isValid = validator.validateRecordIds(data, 'stringField');
         expect(isValid).toBeTrue();
         expect(validator.isValid()).toBeTrue();
 
-        isValid = validator.validateDataIds(data, 'missingField');
+        isValid = validator.validateRecordIds(data, 'missingField');
         expect(isValid).toBeFalse();
         expect(validator.isValid()).toBeFalse();
     });
@@ -221,7 +221,7 @@ describe('TableValidator', () => {
         ];
         const validator = new TableValidator();
 
-        const isValid = validator.validateDataIds(data, '');
+        const isValid = validator.validateRecordIds(data, '');
         expect(isValid).toBeTrue();
         expect(validator.isValid()).toBeTrue();
         const validity = validator.getValidity();
@@ -239,7 +239,7 @@ describe('TableValidator', () => {
         ];
         const validator = new TableValidator();
 
-        const isValid = validator.validateDataIds(data, '');
+        const isValid = validator.validateRecordIds(data, '');
         expect(isValid).toBeFalse();
         expect(validator.isValid()).toBeFalse();
         const validity = validator.getValidity();

--- a/packages/nimble-components/src/table/models/table-validator.spec.ts
+++ b/packages/nimble-components/src/table/models/table-validator.spec.ts
@@ -12,9 +12,9 @@ describe('TableValidator', () => {
         expect(isValid).toBeTrue();
         expect(validator.isValid()).toBeTrue();
         const validity = validator.getValidity();
-        expect(validity.duplicateRowId).toBeFalse();
-        expect(validity.invalidRowId).toBeFalse();
-        expect(validity.missingRowId).toBeFalse();
+        expect(validity.duplicateRecordId).toBeFalse();
+        expect(validity.invalidRecordId).toBeFalse();
+        expect(validity.missingRecordId).toBeFalse();
     });
 
     it('setting `undefined` field for ID is valid', () => {
@@ -28,9 +28,9 @@ describe('TableValidator', () => {
         expect(isValid).toBeTrue();
         expect(validator.isValid()).toBeTrue();
         const validity = validator.getValidity();
-        expect(validity.duplicateRowId).toBeFalse();
-        expect(validity.invalidRowId).toBeFalse();
-        expect(validity.missingRowId).toBeFalse();
+        expect(validity.duplicateRecordId).toBeFalse();
+        expect(validity.invalidRecordId).toBeFalse();
+        expect(validity.missingRecordId).toBeFalse();
     });
 
     it('setting `null` field for ID is valid', () => {
@@ -44,9 +44,9 @@ describe('TableValidator', () => {
         expect(isValid).toBeTrue();
         expect(validator.isValid()).toBeTrue();
         const validity = validator.getValidity();
-        expect(validity.duplicateRowId).toBeFalse();
-        expect(validity.invalidRowId).toBeFalse();
-        expect(validity.missingRowId).toBeFalse();
+        expect(validity.duplicateRecordId).toBeFalse();
+        expect(validity.invalidRecordId).toBeFalse();
+        expect(validity.missingRecordId).toBeFalse();
     });
 
     it('setting data with duplicate IDs is invalid', () => {
@@ -60,9 +60,9 @@ describe('TableValidator', () => {
         expect(isValid).toBeFalse();
         expect(validator.isValid()).toBeFalse();
         const validity = validator.getValidity();
-        expect(validity.duplicateRowId).toBeTrue();
-        expect(validity.invalidRowId).toBeFalse();
-        expect(validity.missingRowId).toBeFalse();
+        expect(validity.duplicateRecordId).toBeTrue();
+        expect(validity.invalidRecordId).toBeFalse();
+        expect(validity.missingRecordId).toBeFalse();
     });
 
     it('setting data with invalid ID value type is invalid', () => {
@@ -76,12 +76,12 @@ describe('TableValidator', () => {
         expect(isValid).toBeFalse();
         expect(validator.isValid()).toBeFalse();
         const validity = validator.getValidity();
-        expect(validity.duplicateRowId).toBeFalse();
-        expect(validity.invalidRowId).toBeTrue();
-        expect(validity.missingRowId).toBeFalse();
+        expect(validity.duplicateRecordId).toBeFalse();
+        expect(validity.invalidRecordId).toBeTrue();
+        expect(validity.missingRecordId).toBeFalse();
     });
 
-    it('setting data with empty ID value is invalid', () => {
+    it('setting data with empty ID value is valid', () => {
         const data = [
             { stringField: 'value-1', numberField: 10 },
             { stringField: '', numberField: 11 }
@@ -89,12 +89,12 @@ describe('TableValidator', () => {
         const validator = new TableValidator();
 
         const isValid = validator.validateDataIds(data, 'stringField');
-        expect(isValid).toBeFalse();
-        expect(validator.isValid()).toBeFalse();
+        expect(isValid).toBeTrue();
+        expect(validator.isValid()).toBeTrue();
         const validity = validator.getValidity();
-        expect(validity.duplicateRowId).toBeFalse();
-        expect(validity.invalidRowId).toBeTrue();
-        expect(validity.missingRowId).toBeFalse();
+        expect(validity.duplicateRecordId).toBeFalse();
+        expect(validity.invalidRecordId).toBeFalse();
+        expect(validity.missingRecordId).toBeFalse();
     });
 
     it('setting data with undefined ID value is invalid', () => {
@@ -108,9 +108,9 @@ describe('TableValidator', () => {
         expect(isValid).toBeFalse();
         expect(validator.isValid()).toBeFalse();
         const validity = validator.getValidity();
-        expect(validity.duplicateRowId).toBeFalse();
-        expect(validity.invalidRowId).toBeTrue();
-        expect(validity.missingRowId).toBeFalse();
+        expect(validity.duplicateRecordId).toBeFalse();
+        expect(validity.invalidRecordId).toBeTrue();
+        expect(validity.missingRecordId).toBeFalse();
     });
 
     it('setting data with null ID value is invalid', () => {
@@ -124,9 +124,9 @@ describe('TableValidator', () => {
         expect(isValid).toBeFalse();
         expect(validator.isValid()).toBeFalse();
         const validity = validator.getValidity();
-        expect(validity.duplicateRowId).toBeFalse();
-        expect(validity.invalidRowId).toBeTrue();
-        expect(validity.missingRowId).toBeFalse();
+        expect(validity.duplicateRecordId).toBeFalse();
+        expect(validity.invalidRecordId).toBeTrue();
+        expect(validity.missingRecordId).toBeFalse();
     });
 
     it('setting data with missing IDs is invalid', () => {
@@ -140,9 +140,9 @@ describe('TableValidator', () => {
         expect(isValid).toBeFalse();
         expect(validator.isValid()).toBeFalse();
         const validity = validator.getValidity();
-        expect(validity.duplicateRowId).toBeFalse();
-        expect(validity.invalidRowId).toBeFalse();
-        expect(validity.missingRowId).toBeTrue();
+        expect(validity.duplicateRecordId).toBeFalse();
+        expect(validity.invalidRecordId).toBeFalse();
+        expect(validity.missingRecordId).toBeTrue();
     });
 
     it('multiple errors are reported during validation', () => {
@@ -159,9 +159,9 @@ describe('TableValidator', () => {
         expect(isValid).toBeFalse();
         expect(validator.isValid()).toBeFalse();
         const validity = validator.getValidity();
-        expect(validity.duplicateRowId).toBeTrue();
-        expect(validity.invalidRowId).toBeTrue();
-        expect(validity.missingRowId).toBeTrue();
+        expect(validity.duplicateRecordId).toBeTrue();
+        expect(validity.invalidRecordId).toBeTrue();
+        expect(validity.missingRecordId).toBeTrue();
     });
 
     it('setting ID field name to undefined makes configuration valid', () => {
@@ -225,9 +225,9 @@ describe('TableValidator', () => {
         expect(isValid).toBeTrue();
         expect(validator.isValid()).toBeTrue();
         const validity = validator.getValidity();
-        expect(validity.duplicateRowId).toBeFalse();
-        expect(validity.invalidRowId).toBeFalse();
-        expect(validity.missingRowId).toBeFalse();
+        expect(validity.duplicateRecordId).toBeFalse();
+        expect(validity.invalidRecordId).toBeFalse();
+        expect(validity.missingRecordId).toBeFalse();
     });
 
     it('validation occurs when ID field name is an empty string', () => {
@@ -243,8 +243,8 @@ describe('TableValidator', () => {
         expect(isValid).toBeFalse();
         expect(validator.isValid()).toBeFalse();
         const validity = validator.getValidity();
-        expect(validity.duplicateRowId).toBeTrue();
-        expect(validity.invalidRowId).toBeFalse();
-        expect(validity.missingRowId).toBeFalse();
+        expect(validity.duplicateRecordId).toBeTrue();
+        expect(validity.invalidRecordId).toBeFalse();
+        expect(validity.missingRecordId).toBeFalse();
     });
 });

--- a/packages/nimble-components/src/table/models/table-validator.ts
+++ b/packages/nimble-components/src/table/models/table-validator.ts
@@ -21,7 +21,7 @@ export class TableValidator<TData extends TableRecord> {
         return Object.values(this.getValidity()).every(x => x === false);
     }
 
-    public validateDataIds(
+    public validateRecordIds(
         data: TData[],
         idFieldName: string | null | undefined
     ): boolean {

--- a/packages/nimble-components/src/table/models/table-validator.ts
+++ b/packages/nimble-components/src/table/models/table-validator.ts
@@ -30,7 +30,7 @@ export class TableValidator<TData extends TableRecord> {
         this.missingRecordId = false;
         this.invalidRecordId = false;
 
-        if (idFieldName == null) {
+        if (idFieldName === undefined || idFieldName === null) {
             return true;
         }
 

--- a/packages/nimble-components/src/table/models/table-validator.ts
+++ b/packages/nimble-components/src/table/models/table-validator.ts
@@ -53,6 +53,10 @@ export class TableValidator<TData extends TableRecord> {
             ids.add(id);
         }
 
-        return !this.missingRecordId && !this.invalidRecordId && !this.duplicateRecordId;
+        return (
+            !this.missingRecordId
+            && !this.invalidRecordId
+            && !this.duplicateRecordId
+        );
     }
 }

--- a/packages/nimble-components/src/table/models/table-validator.ts
+++ b/packages/nimble-components/src/table/models/table-validator.ts
@@ -5,15 +5,15 @@ import type { TableRecord, TableValidity } from '../types';
  * is valid and report which aspects of the configuration are valid or invalid.
  */
 export class TableValidator<TData extends TableRecord> {
-    private duplicateRowId = false;
-    private missingRowId = false;
-    private invalidRowId = false;
+    private duplicateRecordId = false;
+    private missingRecordId = false;
+    private invalidRecordId = false;
 
     public getValidity(): TableValidity {
         return {
-            duplicateRowId: this.duplicateRowId,
-            missingRowId: this.missingRowId,
-            invalidRowId: this.invalidRowId
+            duplicateRecordId: this.duplicateRecordId,
+            missingRecordId: this.missingRecordId,
+            invalidRecordId: this.invalidRecordId
         };
     }
 
@@ -26,9 +26,9 @@ export class TableValidator<TData extends TableRecord> {
         idFieldName: string | null | undefined
     ): boolean {
         // Start off by assuming all IDs are valid.
-        this.duplicateRowId = false;
-        this.missingRowId = false;
-        this.invalidRowId = false;
+        this.duplicateRecordId = false;
+        this.missingRecordId = false;
+        this.invalidRecordId = false;
 
         if (idFieldName == null) {
             return true;
@@ -37,22 +37,22 @@ export class TableValidator<TData extends TableRecord> {
         const ids = new Set<string>();
         for (const record of data) {
             if (!Object.prototype.hasOwnProperty.call(record, idFieldName)) {
-                this.missingRowId = true;
+                this.missingRecordId = true;
                 continue;
             }
 
             const id = record[idFieldName];
-            if (typeof id !== 'string' || id === '') {
-                this.invalidRowId = true;
+            if (typeof id !== 'string') {
+                this.invalidRecordId = true;
                 continue;
             }
 
             if (ids.has(id)) {
-                this.duplicateRowId = true;
+                this.duplicateRecordId = true;
             }
             ids.add(id);
         }
 
-        return !this.missingRowId && !this.invalidRowId && !this.duplicateRowId;
+        return !this.missingRecordId && !this.invalidRecordId && !this.duplicateRecordId;
     }
 }

--- a/packages/nimble-components/src/table/template.ts
+++ b/packages/nimble-components/src/table/template.ts
@@ -40,6 +40,7 @@ export const template = html<Table>`
             ${when(x => x.columns.length > 0, html<Table>`
                 ${repeat(x => x.tableData, html<TableRowState>`
                     <${DesignSystem.tagFor(TableRow)}
+                        record-id="${x => x.id}"
                         :dataRecord="${x => x.record}"
                         :columns="${(_, c) => (c.parent as Table).columns}"
                     >

--- a/packages/nimble-components/src/table/tests/table.pageobject.ts
+++ b/packages/nimble-components/src/table/tests/table.pageobject.ts
@@ -55,4 +55,15 @@ export class TablePageObject<T extends TableRecord> {
 
         return cells.item(columnIndex).shadowRoot!.textContent?.trim() ?? '';
     }
+
+    public getRowId(rowIndex: number): string | undefined {
+        const rows = this.tableElement.shadowRoot!.querySelectorAll('nimble-table-row');
+        if (rowIndex >= rows.length) {
+            throw new Error(
+                'Attempting to index past the total number of rendered rows'
+            );
+        }
+
+        return rows.item(rowIndex).recordId;
+    }
 }

--- a/packages/nimble-components/src/table/tests/table.pageobject.ts
+++ b/packages/nimble-components/src/table/tests/table.pageobject.ts
@@ -56,7 +56,7 @@ export class TablePageObject<T extends TableRecord> {
         return cells.item(columnIndex).shadowRoot!.textContent?.trim() ?? '';
     }
 
-    public getRowId(rowIndex: number): string | undefined {
+    public getRecordId(rowIndex: number): string | undefined {
         const rows = this.tableElement.shadowRoot!.querySelectorAll('nimble-table-row');
         if (rowIndex >= rows.length) {
             throw new Error(

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -230,7 +230,7 @@ describe('Table', () => {
         verifyRenderedData();
     });
 
-    describe('Row ID', () => {
+    describe('record IDs', () => {
         it('setting ID field uses field value for ID', async () => {
             const data = [...simpleTableData];
             element.data = data;

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -88,7 +88,9 @@ describe('Table', () => {
     function verifyRowIDs(expectedRowIds: string[]): void {
         const expectedRowCount = expectedRowIds.length;
         for (let rowIndex = 0; rowIndex < expectedRowCount; rowIndex++) {
-            expect(pageObject.getRowId(rowIndex)).toEqual(expectedRowIds[rowIndex]);
+            expect(pageObject.getRowId(rowIndex)).toEqual(
+                expectedRowIds[rowIndex]
+            );
         }
     }
 

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -85,11 +85,11 @@ describe('Table', () => {
         }
     }
 
-    function verifyRowIDs(expectedRowIds: string[]): void {
-        const expectedRowCount = expectedRowIds.length;
+    function verifyRecordIDs(expectedRecordIds: string[]): void {
+        const expectedRowCount = expectedRecordIds.length;
         for (let rowIndex = 0; rowIndex < expectedRowCount; rowIndex++) {
-            expect(pageObject.getRowId(rowIndex)).toEqual(
-                expectedRowIds[rowIndex]
+            expect(pageObject.getRecordId(rowIndex)).toEqual(
+                expectedRecordIds[rowIndex]
             );
         }
     }
@@ -238,7 +238,7 @@ describe('Table', () => {
             await connect();
             await waitForUpdatesAsync();
 
-            verifyRowIDs(data.map(x => x.stringData));
+            verifyRecordIDs(data.map(x => x.stringData));
         });
 
         it('not setting ID field uses generated ID', async () => {
@@ -247,7 +247,7 @@ describe('Table', () => {
             await connect();
             await waitForUpdatesAsync();
 
-            verifyRowIDs(data.map((_, index: number) => index.toString()));
+            verifyRecordIDs(data.map((_, index: number) => index.toString()));
         });
 
         it('row IDs update when id-field-name attribute is updated', async () => {
@@ -258,11 +258,11 @@ describe('Table', () => {
 
             element.idFieldName = 'stringData';
             await waitForUpdatesAsync();
-            verifyRowIDs(data.map(x => x.stringData));
+            verifyRecordIDs(data.map(x => x.stringData));
 
             element.idFieldName = undefined;
             await waitForUpdatesAsync();
-            verifyRowIDs(data.map((_, index: number) => index.toString()));
+            verifyRecordIDs(data.map((_, index: number) => index.toString()));
         });
     });
 

--- a/packages/nimble-components/src/table/tests/table.stories.ts
+++ b/packages/nimble-components/src/table/tests/table.stories.ts
@@ -58,16 +58,16 @@ If the attribute is not specified, a default ID will be generated. If the attrib
 and the table will enter an invalid state according to the \`validity\` property and \`checkValidity()\` function.
 
 The attribute is invalid in the following conditions:
--   Multiple records were found with the same ID. This will cause \`validity.duplicateRowId\` to be \`true\`.
--   A record was found that did not have a field with the name specified by \`id-field-name\`. This will cause \`validity.missingRowId\` to be \`true\`.
--   A record was found where \`id-field-name\` did not refer to a value of type \`string\` with a non-empty value. This will cause \`validity.invalidRowId\` to be \`true\`.`;
+-   Multiple records were found with the same ID. This will cause \`validity.duplicateRecordId\` to be \`true\`.
+-   A record was found that did not have a field with the name specified by \`id-field-name\`. This will cause \`validity.missingRecordId\` to be \`true\`.
+-   A record was found where \`id-field-name\` did not refer to a value of type \`string\`. This will cause \`validity.invalidRecordId\` to be \`true\`.`;
 
 const validityDescription = `Readonly object of boolean values that represents the validity states that the table's configuration can be in.
 The object's type is \`TableValidityState\`, and it contains the following boolean properties:
 
--   \`duplicateRowId\`: \`true\` when multiple records were found with the same ID
--   \`missingRowId\`: \`true\` when a record was found that did not have a field with the name specified by \`id-field-name\`
--   \`invalidRowId\`: \`true\` when record was found where \`id-field-name\` did not refer to a value of type \`string\` with a non-empty value
+-   \`duplicateRecordId\`: \`true\` when multiple records were found with the same ID
+-   \`missingRecordId\`: \`true\` when a record was found that did not have a field with the name specified by \`id-field-name\`
+-   \`invalidRecordId\`: \`true\` when record was found where \`id-field-name\` did not refer to a value of type \`string\`
 `;
 
 const metadata: Meta<TableArgs> = {

--- a/packages/nimble-components/src/table/types.ts
+++ b/packages/nimble-components/src/table/types.ts
@@ -49,11 +49,12 @@ export interface TableCellState<
 }
 
 export interface TableValidity {
-    readonly duplicateRowId: boolean;
-    readonly missingRowId: boolean;
-    readonly invalidRowId: boolean;
+    readonly duplicateRecordId: boolean;
+    readonly missingRecordId: boolean;
+    readonly invalidRecordId: boolean;
 }
 
 export interface TableRowState<TData extends TableRecord = TableRecord> {
     record: TData;
+    id: string;
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

After merging #953, I realized that the code to return an empty string from `getRowId` wasn't causing TanStack to generate an ID. Instead, it was using an empty string as the row ID. Therefore, when `id-field-name` wasn't set on the table, every row had the same record ID. I'm not sure how I missed this because I know I manually tested it, but something else must have been different in my branch at that time. Regardless, I fixed the issue and also added a bit more code in order to be able to write auto tests for record IDs.

Additionally, from an offline conversation, we decided to standardize on `recordId` rather than `rowId`, so I renamed the validation fields in this PR as well since I was touching that code. 

## 👩‍💻 Implementation

- Add/remove the `getRowId` option on TanStack when `id-field-name` changes.
- Update the table validator to allow empty string as the value of a record ID
- Update the field names on `TableValidity` to refer to the `recordId` rather than the `rowId`
    - Update docs & tests with this change
- Add `record-id` attribute to the table row
    - This allowed me to write auto tests. It should also be used in future features, such as adding an action menu.

## 🧪 Testing

Added auto tests for the table that verify that the correct `record-id` is set on the `nimble-table-row` elements

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
