### PR TITLE
Prevent double clicking on a table column header from selecting text

### DIFF
--- a/change/@ni-nimble-components-8b88d8f8-6d94-4829-beab-98c9c393b3a3.json
+++ b/change/@ni-nimble-components-8b88d8f8-6d94-4829-beab-98c9c393b3a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Prevent double click select text on header",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/components/header/template.ts
+++ b/packages/nimble-components/src/table/components/header/template.ts
@@ -7,7 +7,10 @@ import { TableColumnSortDirection } from '../../types';
 
 // prettier-ignore
 export const template = html<TableHeader>`
-    <template role="columnheader" aria-sort="${x => x.ariaSort}">
+    <template role="columnheader"
+        aria-sort="${x => x.ariaSort}"
+        @mousedown="${(_x, c) => !((c.event as MouseEvent).detail > 1)}"
+    >
         <slot></slot>
 
         ${when(x => x.sortDirection === TableColumnSortDirection.ascending, html`


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Small patch to prevent double clicking on a table column header from selecting text. Still allows text selection with click and drag but prevents rapidly changing sort direction interactively from selecting header text.

## 👩‍💻 Implementation

Used this idea: https://stackoverflow.com/a/43321596/338923
Coupled with FAST event handler built-in prevent default behavior: https://www.fast.design/docs/fast-element/declaring-templates/#events

## 🧪 Testing

Manual test in storybook

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
