### PR TITLE
Revert icon timing workaround

### DIFF
--- a/change/@ni-nimble-components-1023803a-478f-4d1d-afab-9fe6236fd90d.json
+++ b/change/@ni-nimble-components-1023803a-478f-4d1d-afab-9fe6236fd90d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert icon timing workaround",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -106,7 +106,8 @@ describe('Select', () => {
             return fixture<Select>(viewTemplate);
         }
 
-        it('should limit dropdown height to viewport', async () => {
+        // Disabled due to intermittancy, see: https://github.com/ni/nimble/issues/1172
+        xit('should limit dropdown height to viewport', async () => {
             const { element, connect, disconnect } = await setup500Options();
             await connect();
             const listbox: HTMLElement = element.shadowRoot!.querySelector('.listbox')!;

--- a/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
@@ -18,10 +18,13 @@ describe('Tooltip', () => {
     function isIconVisible(elementName: string): boolean {
         const iconElement = element.shadowRoot?.querySelector(elementName);
         if (!iconElement) {
-            return false;
+            throw new Error(`Cannot find icon with name ${elementName}`);
         }
         const display = window.getComputedStyle(iconElement).display;
-        return typeof display === 'string' && display !== '';
+        if (typeof display !== 'string' || display === '') {
+            throw new Error(`Invalid display value was calcualted for ${elementName}`);
+        }
+        return display !== 'none';
     }
 
     beforeEach(async () => {

--- a/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
@@ -21,9 +21,7 @@ describe('Tooltip', () => {
             return false;
         }
         const display = window.getComputedStyle(iconElement).display;
-        return (
-            typeof display === 'string' && display !== ''
-        );
+        return typeof display === 'string' && display !== '';
     }
 
     beforeEach(async () => {

--- a/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
@@ -22,7 +22,9 @@ describe('Tooltip', () => {
         }
         const display = window.getComputedStyle(iconElement).display;
         if (typeof display !== 'string' || display === '') {
-            throw new Error(`Invalid display value was calcualted for ${elementName}`);
+            throw new Error(
+                `Invalid display value was calcualted for ${elementName}`
+            );
         }
         return display !== 'none';
     }

--- a/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
@@ -9,14 +9,6 @@ async function setup(): Promise<Fixture<Tooltip>> {
     return fixture<Tooltip>(html`<nimble-tooltip></nimble-tooltip>`);
 }
 
-// For some reason, on Firefox, it takes two calls to waitForUpdatesAsync before
-// the icon elements have computed styles. If we call it just once, getComputedStyles()
-// returns an empty styles object.
-async function waitForIconVisibilityCheck(): Promise<void> {
-    await waitForUpdatesAsync();
-    await waitForUpdatesAsync();
-}
-
 describe('Tooltip', () => {
     let parent: HTMLElement;
     let element: Tooltip;
@@ -29,11 +21,8 @@ describe('Tooltip', () => {
             return false;
         }
         const display = window.getComputedStyle(iconElement).display;
-        if (display === '') {
-            throw new Error('Value of display was unexpectedly empty');
-        }
         return (
-            display === 'block' || display === 'inline' || display === 'flex'
+            typeof display === 'string' && display !== ''
         );
     }
 
@@ -131,11 +120,12 @@ describe('Tooltip', () => {
         await disconnect();
     });
 
-    it('should render the default state when selected', async () => {
+    // Firefox skipped, see: https://github.com/ni/nimble/issues/1075
+    it('should render the default state when selected #SkipFirefox', async () => {
         element.visible = true;
 
         await connect();
-        await waitForIconVisibilityCheck();
+        await waitForUpdatesAsync();
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
         expect(isIconVisible('nimble-icon-info')).toBeFalse();
@@ -143,12 +133,13 @@ describe('Tooltip', () => {
         await disconnect();
     });
 
-    it('should render the default state when selected and not render an icon when true', async () => {
+    // Firefox skipped, see: https://github.com/ni/nimble/issues/1075
+    it('should render the default state when selected and not render an icon when true #SkipFirefox', async () => {
         element.visible = true;
         element.iconVisible = true;
 
         await connect();
-        await waitForIconVisibilityCheck();
+        await waitForUpdatesAsync();
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
         expect(isIconVisible('nimble-icon-info')).toBeFalse();
@@ -156,12 +147,13 @@ describe('Tooltip', () => {
         await disconnect();
     });
 
-    it('should render the error severity when selected', async () => {
+    // Firefox skipped, see: https://github.com/ni/nimble/issues/1075
+    it('should render the error severity when selected #SkipFirefox', async () => {
         element.visible = true;
         element.severity = 'error';
 
         await connect();
-        await waitForIconVisibilityCheck();
+        await waitForUpdatesAsync();
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
         expect(isIconVisible('nimble-icon-info')).toBeFalse();
@@ -169,13 +161,14 @@ describe('Tooltip', () => {
         await disconnect();
     });
 
-    it('should render the error severity when selected and render the corresponding icon when true', async () => {
+    // Firefox skipped, see: https://github.com/ni/nimble/issues/1075
+    it('should render the error severity when selected and render the corresponding icon when true #SkipFirefox', async () => {
         element.visible = true;
         element.severity = 'error';
         element.iconVisible = true;
 
         await connect();
-        await waitForIconVisibilityCheck();
+        await waitForUpdatesAsync();
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeTrue();
         expect(isIconVisible('nimble-icon-info')).toBeFalse();
@@ -183,12 +176,13 @@ describe('Tooltip', () => {
         await disconnect();
     });
 
-    it('should render the information severity when selected', async () => {
+    // Firefox skipped, see: https://github.com/ni/nimble/issues/1075
+    it('should render the information severity when selected #SkipFirefox', async () => {
         element.visible = true;
         element.severity = 'information';
 
         await connect();
-        await waitForIconVisibilityCheck();
+        await waitForUpdatesAsync();
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
         expect(isIconVisible('nimble-icon-info')).toBeFalse();
@@ -196,13 +190,14 @@ describe('Tooltip', () => {
         await disconnect();
     });
 
-    it('should render the information severity when selected and render the corresponding icon when true', async () => {
+    // Firefox skipped, see: https://github.com/ni/nimble/issues/1075
+    it('should render the information severity when selected and render the corresponding icon when true #SkipFirefox', async () => {
         element.visible = true;
         element.severity = 'information';
         element.iconVisible = true;
 
         await connect();
-        await waitForIconVisibilityCheck();
+        await waitForUpdatesAsync();
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
         expect(isIconVisible('nimble-icon-info')).toBeTrue();


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As part of #1156 a change was made to tooltip icon tests to run in Firefox. The implemented solution added arbitrary additional waits which are turning out to be intermittent. This PR disables those tests until a more robust implementation can be found. Additional investigation is being skipped to get main stable at the moment.

Fixes #1166 (fixes the intermittency on main, and #1075 covers fixing the actual disabled tests)

I'm also disabling the intermittent test associated with https://github.com/ni/nimble/issues/1172 as it was causing failues locally trying to reproduce the intermittency of this test.

## 👩‍💻 Implementation

Revert the test changes and place them into the existing original bucket of firefox failing tests.

## 🧪 Testing

Relying on CI

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
