### PR TITLE
Fix bug: Table virtualizer doesn't render enough rows after a height increase, until a scroll

### DIFF
--- a/change/@ni-nimble-components-fb8496d4-c25f-4d03-93e5-97fe8190515e.json
+++ b/change/@ni-nimble-components-fb8496d4-c25f-4d03-93e5-97fe8190515e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix nimble-table virtualizer bug (when table height changes)",
+  "packageName": "@ni/nimble-components",
+  "email": "20709258+msmithNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12015,9 +12015,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.41.tgz",
-      "integrity": "sha512-dqnaR9dK9rp7QyXhEdg8jr1FKxUbbClRtqp0nuirmyDGQFN1IqlGCvnKXeRyZP1SU7ZisePxFdjbFOgy5T51tg==",
+      "version": "3.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.44.tgz",
+      "integrity": "sha512-gwE4s5OIlMwwaDr8WoRtuMaA4ONbH7Y9pPEi96ZSWWRbu7thXJNAgDygTvFPRUh4Fm0RUPF4VBL8XyrCfZMUtg==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -39723,7 +39723,7 @@
         "@microsoft/fast-web-utilities": "^6.0.0",
         "@ni/nimble-tokens": "^4.4.0",
         "@tanstack/table-core": "^8.7.0",
-        "@tanstack/virtual-core": "^3.0.0-beta.34",
+        "@tanstack/virtual-core": "^3.0.0-beta.44",
         "@types/d3": "^7.4.0",
         "@types/d3-scale": "^4.0.2",
         "@types/d3-selection": "^3.0.0",
@@ -44398,7 +44398,7 @@
         "@storybook/mdx2-csf": "^0.0.4",
         "@storybook/theming": "^6.5.10",
         "@tanstack/table-core": "^8.7.0",
-        "@tanstack/virtual-core": "^3.0.0-beta.34",
+        "@tanstack/virtual-core": "3.0.0-beta.44",
         "@types/d3": "^7.4.0",
         "@types/d3-scale": "^4.0.2",
         "@types/d3-selection": "^3.0.0",
@@ -50392,9 +50392,9 @@
       "integrity": "sha512-OvKx7v0qJTyPkMhqsWzVPZnARiqdGvDvEg8tZ/GSQs7t0Vb2sdtkGg7cdzUZ67sIg9o5/gSwvvT84ouSaP8euA=="
     },
     "@tanstack/virtual-core": {
-      "version": "3.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.41.tgz",
-      "integrity": "sha512-dqnaR9dK9rp7QyXhEdg8jr1FKxUbbClRtqp0nuirmyDGQFN1IqlGCvnKXeRyZP1SU7ZisePxFdjbFOgy5T51tg=="
+      "version": "3.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.44.tgz",
+      "integrity": "sha512-gwE4s5OIlMwwaDr8WoRtuMaA4ONbH7Y9pPEi96ZSWWRbu7thXJNAgDygTvFPRUh4Fm0RUPF4VBL8XyrCfZMUtg=="
     },
     "@tootallnate/once": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44398,7 +44398,7 @@
         "@storybook/mdx2-csf": "^0.0.4",
         "@storybook/theming": "^6.5.10",
         "@tanstack/table-core": "^8.7.0",
-        "@tanstack/virtual-core": "3.0.0-beta.44",
+        "@tanstack/virtual-core": "^3.0.0-beta.44",
         "@types/d3": "^7.4.0",
         "@types/d3-scale": "^4.0.2",
         "@types/d3-selection": "^3.0.0",

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -51,7 +51,7 @@
     "@microsoft/fast-web-utilities": "^6.0.0",
     "@ni/nimble-tokens": "^4.4.0",
     "@tanstack/table-core": "^8.7.0",
-    "@tanstack/virtual-core": "^3.0.0-beta.34",
+    "@tanstack/virtual-core": "^3.0.0-beta.44",
     "@types/d3": "^7.4.0",
     "@types/d3-scale": "^4.0.2",
     "@types/d3-zoom": "^3.0.0",

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -457,8 +457,6 @@ describe('Table', () => {
             const originalRenderedRowCount = pageObject.getRenderedRowCount();
 
             element.style.height = '700px';
-            // Workaround for https://github.com/ni/nimble/issues/1008
-            element.viewport.scrollTop = 2;
             await waitForUpdatesAsync();
 
             const newRenderedRowCount = pageObject.getRenderedRowCount();


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #1008 

## 👩‍💻 Implementation

- Update TanStack Virtualizer package to latest (beta44). The [TanStack Virtual bug I filed](https://github.com/TanStack/virtual/issues/492) was fixed in beta43.

## 🧪 Testing

- Tested in Storybook locally
- Autotests. Removed workaround in autotest that triggered a scroll after changing table height, which was due to this bug.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
