### PR TITLE
Minor component test clean-up

### DIFF
--- a/change/@ni-nimble-components-2c09cab7-64a5-4bcf-9023-414af72d8ac3.json
+++ b/change/@ni-nimble-components-2c09cab7-64a5-4bcf-9023-414af72d8ac3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Test updates",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/.eslintrc.js
+++ b/packages/nimble-components/src/.eslintrc.js
@@ -1,3 +1,17 @@
+const restrictedImportsPaths = () => ([
+    {
+        name: '@microsoft/fast-foundation',
+        importNames: ['focusVisible'],
+        message:
+            'Please use focusVisible from src/utilities/style/focus instead.'
+    },
+    {
+        name: '@microsoft/fast-components',
+        message:
+            'It is not expected to leverage @microsoft/fast-components directly as they are coupled to FAST design tokens.'
+    }
+]);
+
 module.exports = {
     root: true,
     plugins: ['jsdoc'],
@@ -43,19 +57,7 @@ module.exports = {
         'no-restricted-imports': [
             'error',
             {
-                paths: [
-                    {
-                        name: '@microsoft/fast-foundation',
-                        importNames: ['focusVisible'],
-                        message:
-                            'Please use focusVisible from src/utilities/style/focus instead.'
-                    },
-                    {
-                        name: '@microsoft/fast-components',
-                        message:
-                            'It is not expected to leverage @microsoft/fast-components directly as they are coupled to FAST design tokens.'
-                    }
-                ]
+                paths: restrictedImportsPaths()
             }
         ],
 
@@ -85,7 +87,20 @@ module.exports = {
             rules: {
                 // Classes defined in test code aren't part of the public API so don't need docs
                 'jsdoc/require-jsdoc': 'off',
-                'jsdoc/require-description': 'off'
+                'jsdoc/require-description': 'off',
+                'no-restricted-imports': [
+                    'error',
+                    {
+                        paths: [
+                            ...restrictedImportsPaths(),
+                            {
+                                name: '@microsoft/fast-element',
+                                importNames: ['DOM'],
+                                message: 'For tests, please use functions from src/testing/async-helpers instead.'
+                            }
+                        ]
+                    }
+                ],
             }
         },
         {

--- a/packages/nimble-components/src/anchor-button/tests/anchor-button.spec.ts
+++ b/packages/nimble-components/src/anchor-button/tests/anchor-button.spec.ts
@@ -1,5 +1,6 @@
-import { DOM, html } from '@microsoft/fast-element';
+import { html } from '@microsoft/fast-element';
 import { AnchorButton } from '..';
+import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { getSpecTypeByNamedList } from '../../utilities/tests/parameterized';
 
@@ -43,7 +44,7 @@ describe('AnchorButton', () => {
         element.control.setAttribute('href', 'http://www.ni.com');
 
         element.disabled = true;
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.control.getAttribute('href')).toBeNull();
     });
@@ -91,7 +92,7 @@ describe('AnchorButton', () => {
                 await connect();
 
                 element.setAttribute(attribute.name, 'foo');
-                await DOM.nextUpdate();
+                await waitForUpdatesAsync();
 
                 expect(element.control.getAttribute(attribute.name)).toBe(
                     'foo'

--- a/packages/nimble-components/src/anchor-tab/tests/anchor-tab.spec.ts
+++ b/packages/nimble-components/src/anchor-tab/tests/anchor-tab.spec.ts
@@ -1,5 +1,6 @@
-import { DOM, html } from '@microsoft/fast-element';
+import { html } from '@microsoft/fast-element';
 import { AnchorTab } from '..';
+import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { Fixture, fixture } from '../../utilities/tests/fixture';
 import { getSpecTypeByNamedList } from '../../utilities/tests/parameterized';
 
@@ -50,7 +51,7 @@ describe('AnchorTab', () => {
                 await connect();
 
                 element.setAttribute(attribute.name, 'foo');
-                await DOM.nextUpdate();
+                await waitForUpdatesAsync();
 
                 expect(
                     element

--- a/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
+++ b/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
@@ -1,4 +1,4 @@
-import { DOM, html } from '@microsoft/fast-element';
+import { html } from '@microsoft/fast-element';
 import {
     keyArrowLeft,
     keyArrowRight,
@@ -11,6 +11,7 @@ import {
 import { AnchorTabs } from '..';
 import '../../anchor-tab';
 import type { AnchorTab } from '../../anchor-tab';
+import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { getSpecTypeByNamedList } from '../../utilities/tests/parameterized';
 
@@ -108,13 +109,13 @@ describe('AnchorTabs', () => {
 
     it('should clear activetab when active tab is removed', async () => {
         tab(1).remove();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         expect(element.activetab).toBeUndefined();
     });
 
     it('should keep activetab when active tab is disabled', async () => {
         tab(1).disabled = true;
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         expect(element.activetab).toBe(tab(1));
     });
 
@@ -214,13 +215,13 @@ describe('AnchorTabs', () => {
                 await connect();
                 if (test.disabledIndex !== undefined) {
                     tab(test.disabledIndex).disabled = true;
-                    await DOM.nextUpdate();
+                    await waitForUpdatesAsync();
                 }
                 tab(test.initialFocusIndex).focus();
                 tab(test.initialFocusIndex).dispatchEvent(
                     new KeyboardEvent('keydown', { key: test.keyName })
                 );
-                await DOM.nextUpdate();
+                await waitForUpdatesAsync();
                 expect(document.activeElement).toBe(
                     tab(test.expectedFinalFocusIndex)
                 );
@@ -231,25 +232,25 @@ describe('AnchorTabs', () => {
     it('should skip past other tabs when pressing tab key after click', async () => {
         tab(1).focus();
         tab(1).dispatchEvent(new Event('click'));
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         document.activeElement!.dispatchEvent(
             new KeyboardEvent('keydown', { key: keyTab })
         );
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         expect(document.activeElement).toBe(tab(1));
     });
 
     it('should skip past other tabs when pressing tab key after arrow key', async () => {
         tab(1).focus();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         document.activeElement!.dispatchEvent(
             new KeyboardEvent('keydown', { key: keyArrowLeft })
         );
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         document.activeElement!.dispatchEvent(
             new KeyboardEvent('keydown', { key: keyTab })
         );
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         expect(document.activeElement).toBe(tab(0));
     });
 
@@ -258,7 +259,7 @@ describe('AnchorTabs', () => {
         expect(tab(1).tabIndex).toBe(0);
         expect(tab(2).tabIndex).toBe(-1);
         tab(0).dispatchEvent(new Event('click'));
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         expect(tab(0).tabIndex).toBe(0);
         expect(tab(1).tabIndex).toBe(-1);
         expect(tab(2).tabIndex).toBe(-1);
@@ -270,7 +271,7 @@ describe('AnchorTabs', () => {
             timesClicked += 1;
         });
         tab(0).dispatchEvent(new KeyboardEvent('keydown', { key: keySpace }));
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         expect(timesClicked).toBe(1);
     });
 
@@ -280,7 +281,7 @@ describe('AnchorTabs', () => {
             timesClicked += 1;
         });
         tab(0).dispatchEvent(new KeyboardEvent('keydown', { key: keyEnter }));
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         expect(timesClicked).toBe(1);
     });
 });

--- a/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
+++ b/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
@@ -39,6 +39,7 @@ describe('AnchorTabs', () => {
 
     beforeEach(async () => {
         ({ element, connect, disconnect } = await setup());
+        await connect();
     });
 
     afterEach(async () => {
@@ -51,41 +52,34 @@ describe('AnchorTabs', () => {
         );
     });
 
-    it('should set the "tablist" class on the internal div', async () => {
-        await connect();
+    it('should set the "tablist" class on the internal div', () => {
         expect(element.tablist.classList.contains('tablist')).toBeTrue();
     });
 
-    it('should set the `part` attribute to "tablist" on the internal div', async () => {
-        await connect();
+    it('should set the `part` attribute to "tablist" on the internal div', () => {
         expect(element.tablist.part.contains('tablist')).toBeTrue();
     });
 
-    it('should set the `role` attribute to "tablist" on the internal div', async () => {
-        await connect();
+    it('should set the `role` attribute to "tablist" on the internal div', () => {
         expect(element.tablist.getAttribute('role')).toBe('tablist');
     });
 
-    it('should have a slots named "start", "anchortab", and "end", in that order', async () => {
-        await connect();
+    it('should have a slots named "start", "anchortab", and "end", in that order', () => {
         const slots = element.shadowRoot?.querySelectorAll('slot');
         expect(slots![0]?.getAttribute('name')).toBe('start');
         expect(slots![1]?.getAttribute('name')).toBe('anchortab');
         expect(slots![2]?.getAttribute('name')).toBe('end');
     });
 
-    it('should assign tab id when unspecified', async () => {
-        await connect();
+    it('should assign tab id when unspecified', () => {
         expect(tab(0).id).toBeDefined();
     });
 
-    it('should set activeid property from attribute value', async () => {
-        await connect();
+    it('should set activeid property from attribute value', () => {
         expect(element.activeid).toBe('tab-2');
     });
 
-    it('should populate tabs array with anchor tabs', async () => {
-        await connect();
+    it('should populate tabs array with anchor tabs', () => {
         expect(element.tabs.length).toBe(3);
         expect(element.tabs[0]?.nodeName.toLowerCase()).toBe(
             'nimble-anchor-tab'
@@ -98,32 +92,27 @@ describe('AnchorTabs', () => {
         );
     });
 
-    it('should set activetab property based on activeid', async () => {
-        await connect();
+    it('should set activetab property based on activeid', () => {
         expect(element.activetab).toBeDefined();
         expect(element.activetab).toBe(tab(1));
     });
 
-    it('should set aria-selected on active tab', async () => {
-        await connect();
+    it('should set aria-selected on active tab', () => {
         expect(element.activetab?.ariaSelected).toBe('true');
     });
 
-    it('should update activetab when activeid is changed', async () => {
-        await connect();
+    it('should update activetab when activeid is changed', () => {
         element.activeid = 'tab-3';
         expect(element.activetab).toBe(tab(2));
     });
 
     it('should clear activetab when active tab is removed', async () => {
-        await connect();
         tab(1).remove();
         await DOM.nextUpdate();
         expect(element.activetab).toBeUndefined();
     });
 
     it('should keep activetab when active tab is disabled', async () => {
-        await connect();
         tab(1).disabled = true;
         await DOM.nextUpdate();
         expect(element.activetab).toBe(tab(1));
@@ -240,7 +229,6 @@ describe('AnchorTabs', () => {
     });
 
     it('should skip past other tabs when pressing tab key after click', async () => {
-        await connect();
         tab(1).focus();
         tab(1).dispatchEvent(new Event('click'));
         await DOM.nextUpdate();
@@ -252,7 +240,6 @@ describe('AnchorTabs', () => {
     });
 
     it('should skip past other tabs when pressing tab key after arrow key', async () => {
-        await connect();
         tab(1).focus();
         await DOM.nextUpdate();
         document.activeElement!.dispatchEvent(
@@ -267,7 +254,6 @@ describe('AnchorTabs', () => {
     });
 
     it('should update tabindex values on tab click', async () => {
-        await connect();
         expect(tab(0).tabIndex).toBe(-1);
         expect(tab(1).tabIndex).toBe(0);
         expect(tab(2).tabIndex).toBe(-1);
@@ -279,7 +265,6 @@ describe('AnchorTabs', () => {
     });
 
     it('should turn tab Space key press into click on inner anchor element', async () => {
-        await connect();
         let timesClicked = 0;
         anchor(0).addEventListener('click', () => {
             timesClicked += 1;
@@ -290,7 +275,6 @@ describe('AnchorTabs', () => {
     });
 
     it('should turn tab Enter key press into click on inner anchor element', async () => {
-        await connect();
         let timesClicked = 0;
         anchor(0).addEventListener('click', () => {
             timesClicked += 1;

--- a/packages/nimble-components/src/anchor/tests/anchor.spec.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor.spec.ts
@@ -1,9 +1,10 @@
-import { DOM, html } from '@microsoft/fast-element';
+import { html } from '@microsoft/fast-element';
 import {
     DesignSystem,
     Anchor as FoundationAnchor
 } from '@microsoft/fast-foundation';
 import { Anchor } from '..';
+import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { getSpecTypeByNamedList } from '../../utilities/tests/parameterized';
 
@@ -86,7 +87,7 @@ describe('Anchor', () => {
                 await connect();
 
                 element.setAttribute(attribute.name, 'foo');
-                await DOM.nextUpdate();
+                await waitForUpdatesAsync();
 
                 expect(element.control.getAttribute(attribute.name)).toBe(
                     'foo'

--- a/packages/nimble-components/src/combobox/tests/combobox.spec.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox.spec.ts
@@ -2,12 +2,13 @@ import {
     DesignSystem,
     Combobox as FoundationCombobox
 } from '@microsoft/fast-foundation';
-import { DOM, html } from '@microsoft/fast-element';
+import { html } from '@microsoft/fast-element';
 import { keyArrowDown, keyEnter } from '@microsoft/fast-web-utilities';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Combobox } from '..';
 import '../../list-option';
 import { ComboboxAutocomplete } from '../types';
+import { waitForUpdatesAsync } from '../../testing/async-helpers';
 
 async function setup(
     position?: string,
@@ -54,7 +55,7 @@ describe('Combobox', () => {
         const { element, connect, disconnect } = await setup(position, true);
 
         await connect();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.getAttribute('open')).not.toBeNull();
         expect(element.getAttribute('position')).toBe(position);
@@ -66,7 +67,7 @@ describe('Combobox', () => {
         const { element, connect, disconnect } = await setup();
         await connect();
         element.value = 'two';
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         expect(element.value).toBe('Two');
 
         // Add option zero at the top of the options list
@@ -75,7 +76,7 @@ describe('Combobox', () => {
             'afterbegin',
             '<nimble-list-option value="zero">Zero</nimble-list-option>'
         );
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.value).toBe('Two');
 
@@ -96,7 +97,7 @@ describe('Combobox', () => {
         const { element, connect, disconnect } = await setup();
         await connect();
         element.disabled = true;
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.dropdownButton!.disabled).toBeTrue();
 
@@ -108,7 +109,7 @@ describe('Combobox', () => {
         await connect();
 
         element.control.click();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.dropdownButton?.checked).toBeTrue();
 
@@ -120,7 +121,7 @@ describe('Combobox', () => {
         await connect();
 
         element.dropdownButton?.control.click();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.open).toBeTrue();
 
@@ -132,7 +133,7 @@ describe('Combobox', () => {
         await connect();
 
         element.dropdownButton?.control.click();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.open).toBeFalse();
 
@@ -144,7 +145,7 @@ describe('Combobox', () => {
         await connect();
 
         element.dropdownButton?.control.click();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.dropdownButton?.checked).toBeFalse();
 
@@ -156,7 +157,7 @@ describe('Combobox', () => {
         await connect();
 
         element.open = true;
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.dropdownButton?.checked).toBeTrue();
 
@@ -168,9 +169,9 @@ describe('Combobox', () => {
         await connect();
 
         element.dropdownButton?.control.click(); // open should be false
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         element.control.click(); // open should be true
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.dropdownButton?.checked).toBeTrue();
 
@@ -183,7 +184,7 @@ describe('Combobox', () => {
 
         const expectedLabel = 'new label';
         element.ariaLabel = expectedLabel;
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         const inputElement = element.shadowRoot?.querySelector('.selected-value');
         expect(inputElement?.getAttribute('aria-label')).toEqual(expectedLabel);
@@ -197,10 +198,10 @@ describe('Combobox', () => {
 
         const expectedLabel = 'new label';
         element.ariaLabel = expectedLabel;
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         element.ariaLabel = null;
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         const inputElement = element.shadowRoot?.querySelector('.selected-value');
         expect(inputElement?.getAttribute('aria-label')).toEqual(null);
@@ -211,11 +212,11 @@ describe('Combobox', () => {
     it('value updates on input', async () => {
         const { element, connect, disconnect } = await setup();
         await connect();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         element.autocomplete = ComboboxAutocomplete.both;
         updateComboboxWithText(element, 'O');
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         expect(element.value).toEqual('One'); // value set to input text which should autocomplete to 'One'
 
         element.control.value = 'O';
@@ -224,7 +225,7 @@ describe('Combobox', () => {
         }); // delete autocompleted portion
         element.inputHandler(inputEvent);
         element.dispatchEvent(inputEvent);
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         expect(element.value).toEqual('O');
 
         await disconnect();
@@ -233,17 +234,17 @@ describe('Combobox', () => {
     it('emits one change event after changing value through text entry', async () => {
         const { element, connect, disconnect } = await setup();
         await connect();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         const changeEvent = jasmine.createSpy();
         element.addEventListener('change', changeEvent);
         element.autocomplete = ComboboxAutocomplete.none;
         updateComboboxWithText(element, 'O');
         expect(changeEvent).toHaveBeenCalledTimes(0);
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         updateComboboxWithText(element, 'On');
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         expect(changeEvent).toHaveBeenCalledTimes(0);
 
         const enterEvent = new KeyboardEvent('keydown', {
@@ -264,7 +265,7 @@ describe('Combobox', () => {
     it('should not emit change event if entered text matches value prior to typing', async () => {
         const { element, connect, disconnect } = await setup();
         await connect();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         element.autocomplete = ComboboxAutocomplete.none;
         updateComboboxWithText(element, 'O');
@@ -289,7 +290,7 @@ describe('Combobox', () => {
     it('after text entry if user browses popup and selects option pressing <Enter>, emit only one change event', async () => {
         const { element, connect, disconnect } = await setup();
         await connect();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         element.autocomplete = ComboboxAutocomplete.none;
         const changeEvent = jasmine.createSpy();
@@ -304,7 +305,7 @@ describe('Combobox', () => {
             key: keyEnter
         } as KeyboardEventInit);
         element.dispatchEvent(enterEvent); // commit value ('One')
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(changeEvent).toHaveBeenCalledTimes(1);
 

--- a/packages/nimble-components/src/dialog/tests/dialog.spec.ts
+++ b/packages/nimble-components/src/dialog/tests/dialog.spec.ts
@@ -1,7 +1,8 @@
 import { DesignSystem } from '@microsoft/fast-foundation';
-import { DOM, html } from '@microsoft/fast-element';
+import { html } from '@microsoft/fast-element';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Dialog, ExtendedDialog, UserDismissed } from '..';
+import { waitForUpdatesAsync } from '../../testing/async-helpers';
 
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 async function setup<CloseReason = void>(
@@ -58,7 +59,7 @@ describe('Dialog', () => {
         const { element, connect, disconnect } = await setup();
         await connect();
         void element.show();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(getComputedStyle(nativeDialogElement(element)).display).toBe(
             'flex'
@@ -71,9 +72,9 @@ describe('Dialog', () => {
         const { element, connect, disconnect } = await setup();
         await connect();
         void element.show();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         element.close();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(getComputedStyle(nativeDialogElement(element)).display).toBe(
             'none'
@@ -95,7 +96,7 @@ describe('Dialog', () => {
         const { element, connect, disconnect } = await setup();
         await connect();
         void element.show();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.open).toBeTrue();
 
@@ -106,9 +107,9 @@ describe('Dialog', () => {
         const { element, connect, disconnect } = await setup();
         await connect();
         void element.show();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         element.close();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.open).toBeFalse();
 
@@ -119,9 +120,9 @@ describe('Dialog', () => {
         const { element, connect, disconnect } = await setup();
         await connect();
         const dialogPromise = element.show();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         element.close();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         await expectAsync(dialogPromise).not.toBeRejectedWithError();
 
@@ -133,9 +134,9 @@ describe('Dialog', () => {
         await connect();
         const expectedReason = 'just because';
         const dialogDromise = element.show();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         element.close(expectedReason);
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         await expectAsync(dialogDromise).toBeResolvedTo(expectedReason);
 
@@ -146,9 +147,9 @@ describe('Dialog', () => {
         const { element, connect, disconnect } = await setup();
         await connect();
         const dialogPromise = element.show();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         element.close();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         await expectAsync(dialogPromise).toBeResolvedTo(undefined);
 
@@ -159,12 +160,12 @@ describe('Dialog', () => {
         const { element, connect, disconnect } = await setup();
         await connect();
         const dialogPromise = element.show();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         // Simulate user dismiss events in browser
         const cancelEvent = new Event('cancel', { cancelable: true });
         nativeDialogElement(element).dispatchEvent(cancelEvent);
         nativeDialogElement(element).dispatchEvent(new Event('close'));
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         await expectAsync(dialogPromise).toBeResolvedTo(UserDismissed);
         expect(cancelEvent.defaultPrevented).toBeFalse();
@@ -177,11 +178,11 @@ describe('Dialog', () => {
         const { element, connect, disconnect } = await setup(true);
         await connect();
         void element.show();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         // Simulate user dismiss events in browser that are cancelled
         const cancelEvent = new Event('cancel', { cancelable: true });
         nativeDialogElement(element).dispatchEvent(cancelEvent);
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(cancelEvent.defaultPrevented).toBeTrue();
         expect(element.open).toBeTrue();
@@ -193,7 +194,7 @@ describe('Dialog', () => {
         const { element, connect, disconnect } = await setup();
         await connect();
         void element.show();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         await expectAsync(element.show()).toBeRejectedWithError();
 
@@ -229,10 +230,10 @@ describe('Dialog', () => {
         button2.focus();
         const initialActiveElement = document.activeElement;
         void element.show();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         const afterDialogOpenActiveElement = document.activeElement;
         element.close();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         const afterDialogCloseActiveElement = document.activeElement;
 
         expect(initialActiveElement).toBe(button2);
@@ -247,7 +248,7 @@ describe('Dialog', () => {
         await connect();
         const okButton = document.getElementById('ok')!;
         void element.show();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(document.activeElement).toBe(okButton);
 
@@ -259,9 +260,9 @@ describe('Dialog', () => {
         await connect();
         const cancelButton = document.getElementById('cancel')!;
         cancelButton.setAttribute('autofocus', '');
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         void element.show();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(document.activeElement).toBe(cancelButton);
 
@@ -275,11 +276,11 @@ describe('Dialog', () => {
         const secondDialogButton = document.createElement('nimble-button');
         secondDialog.append(secondDialogButton);
         element.parentElement!.append(secondDialog);
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         void element.show();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         void secondDialog.show();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.open).toBeTrue();
         expect(secondDialog.open).toBeTrue();

--- a/packages/nimble-components/src/drawer/tests/drawer.spec.ts
+++ b/packages/nimble-components/src/drawer/tests/drawer.spec.ts
@@ -1,8 +1,9 @@
-import { DOM, html } from '@microsoft/fast-element';
+import { html } from '@microsoft/fast-element';
 import { eventAnimationEnd } from '@microsoft/fast-web-utilities';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Drawer, UserDismissed } from '..';
 import { DrawerLocation } from '../types';
+import { processUpdates } from '../../testing/async-helpers';
 
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 async function setup<CloseReason = void>(
@@ -181,7 +182,7 @@ describe('Drawer', () => {
         it('forwards value of aria-label to internal dialog element', () => {
             const expectedValue = 'doughnut';
             element.ariaLabel = expectedValue;
-            DOM.processUpdates();
+            processUpdates();
             expect(
                 nativeDialogElement(element).getAttribute('aria-label')
             ).toEqual(expectedValue);
@@ -189,9 +190,9 @@ describe('Drawer', () => {
 
         it('removes value of aria-label from internal dialog element when cleared from host', () => {
             element.ariaLabel = 'not empty';
-            DOM.processUpdates();
+            processUpdates();
             element.ariaLabel = null;
-            DOM.processUpdates();
+            processUpdates();
             expect(
                 nativeDialogElement(element).getAttribute('aria-label')
             ).toBeNull();
@@ -221,7 +222,7 @@ describe('Drawer', () => {
         it('focuses the button with autofocus when the drawer opens', () => {
             const cancelButton = document.getElementById('cancel')!;
             cancelButton.setAttribute('autofocus', '');
-            DOM.processUpdates();
+            processUpdates();
             void element.show();
             expect(document.activeElement).toBe(cancelButton);
         });
@@ -262,7 +263,7 @@ describe('Drawer', () => {
             // Simulate user dismiss event in browser
             const cancelEvent = new Event('cancel', { cancelable: true });
             nativeDialogElement(element).dispatchEvent(cancelEvent);
-            DOM.processUpdates();
+            processUpdates();
 
             expect(element.open).toBeTrue();
             // The drawer should not be closing

--- a/packages/nimble-components/src/menu-button/tests/menu-button.spec.ts
+++ b/packages/nimble-components/src/menu-button/tests/menu-button.spec.ts
@@ -1,4 +1,4 @@
-import { DOM, html } from '@microsoft/fast-element';
+import { html } from '@microsoft/fast-element';
 import {
     eventChange,
     keyArrowDown,
@@ -11,6 +11,7 @@ import { FoundationElement, Menu, MenuItem } from '@microsoft/fast-foundation';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { MenuButton } from '..';
 import { MenuButtonToggleEventDetail, MenuButtonPosition } from '../types';
+import { processUpdates, waitForUpdatesAsync } from '../../testing/async-helpers';
 
 class TestSlottedElement extends FoundationElement {}
 const composedTestSlottedElement = TestSlottedElement.compose({
@@ -168,7 +169,7 @@ describe('MenuButton', () => {
         it('should mark the toggle button as checked when the menu is opened after connect', async () => {
             await connect();
             element.open = true;
-            DOM.processUpdates();
+            processUpdates();
             expect(element.toggleButton!.checked).toBeTrue();
         });
 
@@ -543,9 +544,9 @@ describe('MenuButton', () => {
                 // Start with the focus on the menu button so that it can lose focus later
                 menuButton.focus();
                 menuButton.open = true;
-                await DOM.nextUpdate();
+                await waitForUpdatesAsync();
                 focusableElement.focus();
-                await DOM.nextUpdate();
+                await waitForUpdatesAsync();
                 expect(menuButton.open).toBeFalse();
             });
         });

--- a/packages/nimble-components/src/menu-button/tests/menu-button.spec.ts
+++ b/packages/nimble-components/src/menu-button/tests/menu-button.spec.ts
@@ -543,7 +543,9 @@ describe('MenuButton', () => {
                 // Start with the focus on the menu button so that it can lose focus later
                 menuButton.focus();
                 menuButton.open = true;
+                await DOM.nextUpdate();
                 focusableElement.focus();
+                await DOM.nextUpdate();
                 expect(menuButton.open).toBeFalse();
             });
         });

--- a/packages/nimble-components/src/menu-button/tests/menu-button.spec.ts
+++ b/packages/nimble-components/src/menu-button/tests/menu-button.spec.ts
@@ -11,7 +11,10 @@ import { FoundationElement, Menu, MenuItem } from '@microsoft/fast-foundation';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { MenuButton } from '..';
 import { MenuButtonToggleEventDetail, MenuButtonPosition } from '../types';
-import { processUpdates, waitForUpdatesAsync } from '../../testing/async-helpers';
+import {
+    processUpdates,
+    waitForUpdatesAsync
+} from '../../testing/async-helpers';
 
 class TestSlottedElement extends FoundationElement {}
 const composedTestSlottedElement = TestSlottedElement.compose({

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -2,10 +2,11 @@ import {
     DesignSystem,
     Select as FoundationSelect
 } from '@microsoft/fast-foundation';
-import { DOM, html, repeat } from '@microsoft/fast-element';
+import { html, repeat } from '@microsoft/fast-element';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Select } from '..';
 import '../../list-option';
+import { waitForUpdatesAsync } from '../../testing/async-helpers';
 
 async function setup(
     position?: string,
@@ -27,8 +28,8 @@ async function setup(
 async function clickAndWaitForOpen(select: Select): Promise<void> {
     select.click();
     // Takes two updates for listbox to be rendered
-    await DOM.nextUpdate();
-    await DOM.nextUpdate();
+    await waitForUpdatesAsync();
+    await waitForUpdatesAsync();
 }
 
 async function checkFullyInViewport(element: HTMLElement): Promise<boolean> {
@@ -69,7 +70,7 @@ describe('Select', () => {
         const { element, connect, disconnect } = await setup(position, true);
 
         await connect();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.getAttribute('open')).not.toBeNull();
         expect(element.getAttribute('position')).toBe(position);
@@ -81,7 +82,7 @@ describe('Select', () => {
         const { element, connect, disconnect } = await setup();
         await connect();
         element.value = 'two';
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         expect(element.value).toBe('two');
 
         // Add option zero at the top of the options list
@@ -90,7 +91,7 @@ describe('Select', () => {
             'afterbegin',
             '<nimble-list-option value="zero">Zero</nimble-list-option>'
         );
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.value).toBe('two');
 

--- a/packages/nimble-components/src/switch/tests/switch.spec.ts
+++ b/packages/nimble-components/src/switch/tests/switch.spec.ts
@@ -1,4 +1,4 @@
-import { DOM, html } from '@microsoft/fast-element';
+import { html } from '@microsoft/fast-element';
 import {
     DesignSystem,
     Switch as FoundationSwitch
@@ -6,6 +6,7 @@ import {
 import { keyEnter, keySpace } from '@microsoft/fast-web-utilities';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Switch } from '..';
+import { waitForUpdatesAsync } from '../../testing/async-helpers';
 
 async function setup(): Promise<Fixture<Switch>> {
     return fixture<Switch>(html`<nimble-switch></nimble-switch>`);
@@ -47,7 +48,7 @@ describe('Switch', () => {
 
         expect(element.getAttribute('aria-checked')).toBe('true');
         element.checked = false;
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         expect(element.getAttribute('aria-checked')).toBe('false');
 
         await disconnect();
@@ -76,7 +77,7 @@ describe('Switch', () => {
 
         expect(element.getAttribute('aria-disabled')).toBe('true');
         element.disabled = false;
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         expect(element.getAttribute('aria-disabled')).toBe('false');
 
         await disconnect();
@@ -96,7 +97,7 @@ describe('Switch', () => {
 
         expect(element.getAttribute('aria-readonly')).toBe('true');
         element.readOnly = false;
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
         expect(element.getAttribute('aria-readonly')).toBe('false');
 
         await disconnect();
@@ -206,7 +207,7 @@ describe('Switch', () => {
 
                 wasClicked = true;
             });
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             element.click();
             expect(wasClicked).toBe(true);
 
@@ -225,7 +226,7 @@ describe('Switch', () => {
 
                 wasInvoked = true;
             });
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             element.dispatchEvent(event);
             expect(wasInvoked).toBe(true);
 
@@ -244,7 +245,7 @@ describe('Switch', () => {
 
                 wasInvoked = true;
             });
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             element.dispatchEvent(event);
             expect(wasInvoked).toBe(true);
 

--- a/packages/nimble-components/src/toggle-button/tests/toggle-button.spec.ts
+++ b/packages/nimble-components/src/toggle-button/tests/toggle-button.spec.ts
@@ -1,7 +1,8 @@
-import { DOM, html } from '@microsoft/fast-element';
+import { html } from '@microsoft/fast-element';
 import { keyEnter, keySpace } from '@microsoft/fast-web-utilities';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { ToggleButton } from '..';
+import { waitForUpdatesAsync } from '../../testing/async-helpers';
 
 async function setup(): Promise<Fixture<ToggleButton>> {
     return fixture<ToggleButton>(
@@ -39,7 +40,7 @@ describe('ToggleButton', () => {
         expect(element.control.getAttribute('aria-pressed')).toBe('true');
 
         element.checked = false;
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.control.getAttribute('aria-pressed')).toBe('false');
     });
@@ -61,7 +62,7 @@ describe('ToggleButton', () => {
         expect(element.control.getAttribute('aria-disabled')).toBe('true');
 
         element.disabled = false;
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.control.getAttribute('aria-disabled')).toBe('false');
     });
@@ -77,7 +78,7 @@ describe('ToggleButton', () => {
         expect(element.control.getAttribute('aria-readonly')).toBe('true');
 
         element.readOnly = false;
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.control.getAttribute('aria-readonly')).toBe('false');
     });
@@ -91,7 +92,7 @@ describe('ToggleButton', () => {
         await connect();
 
         element.setAttribute('aria-haspopup', 'menu');
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.control.getAttribute('aria-haspopup')).toBe('menu');
     });

--- a/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
@@ -3,10 +3,11 @@ import {
     TooltipPosition,
     Tooltip as FoundationTooltip
 } from '@microsoft/fast-foundation';
-import { DOM, html } from '@microsoft/fast-element';
+import { html } from '@microsoft/fast-element';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Tooltip } from '..';
 import { AnchoredRegion } from '../../anchored-region';
+import { waitForUpdatesAsync } from '../../testing/async-helpers';
 
 async function setup(): Promise<Fixture<Tooltip>> {
     return fixture<Tooltip>(html`<nimble-tooltip></nimble-tooltip>`);
@@ -49,7 +50,7 @@ describe('Tooltip', () => {
         element.delay = 0;
 
         await connect();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.visible).toBeUndefined();
         expect(
@@ -66,7 +67,7 @@ describe('Tooltip', () => {
         element.delay = 0;
 
         await connect();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.visible).toBe(true);
         expect(
@@ -83,7 +84,7 @@ describe('Tooltip', () => {
         element.delay = 0;
 
         await connect();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.visible).toBe(false);
         expect(
@@ -134,7 +135,7 @@ describe('Tooltip', () => {
         element.visible = true;
 
         await connect();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
         expect(isIconVisible('nimble-icon-info')).toBeFalse();
@@ -147,7 +148,7 @@ describe('Tooltip', () => {
         element.iconVisible = true;
 
         await connect();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
         expect(isIconVisible('nimble-icon-info')).toBeFalse();
@@ -160,7 +161,7 @@ describe('Tooltip', () => {
         element.severity = 'error';
 
         await connect();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
         expect(isIconVisible('nimble-icon-info')).toBeFalse();
@@ -174,7 +175,7 @@ describe('Tooltip', () => {
         element.iconVisible = true;
 
         await connect();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeTrue();
         expect(isIconVisible('nimble-icon-info')).toBeFalse();
@@ -187,7 +188,7 @@ describe('Tooltip', () => {
         element.severity = 'information';
 
         await connect();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
         expect(isIconVisible('nimble-icon-info')).toBeFalse();
@@ -201,7 +202,7 @@ describe('Tooltip', () => {
         element.iconVisible = true;
 
         await connect();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
         expect(isIconVisible('nimble-icon-info')).toBeTrue();

--- a/packages/nimble-components/src/tree-view/tests/tree.spec.ts
+++ b/packages/nimble-components/src/tree-view/tests/tree.spec.ts
@@ -2,7 +2,7 @@ import {
     DesignSystem,
     TreeView as FoundationTreeView
 } from '@microsoft/fast-foundation';
-import { DOM, html, ref } from '@microsoft/fast-element';
+import { html, ref } from '@microsoft/fast-element';
 import { notebook16X16 } from '@ni/nimble-tokens/dist/icons/js';
 import { keyEnter } from '@microsoft/fast-web-utilities';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
@@ -68,7 +68,7 @@ describe('TreeView', () => {
         model = new Model();
         ({ connect, disconnect } = await setup(model));
         await connect();
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
     });
 
     afterEach(async () => {

--- a/packages/nimble-components/src/utilities/style/tests/multivalue-property-stylesheet-behavior.spec.ts
+++ b/packages/nimble-components/src/utilities/style/tests/multivalue-property-stylesheet-behavior.spec.ts
@@ -157,7 +157,7 @@ describe('The MultivaluePropertyStyleSheetBehavior', () => {
 
         it('has a default appearance', async () => {
             const appearanceController = new AppearanceController();
-            const { connect } = await setup(
+            const { connect, disconnect } = await setup(
                 appearanceController,
                 AppearanceElement.allAppearanceStyles
             );
@@ -165,11 +165,12 @@ describe('The MultivaluePropertyStyleSheetBehavior', () => {
             expect(
                 appearanceController.appearanceElement.resolveApearanceStyle()
             ).toBe(TestAppearance.default);
+            await disconnect();
         });
 
         it('has an appearance of awesome', async () => {
             const appearanceController = new AppearanceController();
-            const { connect } = await setup(
+            const { connect, disconnect } = await setup(
                 appearanceController,
                 AppearanceElement.allAppearanceStyles
             );
@@ -179,11 +180,12 @@ describe('The MultivaluePropertyStyleSheetBehavior', () => {
             expect(
                 appearanceController.appearanceElement.resolveApearanceStyle()
             ).toBe(TestAppearance.awesome);
+            await disconnect();
         });
 
         it('responds to change of appearance from awesome to best', async () => {
             const appearanceController = new AppearanceController();
-            const { connect } = await setup(
+            const { connect, disconnect } = await setup(
                 appearanceController,
                 AppearanceElement.allAppearanceStyles
             );
@@ -198,11 +200,12 @@ describe('The MultivaluePropertyStyleSheetBehavior', () => {
             expect(
                 appearanceController.appearanceElement.resolveApearanceStyle()
             ).toBe(TestAppearance.best);
+            await disconnect();
         });
 
         it('can share styles for appearances awesome and best', async () => {
             const appearanceController = new AppearanceController();
-            const { connect } = await setup(
+            const { connect, disconnect } = await setup(
                 appearanceController,
                 AppearanceElement.sharedAppearanceStyles
             );
@@ -217,11 +220,12 @@ describe('The MultivaluePropertyStyleSheetBehavior', () => {
             expect(
                 appearanceController.appearanceElement.resolveApearanceStyle()
             ).toBe(TestAppearance.awesome);
+            await disconnect();
         });
 
         it('can have an unset appearance best', async () => {
             const appearanceController = new AppearanceController();
-            const { connect } = await setup(
+            const { connect, disconnect } = await setup(
                 appearanceController,
                 AppearanceElement.unsetAppearanceStyles
             );
@@ -239,6 +243,7 @@ describe('The MultivaluePropertyStyleSheetBehavior', () => {
             expect(
                 appearanceController.appearanceElement.resolveApearanceStyle()
             ).toBe(TestAppearance.default);
+            await disconnect();
         });
     });
 
@@ -296,7 +301,7 @@ describe('The MultivaluePropertyStyleSheetBehavior', () => {
 
         it('can have one default and one awesome element', async () => {
             const appearanceController = new AppearanceController();
-            const { connect } = await setup(
+            const { connect, disconnect } = await setup(
                 appearanceController,
                 AppearanceElement.allAppearanceStyles
             );
@@ -309,11 +314,12 @@ describe('The MultivaluePropertyStyleSheetBehavior', () => {
             expect(
                 appearanceController.appearanceElement2.resolveApearanceStyle()
             ).toBe(TestAppearance.awesome);
+            await disconnect();
         });
 
         it('can have one awesome and one best element', async () => {
             const appearanceController = new AppearanceController();
-            const { connect } = await setup(
+            const { connect, disconnect } = await setup(
                 appearanceController,
                 AppearanceElement.allAppearanceStyles
             );
@@ -327,6 +333,7 @@ describe('The MultivaluePropertyStyleSheetBehavior', () => {
             expect(
                 appearanceController.appearanceElement2.resolveApearanceStyle()
             ).toBe(TestAppearance.best);
+            await disconnect();
         });
     });
 });

--- a/packages/nimble-components/src/utilities/style/tests/multivalue-property-stylesheet-behavior.spec.ts
+++ b/packages/nimble-components/src/utilities/style/tests/multivalue-property-stylesheet-behavior.spec.ts
@@ -7,7 +7,6 @@ import {
     css,
     ref,
     ElementStyles,
-    DOM,
     Behavior,
     attr
 } from '@microsoft/fast-element';
@@ -15,6 +14,7 @@ import { uniqueElementName, fixture } from '../../tests/fixture';
 import type { Fixture } from '../../tests/fixture';
 import { TestAppearance } from './types';
 import { MultivaluePropertyStyleSheetBehavior } from '../multivalue-property-stylesheet-behavior';
+import { waitForUpdatesAsync } from '../../../testing/async-helpers';
 
 const testAppearance = (
     value: TestAppearance | TestAppearance[],
@@ -176,7 +176,7 @@ describe('The MultivaluePropertyStyleSheetBehavior', () => {
             );
             await connect();
             appearanceController.appearance = TestAppearance.awesome;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(
                 appearanceController.appearanceElement.resolveApearanceStyle()
             ).toBe(TestAppearance.awesome);
@@ -191,12 +191,12 @@ describe('The MultivaluePropertyStyleSheetBehavior', () => {
             );
             await connect();
             appearanceController.appearance = TestAppearance.awesome;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(
                 appearanceController.appearanceElement.resolveApearanceStyle()
             ).toBe(TestAppearance.awesome);
             appearanceController.appearance = TestAppearance.best;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(
                 appearanceController.appearanceElement.resolveApearanceStyle()
             ).toBe(TestAppearance.best);
@@ -211,12 +211,12 @@ describe('The MultivaluePropertyStyleSheetBehavior', () => {
             );
             await connect();
             appearanceController.appearance = TestAppearance.awesome;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(
                 appearanceController.appearanceElement.resolveApearanceStyle()
             ).toBe(TestAppearance.awesome);
             appearanceController.appearance = TestAppearance.best;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(
                 appearanceController.appearanceElement.resolveApearanceStyle()
             ).toBe(TestAppearance.awesome);
@@ -234,12 +234,12 @@ describe('The MultivaluePropertyStyleSheetBehavior', () => {
                 appearanceController.appearanceElement.resolveApearanceStyle()
             ).toBe(TestAppearance.default);
             appearanceController.appearance = TestAppearance.awesome;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(
                 appearanceController.appearanceElement.resolveApearanceStyle()
             ).toBe(TestAppearance.awesome);
             appearanceController.appearance = TestAppearance.best;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(
                 appearanceController.appearanceElement.resolveApearanceStyle()
             ).toBe(TestAppearance.default);
@@ -307,7 +307,7 @@ describe('The MultivaluePropertyStyleSheetBehavior', () => {
             );
             await connect();
             appearanceController.appearance2 = TestAppearance.awesome;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(
                 appearanceController.appearanceElement1.resolveApearanceStyle()
             ).toBe(TestAppearance.default);
@@ -326,7 +326,7 @@ describe('The MultivaluePropertyStyleSheetBehavior', () => {
             await connect();
             appearanceController.appearance1 = TestAppearance.awesome;
             appearanceController.appearance2 = TestAppearance.best;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(
                 appearanceController.appearanceElement1.resolveApearanceStyle()
             ).toBe(TestAppearance.awesome);

--- a/packages/nimble-components/src/utilities/style/tests/theme.spec.ts
+++ b/packages/nimble-components/src/utilities/style/tests/theme.spec.ts
@@ -157,7 +157,7 @@ describe('The ThemeStylesheetBehavior', () => {
 
         it('responds to light theme', async () => {
             const themeController = new ThemeController();
-            const { connect } = await setup(
+            const { connect, disconnect } = await setup(
                 themeController,
                 ThemedElement.allBehaviorsStyles
             );
@@ -167,11 +167,12 @@ describe('The ThemeStylesheetBehavior', () => {
             expect(themeController.themedElement.resolveThemedStyle()).toBe(
                 Theme.light
             );
+            await disconnect();
         });
 
         it('responds to dark theme', async () => {
             const themeController = new ThemeController();
-            const { connect } = await setup(
+            const { connect, disconnect } = await setup(
                 themeController,
                 ThemedElement.allBehaviorsStyles
             );
@@ -181,11 +182,12 @@ describe('The ThemeStylesheetBehavior', () => {
             expect(themeController.themedElement.resolveThemedStyle()).toBe(
                 Theme.dark
             );
+            await disconnect();
         });
 
         it('responds to color theme', async () => {
             const themeController = new ThemeController();
-            const { connect } = await setup(
+            const { connect, disconnect } = await setup(
                 themeController,
                 ThemedElement.allBehaviorsStyles
             );
@@ -195,11 +197,12 @@ describe('The ThemeStylesheetBehavior', () => {
             expect(themeController.themedElement.resolveThemedStyle()).toBe(
                 Theme.color
             );
+            await disconnect();
         });
 
         it('responds to change from light theme to dark theme', async () => {
             const themeController = new ThemeController();
-            const { connect } = await setup(
+            const { connect, disconnect } = await setup(
                 themeController,
                 ThemedElement.allBehaviorsStyles
             );
@@ -214,11 +217,12 @@ describe('The ThemeStylesheetBehavior', () => {
             expect(themeController.themedElement.resolveThemedStyle()).toBe(
                 Theme.dark
             );
+            await disconnect();
         });
 
         it('can share styles for dark and color themes', async () => {
             const themeController = new ThemeController();
-            const { connect } = await setup(
+            const { connect, disconnect } = await setup(
                 themeController,
                 ThemedElement.sharedDarkColorBehaviorsStyles
             );
@@ -233,11 +237,12 @@ describe('The ThemeStylesheetBehavior', () => {
             expect(themeController.themedElement.resolveThemedStyle()).toBe(
                 Theme.dark
             );
+            await disconnect();
         });
 
         it('can have unset color and dark themes', async () => {
             const themeController = new ThemeController();
-            const { connect } = await setup(
+            const { connect, disconnect } = await setup(
                 themeController,
                 ThemedElement.unsetDarkColorBehaviorsStyles
             );
@@ -257,6 +262,7 @@ describe('The ThemeStylesheetBehavior', () => {
             expect(themeController.themedElement.resolveThemedStyle()).toBe(
                 'theme-unset'
             );
+            await disconnect();
         });
     });
 
@@ -308,7 +314,7 @@ describe('The ThemeStylesheetBehavior', () => {
 
         it('can have one light and one dark themed element', async () => {
             const themeController = new ThemeController();
-            const { connect } = await setup(
+            const { connect, disconnect } = await setup(
                 themeController,
                 ThemedElement.allBehaviorsStyles
             );
@@ -322,11 +328,12 @@ describe('The ThemeStylesheetBehavior', () => {
             expect(themeController.themedElement2.resolveThemedStyle()).toBe(
                 Theme.dark
             );
+            await disconnect();
         });
 
         it('can have one dark and one color themed element', async () => {
             const themeController = new ThemeController();
-            const { connect } = await setup(
+            const { connect, disconnect } = await setup(
                 themeController,
                 ThemedElement.allBehaviorsStyles
             );
@@ -341,6 +348,7 @@ describe('The ThemeStylesheetBehavior', () => {
             expect(themeController.themedElement2.resolveThemedStyle()).toBe(
                 Theme.color
             );
+            await disconnect();
         });
     });
 });

--- a/packages/nimble-components/src/utilities/style/tests/theme.spec.ts
+++ b/packages/nimble-components/src/utilities/style/tests/theme.spec.ts
@@ -6,14 +6,14 @@ import {
     observable,
     css,
     ref,
-    ElementStyles,
-    DOM
+    ElementStyles
 } from '@microsoft/fast-element';
 import type { ThemeProvider } from '../../../theme-provider';
 import { Theme } from '../../../theme-provider/types';
 import { uniqueElementName, fixture } from '../../tests/fixture';
 import type { Fixture } from '../../tests/fixture';
 import { themeBehavior } from '../theme';
+import { waitForUpdatesAsync } from '../../../testing/async-helpers';
 
 /**
  * Test element with theme-aware styles
@@ -163,7 +163,7 @@ describe('The ThemeStylesheetBehavior', () => {
             );
             await connect();
             themeController.theme = Theme.light;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(themeController.themedElement.resolveThemedStyle()).toBe(
                 Theme.light
             );
@@ -178,7 +178,7 @@ describe('The ThemeStylesheetBehavior', () => {
             );
             await connect();
             themeController.theme = Theme.dark;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(themeController.themedElement.resolveThemedStyle()).toBe(
                 Theme.dark
             );
@@ -193,7 +193,7 @@ describe('The ThemeStylesheetBehavior', () => {
             );
             await connect();
             themeController.theme = Theme.color;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(themeController.themedElement.resolveThemedStyle()).toBe(
                 Theme.color
             );
@@ -208,12 +208,12 @@ describe('The ThemeStylesheetBehavior', () => {
             );
             await connect();
             themeController.theme = Theme.light;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(themeController.themedElement.resolveThemedStyle()).toBe(
                 Theme.light
             );
             themeController.theme = Theme.dark;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(themeController.themedElement.resolveThemedStyle()).toBe(
                 Theme.dark
             );
@@ -228,12 +228,12 @@ describe('The ThemeStylesheetBehavior', () => {
             );
             await connect();
             themeController.theme = Theme.dark;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(themeController.themedElement.resolveThemedStyle()).toBe(
                 Theme.dark
             );
             themeController.theme = Theme.color;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(themeController.themedElement.resolveThemedStyle()).toBe(
                 Theme.dark
             );
@@ -248,17 +248,17 @@ describe('The ThemeStylesheetBehavior', () => {
             );
             await connect();
             themeController.theme = Theme.light;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(themeController.themedElement.resolveThemedStyle()).toBe(
                 Theme.light
             );
             themeController.theme = Theme.dark;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(themeController.themedElement.resolveThemedStyle()).toBe(
                 'theme-unset'
             );
             themeController.theme = Theme.color;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(themeController.themedElement.resolveThemedStyle()).toBe(
                 'theme-unset'
             );
@@ -321,7 +321,7 @@ describe('The ThemeStylesheetBehavior', () => {
             await connect();
             themeController.theme1 = Theme.light;
             themeController.theme2 = Theme.dark;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
             expect(themeController.themedElement1.resolveThemedStyle()).toBe(
                 Theme.light
             );
@@ -340,7 +340,7 @@ describe('The ThemeStylesheetBehavior', () => {
             await connect();
             themeController.theme1 = Theme.dark;
             themeController.theme2 = Theme.color;
-            await DOM.nextUpdate();
+            await waitForUpdatesAsync();
 
             expect(themeController.themedElement1.resolveThemedStyle()).toBe(
                 Theme.dark

--- a/packages/nimble-components/src/utilities/tests/component.ts
+++ b/packages/nimble-components/src/utilities/tests/component.ts
@@ -1,6 +1,6 @@
-import { DOM } from '@microsoft/fast-element';
+import { waitForUpdatesAsync } from '../../testing/async-helpers';
 
 export async function clickElement(element: HTMLElement): Promise<void> {
     element.click();
-    await DOM.nextUpdate();
+    await waitForUpdatesAsync();
 }

--- a/packages/nimble-components/src/utilities/tests/tests/fixture.spec.ts
+++ b/packages/nimble-components/src/utilities/tests/tests/fixture.spec.ts
@@ -9,9 +9,9 @@ import {
     customElement,
     FASTElement,
     html,
-    DOM,
     observable,
 } from "@microsoft/fast-element";
+import { waitForUpdatesAsync } from "../../../testing/async-helpers";
 import { uniqueElementName, fixture } from "../fixture";
 
 describe("The fixture helper", () => {
@@ -88,7 +88,7 @@ describe("The fixture helper", () => {
 
         source.value = "something else";
 
-        await DOM.nextUpdate();
+        await waitForUpdatesAsync();
 
         expect(element.value).toEqual(source.value);
 

--- a/packages/nimble-components/src/wafer-map/tests/wafer-map.spec.ts
+++ b/packages/nimble-components/src/wafer-map/tests/wafer-map.spec.ts
@@ -1,5 +1,6 @@
-import { DOM, html } from '@microsoft/fast-element';
+import { html } from '@microsoft/fast-element';
 import { WaferMap } from '..';
+import { processUpdates } from '../../testing/async-helpers';
 import { type Fixture, fixture } from '../../utilities/tests/fixture';
 import {
     WaferMapColorScaleMode,
@@ -20,7 +21,7 @@ describe('WaferMap', () => {
         ({ element, connect, disconnect } = await setup());
         await connect();
         element.canvasSideLength = 500;
-        DOM.processUpdates();
+        processUpdates();
         spy = spyOn(element, 'render');
     });
 
@@ -36,55 +37,55 @@ describe('WaferMap', () => {
 
     it('will render once after quadrant changes', () => {
         element.quadrant = WaferMapQuadrant.topRight;
-        DOM.processUpdates();
+        processUpdates();
         expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('will render once after orientation changes', () => {
         element.orientation = WaferMapOrientation.right;
-        DOM.processUpdates();
+        processUpdates();
         expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('will render once after maxCharacters change', () => {
         element.maxCharacters = 3;
-        DOM.processUpdates();
+        processUpdates();
         expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('will render once after dieLabelsHidden change', () => {
         element.dieLabelsHidden = true;
-        DOM.processUpdates();
+        processUpdates();
         expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('will render once after dieLabelsSuffix changes', () => {
         element.dieLabelsSuffix = '%';
-        DOM.processUpdates();
+        processUpdates();
         expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('will render once after colorScaleMode changes', () => {
         element.colorScaleMode = WaferMapColorScaleMode.ordinal;
-        DOM.processUpdates();
+        processUpdates();
         expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('will render once after highlightedValues change', () => {
         element.highlightedValues = ['1'];
-        DOM.processUpdates();
+        processUpdates();
         expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('will render once after dies change', () => {
         element.dies = [{ x: 1, y: 1, value: '1' }];
-        DOM.processUpdates();
+        processUpdates();
         expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('will render once after colorScale changes', () => {
         element.colorScale = { colors: ['red'], values: ['1'] };
-        DOM.processUpdates();
+        processUpdates();
         expect(spy).toHaveBeenCalledTimes(1);
     });
 
@@ -98,7 +99,7 @@ describe('WaferMap', () => {
         element.highlightedValues = ['1'];
         element.dies = [{ x: 1, y: 1, value: '1' }];
         element.colorScale = { colors: ['red'], values: ['1'] };
-        DOM.processUpdates();
+        processUpdates();
         expect(spy).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Cleans-up a few things I found in tests:
- Using the async-helpers public API consistently instead of reaching into FAST (will also help in FEv2 where those APIs are changing). Enforced via a lint rule.
- Making some clean-up code consistent in tests. In particular the behavior tests were not cleaning up correctly and some tests had mixed beforeEach / afterEach clean-up patterns that were made consistent.

## 👩‍💻 Implementation

See above.

## 🧪 Testing

Relying on CI.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
