### PR TITLE
Provide tooltip for column header

### DIFF
--- a/packages/nimble-components/src/table-column/base/template.ts
+++ b/packages/nimble-components/src/table-column/base/template.ts
@@ -1,8 +1,9 @@
 import { html } from '@microsoft/fast-element';
+import type { TableColumn } from '.';
 
-export const template = html`
+export const template = html<TableColumn>`
     <template>
-        <span class="header-content">
+        <span class="header-content" title="${x => x.textContent}">
             <slot></slot>
         </span>
     </template>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

We want a tooltip on column headers so that you can see the full value when there is ellipsized text.

## 👩‍💻 Implementation

Set the `title` based on the column element's `textContent`. This should be fine even when the header has no text (i.e. is an icon). If we support headers with both an icon and some text, I think this still gives the behavior we would want, i.e. hovering over the icon gives the icon tooltip text (if provided by the user), but hovering over the text gives that value in a tooltip.

## 🧪 Testing

Tested in Storybook

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
