### PR TITLE
Fix bug with BlazorTabPanel event handling

### DIFF
--- a/change/@ni-nimble-blazor-83455a58-9eff-4d01-88bb-e28216ea5f42.json
+++ b/change/@ni-nimble-blazor-83455a58-9eff-4d01-88bb-e28216ea5f42.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Fix bug where NimbleTab would respond to `change` event from children components, causing tabs to change. Also made NimbleTabs.UpdateActiveId private.",
+  "packageName": "@ni/nimble-blazor",
+  "email": "6438377+tatwood2@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-blazor-ad0b7e2c-d4ff-4837-b0c0-ec203eee88f7.json
+++ b/change/@ni-nimble-blazor-ad0b7e2c-d4ff-4837-b0c0-ec203eee88f7.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Added logic to stop NimbleTabs from seeing `change` event from children components. Followed the pattern FluentUI Blazor uses for their Tab component.",
-  "packageName": "@ni/nimble-blazor",
-  "email": "tim.atwood@ni.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@ni-nimble-blazor-ad0b7e2c-d4ff-4837-b0c0-ec203eee88f7.json
+++ b/change/@ni-nimble-blazor-ad0b7e2c-d4ff-4837-b0c0-ec203eee88f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added logic to stop NimbleTabs from seeing `change` event from children components. Followed the pattern FluentUI Blazor uses for their Tab component.",
+  "packageName": "@ni/nimble-blazor",
+  "email": "tim.atwood@ni.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-blazor/Examples/Demo.Shared/Pages/ComponentsDemo.razor
+++ b/packages/nimble-blazor/Examples/Demo.Shared/Pages/ComponentsDemo.razor
@@ -242,6 +242,7 @@
                 </NimbleTabPanel>
                 <NimbleTabPanel>
                     <div class="container-label">Tab 2 content</div>
+                    <NimbleTextField Placeholder="Enter text into Tab here" />
                 </NimbleTabPanel>
                 <NimbleTabPanel>
                     <div class="container-label">Tab 3 content</div>

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleTabs.razor
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleTabs.razor
@@ -1,7 +1,7 @@
 @namespace NimbleBlazor
 <nimble-tabs
     activeid="@BindConverter.FormatValue(ActiveId)"
-    @onnimbletabsactiveidchange="(__value) => UpdateActiveId(__value.ActiveId)"
+    @onnimbletabsactiveidchange="(__value) => UpdateActiveId(__value?.ActiveId)"
     @attributes="AdditionalAttributes">
     @ChildContent
 </nimble-tabs>

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleTabs.razor.cs
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleTabs.razor.cs
@@ -15,15 +15,7 @@ public partial class NimbleTabs : ComponentBase
     /// </summary>
     [Parameter] public EventCallback<string?> ActiveIdChanged { get; set; }
 
-    /// <summary>
-    /// Called when `change` event is called on the web component or its children
-    /// </summary>
-    /// <remarks>
-    /// If <paramref name="value"/> is null, ignore the change event. Due to the way
-    /// Blazor Custom Events work, this event gets triggered when a child <see cref="NimbleTextField"/>'s Value changes.
-    /// </remarks>
-    /// <param name="value">New value of activeid</param>
-    protected async void UpdateActiveId(string? value)
+    private async void UpdateActiveId(string? value)
     {
         if (value != null)
         {

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleTabs.razor.cs
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleTabs.razor.cs
@@ -16,13 +16,20 @@ public partial class NimbleTabs : ComponentBase
     [Parameter] public EventCallback<string?> ActiveIdChanged { get; set; }
 
     /// <summary>
-    /// Called when activeid changes on the web component
+    /// Called when `change` event is called on the web component or its children
     /// </summary>
+    /// <remarks>
+    /// If <paramref name="value"/> is null, ignore the change event. Due to the way
+    /// Blazor Custom Events work, this event gets triggered when a child <see cref="NimbleTextField"/>'s Value changes.
+    /// </remarks>
     /// <param name="value">New value of activeid</param>
     protected async void UpdateActiveId(string? value)
     {
-        ActiveId = value;
-        await ActiveIdChanged.InvokeAsync(value);
+        if (value != null)
+        {
+            ActiveId = value;
+            await ActiveIdChanged.InvokeAsync(value);
+        }
     }
 
     public IDictionary<string, object>? AdditionalAttributes { get; set; }

--- a/packages/nimble-blazor/NimbleBlazor/wwwroot/NimbleBlazor.lib.module.js
+++ b/packages/nimble-blazor/NimbleBlazor/wwwroot/NimbleBlazor.lib.module.js
@@ -22,12 +22,16 @@ export function afterStarted(Blazor) {
     // Used by NimbleTabs.razor
     // Necessary because the tab control uses a 'change' event but not a value/currentValue property,
     // and we do want to be notified of activeid changes (via the change event) for 2-way binding support.
+    // 'localName' check is required to guard against children's change event trickling into the NimbleTabs.
     Blazor.registerCustomEventType('nimbletabsactiveidchange', {
         browserEventName: 'change',
         createEventArgs: event => {
-            return {
-                activeId: event.target.activeid
-            };
+            if (event.target.localName === 'nimble-tabs') {
+                return {
+                    activeId: event.target.activeid
+                };
+            }
+            return null;
         }
     });
     // Used by NimbleMenuButton.razor


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

<!---
Provide some background and a description of your work.
What problem does this change solve?

Include links to issues, work items, or other discussions.
-->

This PR fixes #1144.  The Nimble Blazor TabPanel component should not switch the active tab when children components have `change` events.

## 👩‍💻 Implementation

I was able to copy the pattern the FluentUI Blazor Tab component uses to ignore children `change` events.  See [HandleOnTabChanged](https://github.com/microsoft/fluentui-blazor/blob/28decc36e68b5de0eea8e0ea39b43d31b583cc3c/src/Microsoft.Fast.Components.FluentUI/Components/Tabs/FluentTabs.razor.cs#L52) and where [they register the browser event](https://github.com/microsoft/fluentui-blazor/blob/5dfe01f5966a2d4474125962f96b565c78f67280/src/Microsoft.Fast.Components.FluentUI/wwwroot/Microsoft.Fast.Components.FluentUI.lib.module.js#L37).

## 🧪 Testing

I manually tested this change in the Demo page and left the code there so others can manually test it easily in the future.  I also wrote two new automated unit tests.

The new behavior is:
![Tab no longer changes on child content change](https://user-images.githubusercontent.com/6438377/229179827-7a2cc110-cb2a-45d9-ae88-1f320ab9b6b5.gif)
(If this gif isn't playing, click to open in a new tab to see the full new behavior)

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ]~~I have updated the project documentation to reflect my changes or determined no changes are needed.~~
    - This is just a bug fix so no documentation required to change.  I did update summary tags and comments around the code I changed.
