### PR TITLE
Format source using prettier-eslint on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,7 @@
   ],
   "xd.globalEditor": true,
   "editor.defaultFormatter": "rvest.vs-code-prettier-eslint",
+  "editor.formatOnSave": true,
+  "editor.formatOnSaveMode": "file",
   "omnisharp.useModernNet": true
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The build requires that we format our code according to prettier and eslint. We should do this automatically on save so that we can avoid failed builds and subsequent manual runs of prettier/eslint.

## 👩‍💻 Implementation

Update VS Code settings to run the formatter on save. We already had prettier-eslint configured as the default formatter.

## 🧪 Testing

Manual testing in VS Code.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
