### PR TITLE
Table row selection blazor

### DIFF
--- a/change/@ni-nimble-blazor-dfb12cff-3881-43cb-b3b7-582db3aaf076.json
+++ b/change/@ni-nimble-blazor-dfb12cff-3881-43cb-b3b7-582db3aaf076.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Blazor support for row selection in the table",
+  "packageName": "@ni/nimble-blazor",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-blazor/Examples/Demo.Shared/Pages/ComponentsDemo.razor
+++ b/packages/nimble-blazor/Examples/Demo.Shared/Pages/ComponentsDemo.razor
@@ -206,7 +206,7 @@
         </div>
         <div class="sub-container">
             <div class="container-label">Table</div>
-            <NimbleTable @bind-Data="TableData" class="table">
+            <NimbleTable IdFieldName="Id" @bind-Data="TableData" SelectionMode="TableRowSelectionMode.Multiple" class="table">
                 <NimbleTableColumnText
                     FieldName="FirstName"
                     Placeholder="no value"

--- a/packages/nimble-blazor/Examples/Demo.Shared/Pages/ComponentsDemo.razor.cs
+++ b/packages/nimble-blazor/Examples/Demo.Shared/Pages/ComponentsDemo.razor.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using NimbleBlazor;
 
 namespace Demo.Shared.Pages
@@ -62,9 +61,15 @@ namespace Demo.Shared.Pages
             var tableData = new Person[numberOfRows + 1];
             for (int i = 0; i < numberOfRows; i++)
             {
-                tableData[i] = new Person(Faker.Name.First(), Faker.Name.Last());
+                tableData[i] = new Person(
+                    i.ToString(null, null),
+                    Faker.Name.First(),
+                    Faker.Name.Last());
             }
-            tableData[numberOfRows] = new Person(null, null);
+            tableData[numberOfRows] = new Person(
+                numberOfRows.ToString(null, null),
+                null,
+                null);
 
             TableData = tableData;
         }
@@ -72,12 +77,14 @@ namespace Demo.Shared.Pages
 
     public class Person
     {
-        public Person(string? firstName, string? lastName)
+        public Person(string id, string? firstName, string? lastName)
         {
+            Id = id;
             FirstName = firstName;
             LastName = lastName;
         }
 
+        public string Id { get; }
         public string? FirstName { get; }
         public string? LastName { get; }
     }

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleTable.razor
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleTable.razor
@@ -3,8 +3,11 @@
 <nimble-table
     @ref="_table"
     id-field-name="@IdFieldName"
+    selection-mode="@SelectionMode.ToAttributeValue()"
     @attributes="AdditionalAttributes"
     @onnimbleactionmenubeforetoggle="(__value) => HandleActionMenuBeforeToggle(__value)"
-    @onnimbleactionmenutoggle="(__value) => HandleActionMenuToggle(__value)">
+    @onnimbleactionmenutoggle="(__value) => HandleActionMenuToggle(__value)"
+    @onnimbletablerowselectionchange="(__value) => HandleSelectionChange(__value)"
+>
     @ChildContent
 </nimble-table>

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleTable.razor.cs
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleTable.razor.cs
@@ -16,6 +16,8 @@ public partial class NimbleTable<TData> : ComponentBase
     private bool _dataUpdated = false;
     private IEnumerable<TData> _data = Enumerable.Empty<TData>();
     internal static string SetTableDataMethodName = "NimbleBlazor.Table.setData";
+    internal static string GetSelectedRecordIdsMethodName = "NimbleBlazor.Table.getSelectedRecordIds";
+    internal static string SetSelectedRecordIdsMethodName = "NimbleBlazor.Table.setSelectedRecordIds";
     internal static string CheckTableValidityMethodName = "NimbleBlazor.Table.checkValidity";
     internal static string GetTableValidityMethodName = "NimbleBlazor.Table.getValidity";
 
@@ -24,6 +26,9 @@ public partial class NimbleTable<TData> : ComponentBase
 
     [Parameter]
     public string? IdFieldName { get; set; }
+
+    [Parameter]
+    public TableRowSelectionMode? SelectionMode { get; set; }
 
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
@@ -55,6 +60,23 @@ public partial class NimbleTable<TData> : ComponentBase
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
 
     /// <summary>
+    /// Returns the set of selected record IDs.
+    /// </summary>
+    public async Task<IEnumerable<string>> GetSelectedRecordIdsAsync()
+    {
+        return await JSRuntime!.InvokeAsync<IEnumerable<string>>(GetSelectedRecordIdsMethodName, _table);
+    }
+
+    /// <summary>
+    /// Sets the record IDs that should be selected in the table.
+    /// </summary>
+    /// <param name="recordIds">The record IDs to select in the table</param>
+    public async Task SetSelectedRecordIdsAsync(IEnumerable<string> recordIds)
+    {
+        await JSRuntime!.InvokeAsync<TableValidity>(SetSelectedRecordIdsMethodName, _table, recordIds);
+    }
+
+    /// <summary>
     /// Returns whether or not the table is valid.
     /// </summary>
     public async Task<bool> CheckValidityAsync()
@@ -83,6 +105,12 @@ public partial class NimbleTable<TData> : ComponentBase
     public EventCallback<TableActionMenuToggleEventArgs> ActionMenuBeforeToggle { get; set; }
 
     /// <summary>
+    /// Gets or sets a callback that's invoked when selection is changed on the table.
+    /// </summary>
+    [Parameter]
+    public EventCallback<TableRowSelectionEventArgs> RowSelectionChange { get; set; }
+
+    /// <summary>
     /// Called when 'action-menu-toggle' changes on the web component.
     /// </summary>
     /// <param name="eventArgs">The state of the action menu on the table</param>
@@ -98,6 +126,15 @@ public partial class NimbleTable<TData> : ComponentBase
     protected async void HandleActionMenuBeforeToggle(TableActionMenuToggleEventArgs eventArgs)
     {
         await ActionMenuBeforeToggle.InvokeAsync(eventArgs);
+    }
+
+    /// <summary>
+    /// Called when the 'selection-change' event is fired on the web component.
+    /// </summary>
+    /// <param name="eventArgs">The selection state of the table</param>
+    protected async void HandleSelectionChange(TableRowSelectionEventArgs eventArgs)
+    {
+        await RowSelectionChange.InvokeAsync(eventArgs);
     }
 
     /// <inheritdoc/>

--- a/packages/nimble-blazor/NimbleBlazor/EventHandlers.cs
+++ b/packages/nimble-blazor/NimbleBlazor/EventHandlers.cs
@@ -33,6 +33,11 @@ public class TableActionMenuToggleEventArgs : EventArgs
     public string? ColumnId { get; set; }
 }
 
+public class TableRowSelectionEventArgs : EventArgs
+{
+    public IEnumerable<string>? SelectedRecordIds { get; set; }
+}
+
 [EventHandler("onnimbletabsactiveidchange", typeof(TabsChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("onnimblecheckedchange", typeof(CheckboxChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("onnimblemenubuttontoggle", typeof(MenuButtonToggleEventArgs), enableStopPropagation: true, enablePreventDefault: false)]
@@ -40,6 +45,7 @@ public class TableActionMenuToggleEventArgs : EventArgs
 [EventHandler("onnimblebannertoggle", typeof(BannerToggleEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("onnimbleactionmenutoggle", typeof(TableActionMenuToggleEventArgs), enableStopPropagation: true, enablePreventDefault: false)]
 [EventHandler("onnimbleactionmenubeforetoggle", typeof(TableActionMenuToggleEventArgs), enableStopPropagation: true, enablePreventDefault: false)]
+[EventHandler("onnimbletablerowselectionchange", typeof(TableRowSelectionEventArgs), enableStopPropagation: true, enablePreventDefault: false)]
 public static class EventHandlers
 {
 }

--- a/packages/nimble-blazor/NimbleBlazor/TableRowSelectionMode.cs
+++ b/packages/nimble-blazor/NimbleBlazor/TableRowSelectionMode.cs
@@ -3,7 +3,9 @@
 public enum TableRowSelectionMode
 {
     None,
+#pragma warning disable CA1720 // Identifier contains type name
     Single,
+#pragma warning restore CA1720 // Identifier contains type name
     Multiple
 }
 

--- a/packages/nimble-blazor/NimbleBlazor/TableRowSelectionMode.cs
+++ b/packages/nimble-blazor/NimbleBlazor/TableRowSelectionMode.cs
@@ -11,5 +11,5 @@ internal static class TableRowSelectionModeExtensions
 {
     private static readonly Dictionary<TableRowSelectionMode, string> _enumValues = AttributeHelpers.GetEnumNamesAsKebabCaseValues<TableRowSelectionMode>();
 
-    public static string? ToAttributeValue(this TableRowSelectionMode? value) => value == null ? null : _enumValues[value.Value];
+    public static string? ToAttributeValue(this TableRowSelectionMode? value) => (value == null || value == TableRowSelectionMode.None) ? null : _enumValues[value.Value];
 }

--- a/packages/nimble-blazor/NimbleBlazor/TableRowSelectionMode.cs
+++ b/packages/nimble-blazor/NimbleBlazor/TableRowSelectionMode.cs
@@ -1,0 +1,15 @@
+﻿namespace NimbleBlazor;
+
+public enum TableRowSelectionMode
+{
+    None,
+    Single,
+    Multiple
+}
+
+internal static class TableRowSelectionModeExtensions
+{
+    private static readonly Dictionary<TableRowSelectionMode, string> _enumValues = AttributeHelpers.GetEnumNamesAsKebabCaseValues<TableRowSelectionMode>();
+
+    public static string? ToAttributeValue(this TableRowSelectionMode? value) => value == null ? null : _enumValues[value.Value];
+}

--- a/packages/nimble-blazor/NimbleBlazor/TableValidity.cs
+++ b/packages/nimble-blazor/NimbleBlazor/TableValidity.cs
@@ -15,6 +15,8 @@ public interface ITableValidity
     public bool MissingColumnId { get; }
 
     public bool DuplicateSortIndex { get; }
+
+    public bool IdFieldNameNotConfigured { get; }
 }
 
 internal class TableValidity : ITableValidity
@@ -36,4 +38,7 @@ internal class TableValidity : ITableValidity
 
     [JsonPropertyName("duplicateSortIndex")]
     public bool DuplicateSortIndex { get; set; }
+
+    [JsonPropertyName("idFieldNameNotConfigured")]
+    public bool IdFieldNameNotConfigured { get; set; }
 }

--- a/packages/nimble-blazor/NimbleBlazor/TableValidity.cs
+++ b/packages/nimble-blazor/NimbleBlazor/TableValidity.cs
@@ -16,6 +16,8 @@ public interface ITableValidity
 
     public bool DuplicateSortIndex { get; }
 
+    public bool DuplicateGroupIndex { get; }
+
     public bool IdFieldNameNotConfigured { get; }
 }
 
@@ -38,6 +40,9 @@ internal class TableValidity : ITableValidity
 
     [JsonPropertyName("duplicateSortIndex")]
     public bool DuplicateSortIndex { get; set; }
+
+    [JsonPropertyName("duplicateGroupIndex")]
+    public bool DuplicateGroupIndex { get; set; }
 
     [JsonPropertyName("idFieldNameNotConfigured")]
     public bool IdFieldNameNotConfigured { get; set; }

--- a/packages/nimble-blazor/NimbleBlazor/wwwroot/NimbleBlazor.lib.module.js
+++ b/packages/nimble-blazor/NimbleBlazor/wwwroot/NimbleBlazor.lib.module.js
@@ -88,6 +88,15 @@ export function afterStarted(Blazor) {
             };
         }
     });
+    // Used by NimbleTable.razor
+    Blazor.registerCustomEventType('nimbletablerowselectionchange', {
+        browserEventName: 'selection-change',
+        createEventArgs: event => {
+            return {
+                selectedRecordIds: event.detail.selectedRecordIds
+            };
+        }
+    });
 }
 
 window.NimbleBlazor = {
@@ -113,6 +122,13 @@ window.NimbleBlazor = {
         setData: async function (tableReference, data) {
             const dataObject = JSON.parse(data);
             await tableReference.setData(dataObject);
+        },
+        getSelectedRecordIds: async function (tableReference) {
+            await tableReference.getSelectedRecordIds();
+        },
+        setSelectedRecordIds: async function (tableReference, selectedRecordIds) {
+            const parsedRecordIds = JSON.parse(selectedRecordIds);
+            await tableReference.setSelectedRecordIds(parsedRecordIds);
         },
         checkValidity: function (tableReference) {
             return tableReference.checkValidity();

--- a/packages/nimble-blazor/NimbleBlazor/wwwroot/NimbleBlazor.lib.module.js
+++ b/packages/nimble-blazor/NimbleBlazor/wwwroot/NimbleBlazor.lib.module.js
@@ -124,7 +124,7 @@ window.NimbleBlazor = {
             await tableReference.setData(dataObject);
         },
         getSelectedRecordIds: async function (tableReference) {
-            return await tableReference.getSelectedRecordIds();
+            return tableReference.getSelectedRecordIds();
         },
         setSelectedRecordIds: async function (tableReference, selectedRecordIds) {
             await tableReference.setSelectedRecordIds(selectedRecordIds);

--- a/packages/nimble-blazor/NimbleBlazor/wwwroot/NimbleBlazor.lib.module.js
+++ b/packages/nimble-blazor/NimbleBlazor/wwwroot/NimbleBlazor.lib.module.js
@@ -124,11 +124,10 @@ window.NimbleBlazor = {
             await tableReference.setData(dataObject);
         },
         getSelectedRecordIds: async function (tableReference) {
-            await tableReference.getSelectedRecordIds();
+            return await tableReference.getSelectedRecordIds();
         },
         setSelectedRecordIds: async function (tableReference, selectedRecordIds) {
-            const parsedRecordIds = JSON.parse(selectedRecordIds);
-            await tableReference.setSelectedRecordIds(parsedRecordIds);
+            await tableReference.setSelectedRecordIds(selectedRecordIds);
         },
         checkValidity: function (tableReference) {
             return tableReference.checkValidity();

--- a/packages/nimble-blazor/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableTests.cs
+++ b/packages/nimble-blazor/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableTests.cs
@@ -56,6 +56,25 @@ public class NimbleTableTests
         Assert.Contains(expectedMarkup, table.Markup);
     }
 
+    [Theory]
+    [InlineData(TableRowSelectionMode.None, null)]
+    [InlineData(TableRowSelectionMode.Single, "single")]
+    [InlineData(TableRowSelectionMode.Multiple, "multiple")]
+    public void TextFieldAppearance_AttributeIsSet(TableRowSelectionMode value, string expectedAttribute)
+    {
+        var table = RenderWithPropertySet<TableRowSelectionMode?, TableRowData>(x => x.SelectionMode, value);
+
+        if (expectedAttribute == null)
+        {
+            Assert.DoesNotContain("selection-mode", table.Markup);
+        }
+        else
+        {
+            var expectedMarkup = $"selection-mode=\"${expectedAttribute}\"";
+            Assert.Contains(expectedMarkup, table.Markup);
+        }
+    }
+
     [Fact]
     public void NimbleTable_WithClassAttribute_HasTableMarkup()
     {

--- a/packages/nimble-blazor/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableTests.cs
+++ b/packages/nimble-blazor/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableTests.cs
@@ -70,7 +70,7 @@ public class NimbleTableTests
         }
         else
         {
-            var expectedMarkup = $"selection-mode=\"${expectedAttribute}\"";
+            var expectedMarkup = $"selection-mode=\"{expectedAttribute}\"";
             Assert.Contains(expectedMarkup, table.Markup);
         }
     }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Add Blazor support for row selection in the table, which is part of #856.

## 👩‍💻 Implementation

- Create `TableRowSelectionMode` enum
    - Note: I had to suppress a CA warning because `Single` is a keyword in C#. However, I did verify that usages of `TableRowSelectionMode.Single` do not require further suppression.
- Add `SelectionMode` to the table
- Add `GetSelectedRecordIdsAsync()` and `SetSelectedRecordIdsAsync()` methods to the table
- Extend `TableValidity` to include `IdFieldNameNotConfigured`
- Extend `TableValidity` to include `DuplicateGroupIndex` because I noticed it was missing. It technically has nothing to do with row selection.
- Add event handling for selection changed
- Update example app to enable multi-row selection

## 🧪 Testing

- Added new test for `SelectionMode` configuration on the table
- Manually tested that `GetSelectedRecordIdsAsync()` and `SetSelectedRecordIdsAsync()` work as expected
- Manually tested that the selection change event works as expected
- Manually tested that the `TableValidity` changes work as expected

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
