### PR TITLE
Set fixed height/width of div in tooltip matrix story

### DIFF
--- a/change/@ni-nimble-components-551098ab-47c2-4a26-bd8a-a8dec2bc2e16.json
+++ b/change/@ni-nimble-components-551098ab-47c2-4a26-bd8a-a8dec2bc2e16.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Set fixed height/width of div in tooltip matrix story",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/tooltip/styles.ts
+++ b/packages/nimble-components/src/tooltip/styles.ts
@@ -30,7 +30,7 @@ export const styles = css`
         color: ${tooltipCaptionFontColor};
         text-align: left;
         --ni-private-tooltip-border-color: ${hexToRgbaCssColor(Black91, 0.3)};
-        --ni-private-tooltip-background-color: ${White};
+        --ni-private-tooltip-background-color: ${Black15};
     }
 
     .tooltip {
@@ -69,10 +69,12 @@ export const styles = css`
         css`
             :host([severity='error']) {
                 --ni-private-tooltip-border-color: ${BannerFail100DarkUi};
+                --ni-private-tooltip-background-color: ${White};
             }
 
             :host([severity='information']) {
                 --ni-private-tooltip-border-color: ${Information100LightUi};
+                --ni-private-tooltip-background-color: ${White};
             }
         `
     ),

--- a/packages/nimble-components/src/tooltip/styles.ts
+++ b/packages/nimble-components/src/tooltip/styles.ts
@@ -30,7 +30,7 @@ export const styles = css`
         color: ${tooltipCaptionFontColor};
         text-align: left;
         --ni-private-tooltip-border-color: ${hexToRgbaCssColor(Black91, 0.3)};
-        --ni-private-tooltip-background-color: ${Black15};
+        --ni-private-tooltip-background-color: ${White};
     }
 
     .tooltip {
@@ -69,12 +69,10 @@ export const styles = css`
         css`
             :host([severity='error']) {
                 --ni-private-tooltip-border-color: ${BannerFail100DarkUi};
-                --ni-private-tooltip-background-color: ${White};
             }
 
             :host([severity='information']) {
                 --ni-private-tooltip-border-color: ${Information100LightUi};
-                --ni-private-tooltip-background-color: ${White};
             }
         `
     ),

--- a/packages/nimble-components/src/tooltip/tests/tooltip-matrix.stories.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip-matrix.stories.ts
@@ -63,7 +63,7 @@ const component = (
         }
 
         .container {
-            padding: 200px;
+            padding: 10px 200px 150px 200px;
             width: 100px;
             height: 50px;
         }
@@ -72,6 +72,8 @@ const component = (
             border: 1px solid var(${borderColor.cssCustomProperty});
             font: var(${bodyFont.cssCustomProperty});
             color: var(${bodyFontColor.cssCustomProperty});
+            width: 80px;
+            height: 60px;
         }
     </style>
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The tooltip matrix stories are randomly showing diffs. See #1106 

## 👩‍💻 Implementation

We hypothesize that the recent change to fallback fonts somehow introduced this intermittency. One proposed idea was to set fixed dimensions on the div that anchors the tooltip, in case that div was being resized due to font loading and somehow resulting in inconsistent layout at the time of the snapshot.

I also adjusted the padding so the test cases are arranged more densly.

## 🧪 Testing

We'll see if this reduces/elliminates the intermittency after being submitted.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
