### PR TITLE
Fix six tooltip tests that were failing on Firefox

### DIFF
--- a/change/@ni-nimble-components-ed93262a-3712-4088-aaf8-e65c4f3165b0.json
+++ b/change/@ni-nimble-components-ed93262a-3712-4088-aaf8-e65c4f3165b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix six tooltip tests that were failing on Firefox",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
@@ -29,6 +29,15 @@ describe('Tooltip', () => {
         return display !== 'none';
     }
 
+    async function waitUntilLoaded(tooltip: Tooltip): Promise<void> {
+        const region = tooltip.shadowRoot!.querySelector('nimble-anchored-region')!;
+        return new Promise((resolve, _reject) => {
+            region.addEventListener('loaded', () => {
+                resolve();
+            });
+        });
+    }
+
     beforeEach(async () => {
         ({ element, connect, disconnect, parent } = await setup());
         const button = document.createElement('button');
@@ -123,12 +132,12 @@ describe('Tooltip', () => {
         await disconnect();
     });
 
-    // Firefox skipped, see: https://github.com/ni/nimble/issues/1075
-    it('should render the default state when selected #SkipFirefox', async () => {
+    it('should render the default state when selected', async () => {
         element.visible = true;
 
         await connect();
         await waitForUpdatesAsync();
+        await waitUntilLoaded(element);
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
         expect(isIconVisible('nimble-icon-info')).toBeFalse();
@@ -136,13 +145,13 @@ describe('Tooltip', () => {
         await disconnect();
     });
 
-    // Firefox skipped, see: https://github.com/ni/nimble/issues/1075
-    it('should render the default state when selected and not render an icon when true #SkipFirefox', async () => {
+    it('should render the default state when selected and not render an icon when true', async () => {
         element.visible = true;
         element.iconVisible = true;
 
         await connect();
         await waitForUpdatesAsync();
+        await waitUntilLoaded(element);
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
         expect(isIconVisible('nimble-icon-info')).toBeFalse();
@@ -150,13 +159,13 @@ describe('Tooltip', () => {
         await disconnect();
     });
 
-    // Firefox skipped, see: https://github.com/ni/nimble/issues/1075
-    it('should render the error severity when selected #SkipFirefox', async () => {
+    it('should render the error severity when selected', async () => {
         element.visible = true;
         element.severity = 'error';
 
         await connect();
         await waitForUpdatesAsync();
+        await waitUntilLoaded(element);
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
         expect(isIconVisible('nimble-icon-info')).toBeFalse();
@@ -164,14 +173,14 @@ describe('Tooltip', () => {
         await disconnect();
     });
 
-    // Firefox skipped, see: https://github.com/ni/nimble/issues/1075
-    it('should render the error severity when selected and render the corresponding icon when true #SkipFirefox', async () => {
+    it('should render the error severity when selected and render the corresponding icon when true', async () => {
         element.visible = true;
         element.severity = 'error';
         element.iconVisible = true;
 
         await connect();
         await waitForUpdatesAsync();
+        await waitUntilLoaded(element);
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeTrue();
         expect(isIconVisible('nimble-icon-info')).toBeFalse();
@@ -179,13 +188,13 @@ describe('Tooltip', () => {
         await disconnect();
     });
 
-    // Firefox skipped, see: https://github.com/ni/nimble/issues/1075
-    it('should render the information severity when selected #SkipFirefox', async () => {
+    it('should render the information severity when selected', async () => {
         element.visible = true;
         element.severity = 'information';
 
         await connect();
         await waitForUpdatesAsync();
+        await waitUntilLoaded(element);
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
         expect(isIconVisible('nimble-icon-info')).toBeFalse();
@@ -193,14 +202,14 @@ describe('Tooltip', () => {
         await disconnect();
     });
 
-    // Firefox skipped, see: https://github.com/ni/nimble/issues/1075
-    it('should render the information severity when selected and render the corresponding icon when true #SkipFirefox', async () => {
+    it('should render the information severity when selected and render the corresponding icon when true', async () => {
         element.visible = true;
         element.severity = 'information';
         element.iconVisible = true;
 
         await connect();
         await waitForUpdatesAsync();
+        await waitUntilLoaded(element);
 
         expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
         expect(isIconVisible('nimble-icon-info')).toBeTrue();


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

See #1075 
Six tooltip tests listed in that bug were failing on Firefox, so we marked them to be skipped.

## 👩‍💻 Implementation

The tests were checking for the display property of icons before the anchored region of the tooltip had been loaded. This was resulting in `getComputedStyle` for the icon to return an empty set of style info. Waiting for the `loaded` event of the anchored region results in the tests passing.

## 🧪 Testing

Ran tests locally

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
