### PR TITLE
Update table header styling to not reserve space for sort icon

### DIFF
--- a/change/@ni-nimble-components-6c0ea993-99db-424a-beaa-3efe23616755.json
+++ b/change/@ni-nimble-components-6c0ea993-99db-424a-beaa-3efe23616755.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update table header styling to not reserve space for sort icon",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/components/header/styles.ts
+++ b/packages/nimble-components/src/table/components/header/styles.ts
@@ -23,6 +23,5 @@ export const styles = css`
 
     .sort-indicator {
         padding: 0px calc(${standardPadding} / 2);
-        width: ${standardPadding};
     }
 `;

--- a/packages/nimble-components/src/table/components/header/template.ts
+++ b/packages/nimble-components/src/table/components/header/template.ts
@@ -9,13 +9,11 @@ export const template = html<TableHeader>`
     <template role="columnheader" aria-sort="${x => x.ariaSort}">
         <slot></slot>
 
-        <span class="sort-indicator" aria-hidden="true">
-            ${when(x => x.sortDirection === TableColumnSortDirection.ascending, html`
-                <${iconArrowUpTag}></${iconArrowUpTag}>
-            `)}
-            ${when(x => x.sortDirection === TableColumnSortDirection.descending, html`
-                <${iconArrowDownTag}></${iconArrowDownTag}>
-            `)}
-        </span>
+        ${when(x => x.sortDirection === TableColumnSortDirection.ascending, html`
+            <${iconArrowUpTag} class="sort-indicator" aria-hidden="true"></${iconArrowUpTag}>
+        `)}
+        ${when(x => x.sortDirection === TableColumnSortDirection.descending, html`
+            <${iconArrowDownTag} class="sort-indicator" aria-hidden="true"></${iconArrowDownTag}>
+        `)}
     </template>
 `;

--- a/packages/nimble-components/src/table/components/header/tests/table-header.spec.ts
+++ b/packages/nimble-components/src/table/components/header/tests/table-header.spec.ts
@@ -16,10 +16,9 @@ function getSortIcons(element: TableHeader): {
     ascendingIcon: HTMLElement | null,
     descendingIcon: HTMLElement | null
 } {
-    const sortIndicatorContainer = element.shadowRoot!.querySelector('.sort-indicator')!;
     return {
-        ascendingIcon: sortIndicatorContainer.querySelector(iconArrowUpTag),
-        descendingIcon: sortIndicatorContainer.querySelector(iconArrowDownTag)
+        ascendingIcon: element.shadowRoot!.querySelector(`${iconArrowUpTag}.sort-indicator`),
+        descendingIcon: element.shadowRoot!.querySelector(`${iconArrowDownTag}.sort-indicator`)
     };
 }
 

--- a/packages/nimble-components/src/table/components/header/tests/table-header.spec.ts
+++ b/packages/nimble-components/src/table/components/header/tests/table-header.spec.ts
@@ -17,8 +17,12 @@ function getSortIcons(element: TableHeader): {
     descendingIcon: HTMLElement | null
 } {
     return {
-        ascendingIcon: element.shadowRoot!.querySelector(`${iconArrowUpTag}.sort-indicator`),
-        descendingIcon: element.shadowRoot!.querySelector(`${iconArrowDownTag}.sort-indicator`)
+        ascendingIcon: element.shadowRoot!.querySelector(
+            `${iconArrowUpTag}.sort-indicator`
+        ),
+        descendingIcon: element.shadowRoot!.querySelector(
+            `${iconArrowDownTag}.sort-indicator`
+        )
     };
 }
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #1127 

## 👩‍💻 Implementation

We no longer need a wrapper around the sort icons to reserve their space when neither icon is displayed. Therefore, I got rid of the wrapping `span` and moved the padding to the icon element.

Note: The visual diff is because the `span` was removed. The `span` by default had a line height of 18px even though the icon is only 16px tall. Now, the icon should be correctly vertically centered (though I don't think anyone noticed it was 1px off from center previously).

## 🧪 Testing

- Updated unit tests
- Manually verified that the behavior is correct with a long, ellipsed column header. Previously, the ellipsis in the column header would occur in the same place regardless of whether or not the column was sorted. Now, the location of the ellipsis in the column header is dependent on whether or not the column is sorted.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
