### PR TITLE
Disable Spinner in Chromatic Snapshot tests

### DIFF
--- a/change/@ni-nimble-components-40d84564-84ff-4fcd-bdd3-34b687919711.json
+++ b/change/@ni-nimble-components-40d84564-84ff-4fcd-bdd3-34b687919711.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Disable chromatic snapshot in spinner",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/spinner/tests/spinner-matrix.stories.ts
+++ b/packages/nimble-components/src/spinner/tests/spinner-matrix.stories.ts
@@ -25,6 +25,12 @@ const metadata: Meta = {
         design: {
             artboardUrl:
                 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/dece308f-79e7-48ec-ab41-011f3376b49b/specs/'
+        },
+
+        // Spinner animation causes snapshot changes in chromatic
+        // See https://github.com/ni/nimble/issues/983
+        chromatic: {
+            disableSnapshot: true
         }
     }
 };

--- a/packages/nimble-components/src/spinner/tests/spinner.stories.ts
+++ b/packages/nimble-components/src/spinner/tests/spinner.stories.ts
@@ -39,6 +39,11 @@ const metadata: Meta<SpinnerArgs> = {
         design: {
             artboardUrl:
                 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/dece308f-79e7-48ec-ab41-011f3376b49b/specs/'
+        },
+        // Spinner animation causes snapshot changes in chromatic
+        // See https://github.com/ni/nimble/issues/983
+        chromatic: {
+            disableSnapshot: true
         }
     },
     argTypes: {

--- a/packages/nimble-components/src/spinner/tests/spinner.stories.ts
+++ b/packages/nimble-components/src/spinner/tests/spinner.stories.ts
@@ -40,6 +40,7 @@ const metadata: Meta<SpinnerArgs> = {
             artboardUrl:
                 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/dece308f-79e7-48ec-ab41-011f3376b49b/specs/'
         },
+
         // Spinner animation causes snapshot changes in chromatic
         // See https://github.com/ni/nimble/issues/983
         chromatic: {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Workaround for #983 but not resolved yet. Just disables chromatic snapshots for the spinner.

## 👩‍💻 Implementation

Disabled the chromatic test using: https://www.chromatic.com/docs/ignoring-elements#ignore-stories

## 🧪 Testing

Waiting for PR build

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
