### PR TITLE
Support "." in table record field names

### DIFF
--- a/change/@ni-nimble-components-322fe65d-9bd8-4196-9432-5666963c5a2d.json
+++ b/change/@ni-nimble-components-322fe65d-9bd8-4196-9432-5666963c5a2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Support \".\" in table record field names",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -23,6 +23,7 @@ import { template } from './template';
 import {
     TableActionMenuToggleEventDetail,
     TableColumnSortDirection,
+    TableFieldValue,
     TableRecord,
     TableValidity
 } from './types';
@@ -338,7 +339,13 @@ export class Table<
         const generatedColumns = this.columns.map(column => {
             const columnDef: TanStackColumnDef<TData> = {
                 id: column.internalUniqueId,
-                accessorKey: column.operandDataRecordFieldName,
+                accessorFn: (data: TData): TableFieldValue => {
+                    const fieldName = column.operandDataRecordFieldName;
+                    if (typeof fieldName !== 'string') {
+                        return undefined;
+                    }
+                    return data[fieldName];
+                },
                 sortingFn: getTanStackSortingFunction(column.sortOperation)
             };
             return columnDef;

--- a/packages/nimble-components/src/table/tests/table-sorting.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-sorting.spec.ts
@@ -11,7 +11,6 @@ interface SimpleTableRecord extends TableRecord {
     stringData1?: string | null;
     stringData2?: string | null;
     stringData3?: string | null;
-    stringData4?: string | null;
 }
 
 // prettier-ignore
@@ -312,6 +311,29 @@ describe('Table sorting', () => {
         await waitForUpdatesAsync();
 
         expect(getRenderedRecordIds()).toEqual(['1', '2', '4', '3']);
+    });
+
+    it('can sort with have field names containing "."', async () => {
+        /* eslint-disable @typescript-eslint/naming-convention */
+        interface ExtendedTableRecord extends SimpleTableRecord {
+            'field.name.with.dots': string;
+        }
+
+        const data: readonly ExtendedTableRecord[] = [
+            { id: '1', 'field.name.with.dots': 'abc' },
+            { id: '2', 'field.name.with.dots': 'zzz' },
+            { id: '3', 'field.name.with.dots': 'hello' }
+        ] as const;
+
+        column1.fieldName = 'field.name.with.dots';
+        column1.sortDirection = TableColumnSortDirection.ascending;
+        column1.sortIndex = 0;
+        element.setData(data);
+        await connect();
+        await waitForUpdatesAsync();
+
+        expect(getRenderedRecordIds()).toEqual(['1', '3', '2']);
+        /* eslint-enable @typescript-eslint/naming-convention */
     });
 
     it('updating data maintains sort state and updates row order', async () => {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #1108 

## 👩‍💻 Implementation

Rather than setting `accessorKey` on a TanStack column, which tries to split keys on ".", I am now setting `accessorFn` that allows the nimble-table to do the lookup into the record and no longer split on ".".

## 🧪 Testing

Added a new unit test that failed before I made my change and passes with my change.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
