### PR TITLE
Fix linting by arbitrarily bumping to node 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           dotnet-version: '6.0.x'
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
       # Specify npm version


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Every build on GitHub Actions has been failing on prettier and I don't know why. I tried to reproduce it locally and couldn't. Found that I'm using node 18 locally and it seems to work on CI too.

GitHub actions environment and steps doesn't show any changes. And I don't believe it's related to recent pushes in main because not all the branches are up to date on main but they all just started failing.

`¯\_(ツ)_/¯`

## 👩‍💻 Implementation

Update the CI to node 18, yolo.

## 🧪 Testing

relying on CI.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
