### PR TITLE
Explicitly import anchored-region in menu with side-effects

### DIFF
--- a/change/@ni-nimble-components-72f73446-a714-4fb6-a54c-87fcfb017995.json
+++ b/change/@ni-nimble-components-72f73446-a714-4fb6-a54c-87fcfb017995.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Change menu to explicit side-effect import of anchored-region",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/menu/index.ts
+++ b/packages/nimble-components/src/menu/index.ts
@@ -5,13 +5,9 @@ import {
 } from '@microsoft/fast-foundation';
 import { styles } from './styles';
 
-// FAST menu item uses DesignSystem.tagFor(anchoredRegion) to position nested menus
-// https://github.com/microsoft/fast/blob/3ad50c8eec98b3156a4559586ca76e4abebefad8/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts#L83
-// This needs to be able to find the Nimble anchored region even if the application doesn't import it explicitly or via all-components
-// This may become unnecessary with fast-foundation vNext which no longer uses anchored region
-// https://github.com/microsoft/fast/pull/6457
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { AnchoredRegion } from '../anchored-region';
+// FAST menu template requires an anchored region is available using tagFor DI
+// Register anchored region explicitly to make sure it is defined for the template
+import '../anchored-region';
 
 declare global {
     interface HTMLElementTagNameMap {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale



## 👩‍💻 Implementation

As part of https://github.com/ni/nimble/pull/1134 the menu element definition added an import to the anchored region as an unused variable for the element registration side-effect.

Build tooling with dead code elimination may try to strip out that dependency under the assumption that imports do not have side effects so they can safely remove an unused variable and the associated import tree. Switched to the [side-effect only import syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#import_a_module_for_its_side_effects_only) which is a stronger declaration to bundling tools that the import has side-effects.

## 🧪 Testing

Relying on CI, no additional tests added.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
