### PR TITLE
Remove scrolling from select visibility test

### DIFF
--- a/change/@ni-nimble-components-86a52f43-65f5-4214-88ff-f8fca2002d0c.json
+++ b/change/@ni-nimble-components-86a52f43-65f5-4214-88ff-f8fca2002d0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove scrolling from select visibility test",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -42,6 +42,9 @@ async function checkFullyInViewport(element: HTMLElement): Promise<boolean> {
                     resolve(false);
                 }
             },
+            // As of now, passing a document as root is not supported on Safari:
+            // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#browser_compatibility
+            // If we begin running these tests on Safari, we may need to skip those that use this function.
             { threshold: 1.0, root: document }
         );
         intersectionObserver.observe(element);

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -42,7 +42,7 @@ async function checkFullyInViewport(element: HTMLElement): Promise<boolean> {
                     resolve(false);
                 }
             },
-            { threshold: 1.0 }
+            { threshold: 1.0, root: document }
         );
         intersectionObserver.observe(element);
     });
@@ -111,13 +111,6 @@ describe('Select', () => {
             await connect();
             const listbox: HTMLElement = element.shadowRoot!.querySelector('.listbox')!;
             await clickAndWaitForOpen(element);
-            // The test is run in an iframe, and the containing window has a Karma header.
-            // It seems the window is sized without accounting for the header, so a header-height's
-            // worth of content is scrolled out of view. The approach we take with the
-            // IntersectionObserver only works if the full iframe is visible, so we scroll the
-            // containing window to the bottom (i.e. scrolling the Karma header out of view and
-            // the bottom of the iframe into view).
-            window.parent.scrollTo(0, window.parent.document.body.scrollHeight);
             const fullyVisible = await checkFullyInViewport(listbox);
 
             expect(listbox.scrollHeight).toBeGreaterThan(window.innerHeight);

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -45,6 +45,7 @@ async function checkFullyInViewport(element: HTMLElement): Promise<boolean> {
             // As of now, passing a document as root is not supported on Safari:
             // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#browser_compatibility
             // If we begin running these tests on Safari, we may need to skip those that use this function.
+            // This issue tracks expanding testing to Safari: https://github.com/ni/nimble/issues/990
             { threshold: 1.0, root: document }
         );
         intersectionObserver.observe(element);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #1208 

## 👩‍💻 Implementation

Use `document` as the root element in the IntersectionObserver. This is not currently supported on Safari, but since we do not test on Safari (yet), it is not a problem. I've added a comment to the source about this lack of support.

## 🧪 Testing

Test passes

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
