### PR TITLE
Replaces usages of DesignSystem.tagFor() with exported element tags

### DIFF
--- a/change/@ni-nimble-components-03531a67-a4b6-4da6-9b5d-81020d9f82e2.json
+++ b/change/@ni-nimble-components-03531a67-a4b6-4da6-9b5d-81020d9f82e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Expose element tag name for some components that were missing it",
+  "packageName": "@ni/nimble-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/CONTRIBUTING.md
+++ b/packages/nimble-components/CONTRIBUTING.md
@@ -144,7 +144,7 @@ const nimbleButton = Button.compose({
 If you need to compose multiple elements into a new component, use previously built Nimble elements or basic HTML elements as your template building blocks.
 Extend `FoundationElement` and use a simple, unprefixed name, e.g. `QueryBuilder`.
 
-Use the `html` tagged template helper to define your custom template. See [Declaring Templates](https://www.fast.design/docs/fast-element/declaring-templates) for tips from FAST. Reference other nimble components using `DesignSystem.tagFor(NimbleComponentClass)` instead of hard coding the nimble tag name in templates. This improves the maintainability of the repo because it ensures usages of a component will be updated if it is renamed.
+Use the `html` tagged template helper to define your custom template. See [Declaring Templates](https://www.fast.design/docs/fast-element/declaring-templates) for tips from FAST. Reference other nimble components using `import { componentNameTag } ...;` instead of hard coding the nimble tag name in templates. This improves the maintainability of the repo because it ensures usages of a component will be updated if it is renamed.
 
 #### Build a new component without leveraging FAST Foundation or existing Nimble components
 

--- a/packages/nimble-components/src/anchor/tests/anchor.spec.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor.spec.ts
@@ -1,9 +1,5 @@
 import { html } from '@microsoft/fast-element';
-import {
-    DesignSystem,
-    Anchor as FoundationAnchor
-} from '@microsoft/fast-foundation';
-import { Anchor } from '..';
+import { Anchor, anchorTag } from '..';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { getSpecTypeByNamedList } from '../../utilities/tests/parameterized';
@@ -26,7 +22,7 @@ describe('Anchor', () => {
     });
 
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationAnchor)).toBe('nimble-anchor');
+        expect(anchorTag).toBe('nimble-anchor');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/anchor/tests/anchor.spec.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor.spec.ts
@@ -25,7 +25,7 @@ describe('Anchor', () => {
         await disconnect();
     });
 
-    it('should have its tag returned by tagFor(FoundationAnchor)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationAnchor)).toBe('nimble-anchor');
     });
 

--- a/packages/nimble-components/src/anchored-region/tests/anchored-region.spec.ts
+++ b/packages/nimble-components/src/anchored-region/tests/anchored-region.spec.ts
@@ -1,12 +1,8 @@
-import {
-    DesignSystem,
-    AnchoredRegion as FoundationAnchoredRegion
-} from '@microsoft/fast-foundation';
-import { AnchoredRegion } from '..';
+import { AnchoredRegion, anchoredRegionTag } from '..';
 
 describe('Anchored Region', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationAnchoredRegion)).toBe(
+        expect(anchoredRegionTag).toBe(
             'nimble-anchored-region'
         );
     });

--- a/packages/nimble-components/src/anchored-region/tests/anchored-region.spec.ts
+++ b/packages/nimble-components/src/anchored-region/tests/anchored-region.spec.ts
@@ -2,9 +2,7 @@ import { AnchoredRegion, anchoredRegionTag } from '..';
 
 describe('Anchored Region', () => {
     it('should export its tag', () => {
-        expect(anchoredRegionTag).toBe(
-            'nimble-anchored-region'
-        );
+        expect(anchoredRegionTag).toBe('nimble-anchored-region');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/anchored-region/tests/anchored-region.spec.ts
+++ b/packages/nimble-components/src/anchored-region/tests/anchored-region.spec.ts
@@ -5,7 +5,7 @@ import {
 import { AnchoredRegion } from '..';
 
 describe('Anchored Region', () => {
-    it('should have its tag returned by tagFor(FoundationAnchoredRegion)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationAnchoredRegion)).toBe(
             'nimble-anchored-region'
         );

--- a/packages/nimble-components/src/banner/template.ts
+++ b/packages/nimble-components/src/banner/template.ts
@@ -1,11 +1,10 @@
 import { html, when } from '@microsoft/fast-element';
-import { DesignSystem } from '@microsoft/fast-foundation';
 import type { Banner } from '.';
-import { Button } from '../button';
-import { IconExclamationMark } from '../icons/exclamation-mark';
-import { IconInfo } from '../icons/info';
-import { IconTriangleFilled } from '../icons/triangle-filled';
-import { IconXmark } from '../icons/xmark';
+import { buttonTag } from '../button';
+import { iconExclamationMarkTag } from '../icons/exclamation-mark';
+import { iconInfoTag } from '../icons/info';
+import { iconTriangleFilledTag } from '../icons/triangle-filled';
+import { iconXmarkTag } from '../icons/xmark';
 import { BannerSeverity } from './types';
 
 // prettier-ignore
@@ -35,13 +34,13 @@ export const template = html<Banner>`
     >
         <div class="icon">
             ${when(x => x.severity === BannerSeverity.error, html`
-                <${DesignSystem.tagFor(IconExclamationMark)}></${DesignSystem.tagFor(IconExclamationMark)}>
+                <${iconExclamationMarkTag}></${iconExclamationMarkTag}>
             `)}
             ${when(x => x.severity === BannerSeverity.warning, html`
-                <${DesignSystem.tagFor(IconTriangleFilled)}></${DesignSystem.tagFor(IconTriangleFilled)}>
+                <${iconTriangleFilledTag}></${iconTriangleFilledTag}>
             `)}
             ${when(x => x.severity === BannerSeverity.information, html`
-                <${DesignSystem.tagFor(IconInfo)}></${DesignSystem.tagFor(IconInfo)}>
+                <${iconInfoTag}></${iconInfoTag}>
             `)}
         </div>
         <div class="text">
@@ -52,10 +51,10 @@ export const template = html<Banner>`
             <slot name="action"></slot>
             <div class="dismiss">
                 ${when(x => !x.preventDismiss, html<Banner>`
-                    <${DesignSystem.tagFor(Button)} appearance="ghost" content-hidden @click="${x => x.dismissBanner()}">
-                        <${DesignSystem.tagFor(IconXmark)} slot="start"></${DesignSystem.tagFor(IconXmark)}>
+                    <${buttonTag} appearance="ghost" content-hidden @click="${x => x.dismissBanner()}">
+                        <${iconXmarkTag} slot="start"></${iconXmarkTag}>
                         ${x => x.dismissButtonLabel ?? 'Close'}
-                    </${DesignSystem.tagFor(Button)}>
+                    </${buttonTag}>
                 `)}
             </div>
         </div>

--- a/packages/nimble-components/src/breadcrumb-item/tests/breadcrumb-item.spec.ts
+++ b/packages/nimble-components/src/breadcrumb-item/tests/breadcrumb-item.spec.ts
@@ -1,12 +1,8 @@
-import {
-    DesignSystem,
-    BreadcrumbItem as FoundationBreadcrumbItem
-} from '@microsoft/fast-foundation';
-import { BreadcrumbItem } from '..';
+import { BreadcrumbItem, breadcrumbItemTag } from '..';
 
 describe('Breadcrumb Item', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationBreadcrumbItem)).toBe(
+        expect(breadcrumbItemTag).toBe(
             'nimble-breadcrumb-item'
         );
     });

--- a/packages/nimble-components/src/breadcrumb-item/tests/breadcrumb-item.spec.ts
+++ b/packages/nimble-components/src/breadcrumb-item/tests/breadcrumb-item.spec.ts
@@ -2,9 +2,7 @@ import { BreadcrumbItem, breadcrumbItemTag } from '..';
 
 describe('Breadcrumb Item', () => {
     it('should export its tag', () => {
-        expect(breadcrumbItemTag).toBe(
-            'nimble-breadcrumb-item'
-        );
+        expect(breadcrumbItemTag).toBe('nimble-breadcrumb-item');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/breadcrumb-item/tests/breadcrumb-item.spec.ts
+++ b/packages/nimble-components/src/breadcrumb-item/tests/breadcrumb-item.spec.ts
@@ -5,7 +5,7 @@ import {
 import { BreadcrumbItem } from '..';
 
 describe('Breadcrumb Item', () => {
-    it('should have its tag returned by tagFor(FoundationBreadcrumbItem)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationBreadcrumbItem)).toBe(
             'nimble-breadcrumb-item'
         );

--- a/packages/nimble-components/src/breadcrumb/tests/breadcrumb.spec.ts
+++ b/packages/nimble-components/src/breadcrumb/tests/breadcrumb.spec.ts
@@ -2,9 +2,7 @@ import { Breadcrumb, breadcrumbTag } from '..';
 
 describe('Breadcrumb', () => {
     it('should export its tag', () => {
-        expect(breadcrumbTag).toBe(
-            'nimble-breadcrumb'
-        );
+        expect(breadcrumbTag).toBe('nimble-breadcrumb');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/breadcrumb/tests/breadcrumb.spec.ts
+++ b/packages/nimble-components/src/breadcrumb/tests/breadcrumb.spec.ts
@@ -5,7 +5,7 @@ import {
 import { Breadcrumb } from '..';
 
 describe('Breadcrumb', () => {
-    it('should have its tag returned by tagFor(FoundationBreadcrumb)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationBreadcrumb)).toBe(
             'nimble-breadcrumb'
         );

--- a/packages/nimble-components/src/breadcrumb/tests/breadcrumb.spec.ts
+++ b/packages/nimble-components/src/breadcrumb/tests/breadcrumb.spec.ts
@@ -1,12 +1,8 @@
-import {
-    DesignSystem,
-    Breadcrumb as FoundationBreadcrumb
-} from '@microsoft/fast-foundation';
-import { Breadcrumb } from '..';
+import { Breadcrumb, breadcrumbTag } from '..';
 
 describe('Breadcrumb', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationBreadcrumb)).toBe(
+        expect(breadcrumbTag).toBe(
             'nimble-breadcrumb'
         );
     });

--- a/packages/nimble-components/src/button/tests/button.spec.ts
+++ b/packages/nimble-components/src/button/tests/button.spec.ts
@@ -1,12 +1,8 @@
-import {
-    DesignSystem,
-    Button as FoundationButton
-} from '@microsoft/fast-foundation';
-import { Button } from '..';
+import { Button, buttonTag } from '..';
 
 describe('Button', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationButton)).toBe('nimble-button');
+        expect(buttonTag).toBe('nimble-button');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/button/tests/button.spec.ts
+++ b/packages/nimble-components/src/button/tests/button.spec.ts
@@ -5,7 +5,7 @@ import {
 import { Button } from '..';
 
 describe('Button', () => {
-    it('should have its tag returned by tagFor(FoundationButton)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationButton)).toBe('nimble-button');
     });
 

--- a/packages/nimble-components/src/checkbox/tests/checkbox.spec.ts
+++ b/packages/nimble-components/src/checkbox/tests/checkbox.spec.ts
@@ -5,7 +5,7 @@ import {
 import { Checkbox } from '..';
 
 describe('Checkbox', () => {
-    it('should have its tag returned by tagFor(FoundationCheckbox)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationCheckbox)).toBe('nimble-checkbox');
     });
 

--- a/packages/nimble-components/src/checkbox/tests/checkbox.spec.ts
+++ b/packages/nimble-components/src/checkbox/tests/checkbox.spec.ts
@@ -1,12 +1,8 @@
-import {
-    DesignSystem,
-    Checkbox as FoundationCheckbox
-} from '@microsoft/fast-foundation';
-import { Checkbox } from '..';
+import { Checkbox, checkboxTag } from '..';
 
 describe('Checkbox', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationCheckbox)).toBe('nimble-checkbox');
+        expect(checkboxTag).toBe('nimble-checkbox');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/combobox/index.ts
+++ b/packages/nimble-components/src/combobox/index.ts
@@ -1,6 +1,5 @@
 import { attr, html, observable, ref } from '@microsoft/fast-element';
 import {
-    DesignSystem,
     Combobox as FoundationCombobox,
     ComboboxOptions,
     comboboxTemplate as template
@@ -11,10 +10,10 @@ import {
     keyEnter,
     keySpace
 } from '@microsoft/fast-web-utilities';
-import { ToggleButton } from '../toggle-button';
+import { ToggleButton, toggleButtonTag } from '../toggle-button';
 import { errorTextTemplate } from '../patterns/error/template';
-import { IconArrowExpanderDown } from '../icons/arrow-expander-down';
-import { IconExclamationMark } from '../icons/exclamation-mark';
+import { iconArrowExpanderDownTag } from '../icons/arrow-expander-down';
+import { iconExclamationMarkTag } from '../icons/exclamation-mark';
 
 import { styles } from './styles';
 import type { ErrorPattern } from '../patterns/error/types';
@@ -218,12 +217,12 @@ const nimbleCombobox = Combobox.compose<ComboboxOptions>({
     },
     end: html<Combobox>`
         <div class="end-slot-container">
-            <${DesignSystem.tagFor(IconExclamationMark)}
+            <${iconExclamationMarkTag}
                 severity="error"
                 class="error-icon"
-            ></${DesignSystem.tagFor(IconExclamationMark)}>
+            ></${iconExclamationMarkTag}>
             <div class="separator"></div>
-            <${DesignSystem.tagFor(ToggleButton)}
+            <${toggleButtonTag}
                 ${ref('dropdownButton')}
                 appearance="ghost"
                 ?checked="${x => x.open}"
@@ -238,12 +237,12 @@ const nimbleCombobox = Combobox.compose<ComboboxOptions>({
                 aria-expanded="${x => x.open}"
                 tabindex="-1"
             >
-                <${DesignSystem.tagFor(IconArrowExpanderDown)}
+                <${iconArrowExpanderDownTag}
                     slot="start"
                     class="dropdown-icon"
                 >
-                </${DesignSystem.tagFor(IconArrowExpanderDown)}>
-            </${DesignSystem.tagFor(ToggleButton)}>
+                </${iconArrowExpanderDownTag}>
+            </${toggleButtonTag}>
         </div>
         ${errorTextTemplate}
     `

--- a/packages/nimble-components/src/combobox/index.ts
+++ b/packages/nimble-components/src/combobox/index.ts
@@ -1,5 +1,6 @@
 import { attr, html, observable, ref } from '@microsoft/fast-element';
 import {
+    DesignSystem,
     Combobox as FoundationCombobox,
     ComboboxOptions,
     comboboxTemplate as template

--- a/packages/nimble-components/src/combobox/tests/combobox.spec.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox.spec.ts
@@ -83,7 +83,7 @@ describe('Combobox', () => {
         await disconnect();
     });
 
-    it('should have its tag returned by tagFor(FoundationCombobox)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationCombobox)).toBe('nimble-combobox');
     });
 

--- a/packages/nimble-components/src/combobox/tests/combobox.spec.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox.spec.ts
@@ -1,11 +1,7 @@
-import {
-    DesignSystem,
-    Combobox as FoundationCombobox
-} from '@microsoft/fast-foundation';
 import { html } from '@microsoft/fast-element';
 import { keyArrowDown, keyEnter } from '@microsoft/fast-web-utilities';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
-import { Combobox } from '..';
+import { Combobox, comboboxTag } from '..';
 import '../../list-option';
 import { ComboboxAutocomplete } from '../types';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
@@ -84,7 +80,7 @@ describe('Combobox', () => {
     });
 
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationCombobox)).toBe('nimble-combobox');
+        expect(comboboxTag).toBe('nimble-combobox');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/dialog/tests/dialog.spec.ts
+++ b/packages/nimble-components/src/dialog/tests/dialog.spec.ts
@@ -1,7 +1,6 @@
-import { DesignSystem } from '@microsoft/fast-foundation';
 import { html } from '@microsoft/fast-element';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
-import { Dialog, ExtendedDialog, UserDismissed } from '..';
+import { Dialog, dialogTag, ExtendedDialog, UserDismissed } from '..';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
@@ -27,7 +26,7 @@ describe('Dialog', () => {
     }
 
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(Dialog)).toBe('nimble-dialog');
+        expect(dialogTag).toBe('nimble-dialog');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/dialog/tests/dialog.spec.ts
+++ b/packages/nimble-components/src/dialog/tests/dialog.spec.ts
@@ -26,7 +26,7 @@ describe('Dialog', () => {
         ) as ExtendedDialog;
     }
 
-    it('should have its tag returned by tagFor(Dialog)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(Dialog)).toBe('nimble-dialog');
     });
 

--- a/packages/nimble-components/src/list-option/tests/list-option.spec.ts
+++ b/packages/nimble-components/src/list-option/tests/list-option.spec.ts
@@ -1,12 +1,8 @@
-import {
-    DesignSystem,
-    ListboxOption as FoundationListboxOption
-} from '@microsoft/fast-foundation';
-import { ListOption } from '..';
+import { ListOption, listOptionTag } from '..';
 
 describe('ListboxOption', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationListboxOption)).toBe(
+        expect(listOptionTag).toBe(
             'nimble-list-option'
         );
     });

--- a/packages/nimble-components/src/list-option/tests/list-option.spec.ts
+++ b/packages/nimble-components/src/list-option/tests/list-option.spec.ts
@@ -5,7 +5,7 @@ import {
 import { ListOption } from '..';
 
 describe('ListboxOption', () => {
-    it('should have its tag returned by tagFor(FoundationListboxOption)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationListboxOption)).toBe(
             'nimble-list-option'
         );

--- a/packages/nimble-components/src/list-option/tests/list-option.spec.ts
+++ b/packages/nimble-components/src/list-option/tests/list-option.spec.ts
@@ -2,9 +2,7 @@ import { ListOption, listOptionTag } from '..';
 
 describe('ListboxOption', () => {
     it('should export its tag', () => {
-        expect(listOptionTag).toBe(
-            'nimble-list-option'
-        );
+        expect(listOptionTag).toBe('nimble-list-option');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/menu-button/template.ts
+++ b/packages/nimble-components/src/menu-button/template.ts
@@ -1,8 +1,7 @@
 import { html, ref, slotted, when } from '@microsoft/fast-element';
-import { DesignSystem } from '@microsoft/fast-foundation';
 import type { MenuButton } from '.';
-import { ToggleButton } from '../toggle-button';
-import { AnchoredRegion } from '../anchored-region';
+import { toggleButtonTag } from '../toggle-button';
+import { anchoredRegionTag } from '../anchored-region';
 
 // prettier-ignore
 export const template = html<MenuButton>`
@@ -10,7 +9,7 @@ export const template = html<MenuButton>`
         ?open="${x => x.open}"
         @focusout="${(x, c) => x.focusoutHandler(c.event as FocusEvent)}"
     >
-        <${DesignSystem.tagFor(ToggleButton)}
+        <${toggleButtonTag}
             part="button"
             appearance="${x => x.appearance}"
             ?content-hidden="${x => x.contentHidden}"
@@ -27,11 +26,11 @@ export const template = html<MenuButton>`
             <slot slot="start" name="start"></slot>
             <slot></slot>
             <slot slot="end" name="end"></slot>
-        </${DesignSystem.tagFor(ToggleButton)}>
+        </${toggleButtonTag}>
         ${when(
         x => x.open,
         html<MenuButton>`
-            <${DesignSystem.tagFor(AnchoredRegion)}
+            <${anchoredRegionTag}
                 fixed-placement="true"
                 auto-update-mode="auto"
                 horizontal-inset="true"
@@ -45,7 +44,7 @@ export const template = html<MenuButton>`
                 <span part="menu">
                     <slot name="menu" ${slotted({ property: 'slottedMenus' })}></slot>
                 </span>
-            </${DesignSystem.tagFor(AnchoredRegion)}>
+            </${anchoredRegionTag}>
         `
     )}
     </template>

--- a/packages/nimble-components/src/menu-item/tests/menu-item.spec.ts
+++ b/packages/nimble-components/src/menu-item/tests/menu-item.spec.ts
@@ -2,9 +2,7 @@ import { MenuItem, menuItemTag } from '..';
 
 describe('MenuItem', () => {
     it('should export its tag', () => {
-        expect(menuItemTag).toBe(
-            'nimble-menu-item'
-        );
+        expect(menuItemTag).toBe('nimble-menu-item');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/menu-item/tests/menu-item.spec.ts
+++ b/packages/nimble-components/src/menu-item/tests/menu-item.spec.ts
@@ -1,12 +1,8 @@
-import {
-    DesignSystem,
-    MenuItem as FoundationMenuItem
-} from '@microsoft/fast-foundation';
-import { MenuItem } from '..';
+import { MenuItem, menuItemTag } from '..';
 
 describe('MenuItem', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationMenuItem)).toBe(
+        expect(menuItemTag).toBe(
             'nimble-menu-item'
         );
     });

--- a/packages/nimble-components/src/menu-item/tests/menu-item.spec.ts
+++ b/packages/nimble-components/src/menu-item/tests/menu-item.spec.ts
@@ -5,7 +5,7 @@ import {
 import { MenuItem } from '..';
 
 describe('MenuItem', () => {
-    it('should have its tag returned by tagFor(FoundationMenuItem)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationMenuItem)).toBe(
             'nimble-menu-item'
         );

--- a/packages/nimble-components/src/menu/tests/menu.spec.ts
+++ b/packages/nimble-components/src/menu/tests/menu.spec.ts
@@ -5,7 +5,7 @@ import {
 import { Menu } from '..';
 
 describe('Menu', () => {
-    it('should have its tag returned by tagFor(FoundationMenu)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationMenu)).toBe('nimble-menu');
     });
 

--- a/packages/nimble-components/src/menu/tests/menu.spec.ts
+++ b/packages/nimble-components/src/menu/tests/menu.spec.ts
@@ -1,12 +1,8 @@
-import {
-    DesignSystem,
-    Menu as FoundationMenu
-} from '@microsoft/fast-foundation';
-import { Menu } from '..';
+import { Menu, menuTag } from '..';
 
 describe('Menu', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationMenu)).toBe('nimble-menu');
+        expect(menuTag).toBe('nimble-menu');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/number-field/index.ts
+++ b/packages/nimble-components/src/number-field/index.ts
@@ -1,5 +1,6 @@
 import { attr, html } from '@microsoft/fast-element';
 import {
+    DesignSystem,
     NumberField as FoundationNumberField,
     NumberFieldOptions,
     numberFieldTemplate as template
@@ -87,7 +88,7 @@ const nimbleNumberField = NumberField.compose<NumberFieldOptions>({
             "Increment"
             <${iconAddTag}
                 slot="start">
-            </${IconAddTag}>
+            </${iconAddTag}>
         </${buttonTag}>
     `,
     end: html<NumberField>`

--- a/packages/nimble-components/src/number-field/index.ts
+++ b/packages/nimble-components/src/number-field/index.ts
@@ -1,6 +1,5 @@
 import { attr, html } from '@microsoft/fast-element';
 import {
-    DesignSystem,
     NumberField as FoundationNumberField,
     NumberFieldOptions,
     numberFieldTemplate as template
@@ -9,10 +8,10 @@ import { styles } from './styles';
 import { NumberFieldAppearance } from './types';
 import { errorTextTemplate } from '../patterns/error/template';
 import type { ErrorPattern } from '../patterns/error/types';
-import { Button } from '../button';
-import { IconMinusWide } from '../icons/minus-wide';
-import { IconAdd } from '../icons/add';
-import { IconExclamationMark } from '../icons/exclamation-mark';
+import { buttonTag } from '../button';
+import { iconMinusWideTag } from '../icons/minus-wide';
+import { iconAddTag } from '../icons/add';
+import { iconExclamationMarkTag } from '../icons/exclamation-mark';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -65,37 +64,37 @@ const nimbleNumberField = NumberField.compose<NumberFieldOptions>({
         delegatesFocus: true
     },
     stepDownGlyph: html`
-        <${DesignSystem.tagFor(Button)}
+        <${buttonTag}
             class="step-up-down-button"
             appearance="ghost"
             content-hidden
             tabindex="-1"
         >
             "Decrement"
-            <${DesignSystem.tagFor(IconMinusWide)}
+            <${iconMinusWideTag}
                 slot="start"
             >
-            </${DesignSystem.tagFor(IconMinusWide)}>
-        </${DesignSystem.tagFor(Button)}>
+            </${iconMinusWideTag}>
+        </${buttonTag}>
     `,
     stepUpGlyph: html`
-        <${DesignSystem.tagFor(Button)}
+        <${buttonTag}
             class="step-up-down-button"
             appearance="ghost"
             content-hidden
             tabindex="-1"
         >
             "Increment"
-            <${DesignSystem.tagFor(IconAdd)}
+            <${iconAddTag}
                 slot="start">
-            </${DesignSystem.tagFor(IconAdd)}>
-        </${DesignSystem.tagFor(Button)}>
+            </${IconAddTag}>
+        </${buttonTag}>
     `,
     end: html<NumberField>`
-        <${DesignSystem.tagFor(IconExclamationMark)}
+        <${iconExclamationMarkTag}
             severity="error"
             class="error-icon"
-        ></${DesignSystem.tagFor(IconExclamationMark)}>
+        ></${iconExclamationMarkTag}>
         ${errorTextTemplate}
     `
 });

--- a/packages/nimble-components/src/number-field/tests/number-field.spec.ts
+++ b/packages/nimble-components/src/number-field/tests/number-field.spec.ts
@@ -5,7 +5,7 @@ import {
 import { NumberField } from '..';
 
 describe('NumberField', () => {
-    it('should have its tag returned by tagFor(FoundationNumberField)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationNumberField)).toBe(
             'nimble-number-field'
         );

--- a/packages/nimble-components/src/number-field/tests/number-field.spec.ts
+++ b/packages/nimble-components/src/number-field/tests/number-field.spec.ts
@@ -1,12 +1,8 @@
-import {
-    DesignSystem,
-    NumberField as FoundationNumberField
-} from '@microsoft/fast-foundation';
-import { NumberField } from '..';
+import { NumberField, numberFieldTag } from '..';
 
 describe('NumberField', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationNumberField)).toBe(
+        expect(numberFieldTag).toBe(
             'nimble-number-field'
         );
     });

--- a/packages/nimble-components/src/number-field/tests/number-field.spec.ts
+++ b/packages/nimble-components/src/number-field/tests/number-field.spec.ts
@@ -2,9 +2,7 @@ import { NumberField, numberFieldTag } from '..';
 
 describe('NumberField', () => {
     it('should export its tag', () => {
-        expect(numberFieldTag).toBe(
-            'nimble-number-field'
-        );
+        expect(numberFieldTag).toBe('nimble-number-field');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/radio-group/tests/radio-group.spec.ts
+++ b/packages/nimble-components/src/radio-group/tests/radio-group.spec.ts
@@ -5,7 +5,7 @@ import {
 import { RadioGroup } from '..';
 
 describe('Radio Group', () => {
-    it('should have its tag returned by tagFor(FoundationRadioGroup)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationRadioGroup)).toBe(
             'nimble-radio-group'
         );

--- a/packages/nimble-components/src/radio-group/tests/radio-group.spec.ts
+++ b/packages/nimble-components/src/radio-group/tests/radio-group.spec.ts
@@ -1,12 +1,8 @@
-import {
-    DesignSystem,
-    RadioGroup as FoundationRadioGroup
-} from '@microsoft/fast-foundation';
-import { RadioGroup } from '..';
+import { RadioGroup, radioGroupTag } from '..';
 
 describe('Radio Group', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationRadioGroup)).toBe(
+        expect(radioGroupTag).toBe(
             'nimble-radio-group'
         );
     });

--- a/packages/nimble-components/src/radio-group/tests/radio-group.spec.ts
+++ b/packages/nimble-components/src/radio-group/tests/radio-group.spec.ts
@@ -2,9 +2,7 @@ import { RadioGroup, radioGroupTag } from '..';
 
 describe('Radio Group', () => {
     it('should export its tag', () => {
-        expect(radioGroupTag).toBe(
-            'nimble-radio-group'
-        );
+        expect(radioGroupTag).toBe('nimble-radio-group');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/radio/tests/radio.spec.ts
+++ b/packages/nimble-components/src/radio/tests/radio.spec.ts
@@ -5,7 +5,7 @@ import {
 import { Radio } from '..';
 
 describe('Radio', () => {
-    it('should have its tag returned by tagFor(FoundationRadio)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationRadio)).toBe('nimble-radio');
     });
 

--- a/packages/nimble-components/src/radio/tests/radio.spec.ts
+++ b/packages/nimble-components/src/radio/tests/radio.spec.ts
@@ -1,12 +1,8 @@
-import {
-    DesignSystem,
-    Radio as FoundationRadio
-} from '@microsoft/fast-foundation';
-import { Radio } from '..';
+import { Radio, radioTag } from '..';
 
 describe('Radio', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationRadio)).toBe('nimble-radio');
+        expect(radioTag).toBe('nimble-radio');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/select/index.ts
+++ b/packages/nimble-components/src/select/index.ts
@@ -10,7 +10,7 @@ import { styles } from './styles';
 import { DropdownAppearance } from '../patterns/dropdown/types';
 import { errorTextTemplate } from '../patterns/error/template';
 import type { ErrorPattern } from '../patterns/error/types';
-import { IconExclamationMark } from '../icons/exclamation-mark';
+import { iconExclamationMarkTag } from '../icons/exclamation-mark';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -82,10 +82,10 @@ const nimbleSelect = Select.compose<SelectOptions>({
     styles,
     indicator: arrowExpanderDown16X16.data,
     end: html<Select>`
-        <${DesignSystem.tagFor(IconExclamationMark)}
+        <${iconExclamationMarkTag}
             severity="error"
             class="error-icon"
-        ></${DesignSystem.tagFor(IconExclamationMark)}>
+        ></${iconExclamationMarkTag}>
         ${errorTextTemplate}
     `
 });

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -1,10 +1,6 @@
-import {
-    DesignSystem,
-    Select as FoundationSelect
-} from '@microsoft/fast-foundation';
 import { html, repeat } from '@microsoft/fast-element';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
-import { Select } from '..';
+import { Select, selectTag } from '..';
 import '../../list-option';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 
@@ -132,7 +128,7 @@ describe('Select', () => {
     });
 
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationSelect)).toBe('nimble-select');
+        expect(selectTag).toBe('nimble-select');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -131,7 +131,7 @@ describe('Select', () => {
         });
     });
 
-    it('should have its tag returned by tagFor(FoundationSelect)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationSelect)).toBe('nimble-select');
     });
 

--- a/packages/nimble-components/src/switch/tests/switch.spec.ts
+++ b/packages/nimble-components/src/switch/tests/switch.spec.ts
@@ -1,11 +1,7 @@
 import { html } from '@microsoft/fast-element';
-import {
-    DesignSystem,
-    Switch as FoundationSwitch
-} from '@microsoft/fast-foundation';
 import { keyEnter, keySpace } from '@microsoft/fast-web-utilities';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
-import { Switch } from '..';
+import { Switch, switchTag } from '..';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 
 async function setup(): Promise<Fixture<Switch>> {
@@ -27,7 +23,7 @@ describe('Switch', () => {
     });
 
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationSwitch)).toBe('nimble-switch');
+        expect(switchTag).toBe('nimble-switch');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/switch/tests/switch.spec.ts
+++ b/packages/nimble-components/src/switch/tests/switch.spec.ts
@@ -26,7 +26,7 @@ describe('Switch', () => {
         await disconnect();
     });
 
-    it('should have its tag returned by tagFor(FoundationSwitch)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationSwitch)).toBe('nimble-switch');
     });
 

--- a/packages/nimble-components/src/tab-panel/tests/tab-panel.spec.ts
+++ b/packages/nimble-components/src/tab-panel/tests/tab-panel.spec.ts
@@ -2,9 +2,7 @@ import { TabPanel, tabPanelTag } from '..';
 
 describe('TabPanel', () => {
     it('should export its tag', () => {
-        expect(tabPanelTag).toBe(
-            'nimble-tab-panel'
-        );
+        expect(tabPanelTag).toBe('nimble-tab-panel');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/tab-panel/tests/tab-panel.spec.ts
+++ b/packages/nimble-components/src/tab-panel/tests/tab-panel.spec.ts
@@ -5,7 +5,7 @@ import {
 import { TabPanel } from '..';
 
 describe('TabPanel', () => {
-    it('should have its tag returned by tagFor(FoundationTabPanel)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationTabPanel)).toBe(
             'nimble-tab-panel'
         );

--- a/packages/nimble-components/src/tab-panel/tests/tab-panel.spec.ts
+++ b/packages/nimble-components/src/tab-panel/tests/tab-panel.spec.ts
@@ -1,12 +1,8 @@
-import {
-    DesignSystem,
-    TabPanel as FoundationTabPanel
-} from '@microsoft/fast-foundation';
-import { TabPanel } from '..';
+import { TabPanel, tabPanelTag } from '..';
 
 describe('TabPanel', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationTabPanel)).toBe(
+        expect(tabPanelTag).toBe(
             'nimble-tab-panel'
         );
     });

--- a/packages/nimble-components/src/tab/tests/tab.spec.ts
+++ b/packages/nimble-components/src/tab/tests/tab.spec.ts
@@ -2,7 +2,7 @@ import { DesignSystem, Tab as FoundationTab } from '@microsoft/fast-foundation';
 import { Tab } from '..';
 
 describe('Tab', () => {
-    it('should have its tag returned by tagFor(FoundationTab)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationTab)).toBe('nimble-tab');
     });
 

--- a/packages/nimble-components/src/tab/tests/tab.spec.ts
+++ b/packages/nimble-components/src/tab/tests/tab.spec.ts
@@ -1,9 +1,8 @@
-import { DesignSystem, Tab as FoundationTab } from '@microsoft/fast-foundation';
-import { Tab } from '..';
+import { Tab, tabTag } from '..';
 
 describe('Tab', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationTab)).toBe('nimble-tab');
+        expect(tabTag).toBe('nimble-tab');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/table-column/text/tests/table-column-text.spec.ts
+++ b/packages/nimble-components/src/table-column/text/tests/table-column-text.spec.ts
@@ -1,7 +1,7 @@
 import { html } from '@microsoft/fast-element';
 import { DesignSystem } from '@microsoft/fast-foundation';
 import type { Table } from '../../../table';
-import { TableColumnText } from '..';
+import { tableColumnTextTag } from '..';
 import { waitForUpdatesAsync } from '../../../testing/async-helpers';
 import { type Fixture, fixture } from '../../../utilities/tests/fixture';
 import type { TableRecord } from '../../../table/types';
@@ -15,18 +15,16 @@ interface SimpleTableRecord extends TableRecord {
     anotherField?: string | null;
 }
 
-const tableColumnText = DesignSystem.tagFor(TableColumnText);
-
 // prettier-ignore
 async function setup(): Promise<Fixture<Table<SimpleTableRecord>>> {
     return fixture<Table<SimpleTableRecord>>(
         html`<nimble-table>
-                <${tableColumnText} field-name="field" placeholder="no value">
+                <${tableColumnTextTag} field-name="field" placeholder="no value">
                     Column 1
-                </${tableColumnText}>
-                <${tableColumnText} field-name="noPlaceholder">
+                </${tableColumnTextTag}>
+                <${tableColumnTextTag} field-name="noPlaceholder">
                     Column 2
-                </${tableColumnText}>
+                </${tableColumnTextTag}>
             </nimble-table>`
     );
 }

--- a/packages/nimble-components/src/table-column/text/tests/table-column-text.spec.ts
+++ b/packages/nimble-components/src/table-column/text/tests/table-column-text.spec.ts
@@ -1,7 +1,6 @@
 import { html } from '@microsoft/fast-element';
-import { DesignSystem } from '@microsoft/fast-foundation';
 import type { Table } from '../../../table';
-import { tableColumnTextTag } from '..';
+import { TableColumnText, tableColumnTextTag } from '..';
 import { waitForUpdatesAsync } from '../../../testing/async-helpers';
 import { type Fixture, fixture } from '../../../utilities/tests/fixture';
 import type { TableRecord } from '../../../table/types';

--- a/packages/nimble-components/src/table/components/cell/index.ts
+++ b/packages/nimble-components/src/table/components/cell/index.ts
@@ -117,3 +117,4 @@ const nimbleTableCell = TableCell.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleTableCell());
+export const tableCellTag = DesignSystem.tagFor(TableCell);

--- a/packages/nimble-components/src/table/components/cell/template.ts
+++ b/packages/nimble-components/src/table/components/cell/template.ts
@@ -1,8 +1,7 @@
 import { html, ref, when } from '@microsoft/fast-element';
-import { DesignSystem } from '@microsoft/fast-foundation';
 import type { TableCell } from '.';
-import { IconThreeDotsLine } from '../../../icons/three-dots-line';
-import { MenuButton } from '../../../menu-button';
+import { iconThreeDotsLineTag } from '../../../icons/three-dots-line';
+import { menuButtonTag } from '../../../menu-button';
 import {
     ButtonAppearance,
     MenuButtonToggleEventDetail
@@ -14,17 +13,17 @@ export const template = html<TableCell>`
         <div ${ref('cellContentContainer')} class="cell-content-container"></div>
 
         ${when(x => x.hasActionMenu, html<TableCell>`
-            <${DesignSystem.tagFor(MenuButton)}
+            <${menuButtonTag}
                 content-hidden
                 appearance="${ButtonAppearance.ghost}"
                 @beforetoggle="${(x, c) => x.onActionMenuBeforeToggle(c.event as CustomEvent<MenuButtonToggleEventDetail>)}"
                 @toggle="${(x, c) => x.onActionMenuToggle(c.event as CustomEvent<MenuButtonToggleEventDetail>)}"
                 class="action-menu"
             >
-                <${DesignSystem.tagFor(IconThreeDotsLine)} slot="start"></${DesignSystem.tagFor(IconThreeDotsLine)}>
+                <${iconThreeDotsLineTag} slot="start"></${iconThreeDotsLineTag}>
                 ${x => x.actionMenuLabel}
                 <slot name="cellActionMenu" slot="menu"></slot>
-            </${DesignSystem.tagFor(MenuButton)}>
+            </${menuButtonTag}>
         `)}
     </template>
 `;

--- a/packages/nimble-components/src/table/components/header/index.ts
+++ b/packages/nimble-components/src/table/components/header/index.ts
@@ -56,3 +56,4 @@ const nimbleTableHeader = TableHeader.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleTableHeader());
+export const tableHeaderTag = DesignSystem.tagFor(TableHeader);

--- a/packages/nimble-components/src/table/components/header/template.ts
+++ b/packages/nimble-components/src/table/components/header/template.ts
@@ -1,8 +1,7 @@
 import { html, when } from '@microsoft/fast-element';
-import { DesignSystem } from '@microsoft/fast-foundation';
 import type { TableHeader } from '.';
-import { IconArrowDown } from '../../../icons/arrow-down';
-import { IconArrowUp } from '../../../icons/arrow-up';
+import { iconArrowDownTag } from '../../../icons/arrow-down';
+import { iconArrowUpTag } from '../../../icons/arrow-up';
 import { TableColumnSortDirection } from '../../types';
 
 // prettier-ignore
@@ -12,10 +11,10 @@ export const template = html<TableHeader>`
 
         <span class="sort-indicator" aria-hidden="true">
             ${when(x => x.sortDirection === TableColumnSortDirection.ascending, html`
-                <${DesignSystem.tagFor(IconArrowUp)}></${DesignSystem.tagFor(IconArrowUp)}>
+                <${iconArrowUpTag}></${iconArrowUpTag}>
             `)}
             ${when(x => x.sortDirection === TableColumnSortDirection.descending, html`
-                <${DesignSystem.tagFor(IconArrowDown)}></${DesignSystem.tagFor(IconArrowDown)}>
+                <${iconArrowDownTag}></${iconArrowDownTag}>
             `)}
         </span>
     </template>

--- a/packages/nimble-components/src/table/components/header/tests/table-header.spec.ts
+++ b/packages/nimble-components/src/table/components/header/tests/table-header.spec.ts
@@ -1,8 +1,7 @@
 import { html } from '@microsoft/fast-element';
-import { DesignSystem } from '@microsoft/fast-foundation';
 import { TableHeader } from '..';
-import { IconArrowDown } from '../../../../icons/arrow-down';
-import { IconArrowUp } from '../../../../icons/arrow-up';
+import { iconArrowDownTag } from '../../../../icons/arrow-down';
+import { iconArrowUpTag } from '../../../../icons/arrow-up';
 import { waitForUpdatesAsync } from '../../../../testing/async-helpers';
 import { type Fixture, fixture } from '../../../../utilities/tests/fixture';
 import { TableColumnSortDirection } from '../../../types';
@@ -20,10 +19,10 @@ function getSortIcons(element: TableHeader): {
     const sortIndicatorContainer = element.shadowRoot!.querySelector('.sort-indicator')!;
     return {
         ascendingIcon: sortIndicatorContainer.querySelector(
-            DesignSystem.tagFor(IconArrowUp)
+            iconArrowUpTag
         ),
         descendingIcon: sortIndicatorContainer.querySelector(
-            DesignSystem.tagFor(IconArrowDown)
+            iconArrowDownTag
         )
     };
 }

--- a/packages/nimble-components/src/table/components/header/tests/table-header.spec.ts
+++ b/packages/nimble-components/src/table/components/header/tests/table-header.spec.ts
@@ -18,12 +18,8 @@ function getSortIcons(element: TableHeader): {
 } {
     const sortIndicatorContainer = element.shadowRoot!.querySelector('.sort-indicator')!;
     return {
-        ascendingIcon: sortIndicatorContainer.querySelector(
-            iconArrowUpTag
-        ),
-        descendingIcon: sortIndicatorContainer.querySelector(
-            iconArrowDownTag
-        )
+        ascendingIcon: sortIndicatorContainer.querySelector(iconArrowUpTag),
+        descendingIcon: sortIndicatorContainer.querySelector(iconArrowDownTag)
     };
 }
 

--- a/packages/nimble-components/src/table/components/row/index.ts
+++ b/packages/nimble-components/src/table/components/row/index.ts
@@ -124,3 +124,4 @@ const nimbleTableRow = TableRow.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleTableRow());
+export const tableRowTag = DesignSystem.tagFor(TableRow);

--- a/packages/nimble-components/src/table/components/row/template.ts
+++ b/packages/nimble-components/src/table/components/row/template.ts
@@ -1,15 +1,14 @@
 import { html, repeat, when } from '@microsoft/fast-element';
-import { DesignSystem } from '@microsoft/fast-foundation';
 import type { TableRow, ColumnState } from '.';
 import type { MenuButtonToggleEventDetail } from '../../../menu-button/types';
-import { TableCell } from '../cell';
+import { tableCellTag } from '../cell';
 
 // prettier-ignore
 export const template = html<TableRow>`
     <template role="row">
         ${repeat(x => x.columnStates, html<ColumnState, TableRow>`
             ${when(x => !x.column.columnHidden, html<ColumnState, TableRow>`
-                <${DesignSystem.tagFor(TableCell)}
+                <${tableCellTag}
                     class="cell"
                     :cellTemplate="${x => x.column.cellTemplate}"
                     :cellStyles="${x => x.column.cellStyles}"
@@ -26,7 +25,7 @@ export const template = html<TableRow>`
                             slot="cellActionMenu"
                         ></slot>
                     `)}
-                </${DesignSystem.tagFor(TableCell)}>
+                </${tableCellTag}>
             `)}
         `)}
     </template>

--- a/packages/nimble-components/src/table/components/row/tests/table-row.pageobject.ts
+++ b/packages/nimble-components/src/table/components/row/tests/table-row.pageobject.ts
@@ -10,6 +10,8 @@ export class TableRowPageObject<T extends TableRecord = TableRecord> {
     public constructor(private readonly tableRowElement: TableRow<T>) {}
 
     public getRenderedCell(columnIndex: number): TableCell | undefined {
-        return this.tableRowElement.shadowRoot!.querySelectorAll<TableCell>(tableCellTag)[columnIndex];
+        return this.tableRowElement.shadowRoot!.querySelectorAll<TableCell>(
+            tableCellTag
+        )[columnIndex];
     }
 }

--- a/packages/nimble-components/src/table/components/row/tests/table-row.pageobject.ts
+++ b/packages/nimble-components/src/table/components/row/tests/table-row.pageobject.ts
@@ -1,7 +1,6 @@
-import { DesignSystem } from '@microsoft/fast-foundation';
 import type { TableRow } from '..';
 import type { TableRecord } from '../../../types';
-import { TableCell } from '../../cell';
+import { tableCellTag, TableCell } from '../../cell';
 
 /**
  * Page object for the `nimble-table-row` component to provide consistent ways
@@ -11,8 +10,6 @@ export class TableRowPageObject<T extends TableRecord = TableRecord> {
     public constructor(private readonly tableRowElement: TableRow<T>) {}
 
     public getRenderedCell(columnIndex: number): TableCell | undefined {
-        return this.tableRowElement.shadowRoot!.querySelectorAll<TableCell>(
-            DesignSystem.tagFor(TableCell)
-        )[columnIndex];
+        return this.tableRowElement.shadowRoot!.querySelectorAll<TableCell>(tableCellTag)[columnIndex];
     }
 }

--- a/packages/nimble-components/src/table/template.ts
+++ b/packages/nimble-components/src/table/template.ts
@@ -6,11 +6,10 @@ import {
     repeat,
     when
 } from '@microsoft/fast-element';
-import { DesignSystem } from '@microsoft/fast-foundation';
 import type { VirtualItem } from '@tanstack/virtual-core';
 import type { Table } from '.';
-import { TableHeader } from './components/header';
-import { TableRow } from './components/row';
+import { tableHeaderTag } from './components/header';
+import { tableRowTag } from './components/row';
 import type { TableColumn } from '../table-column/base';
 import {
     TableActionMenuToggleEventDetail,
@@ -31,13 +30,13 @@ export const template = html<Table>`
                 <div class="header-row" role="row">
                     ${repeat(x => x.columns, html<TableColumn>`
                         ${when(x => !x.columnHidden, html<TableColumn, Table>`
-                            <${DesignSystem.tagFor(TableHeader)}
+                            <${tableHeaderTag}
                                 class="header"
                                 sort-direction="${x => (typeof x.sortIndex === 'number' ? x.sortDirection : TableColumnSortDirection.none)}"
                                 ?first-sorted-column="${(x, c) => x === c.parent.firstSortedColumn}"
                             >
                                 <slot name="${x => x.slot}"></slot>
-                            </${DesignSystem.tagFor(TableHeader)}>
+                            </${tableHeaderTag}>
                         `)}
                     `)}
                     <div class="header-scrollbar-spacer"></div>
@@ -49,7 +48,7 @@ export const template = html<Table>`
                      role="rowgroup">
                     ${when(x => x.columns.length > 0 && x.canRenderRows, html<Table>`
                         ${repeat(x => x.virtualizer.visibleItems, html<VirtualItem, Table>`
-                            <${DesignSystem.tagFor(TableRow)}
+                            <${tableRowTag}
                                 class="row"
                                 record-id="${(x, c) => c.parent.tableData[x.index]?.id}"
                                 :dataRecord="${(x, c) => c.parent.tableData[x.index]?.record}"
@@ -65,7 +64,7 @@ export const template = html<Table>`
                                     </slot>
                                 `)}
                             `)}                        
-                            </${DesignSystem.tagFor(TableRow)}>
+                            </${tableRowTag}>
                         `)}
                     `)}
                 </div>

--- a/packages/nimble-components/src/tabs/tests/tabs.spec.ts
+++ b/packages/nimble-components/src/tabs/tests/tabs.spec.ts
@@ -5,7 +5,7 @@ import {
 import { Tabs } from '..';
 
 describe('Tabs', () => {
-    it('should have its tag returned by tagFor(FoundationTabs)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationTabs)).toBe('nimble-tabs');
     });
 

--- a/packages/nimble-components/src/tabs/tests/tabs.spec.ts
+++ b/packages/nimble-components/src/tabs/tests/tabs.spec.ts
@@ -1,12 +1,8 @@
-import {
-    DesignSystem,
-    Tabs as FoundationTabs
-} from '@microsoft/fast-foundation';
-import { Tabs } from '..';
+import { Tabs, tabsTag } from '..';
 
 describe('Tabs', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationTabs)).toBe('nimble-tabs');
+        expect(tabsTag).toBe('nimble-tabs');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/text-area/tests/text-area.spec.ts
+++ b/packages/nimble-components/src/text-area/tests/text-area.spec.ts
@@ -1,12 +1,8 @@
-import {
-    DesignSystem,
-    TextArea as FoundationTextArea
-} from '@microsoft/fast-foundation';
-import { TextArea } from '..';
+import { TextArea, textAreaTag } from '..';
 
 describe('Text Area', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationTextArea)).toBe(
+        expect(textAreaTag).toBe(
             'nimble-text-area'
         );
     });

--- a/packages/nimble-components/src/text-area/tests/text-area.spec.ts
+++ b/packages/nimble-components/src/text-area/tests/text-area.spec.ts
@@ -2,9 +2,7 @@ import { TextArea, textAreaTag } from '..';
 
 describe('Text Area', () => {
     it('should export its tag', () => {
-        expect(textAreaTag).toBe(
-            'nimble-text-area'
-        );
+        expect(textAreaTag).toBe('nimble-text-area');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/text-area/tests/text-area.spec.ts
+++ b/packages/nimble-components/src/text-area/tests/text-area.spec.ts
@@ -5,7 +5,7 @@ import {
 import { TextArea } from '..';
 
 describe('Text Area', () => {
-    it('should have its tag returned by tagFor(FoundationTextArea)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationTextArea)).toBe(
             'nimble-text-area'
         );

--- a/packages/nimble-components/src/text-field/index.ts
+++ b/packages/nimble-components/src/text-field/index.ts
@@ -9,7 +9,7 @@ import { styles } from './styles';
 import { TextFieldAppearance } from './types';
 import { errorTextTemplate } from '../patterns/error/template';
 import type { ErrorPattern } from '../patterns/error/types';
-import { IconExclamationMark } from '../icons/exclamation-mark';
+import { iconExclamationMarkTag } from '../icons/exclamation-mark';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -57,10 +57,10 @@ const nimbleTextField = TextField.compose<TextFieldOptions>({
         delegatesFocus: true
     },
     end: html<TextField>`
-        <${DesignSystem.tagFor(IconExclamationMark)}
+        <${iconExclamationMarkTag}
             severity="error"
             class="error-icon"
-        ></${DesignSystem.tagFor(IconExclamationMark)}>
+        ></${iconExclamationMarkTag}>
         <span part="actions">
             <slot name="actions"></slot>
         </span>

--- a/packages/nimble-components/src/text-field/tests/text-field.spec.ts
+++ b/packages/nimble-components/src/text-field/tests/text-field.spec.ts
@@ -1,12 +1,8 @@
-import {
-    DesignSystem,
-    TextField as FoundationTextField
-} from '@microsoft/fast-foundation';
-import { TextField } from '..';
+import { TextField, textFieldTag } from '..';
 
 describe('TextField', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationTextField)).toBe(
+        expect(textFieldTag).toBe(
             'nimble-text-field'
         );
     });

--- a/packages/nimble-components/src/text-field/tests/text-field.spec.ts
+++ b/packages/nimble-components/src/text-field/tests/text-field.spec.ts
@@ -5,7 +5,7 @@ import {
 import { TextField } from '..';
 
 describe('TextField', () => {
-    it('should have its tag returned by tagFor(FoundationTextField)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationTextField)).toBe(
             'nimble-text-field'
         );

--- a/packages/nimble-components/src/text-field/tests/text-field.spec.ts
+++ b/packages/nimble-components/src/text-field/tests/text-field.spec.ts
@@ -2,9 +2,7 @@ import { TextField, textFieldTag } from '..';
 
 describe('TextField', () => {
     it('should export its tag', () => {
-        expect(textFieldTag).toBe(
-            'nimble-text-field'
-        );
+        expect(textFieldTag).toBe('nimble-text-field');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/toolbar/tests/toolbar.spec.ts
+++ b/packages/nimble-components/src/toolbar/tests/toolbar.spec.ts
@@ -1,12 +1,8 @@
-import {
-    DesignSystem,
-    Toolbar as FoundationToolbar
-} from '@microsoft/fast-foundation';
-import { Toolbar } from '..';
+import { Toolbar, toolbarTag } from '..';
 
 describe('Toolbar', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationToolbar)).toBe('nimble-toolbar');
+        expect(toolbarTag).toBe('nimble-toolbar');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/toolbar/tests/toolbar.spec.ts
+++ b/packages/nimble-components/src/toolbar/tests/toolbar.spec.ts
@@ -5,7 +5,7 @@ import {
 import { Toolbar } from '..';
 
 describe('Toolbar', () => {
-    it('should have its tag returned by tagFor(FoundationToolbar)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationToolbar)).toBe('nimble-toolbar');
     });
 

--- a/packages/nimble-components/src/tooltip/template.ts
+++ b/packages/nimble-components/src/tooltip/template.ts
@@ -1,8 +1,7 @@
 import { html, ref, when } from '@microsoft/fast-element';
-import { DesignSystem } from '@microsoft/fast-foundation';
-import { AnchoredRegion } from '../anchored-region';
-import { IconExclamationMark } from '../icons/exclamation-mark';
-import { IconInfo } from '../icons/info';
+import { anchoredRegionTag } from '../anchored-region';
+import { iconExclamationMarkTag } from '../icons/exclamation-mark';
+import { iconInfoTag } from '../icons/info';
 import type { Tooltip } from '.';
 
 // prettier-ignore
@@ -10,7 +9,7 @@ export const template = html<Tooltip>`
             ${when(
         x => x.tooltipVisible,
         html<Tooltip>`
-            <${DesignSystem.tagFor(AnchoredRegion)}
+            <${anchoredRegionTag}
                 class="anchored-region"
                 fixed-placement="true"
                 auto-update-mode="${x => x.autoUpdateMode}"
@@ -28,17 +27,17 @@ export const template = html<Tooltip>`
                 ${ref('region')}
             >
                 <div class="tooltip" part="tooltip" role="tooltip">
-                    <${DesignSystem.tagFor(IconExclamationMark)}
+                    <${iconExclamationMarkTag}
                         severity="error"
                         class="status-icon"
-                    ></${DesignSystem.tagFor(IconExclamationMark)}>
-                    <${DesignSystem.tagFor(IconInfo)}
+                    ></${iconExclamationMarkTag}>
+                    <${iconInfoTag}
                         severity="information"
                         class="status-icon"
-                    ></${DesignSystem.tagFor(IconInfo)}>
+                    ></${iconInfoTag}>
                     <slot></slot>
                 </div>
-            </${DesignSystem.tagFor(AnchoredRegion)}>
+            </${anchoredRegionTag}>
         `
     )}
 `;

--- a/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
@@ -371,7 +371,7 @@ describe('Tooltip', () => {
 
     // end of position tests ^
 
-    it('should have its tag returned by tagFor(FoundationTooltip)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationTooltip)).toBe('nimble-tooltip');
     });
 

--- a/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
@@ -1,12 +1,10 @@
 import {
-    DesignSystem,
     TooltipPosition,
-    Tooltip as FoundationTooltip
 } from '@microsoft/fast-foundation';
 import { html } from '@microsoft/fast-element';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
-import { Tooltip } from '..';
-import { AnchoredRegion } from '../../anchored-region';
+import { Tooltip, tooltipTag } from '..';
+import { anchoredRegionTag } from '../../anchored-region';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 
 async function setup(): Promise<Fixture<Tooltip>> {
@@ -55,7 +53,7 @@ describe('Tooltip', () => {
         expect(element.visible).toBeUndefined();
         expect(
             element.shadowRoot?.querySelector(
-                DesignSystem.tagFor(AnchoredRegion)
+                anchoredRegionTag
             )
         ).toBeNull();
 
@@ -72,7 +70,7 @@ describe('Tooltip', () => {
         expect(element.visible).toBe(true);
         expect(
             element.shadowRoot?.querySelector(
-                DesignSystem.tagFor(AnchoredRegion)
+                anchoredRegionTag
             )
         ).not.toBeNull();
 
@@ -89,7 +87,7 @@ describe('Tooltip', () => {
         expect(element.visible).toBe(false);
         expect(
             element.shadowRoot?.querySelector(
-                DesignSystem.tagFor(AnchoredRegion)
+                anchoredRegionTag
             )
         ).toBeNull();
 
@@ -372,7 +370,7 @@ describe('Tooltip', () => {
     // end of position tests ^
 
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationTooltip)).toBe('nimble-tooltip');
+        expect(tooltipTag).toBe('nimble-tooltip');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
@@ -1,6 +1,4 @@
-import {
-    TooltipPosition,
-} from '@microsoft/fast-foundation';
+import { TooltipPosition } from '@microsoft/fast-foundation';
 import { html } from '@microsoft/fast-element';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Tooltip, tooltipTag } from '..';
@@ -51,11 +49,7 @@ describe('Tooltip', () => {
         await waitForUpdatesAsync();
 
         expect(element.visible).toBeUndefined();
-        expect(
-            element.shadowRoot?.querySelector(
-                anchoredRegionTag
-            )
-        ).toBeNull();
+        expect(element.shadowRoot?.querySelector(anchoredRegionTag)).toBeNull();
 
         await disconnect();
     });
@@ -69,9 +63,7 @@ describe('Tooltip', () => {
 
         expect(element.visible).toBe(true);
         expect(
-            element.shadowRoot?.querySelector(
-                anchoredRegionTag
-            )
+            element.shadowRoot?.querySelector(anchoredRegionTag)
         ).not.toBeNull();
 
         await disconnect();
@@ -85,11 +77,7 @@ describe('Tooltip', () => {
         await waitForUpdatesAsync();
 
         expect(element.visible).toBe(false);
-        expect(
-            element.shadowRoot?.querySelector(
-                anchoredRegionTag
-            )
-        ).toBeNull();
+        expect(element.shadowRoot?.querySelector(anchoredRegionTag)).toBeNull();
 
         await disconnect();
     });

--- a/packages/nimble-components/src/tree-item/styles.ts
+++ b/packages/nimble-components/src/tree-item/styles.ts
@@ -147,12 +147,6 @@ export const styles = css`
         height: ${iconSize};
     }
 
-    ${
-        /*
-        Cannot call DesignSystem.tagFor(TreeItem) as this string is evaluated
-        before the registration of the element itself; the style is self-referencing.
-        Instead styling against the role which is more general and likely a better approach.
-    */ ''
     }
     ::slotted([role='treeitem']) {
         --ni-private-tree-item-nested-width: 1em;

--- a/packages/nimble-components/src/tree-item/styles.ts
+++ b/packages/nimble-components/src/tree-item/styles.ts
@@ -147,7 +147,6 @@ export const styles = css`
         height: ${iconSize};
     }
 
-    }
     ::slotted([role='treeitem']) {
         --ni-private-tree-item-nested-width: 1em;
         --ni-private-expand-collapse-button-nested-width: calc(

--- a/packages/nimble-components/src/tree-item/tests/tree-item.spec.ts
+++ b/packages/nimble-components/src/tree-item/tests/tree-item.spec.ts
@@ -1,12 +1,8 @@
-import {
-    DesignSystem,
-    TreeItem as FoundationTreeItem
-} from '@microsoft/fast-foundation';
-import { TreeItem } from '..';
+import { TreeItem, treeItemTag } from '..';
 
 describe('TreeItem', () => {
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationTreeItem)).toBe(
+        expect(treeItemTag).toBe(
             'nimble-tree-item'
         );
     });

--- a/packages/nimble-components/src/tree-item/tests/tree-item.spec.ts
+++ b/packages/nimble-components/src/tree-item/tests/tree-item.spec.ts
@@ -2,9 +2,7 @@ import { TreeItem, treeItemTag } from '..';
 
 describe('TreeItem', () => {
     it('should export its tag', () => {
-        expect(treeItemTag).toBe(
-            'nimble-tree-item'
-        );
+        expect(treeItemTag).toBe('nimble-tree-item');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/tree-item/tests/tree-item.spec.ts
+++ b/packages/nimble-components/src/tree-item/tests/tree-item.spec.ts
@@ -5,7 +5,7 @@ import {
 import { TreeItem } from '..';
 
 describe('TreeItem', () => {
-    it('should have its tag returned by tagFor(FoundationTreeItem)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationTreeItem)).toBe(
             'nimble-tree-item'
         );

--- a/packages/nimble-components/src/tree-view/tests/tree.spec.ts
+++ b/packages/nimble-components/src/tree-view/tests/tree.spec.ts
@@ -72,9 +72,7 @@ describe('TreeView', () => {
     });
 
     it('should export its tag', () => {
-        expect(treeViewTag).toBe(
-            'nimble-tree-view'
-        );
+        expect(treeViewTag).toBe('nimble-tree-view');
     });
 
     it('can construct an element instance', () => {

--- a/packages/nimble-components/src/tree-view/tests/tree.spec.ts
+++ b/packages/nimble-components/src/tree-view/tests/tree.spec.ts
@@ -1,14 +1,10 @@
-import {
-    DesignSystem,
-    TreeView as FoundationTreeView
-} from '@microsoft/fast-foundation';
 import { html, ref } from '@microsoft/fast-element';
 import { notebook16X16 } from '@ni/nimble-tokens/dist/icons/js';
 import { keyEnter } from '@microsoft/fast-web-utilities';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { clickElement } from '../../utilities/tests/component';
 import { TreeViewSelectionMode } from '../types';
-import { TreeView } from '..';
+import { TreeView, treeViewTag } from '..';
 import type { TreeItem } from '../../tree-item';
 import type { Button } from '../../button';
 import '../../tree-item';
@@ -76,7 +72,7 @@ describe('TreeView', () => {
     });
 
     it('should export its tag', () => {
-        expect(DesignSystem.tagFor(FoundationTreeView)).toBe(
+        expect(treeViewTag).toBe(
             'nimble-tree-view'
         );
     });

--- a/packages/nimble-components/src/tree-view/tests/tree.spec.ts
+++ b/packages/nimble-components/src/tree-view/tests/tree.spec.ts
@@ -75,7 +75,7 @@ describe('TreeView', () => {
         await disconnect();
     });
 
-    it('should have its tag returned by tagFor(FoundationTreeView)', () => {
+    it('should export its tag', () => {
         expect(DesignSystem.tagFor(FoundationTreeView)).toBe(
             'nimble-tree-view'
         );

--- a/packages/nimble-components/src/utilities/tests/storybook.ts
+++ b/packages/nimble-components/src/utilities/tests/storybook.ts
@@ -1,7 +1,6 @@
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import { DesignSystem } from '@microsoft/fast-foundation';
 import type { Story } from '@storybook/html';
-import { ThemeProvider } from '../../theme-provider';
+import { themeProviderTag } from '../../theme-provider';
 import type { Theme } from '../../theme-provider/types';
 import { createMatrix } from './matrix';
 import {
@@ -59,12 +58,12 @@ export const createUserSelectedThemeStory = <TSource>(
 ): Story<TSource> => {
     return (source: TSource, context: unknown): Element => {
         const wrappedViewTemplate = html<TSource>`
-            <${DesignSystem.tagFor(ThemeProvider)}
+            <${themeProviderTag}
                 theme="${getGlobalTheme(context)}"
                 class="code-hide-top-container"
             >
                 ${viewTemplate}
-            </${DesignSystem.tagFor(ThemeProvider)}>
+            </${themeProviderTag}>
         `;
         const fragment = renderViewTemplate(wrappedViewTemplate, source);
         const content = fragment.firstElementChild!;
@@ -83,7 +82,7 @@ export const createFixedThemeStory = <TSource>(
 ): Story<TSource> => {
     return (source: TSource, _context: unknown): Element => {
         const wrappedViewTemplate = html<TSource>`
-            <${DesignSystem.tagFor(ThemeProvider)}
+            <${themeProviderTag}
                 theme="${backgroundState.theme}"
                 class="code-hide-top-container"
             >
@@ -101,7 +100,7 @@ export const createFixedThemeStory = <TSource>(
                 >
                     ${viewTemplate}
                 </div>
-            </${DesignSystem.tagFor(ThemeProvider)}>
+            </${themeProviderTag}>
         `;
         const fragment = renderViewTemplate(wrappedViewTemplate, source);
         const content = fragment.firstElementChild!;
@@ -118,12 +117,12 @@ export const createMatrixThemeStory = <TSource>(
     return (source: TSource, _context: unknown): Element => {
         const matrixTemplate = createMatrix(
             ({ theme, value }: BackgroundState) => html`
-                <${DesignSystem.tagFor(ThemeProvider)}
+                <${themeProviderTag}
                     theme="${theme}">
                     <div style="background-color: ${value}; padding:20px;">
                         ${viewTemplate}
                     </div>
-                </${DesignSystem.tagFor(ThemeProvider)}>
+                </${themeProviderTag}>
             `,
             [backgroundStates]
         );


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Addresses most of #1095. We're moving to a custom Nimble API that encapsulates from `DesignSystem.tagFor()` because it appears to be going away in a future FAST version.

## 👩‍💻 Implementation

- Find and replace usages of tagFor except for those within each component that are used to expose the tag
- Expose component tags for a few components that were missing it

## 🧪 Testing

Relying on pipeline.

I briefly considered adding `no-restricted-imports` lint configuration to enforce this but it seemed like it would be incomplete to still allow it in `index.ts` and `*.spec.ts` (not to mention a bit messy to add more conditional configuration when [our configuration is already moderately complex](https://github.com/ni/nimble/blob/d0454c23c82195d6b7530cbb3ff3da2ce21afabb/packages/nimble-components/src/.eslintrc.js#L95)).


## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
