### PR TITLE
Added token for Ozone Library background color (#E6E6E6)

### DIFF
--- a/packages/nimble-components/src/theme-provider/design-token-names.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-names.ts
@@ -25,6 +25,7 @@ export const tokenNames: { readonly [key in TokenName]: string } = {
     passColor: 'pass-color',
     informationColor: 'information-color',
     borderHoverColor: 'border-hover-color',
+    ozoneLibraryBackgroundColor: 'ozone-library-background-color',
     iconColor: 'icon-color',
     modalBackdropColor: 'modal-backdrop-color',
     popupBorderColor: 'popup-border-color',

--- a/packages/nimble-components/src/theme-provider/design-tokens.ts
+++ b/packages/nimble-components/src/theme-provider/design-tokens.ts
@@ -7,6 +7,7 @@ import {
     Black15,
     Black80,
     Black88,
+    Black22,
     White,
     ForestGreen,
     DigitalGreenLight,
@@ -169,6 +170,10 @@ export const informationColor = DesignToken.create<string>(
 export const borderHoverColor = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.borderHoverColor)
 ).withDefault((element: HTMLElement) => getColorForTheme(element, DigitalGreenLight, DigitalGreenLight, White));
+
+export const ozoneLibraryBackgroundColor = DesignToken.create<string>(
+    styleNameFromTokenName(tokenNames.borderHoverColor)
+).withDefault((element: HTMLElement) => getColorForTheme(element, Black22, Black22, Black22));
 
 // Component Color Tokens
 export const iconColor = DesignToken.create<string>(


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

We want the color #E6E6E6 as a token, to be used for the background color of the Ozone Microstrategy Library

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
