### PR TITLE
Minor improvements to spec templates

### DIFF
--- a/specs/templates/custom-component.md
+++ b/specs/templates/custom-component.md
@@ -36,6 +36,10 @@
 - *A developer building an app with the component and interacting through HTML/CSS/JavaScript.*
 - *A designer customizing the component.*
 
+*Include code snippets showing basic component use and any interesting configurations.*
+
+*For each section below, consider adding an "Alternatives" sub-section to describe any design alternatives and discuss why they were rejected.*
+
 ### API
 
 *The key elements of the component's public API surface:*

--- a/specs/templates/fast-based-component.md
+++ b/specs/templates/fast-based-component.md
@@ -14,6 +14,10 @@
 
 ## Design
 
+*Include code snippets showing basic component use and any interesting configurations.*
+
+*For each section below, consider adding an "Alternatives" sub-section to describe any design alternatives and discuss why they were rejected.*
+
 ### API
 
 *Include a permalink to FAST's API documentation (from the FAST component spec on GitHub, press `y` to update the URL bar to show the latest commit)*

--- a/specs/templates/high-level-design.md
+++ b/specs/templates/high-level-design.md
@@ -17,6 +17,8 @@
    - *Does the design create new requirements on clients or break any APIs?*
    - *How does the design affect testing, documentation, performance, security, etc?*
 
+*It may be useful to review the sections of the custom component spec template to remind you of other items to consider.*
+
 ## Alternative Implementations / Designs
 
 *Describe any design alternatives and discuss why they were rejected.*


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As we've reviewed spec/HLD PRs recently we've noticed a few patterns that make them easier to read and review. I think it will be useful to include these in our templates but I welcome author and reviewer feedback about whether each of these would help.

## 👩‍💻 Implementation

Added notes to the new component spec templates to encourage:
1. showing examples of component usage
2. listing rejected alternatives

Also updated HLD template to encourage mining the other templates for ideas.

## 🧪 Testing

N/A

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
