### PR TITLE
Fix bad import

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/src/directives/table-column/anchor/tests/nimble-table-column-anchor-router-link-with-href.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/table-column/anchor/tests/nimble-table-column-anchor-router-link-with-href.directive.spec.ts
@@ -3,11 +3,14 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { Router } from '@angular/router';
 import { CommonModule, Location } from '@angular/common';
 import { RouterTestingModule } from '@angular/router/testing';
+// Cannot import from table directive, because tests is not exported in release
+// eslint-disable-next-line no-restricted-imports
+import { TablePageObject } from '@ni/nimble-components/dist/esm/table/tests/table.pageobject';
 import { processUpdates, waitForUpdatesAsync } from '../../../../testing/async-helpers';
 import { NimbleTableColumnAnchorModule } from '../nimble-table-column-anchor.module';
 import { NimbleTableColumnAnchorRouterLinkWithHrefDirective } from '../nimble-table-column-anchor-router-link-with-href.directive';
 import type { TableColumnAnchor } from '../nimble-table-column-anchor.directive';
-import { Table, TablePageObject } from '../../../table/nimble-table.directive';
+import type { Table } from '../../../table/nimble-table.directive';
 import type { Anchor } from '../../../anchor/nimble-anchor.directive';
 import { NimbleTableModule } from '../../../table/nimble-table.module';
 

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/table/nimble-table.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/table/nimble-table.directive.ts
@@ -2,12 +2,11 @@ import { Directive, ElementRef, Input, OnDestroy, Renderer2 } from '@angular/cor
 import type { Table } from '@ni/nimble-components/dist/esm/table';
 import type { TableRecord, TableFieldName, TableFieldValue, TableValidity, TableActionMenuToggleEventDetail, TableRowSelectionEventDetail } from '@ni/nimble-components/dist/esm/table/types';
 import { TableRowSelectionMode } from '@ni/nimble-components/dist/esm/table/types';
-import { TablePageObject } from '@ni/nimble-components/dist/esm/table/tests/table.pageobject';
 import type { Observable, Subscription } from 'rxjs';
 
 export type { Table };
 export type { TableActionMenuToggleEventDetail, TableRowSelectionEventDetail };
-export { TableRecord, TableFieldName, TableFieldValue, TableValidity, TableRowSelectionMode, TablePageObject };
+export { TableRecord, TableFieldName, TableFieldValue, TableValidity, TableRowSelectionMode };
 
 /**
  * Directive to provide Angular integration for the table element.

--- a/change/@ni-nimble-angular-ab83ed68-443b-48d8-ae81-fbddfe779a46.json
+++ b/change/@ni-nimble-angular-ab83ed68-443b-48d8-ae81-fbddfe779a46.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bad import",
+  "packageName": "@ni/nimble-angular",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The nimble table directive in nimble-angular now includes an import for a file that doesn't exist. This breaks any app trying to import that version of the package.

## 👩‍💻 Implementation

The import is for a page object under the tests directory, which does not exist in published packages. The anchor column directive tests want to use the table page object, but due to our import restrictions, they could not import directly from the nimble-components package. Instead, it had to import from within nimble-angular, as the pattern is to have the directive import from nimble-components and re-export. This pattern breaks down when dealing with imports from test directories.

I've moved the import back to the angular tests file (so it is now a test file importing from the nimble-components test directory) and added a linter suppression.

## 🧪 Testing

The build should verify that the tests can still use the page object.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
