### PR TITLE
Make tab panels scrollable

### DIFF
--- a/change/@ni-nimble-components-d329848f-500b-44d8-a5d9-a72d84858253.json
+++ b/change/@ni-nimble-components-d329848f-500b-44d8-a5d9-a72d84858253.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make tab panels scrollable",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/tabs/styles.ts
+++ b/packages/nimble-components/src/tabs/styles.ts
@@ -22,5 +22,6 @@ export const styles = css`
         grid-row: 2;
         grid-column-start: 1;
         grid-column-end: 4;
+        overflow: auto;
     }
 `;

--- a/packages/nimble-components/src/tabs/tests/tabs-matrix.stories.ts
+++ b/packages/nimble-components/src/tabs/tests/tabs-matrix.stories.ts
@@ -37,7 +37,7 @@ const component = (
     toolbar: TabsToolbarState,
     [disabledName, disabled]: DisabledState
 ): ViewTemplate => html`
-    <nimble-tabs style="padding: 15px; height: 120px; width: 400px;">
+    <nimble-tabs style="padding: 15px;">
         ${when(() => toolbar, html`
             <nimble-tabs-toolbar>
                 <nimble-button appearance="ghost">Toolbar Button</nimble-button>
@@ -48,7 +48,7 @@ const component = (
             Tab Two ${() => disabledName}
         </nimble-tab>
         <nimble-tab hidden>Tab Three</nimble-tab>
-        <nimble-tab-panel style="width: 450px;">${loremIpsum}</nimble-tab-panel>
+        <nimble-tab-panel>Tab content one</nimble-tab-panel>
         <nimble-tab-panel>Tab content two</nimble-tab-panel>
         <nimble-tab-panel>Tab content three</nimble-tab-panel>
     </nimble-tabs>
@@ -77,4 +77,13 @@ export const textCustomized: Story = createMatrixThemeStory(
             </nimble-tabs>
         `
     )
+);
+
+export const panelOverflow: Story = createStory(
+    html`
+        <nimble-tabs style="height: 120px; width: 400px;">
+            <nimble-tab>Tab One</nimble-tab>
+            <nimble-tab-panel style="width: 450px;">${loremIpsum}</nimble-tab-panel>
+        </nimble-tabs>
+    `
 );

--- a/packages/nimble-components/src/tabs/tests/tabs-matrix.stories.ts
+++ b/packages/nimble-components/src/tabs/tests/tabs-matrix.stories.ts
@@ -13,6 +13,7 @@ import { DisabledState, disabledStates } from '../../utilities/tests/states';
 import { hiddenWrapper } from '../../utilities/tests/hidden';
 import '../../all-components';
 import { textCustomizationWrapper } from '../../utilities/tests/text-customization';
+import { loremIpsum } from '../../utilities/tests/lorem-ipsum';
 
 const metadata: Meta = {
     title: 'Tests/Tabs',
@@ -36,7 +37,7 @@ const component = (
     toolbar: TabsToolbarState,
     [disabledName, disabled]: DisabledState
 ): ViewTemplate => html`
-    <nimble-tabs style="padding: 15px;">
+    <nimble-tabs style="padding: 15px; height: 120px; width: 400px;">
         ${when(() => toolbar, html`
             <nimble-tabs-toolbar>
                 <nimble-button appearance="ghost">Toolbar Button</nimble-button>
@@ -47,7 +48,7 @@ const component = (
             Tab Two ${() => disabledName}
         </nimble-tab>
         <nimble-tab hidden>Tab Three</nimble-tab>
-        <nimble-tab-panel>Tab content one</nimble-tab-panel>
+        <nimble-tab-panel style="width: 450px;">${loremIpsum}</nimble-tab-panel>
         <nimble-tab-panel>Tab content two</nimble-tab-panel>
         <nimble-tab-panel>Tab content three</nimble-tab-panel>
     </nimble-tabs>

--- a/packages/nimble-components/src/tabs/tests/tabs-matrix.stories.ts
+++ b/packages/nimble-components/src/tabs/tests/tabs-matrix.stories.ts
@@ -83,7 +83,9 @@ export const panelOverflow: Story = createStory(
     html`
         <nimble-tabs style="height: 120px; width: 400px;">
             <nimble-tab>Tab One</nimble-tab>
-            <nimble-tab-panel style="width: 450px;">${loremIpsum}</nimble-tab-panel>
+            <nimble-tab-panel style="width: 450px;"
+                >${loremIpsum}</nimble-tab-panel
+            >
         </nimble-tabs>
     `
 );

--- a/packages/nimble-components/src/tabs/tests/tabs.stories.ts
+++ b/packages/nimble-components/src/tabs/tests/tabs.stories.ts
@@ -15,8 +15,8 @@ sections of content, known as tab panels, that display one panel of content at a
 associated tab element, that when activated, displays the panel. The list of tab elements is arranged along
 one edge of the currently displayed panel, most commonly the top edge.
 
-Content in tab panels should be sized and arranged such that it fits horizontally within the panel. Your panels
-should not be horizontally scrollable. Vertical scrolling is perfectly acceptable.
+Content in tab panels should be sized and arranged such that it fits horizontally within the panel to avoid
+horizontal scrolling. Content may be any height; the tab panel will display a vertical scrollbar if necessary.
 
 If you want a sequence of tabs that navigate to different URLs, use the Anchor Tabs component instead.`;
 

--- a/packages/nimble-components/src/tabs/tests/tabs.stories.ts
+++ b/packages/nimble-components/src/tabs/tests/tabs.stories.ts
@@ -15,6 +15,9 @@ sections of content, known as tab panels, that display one panel of content at a
 associated tab element, that when activated, displays the panel. The list of tab elements is arranged along
 one edge of the currently displayed panel, most commonly the top edge.
 
+Content in tab panels should be sized and arranged such that it fits horizontally within the panel. Your panels
+should not be horizontally scrollable. Vertical scrolling is perfectly acceptable.
+
 If you want a sequence of tabs that navigate to different URLs, use the Anchor Tabs component instead.`;
 
 const metadata: Meta<TabsArgs> = {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Motivated by [AzDO bug 2247592](https://ni.visualstudio.com/DevCentral/_workitems/edit/2247592)
I think the correct fix to that bug is that we modify the `nimble-tabs` control itself to have tab panel contents be scrollable.


## 👩‍💻 Implementation

In tabs control, set the `overflow` of tab panels to `auto`.

## 🧪 Testing

Temporarily updated tabs story to include contents that were larger than the bounds of the panel and verified a scrollbar appeared.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
