### PR TITLE
Fix intermittent anchor tabs test

### DIFF
--- a/change/@ni-nimble-components-d048678f-c842-4eeb-9a6c-d0637ee75498.json
+++ b/change/@ni-nimble-components-d048678f-c842-4eeb-9a6c-d0637ee75498.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix intermittent test failure",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
+++ b/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
@@ -17,10 +17,10 @@ import { getSpecTypeByNamedList } from '../../utilities/tests/parameterized';
 
 async function setup(): Promise<Fixture<AnchorTabs>> {
     return fixture<AnchorTabs>(
-        html`<nimble-anchor-tabs activeid="tab-2">
+        html`<nimble-anchor-tabs activeid="tab-two">
             <nimble-anchor-tab></nimble-anchor-tab>
-            <nimble-anchor-tab id="tab-2"></nimble-anchor-tab>
-            <nimble-anchor-tab id="tab-3"></nimble-anchor-tab>
+            <nimble-anchor-tab id="tab-two"></nimble-anchor-tab>
+            <nimble-anchor-tab id="tab-three"></nimble-anchor-tab>
         </nimble-anchor-tabs>`
     );
 }
@@ -77,7 +77,7 @@ describe('AnchorTabs', () => {
     });
 
     it('should set activeid property from attribute value', () => {
-        expect(element.activeid).toBe('tab-2');
+        expect(element.activeid).toBe('tab-two');
     });
 
     it('should populate tabs array with anchor tabs', () => {
@@ -103,7 +103,7 @@ describe('AnchorTabs', () => {
     });
 
     it('should update activetab when activeid is changed', () => {
-        element.activeid = 'tab-3';
+        element.activeid = 'tab-three';
         expect(element.activetab).toBe(tab(2));
     });
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #1034

## 👩‍💻 Implementation

I discovered that this test (and at least one other) always failed if it was the third anchor tabs test run. It turns out that's because I was letting the first child tab element get its `id` assigned automatically, and it uses a counter-based function to generate that id value. It generates values like "tab-x", where x is the counter value. The counter starts at zero, thus on the third test, the tab was getting the id "tab-2". This conflicts with the id I explicitly give the second tab, and the result is some unexpected behavior. I resolved this by changing my explicit id values such that they would never conflict with the auto-generated one.

## 🧪 Testing

Ran three copies of the test in question with and without my fix. The third instance fails without my change, but passes with it.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
