### PR TITLE
Fix bug where pointer events were being swallowed by table row hover

### DIFF
--- a/change/@ni-nimble-components-e5858a19-b6b5-4b00-ab4f-89a9baeb305d.json
+++ b/change/@ni-nimble-components-e5858a19-b6b5-4b00-ab4f-89a9baeb305d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bug where pointer events were being swallowed by table row hover",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/styles.ts
+++ b/packages/nimble-components/src/table/styles.ts
@@ -73,6 +73,7 @@ export const styles = css`
         width: 100%;
         height: 100%;
         position: absolute;
+        pointer-events: none;
     }
 
     .row:hover::before {
@@ -88,6 +89,7 @@ export const styles = css`
                 height: 100%;
                 position: absolute;
                 background: ${fillHoverColor};
+                pointer-events: none;
             }
 
             .row::before {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Mouse events (e.g. text selection) are not working correctly within the table because the `::before` styling that is intended to make the row background color change on hover is swallowing the pointer events.

## 👩‍💻 Implementation

Set `pointer-events: none;` on the `::before` styling within the table.

I also did a search for other `::before` and `::after` styles within the repo where this might be a problem, but I didn't find any. Most of our usages of `::before` and `::after` are to change the bottom border of controls on hover and/or focus.

## 🧪 Testing

Verified text can now be selected correctly within the table.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
