### PR TITLE
Introduce shared user-select styling

### DIFF
--- a/change/@ni-nimble-components-c4cd133e-dc68-4162-a6c5-81510fdcbe97.json
+++ b/change/@ni-nimble-components-c4cd133e-dc68-4162-a6c5-81510fdcbe97.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Introduce shared user-select styling",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/anchor-tree-item/styles.ts
+++ b/packages/nimble-components/src/anchor-tree-item/styles.ts
@@ -13,7 +13,7 @@ import {
     bodyFontSize
 } from '../theme-provider/design-tokens';
 import { focusVisible } from '../utilities/style/focus';
-import { disableSelect } from '../utilities/style/user-select';
+import { userSelectNone } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('block')}
@@ -83,7 +83,7 @@ export const styles = css`
         padding-left: 10px;
         font: inherit;
         font-size: ${bodyFontSize};
-        ${disableSelect}
+        ${userSelectNone}
         position: relative;
         margin-inline-start: ${iconSize};
     }

--- a/packages/nimble-components/src/anchor-tree-item/styles.ts
+++ b/packages/nimble-components/src/anchor-tree-item/styles.ts
@@ -13,6 +13,7 @@ import {
     bodyFontSize
 } from '../theme-provider/design-tokens';
 import { focusVisible } from '../utilities/style/focus';
+import { disableSelect } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('block')}
@@ -82,7 +83,7 @@ export const styles = css`
         padding-left: 10px;
         font: inherit;
         font-size: ${bodyFontSize};
-        user-select: none;
+        ${disableSelect}
         position: relative;
         margin-inline-start: ${iconSize};
     }

--- a/packages/nimble-components/src/checkbox/styles.ts
+++ b/packages/nimble-components/src/checkbox/styles.ts
@@ -14,6 +14,7 @@ import {
     smallDelay,
     buttonLabelFont
 } from '../theme-provider/design-tokens';
+import { disableSelect } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('inline-flex')}
@@ -23,7 +24,7 @@ export const styles = css`
         align-items: center;
         cursor: pointer;
         outline: none;
-        user-select: none;
+        ${disableSelect}
     }
 
     :host([disabled]) {

--- a/packages/nimble-components/src/checkbox/styles.ts
+++ b/packages/nimble-components/src/checkbox/styles.ts
@@ -14,7 +14,7 @@ import {
     smallDelay,
     buttonLabelFont
 } from '../theme-provider/design-tokens';
-import { disableSelect } from '../utilities/style/user-select';
+import { userSelectNone } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('inline-flex')}
@@ -24,7 +24,7 @@ export const styles = css`
         align-items: center;
         cursor: pointer;
         outline: none;
-        ${disableSelect}
+        ${userSelectNone}
     }
 
     :host([disabled]) {

--- a/packages/nimble-components/src/combobox/styles.ts
+++ b/packages/nimble-components/src/combobox/styles.ts
@@ -13,7 +13,7 @@ import { styles as errorStyles } from '../patterns/error/styles';
 import { focusVisible } from '../utilities/style/focus';
 import { appearanceBehavior } from '../utilities/style/appearance';
 import { DropdownAppearance } from '../select/types';
-import { disableSelect } from '../utilities/style/user-select';
+import { userSelectNone } from '../utilities/style/user-select';
 
 export const styles = css`
     ${dropdownStyles}
@@ -29,7 +29,7 @@ export const styles = css`
 
     :host([disabled]) *,
     :host([disabled]) {
-        ${disableSelect}
+        ${userSelectNone}
         color: ${bodyDisabledFontColor};
     }
 

--- a/packages/nimble-components/src/combobox/styles.ts
+++ b/packages/nimble-components/src/combobox/styles.ts
@@ -13,6 +13,7 @@ import { styles as errorStyles } from '../patterns/error/styles';
 import { focusVisible } from '../utilities/style/focus';
 import { appearanceBehavior } from '../utilities/style/appearance';
 import { DropdownAppearance } from '../select/types';
+import { disableSelect } from '../utilities/style/user-select';
 
 export const styles = css`
     ${dropdownStyles}
@@ -28,7 +29,7 @@ export const styles = css`
 
     :host([disabled]) *,
     :host([disabled]) {
-        user-select: none;
+        ${disableSelect}
         color: ${bodyDisabledFontColor};
     }
 

--- a/packages/nimble-components/src/icon-base/styles.ts
+++ b/packages/nimble-components/src/icon-base/styles.ts
@@ -8,14 +8,14 @@ import {
     iconColor,
     informationColor
 } from '../theme-provider/design-tokens';
-import { disableSelect } from '../utilities/style/user-select';
+import { userSelectNone } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('inline-flex')}
 
     :host {
         align-items: center;
-        ${disableSelect}
+        ${userSelectNone}
         width: ${iconSize};
         height: ${iconSize};
     }

--- a/packages/nimble-components/src/icon-base/styles.ts
+++ b/packages/nimble-components/src/icon-base/styles.ts
@@ -8,13 +8,14 @@ import {
     iconColor,
     informationColor
 } from '../theme-provider/design-tokens';
+import { disableSelect } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('inline-flex')}
 
     :host {
         align-items: center;
-        user-select: none;
+        ${disableSelect}
         width: ${iconSize};
         height: ${iconSize};
     }

--- a/packages/nimble-components/src/number-field/styles.ts
+++ b/packages/nimble-components/src/number-field/styles.ts
@@ -18,7 +18,7 @@ import {
 import { appearanceBehavior } from '../utilities/style/appearance';
 import { NumberFieldAppearance } from './types';
 import { styles as errorStyles } from '../patterns/error/styles';
-import { disableSelect } from '../utilities/style/user-select';
+import { userSelectNone } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('inline-block')}
@@ -27,7 +27,7 @@ export const styles = css`
     :host {
         font: ${bodyFont};
         outline: none;
-        ${disableSelect}
+        ${userSelectNone}
         color: ${bodyFontColor};
         --ni-private-hover-indicator-width: calc(${borderWidth} + 1px);
         --ni-private-height-within-border: calc(
@@ -79,7 +79,7 @@ export const styles = css`
         content: ' ';
         color: transparent;
         width: 0px;
-        ${disableSelect}
+        ${userSelectNone}
     }
 
     .root::after {

--- a/packages/nimble-components/src/number-field/styles.ts
+++ b/packages/nimble-components/src/number-field/styles.ts
@@ -18,6 +18,7 @@ import {
 import { appearanceBehavior } from '../utilities/style/appearance';
 import { NumberFieldAppearance } from './types';
 import { styles as errorStyles } from '../patterns/error/styles';
+import { disableSelect } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('inline-block')}
@@ -26,7 +27,7 @@ export const styles = css`
     :host {
         font: ${bodyFont};
         outline: none;
-        user-select: none;
+        ${disableSelect}
         color: ${bodyFontColor};
         --ni-private-hover-indicator-width: calc(${borderWidth} + 1px);
         --ni-private-height-within-border: calc(
@@ -78,7 +79,7 @@ export const styles = css`
         content: ' ';
         color: transparent;
         width: 0px;
-        user-select: none;
+        ${disableSelect}
     }
 
     .root::after {

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -24,6 +24,7 @@ import { hexToRgbaCssColor } from '../../utilities/style/colors';
 import { focusVisible } from '../../utilities/style/focus';
 import { themeBehavior } from '../../utilities/style/theme';
 import { DropdownAppearance } from './types';
+import { disableSelect } from '../../utilities/style/user-select';
 
 export const styles = css`
     ${display('inline-flex')}
@@ -35,7 +36,7 @@ export const styles = css`
         height: ${controlHeight};
         position: relative;
         justify-content: center;
-        user-select: none;
+        ${disableSelect}
         min-width: 250px;
         outline: none;
         vertical-align: top;

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -24,7 +24,7 @@ import { hexToRgbaCssColor } from '../../utilities/style/colors';
 import { focusVisible } from '../../utilities/style/focus';
 import { themeBehavior } from '../../utilities/style/theme';
 import { DropdownAppearance } from './types';
-import { disableSelect } from '../../utilities/style/user-select';
+import { userSelectNone } from '../../utilities/style/user-select';
 
 export const styles = css`
     ${display('inline-flex')}
@@ -36,7 +36,7 @@ export const styles = css`
         height: ${controlHeight};
         position: relative;
         justify-content: center;
-        ${disableSelect}
+        ${userSelectNone}
         min-width: 250px;
         outline: none;
         vertical-align: top;

--- a/packages/nimble-components/src/table/components/group-row/styles.ts
+++ b/packages/nimble-components/src/table/components/group-row/styles.ts
@@ -14,7 +14,7 @@ import {
 import { Theme } from '../../../theme-provider/types';
 import { hexToRgbaCssColor } from '../../../utilities/style/colors';
 import { themeBehavior } from '../../../utilities/style/theme';
-import { disableSelect } from '../../../utilities/style/user-select';
+import { userSelectNone } from '../../../utilities/style/user-select';
 
 export const styles = css`
     ${display('flex')}
@@ -67,7 +67,7 @@ export const styles = css`
 
     .group-header-view {
         padding-left: calc(${standardPadding} / 2);
-        ${disableSelect}
+        ${userSelectNone}
         overflow: hidden;
         display: flex;
     }
@@ -75,7 +75,7 @@ export const styles = css`
     .group-row-child-count {
         padding-left: 2px;
         pointer-events: none;
-        ${disableSelect}
+        ${userSelectNone}
     }
 
     @media (prefers-reduced-motion) {

--- a/packages/nimble-components/src/table/components/group-row/styles.ts
+++ b/packages/nimble-components/src/table/components/group-row/styles.ts
@@ -14,6 +14,7 @@ import {
 import { Theme } from '../../../theme-provider/types';
 import { hexToRgbaCssColor } from '../../../utilities/style/colors';
 import { themeBehavior } from '../../../utilities/style/theme';
+import { disableSelect } from '../../../utilities/style/user-select';
 
 export const styles = css`
     ${display('flex')}
@@ -66,7 +67,7 @@ export const styles = css`
 
     .group-header-view {
         padding-left: calc(${standardPadding} / 2);
-        user-select: none;
+        ${disableSelect}
         overflow: hidden;
         display: flex;
     }
@@ -74,7 +75,7 @@ export const styles = css`
     .group-row-child-count {
         padding-left: 2px;
         pointer-events: none;
-        user-select: none;
+        ${disableSelect}
     }
 
     @media (prefers-reduced-motion) {

--- a/packages/nimble-components/src/text-area/styles.ts
+++ b/packages/nimble-components/src/text-area/styles.ts
@@ -18,6 +18,7 @@ import {
 import { appearanceBehavior } from '../utilities/style/appearance';
 import { TextAreaAppearance } from './types';
 import { styles as errorStyles } from '../patterns/error/styles';
+import { disableSelect } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('inline-flex')}
@@ -26,7 +27,7 @@ export const styles = css`
     :host {
         font: ${bodyFont};
         outline: none;
-        user-select: none;
+        ${disableSelect}
         color: ${bodyFontColor};
         flex-direction: column;
         vertical-align: top;

--- a/packages/nimble-components/src/text-area/styles.ts
+++ b/packages/nimble-components/src/text-area/styles.ts
@@ -18,7 +18,7 @@ import {
 import { appearanceBehavior } from '../utilities/style/appearance';
 import { TextAreaAppearance } from './types';
 import { styles as errorStyles } from '../patterns/error/styles';
-import { disableSelect } from '../utilities/style/user-select';
+import { userSelectNone } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('inline-flex')}
@@ -27,7 +27,7 @@ export const styles = css`
     :host {
         font: ${bodyFont};
         outline: none;
-        ${disableSelect}
+        ${userSelectNone}
         color: ${bodyFontColor};
         flex-direction: column;
         vertical-align: top;

--- a/packages/nimble-components/src/text-field/styles.ts
+++ b/packages/nimble-components/src/text-field/styles.ts
@@ -21,6 +21,7 @@ import { TextFieldAppearance } from './types';
 import { Theme } from '../theme-provider/types';
 import { themeBehavior } from '../utilities/style/theme';
 import { styles as errorStyles } from '../patterns/error/styles';
+import { disableSelect } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('inline-block')}
@@ -29,8 +30,7 @@ export const styles = css`
     :host {
         font: ${bodyFont};
         outline: none;
-        user-select: none;
-        --webkit-user-select: none;
+        ${disableSelect}
         color: ${bodyFontColor};
         --ni-private-hover-indicator-width: calc(${borderWidth} + 1px);
         --ni-private-height-within-border: calc(
@@ -92,7 +92,7 @@ export const styles = css`
         content: ' ';
         color: transparent;
         width: 0px;
-        user-select: none;
+        ${disableSelect}
     }
 
     :host([appearance='frameless'][full-bleed]) .root::before {
@@ -104,7 +104,7 @@ export const styles = css`
         content: ' ';
         color: transparent;
         width: 0px;
-        user-select: none;
+        ${disableSelect}
     }
 
     :host([appearance='frameless'][full-bleed]) .root::after {

--- a/packages/nimble-components/src/text-field/styles.ts
+++ b/packages/nimble-components/src/text-field/styles.ts
@@ -21,7 +21,7 @@ import { TextFieldAppearance } from './types';
 import { Theme } from '../theme-provider/types';
 import { themeBehavior } from '../utilities/style/theme';
 import { styles as errorStyles } from '../patterns/error/styles';
-import { disableSelect } from '../utilities/style/user-select';
+import { userSelectNone } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('inline-block')}
@@ -30,7 +30,7 @@ export const styles = css`
     :host {
         font: ${bodyFont};
         outline: none;
-        ${disableSelect}
+        ${userSelectNone}
         color: ${bodyFontColor};
         --ni-private-hover-indicator-width: calc(${borderWidth} + 1px);
         --ni-private-height-within-border: calc(
@@ -92,7 +92,7 @@ export const styles = css`
         content: ' ';
         color: transparent;
         width: 0px;
-        ${disableSelect}
+        ${userSelectNone}
     }
 
     :host([appearance='frameless'][full-bleed]) .root::before {
@@ -104,7 +104,7 @@ export const styles = css`
         content: ' ';
         color: transparent;
         width: 0px;
-        ${disableSelect}
+        ${userSelectNone}
     }
 
     :host([appearance='frameless'][full-bleed]) .root::after {

--- a/packages/nimble-components/src/tree-item/styles.ts
+++ b/packages/nimble-components/src/tree-item/styles.ts
@@ -16,7 +16,7 @@ import {
 } from '../theme-provider/design-tokens';
 import { groupSelectedAttribute } from '../tree-view/types';
 import { DirectionalStyleSheetBehavior } from '../utilities/style/direction';
-import { disableSelect } from '../utilities/style/user-select';
+import { userSelectNone } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('block')}
@@ -91,7 +91,7 @@ export const styles = css`
         padding-left: 10px;
         font: inherit;
         font-size: ${bodyFontSize};
-        ${disableSelect}
+        ${userSelectNone}
         position: relative;
         margin-inline-start: ${iconSize};
     }

--- a/packages/nimble-components/src/tree-item/styles.ts
+++ b/packages/nimble-components/src/tree-item/styles.ts
@@ -16,6 +16,7 @@ import {
 } from '../theme-provider/design-tokens';
 import { groupSelectedAttribute } from '../tree-view/types';
 import { DirectionalStyleSheetBehavior } from '../utilities/style/direction';
+import { disableSelect } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('block')}
@@ -90,7 +91,7 @@ export const styles = css`
         padding-left: 10px;
         font: inherit;
         font-size: ${bodyFontSize};
-        user-select: none;
+        ${disableSelect}
         position: relative;
         margin-inline-start: ${iconSize};
     }

--- a/packages/nimble-components/src/utilities/style/user-select.ts
+++ b/packages/nimble-components/src/utilities/style/user-select.ts
@@ -1,0 +1,6 @@
+import { cssPartial } from '@microsoft/fast-element';
+
+export const disableSelect = cssPartial`
+    user-select: none;
+    -webkit-user-select: none;
+`;

--- a/packages/nimble-components/src/utilities/style/user-select.ts
+++ b/packages/nimble-components/src/utilities/style/user-select.ts
@@ -1,6 +1,6 @@
 import { cssPartial } from '@microsoft/fast-element';
 
-export const disableSelect = cssPartial`
+export const userSelectNone = cssPartial`
     user-select: none;
     -webkit-user-select: none;
 `;

--- a/packages/nimble-components/src/utilities/style/user-select.ts
+++ b/packages/nimble-components/src/utilities/style/user-select.ts
@@ -1,5 +1,9 @@
 import { cssPartial } from '@microsoft/fast-element';
 
+/**
+ * Set user-select: none in a way that works across all supported browsers.
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/user-select#browser_compatibility
+ */
 export const userSelectNone = cssPartial`
     user-select: none;
     -webkit-user-select: none;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This came up in [this PR](https://github.com/ni/nimble/pull/1218#discussion_r1186292378). For `user-select` styling to work correctly in Safari, we need to set `-webkit-user-select`. To make this easier, setting both CSS properties is encapsulated in shared styling.

## 👩‍💻 Implementation

- Create shared styling that accounts for Safari and non-Safari ways of disabling selection
- Update existing styling that sets `user-select: none;` to use the shared CSS that works in all browsers

## 🧪 Testing

Manually spot checked in Edge and WebKit

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
