### PR TITLE
Add npmrc pointing to public registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,8 +119,5 @@ package-lock.json
 # macOS
 .DS_Store
 
-# local npmrc files
-.npmrc
-
 # lighthouse build directory
 .lighthouseci/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Specify the public npm registry in an npmrc file for nimble as discussed in the [NI internal npm config doc](https://dev.azure.com/ni/DevCentral/_wiki/wikis/AppCentral.wiki/60920/Configure-NPM-to-use-JFrog-Artifactory).

## 👩‍💻 Implementation

Add an npmrc file configured for the npm repo.

## 🧪 Testing

Verified locally that adding new deps did not pull from the JFrog artifactory.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed. Shouldn't be observable externally.
