### PR TITLE
Disable flaky tooltip tests

### DIFF
--- a/change/@ni-nimble-components-137e9221-a635-4180-8f43-b970c11f8d6e.json
+++ b/change/@ni-nimble-components-137e9221-a635-4180-8f43-b970c11f8d6e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Disable flaky visual tests",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/tooltip/tests/tooltip-matrix.stories.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip-matrix.stories.ts
@@ -111,6 +111,7 @@ export const tooltipLightThemeWhiteBackground: Story = createFixedThemeStory(
 );
 
 // Temporarily disabling this test because of flakiness
+// See: https://github.com/ni/nimble/issues/1106
 tooltipLightThemeWhiteBackground.parameters = {
     chromatic: { disableSnapshot: true }
 };
@@ -125,6 +126,7 @@ export const tooltipColorThemeDarkGreenBackground: Story = createFixedThemeStory
 );
 
 // Temporarily disabling this test because of flakiness
+// See: https://github.com/ni/nimble/issues/1106
 tooltipColorThemeDarkGreenBackground.parameters = {
     chromatic: { disableSnapshot: true }
 };
@@ -135,6 +137,7 @@ export const tooltipDarkThemeBlackBackground: Story = createFixedThemeStory(
 );
 
 // Temporarily disabling this test because of flakiness
+// See: https://github.com/ni/nimble/issues/1106
 tooltipDarkThemeBlackBackground.parameters = {
     chromatic: { disableSnapshot: true }
 };

--- a/packages/nimble-components/src/tooltip/tests/tooltip-matrix.stories.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip-matrix.stories.ts
@@ -110,6 +110,11 @@ export const tooltipLightThemeWhiteBackground: Story = createFixedThemeStory(
     lightThemeWhiteBackground
 );
 
+// Temporarily disabling this test because of flakiness
+tooltipLightThemeWhiteBackground.parameters = {
+    chromatic: { disableSnapshot: true }
+};
+
 export const tooltipColorThemeDarkGreenBackground: Story = createFixedThemeStory(
     createMatrix(component, [
         textStates,
@@ -119,10 +124,20 @@ export const tooltipColorThemeDarkGreenBackground: Story = createFixedThemeStory
     colorThemeDarkGreenBackground
 );
 
+// Temporarily disabling this test because of flakiness
+tooltipColorThemeDarkGreenBackground.parameters = {
+    chromatic: { disableSnapshot: true }
+};
+
 export const tooltipDarkThemeBlackBackground: Story = createFixedThemeStory(
     createMatrix(component, [textStates, severityStates, iconVisibleStates]),
     darkThemeBlackBackground
 );
+
+// Temporarily disabling this test because of flakiness
+tooltipDarkThemeBlackBackground.parameters = {
+    chromatic: { disableSnapshot: true }
+};
 
 export const hiddenTooltip: Story = createStory(
     hiddenWrapper(html`<${tooltipTag} hidden>Hidden Tooltip</${tooltipTag}>`)


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The tooltip matrix visual tests are rendering differently in Firefox from run to run. Until we can get them rendering in a consistent way, we want to disable these so we don't have to keep accepting differences.

## 👩‍💻 Implementation

Used the `disableSnapshot` flag.

## 🧪 Testing

Will be tested by the pipeline build.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
