### PR TITLE
Add missing properties to NimbleAnchorTab in Blazor

### DIFF
--- a/change/@ni-nimble-blazor-70284df8-a76c-4e18-ad77-9309fdd9c3d9.json
+++ b/change/@ni-nimble-blazor-70284df8-a76c-4e18-ad77-9309fdd9c3d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add missing properties to NimbleAnchorTab",
+  "packageName": "@ni/nimble-blazor",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleAnchorTab.razor
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleAnchorTab.razor
@@ -1,5 +1,12 @@
 @namespace NimbleBlazor
 <nimble-anchor-tab
+    href="@Href"
+    hreflang="@HrefLang"
+    ping="@Ping"
+    referrerpolicy="@ReferrerPolicy"
+    rel="@Rel"
+    target="@Target"
+    type="@Type"
     disabled="@Disabled"
     @attributes="AdditionalAttributes">
     @ChildContent

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleAnchorTab.razor.cs
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleAnchorTab.razor.cs
@@ -8,6 +8,48 @@ namespace NimbleBlazor;
 public partial class NimbleAnchorTab : ComponentBase
 {
     /// <summary>
+    /// The URL the hyperlink references. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a for more information.
+    /// </summary>
+    [Parameter]
+    public string? Href { get; set; }
+
+    /// <summary>
+    /// Hints at the human language of the linked URL. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a for more information.
+    /// </summary>
+    [Parameter]
+    public string? HrefLang { get; set; }
+
+    /// <summary>
+    /// A space-separated list of URLs. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a for more information.
+    /// </summary>
+    [Parameter]
+    public string? Ping { get; set; }
+
+    /// <summary>
+    /// How much of the referrer to send when following the link. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a for more information.
+    /// </summary>
+    [Parameter]
+    public string? ReferrerPolicy { get; set; }
+
+    /// <summary>
+    /// The relationship of the linked URL as space-separated link types. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a for more information.
+    /// </summary>
+    [Parameter]
+    public string? Rel { get; set; }
+
+    /// <summary>
+    /// Where to display the linked URL, as the name for a browsing context. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a for more information.
+    /// </summary>
+    [Parameter]
+    public string? Target { get; set; }
+
+    /// <summary>
+    /// Hints at the linked URL's format with a MIME type. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a for more information.
+    /// </summary>
+    [Parameter]
+    public string? Type { get; set; }
+
+    /// <summary>
     /// The child content of the element.
     /// </summary>
     [Parameter]

--- a/packages/nimble-blazor/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorTabTests.cs
+++ b/packages/nimble-blazor/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorTabTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Linq.Expressions;
+using Bunit;
+using Xunit;
+
+namespace NimbleBlazor.Tests.Unit.Components;
+
+/// <summary>
+/// Tests for <see cref="NimbleAnchorTab"/>.
+/// </summary>
+public class NimbleAnchorTabTests
+{
+    [Fact]
+    public void NimbleAnchorTab_Render_HasAnchorTabMarkup()
+    {
+        var context = new TestContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        var expectedMarkup = "nimble-anchor-tab";
+
+        var menuItem = context.RenderComponent<NimbleAnchorTab>();
+
+        Assert.Contains(expectedMarkup, menuItem.Markup);
+    }
+
+    [Fact]
+    public void AnchorTabHref_AttributeIsSet()
+    {
+        var anchorTab = RenderWithPropertySet(x => x.Href, "foo");
+
+        Assert.Contains("href=\"foo\"", anchorTab.Markup);
+    }
+
+    [Fact]
+    public void AnchorTabHrefLang_AttributeIsSet()
+    {
+        var anchorTab = RenderWithPropertySet(x => x.HrefLang, "foo");
+
+        Assert.Contains("hreflang=\"foo\"", anchorTab.Markup);
+    }
+
+    [Fact]
+    public void AnchorTabPing_AttributeIsSet()
+    {
+        var anchorTab = RenderWithPropertySet(x => x.Ping, "foo");
+
+        Assert.Contains("ping=\"foo\"", anchorTab.Markup);
+    }
+
+    [Fact]
+    public void AnchorTabReferrerPolicy_AttributeIsSet()
+    {
+        var anchorTab = RenderWithPropertySet(x => x.ReferrerPolicy, "foo");
+
+        Assert.Contains("referrerpolicy=\"foo\"", anchorTab.Markup);
+    }
+
+    [Fact]
+    public void AnchorTabRel_AttributeIsSet()
+    {
+        var anchorTab = RenderWithPropertySet(x => x.Rel, "foo");
+
+        Assert.Contains("rel=\"foo\"", anchorTab.Markup);
+    }
+
+    [Fact]
+    public void AnchorTabTarget_AttributeIsSet()
+    {
+        var anchorTab = RenderWithPropertySet(x => x.Target, "foo");
+
+        Assert.Contains("target=\"foo\"", anchorTab.Markup);
+    }
+
+    [Fact]
+    public void AnchorTabType_AttributeIsSet()
+    {
+        var anchorTab = RenderWithPropertySet(x => x.Type, "foo");
+
+        Assert.Contains("type=\"foo\"", anchorTab.Markup);
+    }
+
+    [Fact]
+    public void AnchorTabDisabled_AttributeIsSet()
+    {
+        var anchorTab = RenderWithPropertySet(x => x.Disabled, true);
+
+        Assert.Contains("disabled", anchorTab.Markup);
+    }
+
+    private IRenderedComponent<NimbleAnchorTab> RenderWithPropertySet<TProperty>(Expression<Func<NimbleAnchorTab, TProperty>> propertyGetter, TProperty propertyValue)
+    {
+        var context = new TestContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        return context.RenderComponent<NimbleAnchorTab>(p => p.Add(propertyGetter, propertyValue));
+    }
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Somehow I left the seven link properties (href, target, etc) off of the Blazor wrapper for the anchor tab. I didn't notice, because the example app's anchor tabs still navigated as expected.

## 👩‍💻 Implementation

Added the seven missing properties and added tests for them. Previously, only the anchor tabs (as opposed to anchor tab, singular) component had tests.

## 🧪 Testing

Tests pass

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
