### PR TITLE
Make the click area of the breadcrumb-item match the link area

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/src/directives/breadcrumb-item/nimble-breadcrumb-item-router-link-with-href.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/breadcrumb-item/nimble-breadcrumb-item-router-link-with-href.directive.ts
@@ -28,6 +28,9 @@ export class NimbleBreadcrumbItemRouterLinkWithHrefDirective extends RouterLinkW
     }
 
     public override onClick(_button: number, _ctrlKey: boolean, _shiftKey: boolean, _altKey: boolean, _metaKey: boolean): boolean {
+        // onClick is the 'click' @HostListener handler in RouterLinkWithHref. Override it to do nothing so that this directive
+        // can be in control of when the click handler is called. This allows RouterLinkWithHref's onClick to only be called
+        // when the link within the element is clicked rather than any part of the element.
         return true;
     }
 
@@ -36,6 +39,7 @@ export class NimbleBreadcrumbItemRouterLinkWithHrefDirective extends RouterLinkW
         ['$event', '$event.button', '$event.ctrlKey', '$event.shiftKey', '$event.altKey', '$event.metaKey']
     )
     public breadcrumbItemClick(event: MouseEvent): boolean {
+        // Call onClick on the base class only when the anchor within the breadcrumb item was clicked.
         if (event.composedPath().some(el => el === this.elementRef.nativeElement.control)) {
             return super.onClick(event.button, event.ctrlKey, event.shiftKey, event.altKey, event.metaKey);
         }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/breadcrumb-item/nimble-breadcrumb-item-router-link-with-href.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/breadcrumb-item/nimble-breadcrumb-item-router-link-with-href.directive.ts
@@ -1,5 +1,7 @@
-import { Directive, Input } from '@angular/core';
-import { RouterLinkWithHref } from '@angular/router';
+import { LocationStrategy } from '@angular/common';
+import { Directive, ElementRef, HostListener, Injector, Input } from '@angular/core';
+import { ActivatedRoute, Router, RouterLinkWithHref } from '@angular/router';
+import type { BreadcrumbItem } from '@ni/nimble-components/dist/esm/breadcrumb-item';
 
 /**
  * Selectors used for built-in Angular RouterLink directives:
@@ -19,5 +21,25 @@ export class NimbleBreadcrumbItemRouterLinkWithHrefDirective extends RouterLinkW
     @Input()
     public set nimbleRouterLink(commands: never[] | string | null | undefined) {
         this.routerLink = commands;
+    }
+
+    public constructor(injector: Injector, private readonly elementRef: ElementRef<BreadcrumbItem>) {
+        super(injector.get(Router), injector.get(ActivatedRoute), injector.get(LocationStrategy));
+    }
+
+    public override onClick(_button: number, _ctrlKey: boolean, _shiftKey: boolean, _altKey: boolean, _metaKey: boolean): boolean {
+        return true;
+    }
+
+    @HostListener(
+        'click',
+        ['$event', '$event.button', '$event.ctrlKey', '$event.shiftKey', '$event.altKey', '$event.metaKey']
+    )
+    public breadcrumbItemClick(event: MouseEvent): boolean {
+        if (event.composedPath().some(el => el === this.elementRef.nativeElement.control)) {
+            return super.onClick(event.button, event.ctrlKey, event.shiftKey, event.altKey, event.metaKey);
+        }
+
+        return true;
     }
 }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/breadcrumb-item/tests/nimble-breadcrumb-item-router-link-with-href.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/breadcrumb-item/tests/nimble-breadcrumb-item-router-link-with-href.directive.spec.ts
@@ -32,8 +32,10 @@ describe('Nimble breadcrumb item RouterLinkWithHrefDirective', () => {
     let router: Router;
     let location: Location;
     let anchor: HTMLAnchorElement;
+    let separator: HTMLSpanElement;
     let routerNavigateByUrlSpy: jasmine.Spy;
     let anchorClickHandlerSpy: jasmine.Spy;
+    let separatorClickHandlerSpy: jasmine.Spy;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -59,9 +61,12 @@ describe('Nimble breadcrumb item RouterLinkWithHrefDirective', () => {
         tick();
         processUpdates();
         anchor = breadcrumbItem1!.shadowRoot!.querySelector('a')!;
+        separator = breadcrumbItem1!.shadowRoot!.querySelector('.separator')!;
         routerNavigateByUrlSpy = spyOn(router, 'navigateByUrl').and.callThrough();
         anchorClickHandlerSpy = jasmine.createSpy('click');
-        anchor!.addEventListener('click', anchorClickHandlerSpy);
+        separatorClickHandlerSpy = jasmine.createSpy('click');
+        anchor.addEventListener('click', anchorClickHandlerSpy);
+        separator.addEventListener('click', separatorClickHandlerSpy);
     }));
 
     afterEach(() => {
@@ -80,6 +85,14 @@ describe('Nimble breadcrumb item RouterLinkWithHrefDirective', () => {
             }
         }));
         expect(location.path()).toEqual(expectedDestinationUrl);
+    }));
+
+    it('does not navigate via router.navigateByUrl when separator is clicked', fakeAsync(() => {
+        separator!.click();
+        tick();
+
+        expect(separatorClickHandlerSpy).toHaveBeenCalledTimes(1);
+        expect(routerNavigateByUrlSpy).not.toHaveBeenCalled();
     }));
 
     const secondaryClickTests: { testName: string, clickArgs: { [key: string]: unknown } }[] = [

--- a/change/@ni-nimble-angular-ebe7fed6-e2ca-44ed-8022-827bb0cdd299.json
+++ b/change/@ni-nimble-angular-ebe7fed6-e2ca-44ed-8022-827bb0cdd299.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make the click area of the breadcrumb-item match the link area",
+  "packageName": "@ni/nimble-angular",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #557 

## 👩‍💻 Implementation

The issue was that `onClick` in `RouterLinkWithHref` was called when any part of the breadcrumb item was clicked, even if it was the separator or some padding that was clicked. To fix the issue, I:
- provided an override for `onClick` so that the `click` `@HostListener` of `RouterLinkWithHref` would do nothing
- provided my own `click` `@HostListener` in the nimble directive that calls `onClick` on the base class only if the anchor within the breadcrumb item was clicked
- in order to have reference to the element within the directive, I had to implement a constructor. Because of the way `LocationStrategy` works, I needed to inject the `Injector` and dynamically get the values for the `Route`, `ActivatedRoute`, and `LocationStrategy` rather than have them injected directly as the arguments of the constructor.

## 🧪 Testing

- Manually tested the SLE example app with the built angular package
- Wrote new auto test -- verified it failed before my change and passes after my change

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
