### PR TITLE
Define type for banner toggle event detail

### DIFF
--- a/change/@ni-nimble-components-2e8cddd6-0079-4ebe-b853-c18d0031496c.json
+++ b/change/@ni-nimble-components-2e8cddd6-0079-4ebe-b853-c18d0031496c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Define type for banner toggle event detail",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/banner/index.ts
+++ b/packages/nimble-components/src/banner/index.ts
@@ -7,7 +7,7 @@ import {
 } from '@microsoft/fast-foundation';
 import { styles } from './styles';
 import { template } from './template';
-import { BannerSeverity } from './types';
+import { BannerSeverity, BannerToggleEventDetail } from './types';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -63,7 +63,11 @@ export class Banner extends FoundationElement {
      * @internal
      */
     public openChanged(): void {
-        this.$emit('toggle', { oldState: !this.open, newState: this.open });
+        const eventDetail: BannerToggleEventDetail = {
+            newState: this.open,
+            oldState: !this.open
+        };
+        this.$emit('toggle', eventDetail);
     }
 
     /**

--- a/packages/nimble-components/src/banner/types.ts
+++ b/packages/nimble-components/src/banner/types.ts
@@ -11,3 +11,12 @@ export const BannerSeverity = {
 
 export type BannerSeverity =
     (typeof BannerSeverity)[keyof typeof BannerSeverity];
+
+/**
+ * The type of the detail associated with the `toggle`
+ * event on the banner.
+ */
+export interface BannerToggleEventDetail {
+    newState: boolean;
+    oldState: boolean;
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Should define explict type for banner's `toggle` event details. We want to re-export this from `nimble-angular`.

## 👩‍💻 Implementation

Defined new type. Followed example of the menu button's identical event details.

## 🧪 Testing

None

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
