### PR TITLE
Added Blazor EditForm input validation support for some components

### DIFF
--- a/change/@ni-nimble-blazor-db13aa1d-922a-4935-b6da-1490c106d46c.json
+++ b/change/@ni-nimble-blazor-db13aa1d-922a-4935-b6da-1490c106d46c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added Blazor EditForm input validation support for some components.",
+  "packageName": "@ni/nimble-blazor",
+  "email": "demeter.gorog@ni.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleCombobox.razor.cs
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleCombobox.razor.cs
@@ -46,13 +46,15 @@ public partial class NimbleCombobox : NimbleInputBase<string?>
     public string? Placeholder { get; set; }
 
     /// <summary>
-    /// Gets or sets whether the combobox error text
+    /// Gets or sets whether the combobox error text.
+    /// Value is set automatically if the component is used in an <see cref="EditForm"/>.
     /// </summary>
     [Parameter]
     public string? ErrorText { get; set; }
 
     /// <summary>
-    /// Gets or sets whether the combobox error is visible
+    /// Gets or sets whether the combobox error is visible.
+    /// Value is set automatically if the component is used in an <see cref="EditForm"/>.
     /// </summary>
     [Parameter]
     public bool? ErrorVisible { get; set; }

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleNumberField.razor.cs
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleNumberField.razor.cs
@@ -54,12 +54,14 @@ public partial class NimbleNumberField : NimbleInputBase<double?>
 
     /// <summary>
     /// Gets or sets the number field error text.
+    /// Value is set automatically if the component is used in an <see cref="EditForm"/>.
     /// </summary>
     [Parameter]
     public string? ErrorText { get; set; }
 
     /// <summary>
     /// Gets or sets whether the number field error is visible.
+    /// Value is set automatically if the component is used in an <see cref="EditForm"/>.
     /// </summary>
     [Parameter]
     public bool? ErrorVisible { get; set; }

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleSelect.razor.cs
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleSelect.razor.cs
@@ -24,13 +24,15 @@ public partial class NimbleSelect : NimbleInputBase<string?>
     public DropdownAppearance? Appearance { get; set; }
 
     /// <summary>
-    /// Gets or sets the select error text
+    /// Gets or sets the select error text.
+    /// Value is set automatically if the component is used in an <see cref="EditForm"/>.
     /// </summary>
     [Parameter]
     public string? ErrorText { get; set; }
 
     /// <summary>
-    /// Gets or sets whether the select error is visible
+    /// Gets or sets whether the select error is visible.
+    /// Value is set automatically if the component is used in an <see cref="EditForm"/>.
     /// </summary>
     [Parameter]
     public bool? ErrorVisible { get; set; }

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleTextField.razor.cs
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleTextField.razor.cs
@@ -39,7 +39,7 @@ public partial class NimbleTextField : NimbleInputBase<string?>
     public bool? Spellcheck { get; set; }
 
     /// <summary>
-    /// Gets or sets whether the text field error text.
+    /// Gets or sets the text field error text.
     /// Value is set automatically if the component is used in an <see cref="EditForm"/>.
     /// </summary>
     [Parameter]

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleTextField.razor.cs
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleTextField.razor.cs
@@ -39,13 +39,15 @@ public partial class NimbleTextField : NimbleInputBase<string?>
     public bool? Spellcheck { get; set; }
 
     /// <summary>
-    /// Gets or sets whether the combobox error text
+    /// Gets or sets whether the text field error text.
+    /// Value is set automatically if the component is used in an <see cref="EditForm"/>.
     /// </summary>
     [Parameter]
     public string? ErrorText { get; set; }
 
     /// <summary>
-    /// Gets or sets whether the combobox error is visible
+    /// Gets or sets whether the text field error is visible.
+    /// Value is set automatically if the component is used in an <see cref="EditForm"/>.
     /// </summary>
     [Parameter]
     public bool? ErrorVisible { get; set; }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Currently there is no proper EditForm support for Nimble input components in Blazor, therefore the `ErrorVisible` and `ErrorText` attributes do not get automatically changed (like with the standard input components Blazor provides).

This PR adds support for showing the input validation errors automatically for the following input components:
- NimbleInputText
- NimbleInputNumber
- NimbleSelect
- NimbleCombobox

Partially covers #766 

## 👩‍💻 Implementation

Basically we want to change the `ErrorVisible` and `ErrorText` properties at the same time, so the expected behavior is when the `ErrorText` is not empty then we want `ErrorVisible` to be true and vice versa.

Many components are inherited from the `NimbleInputBase` class, but most of them do not have/support the `ErrorVisible/Text` attributes/properties, so I chose not to move these properties from each component to the base class in order to use them.

Instead, I changed the `UpdateAdditionalValidationAttributes` in `NimbleInputBase` to add and remove the `error-text` and `error-visible` attributes to/from the `AdditionalAttributes` dictionary.
This implementation does not affect the behavior when the Nimble input components are not part of an `EditForm`, so they still can be set manually in that case.

I also updated the `summary` section of each supported component.

## 🧪 Testing

I tested the behavior in my sample project manually and it works as expected.
I'm not sure if automated tests are needed and if so how to do it well, since there is no tests for the `NimbleInputBase` yet anyway.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
