### PR TITLE
Swallow the npm outdated error instead of continue-on-error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,10 @@ jobs:
       # See: https://github.com/actions/setup-node/issues/529
       - run: npm i -g npm@8
       - run: npm ci
-      - run: npm outdated
-        continue-on-error: true
+
+      # print a log of outdated npm dependencies
+      # only informational so swallow error codes
+      - run: npm outdated || exit 0
 
       # Audit
       - run: npm audit --only=prod


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Updated the ci to swallow errors resulting from the `npm outdated` command instead of configuring the step to continue on error. Got feedback that the error that bubbles up from continue-on-error is misleading.

## 👩‍💻 Implementation

Updated the workflow to `exit 0` on error

## 🧪 Testing

Ran on CI

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
