### PR TITLE
Fix row styling issue

### DIFF
--- a/change/@ni-nimble-components-1b2f8973-e274-4624-b6d0-9ada96fa1d11.json
+++ b/change/@ni-nimble-components-1b2f8973-e274-4624-b6d0-9ada96fa1d11.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix row styling issue",
+  "packageName": "@ni/nimble-components",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
@@ -619,16 +619,6 @@ export const grouping: StoryObj<GroupingTableArgs> = {
             >
                 Last Name
             </${tableColumnTextTag}>
-            <${tableColumnTextTag}
-                field-name="favoriteColor"
-            >
-                Favorite Color
-            </${tableColumnTextTag}>
-            <${tableColumnTextTag}
-                field-name="quote"
-            >
-                Quote
-            </${tableColumnTextTag}>
 
         </${tableTag}>
     `),

--- a/packages/nimble-components/src/table/components/group-row/styles.ts
+++ b/packages/nimble-components/src/table/components/group-row/styles.ts
@@ -17,13 +17,14 @@ import { themeBehavior } from '../../../utilities/style/theme';
 import { userSelectNone } from '../../../utilities/style/user-select';
 
 export const styles = css`
-    ${display('flex')}
+    ${display('grid')}
 
     :host {
         align-items: center;
         height: calc(${controlHeight} + 2 * ${borderWidth});
         border-top: calc(2 * ${borderWidth}) solid ${applicationBackgroundColor};
         box-sizing: border-box;
+        grid-template-columns: var(--ni-private-table-group-row-grid-columns) auto;
     }
 
     :host([expanded]) .animating,
@@ -74,6 +75,7 @@ export const styles = css`
 
     .group-row-child-count {
         padding-left: 2px;
+        padding-right: calc(${standardPadding} / 2);
         pointer-events: none;
         ${userSelectNone}
     }

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -129,6 +129,12 @@ export class Table<
      * @internal
      */
     @observable
+    public groupRowGridColumns?: string;
+
+    /**
+     * @internal
+     */
+    @observable
     public selectionState: TableRowSelectionState = TableRowSelectionState.notSelected;
 
     public get validity(): TableValidity {
@@ -688,6 +694,8 @@ export class Table<
         this.rowGridColumns = TableLayoutHelper.getGridTemplateColumns(
             this.columns
         );
+
+        this.groupRowGridColumns = TableLayoutHelper.getGroupRowGridTemplateColumns(this.columns);
     }
 
     private validate(): void {

--- a/packages/nimble-components/src/table/models/table-layout-helper.ts
+++ b/packages/nimble-components/src/table/models/table-layout-helper.ts
@@ -1,4 +1,5 @@
 import type { TableColumn } from '../../table-column/base';
+import { controlHeight } from '../../theme-provider/design-tokens';
 
 /**
  * This class provides helper methods for managing the layout of cells within
@@ -25,5 +26,31 @@ export class TableLayoutHelper {
                 return `minmax(${minPixelWidth}px, ${currentFractionalWidth}fr)`;
             })
             .join(' ');
+    }
+
+    public static getGroupRowGridTemplateColumns(
+        columns: TableColumn[]
+    ): string {
+        if (columns.length === 0) {
+            return '1fr';
+        }
+        const totalMinPixelWidth = columns
+            ?.filter(column => !column.columnHidden)
+            .reduce((p, c) => {
+                if (c.columnInternals.currentPixelWidth) {
+                    return (
+                        p
+                        + Math.max(
+                            c.columnInternals.minPixelWidth,
+                            c.columnInternals.currentPixelWidth
+                        )
+                    );
+                }
+
+                return p + c.columnInternals.minPixelWidth;
+            }, 0);
+        return `${controlHeight.getValueFor(
+            columns[0]!
+        )} minmax(${totalMinPixelWidth}px, 1fr)`;
     }
 }

--- a/packages/nimble-components/src/table/styles.ts
+++ b/packages/nimble-components/src/table/styles.ts
@@ -51,7 +51,7 @@ export const styles = css`
     }
 
     .table-row-container {
-        width: 100%;
+        width: fit-content;
         position: relative;
         top: var(--ni-private-table-row-container-top);
         background-color: ${tableRowBorderColor};

--- a/packages/nimble-components/src/table/styles.ts
+++ b/packages/nimble-components/src/table/styles.ts
@@ -52,6 +52,7 @@ export const styles = css`
 
     .table-row-container {
         width: fit-content;
+        min-width: 100%;
         position: relative;
         top: var(--ni-private-table-row-container-top);
         background-color: ${tableRowBorderColor};

--- a/packages/nimble-components/src/table/template.ts
+++ b/packages/nimble-components/src/table/template.ts
@@ -38,6 +38,7 @@ export const template = html<Table>`
             --ni-private-table-scroll-height: ${x => x.virtualizer.allRowsHeight}px;
             --ni-private-table-row-container-top: ${x => x.virtualizer.rowContainerYOffset}px;
             --ni-private-table-row-grid-columns: ${x => x.rowGridColumns ?? ''};
+            --ni-private-table-group-row-grid-columns: ${x => x.groupRowGridColumns ?? ''};
             ">
             <div role="rowgroup" class="header-container">
                 <div class="header-row" role="row">


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

- #1233

## 👩‍💻 Implementation

Follow the pattern from `.header-row` for the `.table-row-container` which sets `width` to `fit-content` and `min-width` to `100%`.

Additionally, I had to make the `group-row` component start using a grid layout where its size is derived from the set of column sizes just as the `row's` size is determined. Otherwise, with its previous `flex` layout the `table-row-container` (with its `width` now set to `fit-content`) would invariably size to the whole contents of the header, which, if large enough, would result in a horizontal scrollbar instead of ellipsized text.

## 🧪 Testing

Manual.

Note: You can see this easily in the existing 'Fractional Width Column' storybook with the 'Color' or 'Dark' theme by changing the `min-pixel-width` in the configuration section to something like `500`.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
