### PR TITLE
Fix issue re-rendering table cells when the table becomes valid

### DIFF
--- a/change/@ni-nimble-components-155bbead-bda9-4f8f-be37-e5adc8265f12.json
+++ b/change/@ni-nimble-components-155bbead-bda9-4f8f-be37-e5adc8265f12.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix issue re-rendering table cells when the table becomes valid again",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/components/cell/index.ts
+++ b/packages/nimble-components/src/table/components/cell/index.ts
@@ -47,6 +47,15 @@ export class TableCell<
         );
     }
 
+    public override disconnectedCallback(): void {
+        super.disconnectedCallback();
+
+        if (this.customCellView) {
+            this.customCellView.dispose();
+            this.customCellView = undefined;
+        }
+    }
+
     protected cellStateChanged(): void {
         this.customCellView?.bind(this.cellState, defaultExecutionContext);
     }

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -303,6 +303,24 @@ describe('Table', () => {
         verifyRenderedData(simpleTableData);
     });
 
+    it('transitioning the table state from valid to invalid and back to valid rerenders the table correctly', async () => {
+        element.setData(simpleTableData);
+        await connect();
+        await waitForUpdatesAsync();
+
+        element.idFieldName = 'missingFieldName';
+        await waitForUpdatesAsync();
+
+        expect(pageObject.getRenderedRowCount()).toBe(0);
+        expect(element.checkValidity()).toBeFalse();
+
+        element.idFieldName = undefined;
+        await waitForUpdatesAsync();
+
+        verifyRenderedData(simpleTableData);
+        expect(element.checkValidity()).toBeTrue();
+    });
+
     describe('record IDs', () => {
         it('setting ID field uses field value for ID', async () => {
             element.setData(simpleTableData);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #1039 

## 👩‍💻 Implementation

When an invalid table become valid again, all the cells are re-added to the DOM. As a result, the `connectedCallback` is called again for a cell that had previously been connected. Calling the `connectedCallback` again caused the cell template to be added an additional time to the `cellContentContainer`. To fix the problem, we need to clean up the cell template in the `disconnectedCallback`.

## 🧪 Testing

- Added new unit test that failed prior to my fix
- Manually tested in storybook

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
