### PR TITLE
Format MDX with Prettier

### DIFF
--- a/change/@ni-nimble-components-53b41e81-fc7a-4f1a-a2e5-612b1af844e6.json
+++ b/change/@ni-nimble-components-53b41e81-fc7a-4f1a-a2e5-612b1af844e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update prettier to support MDX files",
+  "packageName": "@ni/nimble-components",
+  "email": "1458528+fredvisser@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23555,9 +23555,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
-      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -30100,7 +30100,7 @@
         "karma-webkit-launcher": "^2.1.0",
         "karma-webpack": "^5.0.0",
         "playwright": "^1.30.0",
-        "prettier": "^2.0.0",
+        "prettier": "^2.8.8",
         "prettier-eslint": "^15.0.1",
         "prettier-eslint-cli": "^7.1.0",
         "puppeteer": "^10.1.0",
@@ -34156,7 +34156,7 @@
         "karma-webkit-launcher": "^2.1.0",
         "karma-webpack": "^5.0.0",
         "playwright": "^1.30.0",
-        "prettier": "^2.0.0",
+        "prettier": "^2.8.8",
         "prettier-eslint": "^15.0.1",
         "prettier-eslint-cli": "^7.1.0",
         "puppeteer": "^10.1.0",
@@ -48340,9 +48340,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
-      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "prettier-eslint": {

--- a/packages/nimble-components/.prettierignore
+++ b/packages/nimble-components/.prettierignore
@@ -17,6 +17,7 @@
 !src/**/*.mdx
 !src/**/*.json
 
+/docs/**/*.*
 !docs/**/*.mdx
 
 /.storybook/*.*

--- a/packages/nimble-components/.prettierignore
+++ b/packages/nimble-components/.prettierignore
@@ -4,6 +4,7 @@
 !*.ts
 !*.js
 !*.md
+!*.mdx
 !*.json
 !src/
 !/.storybook/
@@ -12,6 +13,7 @@
 !src/**/*.ts
 !src/**/*.js
 !src/**/*.md
+!src/**/*.mdx
 !src/**/*.json
 
 /.storybook/*.*

--- a/packages/nimble-components/.prettierignore
+++ b/packages/nimble-components/.prettierignore
@@ -7,6 +7,7 @@
 !*.mdx
 !*.json
 !src/
+!docs/
 !/.storybook/
 
 /src/**/*.*
@@ -15,6 +16,8 @@
 !src/**/*.md
 !src/**/*.mdx
 !src/**/*.json
+
+!docs/**/*.mdx
 
 /.storybook/*.*
 !/.storybook/*.js

--- a/packages/nimble-components/docs/nimble-intro.stories.mdx
+++ b/packages/nimble-components/docs/nimble-intro.stories.mdx
@@ -1,53 +1,36 @@
 import { Story, Meta } from '@storybook/addon-docs';
 import overviewImage from './storybook-overview.png';
-import nimbleLogo from "./nimble-logo-icon.svg";
+import nimbleLogo from './nimble-logo-icon.svg';
 
-<Meta 
-    title="Getting Started" 
-    parameters={{
-        viewMode: 'docs',
-        previewTabs: { 
-            canvas: { hidden: true } 
-        },
-        backgrounds: {
-            disable: true,
-            grid: {
-                disable: true,
-            }
-        },
-        outline: {
-            disable: true,
-        }
-    }}
-/>
+<Meta title="Getting Started" />
 
 # Nimble Design System
 
-<img src={nimbleLogo} width="100px"/>
+<img src={nimbleLogo} width="100px" />
 
 ## Overview
 
-The [Nimble Design System](https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/) is an easy to use collection of well-designed, 
-styled components that can be used in any NI web application. 
+The [Nimble Design System](https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/) is an easy to use collection of well-designed,
+styled components that can be used in any NI web application.
 
-Refer to the 
-[Nimble GitHub repository](https://github.com/ni/nimble) for documentation on using or 
-contributing to the component library. To add or update component design documentation, 
+Refer to the
+[Nimble GitHub repository](https://github.com/ni/nimble) for documentation on using or
+contributing to the component library. To add or update component design documentation,
 refer to the [documentation guide](https://github.com/ni/nimble/tree/main/packages/nimble-components/docs/creating-storybook-component-documentation.md).
 
 See the <a href="./example-client-app" target="_blank">example Angular app</a> or <a href="./blazor-client-app/wwwroot" target="_blank">example Blazor app</a> using the components!
 
 ## How to use this site?
 
-This Storybook documentation site can be used to browse and interact with all available 
-design system components. 
+This Storybook documentation site can be used to browse and interact with all available
+design system components.
 
-<img src={overviewImage} width="100%"/>
+<img src={overviewImage} width="100%" />
 
-- Browse or search the components tree (**#1**) to preview isolated components and use the **Docs** item to review 
-component-specific design and technical usage information. 
-- **⚙ menu** (**#2**) to open and position the addons pane (**#3**). 
-    - **Controls** tab to interactively configure the component.
-    - **Actions** tab to review events sent by the component.
-    - **Accessibility** tab to check the component for accessibility issues.
-- **Background** toolbar button (**#4**) to switch the preview between supported component themes.
+-   Browse or search the components tree (**#1**) to preview isolated components and use the **Docs** item to review
+    component-specific design and technical usage information.
+-   **⚙ menu** (**#2**) to open and position the addons pane (**#3**).
+    -   **Controls** tab to interactively configure the component.
+    -   **Actions** tab to review events sent by the component.
+    -   **Accessibility** tab to check the component for accessibility issues.
+-   **Background** toolbar button (**#4**) to switch the preview between supported component themes.

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -119,7 +119,7 @@
     "karma-webkit-launcher": "^2.1.0",
     "karma-webpack": "^5.0.0",
     "playwright": "^1.30.0",
-    "prettier": "^2.0.0",
+    "prettier": "^2.8.8",
     "prettier-eslint": "^15.0.1",
     "prettier-eslint-cli": "^7.1.0",
     "puppeteer": "^10.1.0",

--- a/packages/nimble-components/src/button/tests/button.mdx
+++ b/packages/nimble-components/src/button/tests/button.mdx
@@ -1,4 +1,11 @@
-import { Canvas, Meta, Controls, Stories, Title, Description } from '@storybook/blocks';
+import {
+    Canvas,
+    Meta,
+    Controls,
+    Stories,
+    Title,
+    Description
+} from '@storybook/blocks';
 import * as buttonStories from './button.stories';
 
 <Meta of={buttonStories} />


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

With Storybook 7, the new docs architecture uses MDX files, but Prettier was not configured to format files with a `*.mdx` extension. 

## 👩‍💻 Implementation

- Updated `prettier` NPM dependency to the latest because version 2.5 included support for MDX2 (which Storybook uses)
- Added `*.mdx` glob in `prettierignore` file.

## 🧪 Testing

Ran `prettier-fix` and `button.mdx` was correctly formatted with no other changes.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
