### PR TITLE
Exclude docs from files that trigger main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,10 +6,9 @@ on:
     branches:
       - '**'
     paths-ignore:
-      - '/README.md'
-      - '/CONTRIBUTING.md'
-      - '/docs/**'
-      - '/packages/nimble-*/docs/**'
+      - '/*.md'
+      - 'docs/'
+      - 'specs/'
 
 env:
   GITHUB_SERVICE_USER: "rajsite"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - '**'
+    paths-ignore:
+      - '/README.md'
+      - '/CONTRIBUTING.md'
+      - '/packages/nimble-*/docs/**'
 
 env:
   GITHUB_SERVICE_USER: "rajsite"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,10 @@ name: 'main'
 
 on:
   pull_request:
+    paths-ignore:
+      - '/*.md'
+      - 'docs/'
+      - 'specs/'
   push:
     branches:
       - '**'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - '/README.md'
       - '/CONTRIBUTING.md'
+      - '/docs/**'
       - '/packages/nimble-*/docs/**'
 
 env:

--- a/beachball.config.js
+++ b/beachball.config.js
@@ -10,5 +10,6 @@ module.exports = {
                   return `- ${entry.comment} ([ni/nimble@${entry.commit.substring(0,7)}](https://github.com/ni/nimble/commit/${entry.commit}))`;
             }
         }
-    }
+    },
+    ignorePatterns: [ '/*.md', '**/docs/**', '**/specs/**' ]
 };


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

See #401


## 👩‍💻 Implementation

Used `paths-ignore` to exclude the root `README` and `CONTRIBUTING`, and any `docs` or `specs` folders from triggering the build.

## 🧪 Testing

None. Can test after submission.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
