### PR TITLE
Add a "large mode" to nimble dialog

### DIFF
--- a/change/@ni-nimble-components-14b23480-337b-4f84-a769-036ac4a6565c.json
+++ b/change/@ni-nimble-components-14b23480-337b-4f84-a769-036ac4a6565c.json
@@ -2,6 +2,6 @@
   "type": "minor",
   "comment": "Add a \"large mode\" option for the nimble-dialog which simply changes its width to 1024px and its height to 680px",
   "packageName": "@ni/nimble-components",
-  "email": "diana.anca@ni.com",
+  "email": "61456916+CuckooHashing@users.noreply.github.com",
   "dependentChangeType": "patch"
 }

--- a/change/@ni-nimble-components-14b23480-337b-4f84-a769-036ac4a6565c.json
+++ b/change/@ni-nimble-components-14b23480-337b-4f84-a769-036ac4a6565c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add a \"large mode\" option for the nimble-dialog which simply changes its width to 1024px and its height to 640px",
+  "packageName": "@ni/nimble-components",
+  "email": "diana.anca@ni.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-14b23480-337b-4f84-a769-036ac4a6565c.json
+++ b/change/@ni-nimble-components-14b23480-337b-4f84-a769-036ac4a6565c.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add a \"large mode\" option for the nimble-dialog which simply changes its width to 1024px and its height to 640px",
+  "comment": "Add a \"large mode\" option for the nimble-dialog which simply changes its width to 1024px and its height to 680px",
   "packageName": "@ni/nimble-components",
   "email": "diana.anca@ni.com",
   "dependentChangeType": "patch"

--- a/packages/nimble-components/src/dialog/styles.ts
+++ b/packages/nimble-components/src/dialog/styles.ts
@@ -39,6 +39,11 @@ export const styles = css`
         display: flex;
     }
 
+    :host([large-mode]) dialog {
+        min-width: 1024px;
+        min-height: 640px; 
+    }
+
     header {
         min-height: 48px;
         padding: 24px 24px 0px 24px;

--- a/packages/nimble-components/src/dialog/styles.ts
+++ b/packages/nimble-components/src/dialog/styles.ts
@@ -41,7 +41,7 @@ export const styles = css`
 
     :host([large-mode]) dialog {
         min-width: 1024px;
-        min-height: 640px; 
+        min-height: 680px; 
     }
 
     header {

--- a/packages/nimble-components/src/dialog/styles.ts
+++ b/packages/nimble-components/src/dialog/styles.ts
@@ -39,7 +39,7 @@ export const styles = css`
         display: flex;
     }
 
-    :host([large-mode]) dialog {
+    :host([config-dialog]) dialog {
         min-width: 1024px;
         min-height: 680px; 
     }

--- a/packages/nimble-components/src/dialog/tests/dialog.stories.ts
+++ b/packages/nimble-components/src/dialog/tests/dialog.stories.ts
@@ -19,6 +19,7 @@ interface DialogArgs {
     content: ExampleContentType;
     show: undefined;
     close: undefined;
+    largeMode: boolean;
     dialogRef: Dialog<string>;
     textFieldRef: TextField;
     openAndHandleResult: (
@@ -76,6 +77,7 @@ const metadata: Meta<DialogArgs> = {
             ?prevent-dismiss="${x => x.preventDismiss}"
             ?header-hidden="${x => x.headerHidden}"
             ?footer-hidden="${x => x.footerHidden}"
+            ?large-mode="${x => x.largeMode}"
         >
             <span slot="title">${x => x.title}</span>
             <span slot="subtitle">${x => x.subtitle}</span>
@@ -124,6 +126,9 @@ const metadata: Meta<DialogArgs> = {
     argTypes: {
         preventDismiss: {
             name: 'prevent-dismiss'
+        },
+        largeMode: {
+            name: 'large-mode'
         },
         title: {
             description:
@@ -182,6 +187,7 @@ const metadata: Meta<DialogArgs> = {
         footerHidden: false,
         includeFooterButtons: true,
         preventDismiss: false,
+        largeMode: false,
         content: ExampleContentType.shortContent,
         openAndHandleResult: async (dialogRef, textFieldRef) => {
             const reason = await dialogRef.show();

--- a/packages/nimble-components/src/dialog/tests/dialog.stories.ts
+++ b/packages/nimble-components/src/dialog/tests/dialog.stories.ts
@@ -77,7 +77,7 @@ const metadata: Meta<DialogArgs> = {
             ?prevent-dismiss="${x => x.preventDismiss}"
             ?header-hidden="${x => x.headerHidden}"
             ?footer-hidden="${x => x.footerHidden}"
-            ?large-mode="${x => x.largeMode}"
+            ?config-dialog="${x => x.largeMode}"
         >
             <span slot="title">${x => x.title}</span>
             <span slot="subtitle">${x => x.subtitle}</span>
@@ -128,7 +128,8 @@ const metadata: Meta<DialogArgs> = {
             name: 'prevent-dismiss'
         },
         largeMode: {
-            name: 'large-mode'
+            name: 'config-dialog',
+            description: 'Add the `config-dialog` attribute to the dialog to display it at a larger size for experiences like a wizard or configuration dialog.'
         },
         title: {
             description:


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

<!---
Provide some background and a description of your work.
What problem does this change solve?

Include links to issues, work items, or other discussions.
-->
The `nimble-dialog` component could be reused as a central overlay (not unlike how the `nimble-drawer` works as a base for a slide out), but its fixed 400x600px sizing is restrictive, so this change aims to make the dialog more flexible.

## 👩‍💻 Implementation

<!---
Describe how the change addresses the problem. Consider factors such as complexity, alternative solutions, performance impact, etc. 

Consider listing files with important changes or comment on them directly in the pull request.
-->

I added a new option, "large-mode", which sets the dialog's width to 1024px and its height to 680px, [as discussed here.](https://teams.microsoft.com/l/message/19:8e5f3e80de8146d5aaecdc2112e89191@thread.skype/1677858288435?tenantId=87ba1f9a-44cd-43a6-b008-6fdb45a5204e&groupId=41626d4a-3f1f-49e2-abdc-f590be4a329d&parentMessageId=1677858288435&teamName=ASW%20SystemLink&channelName=UX&createdTime=1677858288435&allowXTenantAccess=false) 

## 🧪 Testing

<!---
Detail the testing done to ensure this submission meets requirements. 

Include automated/manual test additions or modifications, testing done on a local build, private CI run results, and additional testing not covered by automatic pull request validation.
-->

Added this new mode to the component's storybook.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
