### PR TITLE
Add column-configuration-change event to the nimble-table

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/src/directives/table/nimble-table.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/table/nimble-table.directive.ts
@@ -1,11 +1,11 @@
 import { Directive, ElementRef, Input, OnDestroy, Renderer2 } from '@angular/core';
 import type { Table } from '@ni/nimble-components/dist/esm/table';
-import type { TableRecord, TableFieldName, TableFieldValue, TableValidity, TableActionMenuToggleEventDetail, TableRowSelectionEventDetail, TableColumnConfigurationChangeEventDetail } from '@ni/nimble-components/dist/esm/table/types';
+import type { TableRecord, TableFieldName, TableFieldValue, TableValidity, TableActionMenuToggleEventDetail, TableRowSelectionEventDetail, TableColumnConfigurationChangeEventDetail, TableColumnConfiguration } from '@ni/nimble-components/dist/esm/table/types';
 import { TableRowSelectionMode } from '@ni/nimble-components/dist/esm/table/types';
 import type { Observable, Subscription } from 'rxjs';
 
 export type { Table };
-export type { TableActionMenuToggleEventDetail, TableRowSelectionEventDetail, TableColumnConfigurationChangeEventDetail };
+export type { TableActionMenuToggleEventDetail, TableRowSelectionEventDetail, TableColumnConfigurationChangeEventDetail, TableColumnConfiguration };
 export { TableRecord, TableFieldName, TableFieldValue, TableValidity, TableRowSelectionMode };
 
 /**

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/table/nimble-table.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/table/nimble-table.directive.ts
@@ -1,11 +1,11 @@
 import { Directive, ElementRef, Input, OnDestroy, Renderer2 } from '@angular/core';
 import type { Table } from '@ni/nimble-components/dist/esm/table';
-import type { TableRecord, TableFieldName, TableFieldValue, TableValidity, TableActionMenuToggleEventDetail, TableRowSelectionEventDetail } from '@ni/nimble-components/dist/esm/table/types';
+import type { TableRecord, TableFieldName, TableFieldValue, TableValidity, TableActionMenuToggleEventDetail, TableRowSelectionEventDetail, TableColumnConfigurationChangeEventDetail } from '@ni/nimble-components/dist/esm/table/types';
 import { TableRowSelectionMode } from '@ni/nimble-components/dist/esm/table/types';
 import type { Observable, Subscription } from 'rxjs';
 
 export type { Table };
-export type { TableActionMenuToggleEventDetail, TableRowSelectionEventDetail };
+export type { TableActionMenuToggleEventDetail, TableRowSelectionEventDetail, TableColumnConfigurationChangeEventDetail };
 export { TableRecord, TableFieldName, TableFieldValue, TableValidity, TableRowSelectionMode };
 
 /**

--- a/change/@ni-nimble-angular-4122bfa1-bbdd-44ee-b88b-dd7cecdd39ba.json
+++ b/change/@ni-nimble-angular-4122bfa1-bbdd-44ee-b88b-dd7cecdd39ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add support for the column-configuration-change event to the table directive",
+  "packageName": "@ni/nimble-angular",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-blazor-dfd5f82d-e9dd-497d-9483-9eb8ce606d80.json
+++ b/change/@ni-nimble-blazor-dfd5f82d-e9dd-497d-9483-9eb8ce606d80.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add support for the column-configuration-change event to the table",
+  "packageName": "@ni/nimble-blazor",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-82511488-93b6-47cf-a8d3-9b48711a4f82.json
+++ b/change/@ni-nimble-components-82511488-93b6-47cf-a8d3-9b48711a4f82.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add column-configuration-change event to the nimble-table",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleTable.razor
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleTable.razor
@@ -8,6 +8,7 @@
     @onnimbleactionmenubeforetoggle="(__value) => HandleActionMenuBeforeToggle(__value)"
     @onnimbleactionmenutoggle="(__value) => HandleActionMenuToggle(__value)"
     @onnimbletablerowselectionchange="(__value) => HandleSelectionChange(__value)"
+    @onnimbletablecolumnconfigurationchange="(__value) => HandleColumnConfigurationChange(__value)"
 >
     @ChildContent
 </nimble-table>

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleTable.razor.cs
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleTable.razor.cs
@@ -111,6 +111,12 @@ public partial class NimbleTable<TData> : ComponentBase
     public EventCallback<TableRowSelectionEventArgs> RowSelectionChange { get; set; }
 
     /// <summary>
+    /// Gets or sets a callback that's invoked when a column's configuration is changed.
+    /// </summary>
+    [Parameter]
+    public EventCallback<TableColumnConfigurationEventArgs> ColumnConfigurationChange { get; set; }
+
+    /// <summary>
     /// Called when 'action-menu-toggle' changes on the web component.
     /// </summary>
     /// <param name="eventArgs">The state of the action menu on the table</param>
@@ -135,6 +141,15 @@ public partial class NimbleTable<TData> : ComponentBase
     protected async void HandleSelectionChange(TableRowSelectionEventArgs eventArgs)
     {
         await RowSelectionChange.InvokeAsync(eventArgs);
+    }
+
+    /// <summary>
+    /// Called when the 'column-configuration-change' event is fired on the web component.
+    /// </summary>
+    /// <param name="eventArgs">The configuration of the columns</param>
+    protected async void HandleColumnConfigurationChange(TableColumnConfigurationEventArgs eventArgs)
+    {
+        await ColumnConfigurationChange.InvokeAsync(eventArgs);
     }
 
     /// <inheritdoc/>

--- a/packages/nimble-blazor/NimbleBlazor/EventHandlers.cs
+++ b/packages/nimble-blazor/NimbleBlazor/EventHandlers.cs
@@ -38,6 +38,22 @@ public class TableRowSelectionEventArgs : EventArgs
     public IEnumerable<string>? SelectedRecordIds { get; set; }
 }
 
+public class TableColumnConfigurationEventArgs : EventArgs
+{
+    public IEnumerable<TableColumnConfiguration>? Columns { get; set; }
+}
+
+public class TableColumnConfiguration
+{
+    public string? ColumnId { get; set; }
+    public int? SortIndex { get; set; }
+    public TableColumnSortDirection SortDirection { get; set; }
+    public int? GroupIndex { get; set; }
+    public bool Hidden { get; set; }
+    public double FractionalWidth { get; set; }
+    public double? PixelWidth { get; set; }
+}
+
 [EventHandler("onnimbletabsactiveidchange", typeof(TabsChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("onnimblecheckedchange", typeof(CheckboxChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("onnimblemenubuttontoggle", typeof(MenuButtonToggleEventArgs), enableStopPropagation: true, enablePreventDefault: false)]
@@ -46,6 +62,7 @@ public class TableRowSelectionEventArgs : EventArgs
 [EventHandler("onnimbleactionmenutoggle", typeof(TableActionMenuToggleEventArgs), enableStopPropagation: true, enablePreventDefault: false)]
 [EventHandler("onnimbleactionmenubeforetoggle", typeof(TableActionMenuToggleEventArgs), enableStopPropagation: true, enablePreventDefault: false)]
 [EventHandler("onnimbletablerowselectionchange", typeof(TableRowSelectionEventArgs), enableStopPropagation: true, enablePreventDefault: false)]
+[EventHandler("onnimbletablecolumnconfigurationchange", typeof(TableColumnConfigurationEventArgs), enableStopPropagation: true, enablePreventDefault: false)]
 public static class EventHandlers
 {
 }

--- a/packages/nimble-blazor/NimbleBlazor/EventHandlers.cs
+++ b/packages/nimble-blazor/NimbleBlazor/EventHandlers.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Components;
 
 namespace NimbleBlazor;
@@ -46,11 +47,18 @@ public class TableColumnConfigurationEventArgs : EventArgs
 public class TableColumnConfiguration
 {
     public string? ColumnId { get; set; }
+
     public int? SortIndex { get; set; }
+
+    [JsonConverter(typeof(TableColumnSortDirectionConverter))]
     public TableColumnSortDirection SortDirection { get; set; }
+
     public int? GroupIndex { get; set; }
+
     public bool Hidden { get; set; }
+
     public double FractionalWidth { get; set; }
+
     public double? PixelWidth { get; set; }
 }
 

--- a/packages/nimble-blazor/NimbleBlazor/TableColumnSortDirection.cs
+++ b/packages/nimble-blazor/NimbleBlazor/TableColumnSortDirection.cs
@@ -1,4 +1,7 @@
-﻿namespace NimbleBlazor;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NimbleBlazor;
 
 public enum TableColumnSortDirection
 {
@@ -9,7 +12,7 @@ public enum TableColumnSortDirection
 
 internal static class TableColumnSortDirectionExtensions
 {
-    private static readonly Dictionary<TableColumnSortDirection, string> _enumValues = AttributeHelpers.GetEnumNamesAsKebabCaseValues<TableColumnSortDirection>();
+    internal static readonly Dictionary<TableColumnSortDirection, string> EnumValues = AttributeHelpers.GetEnumNamesAsKebabCaseValues<TableColumnSortDirection>();
 
-    public static string? ToAttributeValue(this TableColumnSortDirection? value) => (value == null || value == TableColumnSortDirection.None) ? null : _enumValues[value.Value];
+    public static string? ToAttributeValue(this TableColumnSortDirection? value) => (value == null || value == TableColumnSortDirection.None) ? null : EnumValues[value.Value];
 }

--- a/packages/nimble-blazor/NimbleBlazor/TableColumnSortDirection.cs
+++ b/packages/nimble-blazor/NimbleBlazor/TableColumnSortDirection.cs
@@ -1,7 +1,4 @@
-﻿using System.Text.Json;
-using System.Text.Json.Serialization;
-
-namespace NimbleBlazor;
+﻿namespace NimbleBlazor;
 
 public enum TableColumnSortDirection
 {

--- a/packages/nimble-blazor/NimbleBlazor/TableColumnSortDirectionConverter.cs
+++ b/packages/nimble-blazor/NimbleBlazor/TableColumnSortDirectionConverter.cs
@@ -1,0 +1,22 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NimbleBlazor;
+
+internal class TableColumnSortDirectionConverter : JsonConverter<TableColumnSortDirection>
+{
+    public override TableColumnSortDirection Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        return TableColumnSortDirectionExtensions.EnumValues.FirstOrDefault(x => x.Value == value).Key;
+    }
+
+    public override void Write(
+            Utf8JsonWriter writer,
+            TableColumnSortDirection value,
+            JsonSerializerOptions options)
+    {
+        var convertedValue = (value as TableColumnSortDirection?).ToAttributeValue();
+        writer.WriteStringValue(convertedValue);
+    }
+}

--- a/packages/nimble-blazor/NimbleBlazor/TableColumnSortDirectionConverter.cs
+++ b/packages/nimble-blazor/NimbleBlazor/TableColumnSortDirectionConverter.cs
@@ -11,10 +11,7 @@ internal class TableColumnSortDirectionConverter : JsonConverter<TableColumnSort
         return TableColumnSortDirectionExtensions.EnumValues.FirstOrDefault(x => x.Value == value).Key;
     }
 
-    public override void Write(
-            Utf8JsonWriter writer,
-            TableColumnSortDirection value,
-            JsonSerializerOptions options)
+    public override void Write(Utf8JsonWriter writer, TableColumnSortDirection value, JsonSerializerOptions options)
     {
         var convertedValue = (value as TableColumnSortDirection?).ToAttributeValue();
         writer.WriteStringValue(convertedValue);

--- a/packages/nimble-blazor/NimbleBlazor/wwwroot/NimbleBlazor.lib.module.js
+++ b/packages/nimble-blazor/NimbleBlazor/wwwroot/NimbleBlazor.lib.module.js
@@ -109,6 +109,15 @@ export function afterStarted(Blazor) {
             };
         }
     });
+    // Used by NimbleTable.razor
+    Blazor.registerCustomEventType('nimbletablecolumnconfigurationchange', {
+        browserEventName: 'column-configuration-change',
+        createEventArgs: event => {
+            return {
+                columns: event.detail.columns
+            };
+        }
+    });
 }
 
 if (window.NimbleBlazor) {

--- a/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.stories.ts
+++ b/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.stories.ts
@@ -1,5 +1,6 @@
 import { html, ref } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
+import { withActions } from '@storybook/addon-actions/decorator';
 import {
     createUserSelectedThemeStory,
     usageWarning
@@ -7,6 +8,7 @@ import {
 import { tableTag } from '../../../table';
 import { tableColumnAnchorTag } from '..';
 import {
+    sharedTableActions,
     SharedTableArgs,
     sharedTableArgs,
     sharedTableArgTypes
@@ -20,12 +22,16 @@ information about common column configuration.`;
 
 const metadata: Meta<SharedTableArgs> = {
     title: 'Table Column Types',
+    decorators: [withActions],
     tags: ['autodocs'],
     parameters: {
         docs: {
             description: {
                 component: columnTypeOverviewText
             }
+        },
+        actions: {
+            handles: sharedTableActions
         }
     },
     // prettier-ignore

--- a/packages/nimble-components/src/table-column/base/tests/table-column-stories-utils.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column-stories-utils.ts
@@ -45,3 +45,8 @@ export const sharedTableArgs = (
         }
     } as const;
 };
+
+export const sharedTableActions = [
+    'selection-change',
+    'column-configuration-change'
+] as const;

--- a/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
@@ -1,5 +1,6 @@
 import { html, ref, when } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
+import { withActions } from '@storybook/addon-actions/decorator';
 import {
     createUserSelectedThemeStory,
     usageWarning
@@ -24,7 +25,6 @@ import {
 import { iconUserTag } from '../../../icons/user';
 import { iconCommentTag } from '../../../icons/comment';
 import { tableColumnTextTag } from '../../text';
-import { withActions } from '@storybook/addon-actions/decorator';
 
 const simpleData = [
     {

--- a/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
@@ -13,6 +13,7 @@ import {
 import { tableTag } from '../../../table';
 import {
     SharedTableArgs,
+    sharedTableActions,
     sharedTableArgTypes,
     sharedTableArgs
 } from './table-column-stories-utils';
@@ -23,6 +24,7 @@ import {
 import { iconUserTag } from '../../../icons/user';
 import { iconCommentTag } from '../../../icons/comment';
 import { tableColumnTextTag } from '../../text';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 const simpleData = [
     {
@@ -80,11 +82,15 @@ information about specific types of column.`;
 
 const metadata: Meta<SharedTableArgs> = {
     title: 'Table Column Configuration',
+    decorators: [withActions],
     parameters: {
         docs: {
             description: {
                 component: overviewText
             }
+        },
+        actions: {
+            handles: sharedTableActions
         }
     },
     // prettier-ignore

--- a/packages/nimble-components/src/table-column/text/tests/table-column-text.stories.ts
+++ b/packages/nimble-components/src/table-column/text/tests/table-column-text.stories.ts
@@ -1,5 +1,6 @@
 import { html, ref } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
+import { withActions } from '@storybook/addon-actions/decorator';
 import {
     createUserSelectedThemeStory,
     usageWarning
@@ -8,6 +9,7 @@ import { tableTag } from '../../../table';
 import { tableColumnTextTag } from '..';
 import {
     SharedTableArgs,
+    sharedTableActions,
     sharedTableArgTypes,
     sharedTableArgs
 } from '../../base/tests/table-column-stories-utils';
@@ -44,11 +46,15 @@ information about common column configuration.`;
 
 const metadata: Meta<SharedTableArgs> = {
     title: 'Table Column Types',
+    decorators: [withActions],
     parameters: {
         docs: {
             description: {
                 component: overviewText
             }
+        },
+        actions: {
+            handles: sharedTableActions
         }
     },
     // prettier-ignore

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -35,6 +35,7 @@ import { styles } from './styles';
 import { template } from './template';
 import {
     TableActionMenuToggleEventDetail,
+    TableColumnConfigurationChangeEventDetail,
     TableColumnSortDirection,
     TableFieldValue,
     TableRecord,
@@ -441,6 +442,8 @@ export class Table<
                 currentColumn.columnInternals.currentSortDirection = TableColumnSortDirection.none;
             }
         }
+
+        this.emitColumnConfigurationChangeEvent();
     }
 
     /**
@@ -714,6 +717,21 @@ export class Table<
     private validateWithData(data: TableRecord[]): void {
         this.tableValidator.validateRecordIds(data, this.idFieldName);
         this.canRenderRows = this.checkValidity();
+    }
+
+    private emitColumnConfigurationChangeEvent(): void {
+        const detail: TableColumnConfigurationChangeEventDetail = {
+            columns: this.columns.map(column => ({
+                columnId: column.columnId,
+                sortIndex: column.columnInternals.currentSortIndex ?? undefined,
+                sortDirection: column.columnInternals.currentSortDirection,
+                groupIndex: column.columnInternals.groupIndex,
+                hidden: column.columnHidden,
+                fractionalWidth: column.columnInternals.currentFractionalWidth,
+                pixelWidth: column.columnInternals.currentPixelWidth
+            }))
+        };
+        this.$emit('column-configuration-change', detail);
     }
 
     private async emitSelectionChangeEvent(): Promise<void> {

--- a/packages/nimble-components/src/table/tests/table-sorting.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-sorting.spec.ts
@@ -3,8 +3,9 @@ import type { Table } from '..';
 import type { TableColumnText } from '../../table-column/text';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { type Fixture, fixture } from '../../utilities/tests/fixture';
-import { TableColumnSortDirection, TableRecord } from '../types';
+import { TableColumnConfigurationChangeEventDetail, TableColumnSortDirection, TableRecord } from '../types';
 import { TablePageObject } from '../testing/table.pageobject';
+import { createEventListener } from '../../utilities/tests/component';
 
 interface SimpleTableRecord extends TableRecord {
     id: string;
@@ -17,9 +18,9 @@ interface SimpleTableRecord extends TableRecord {
 async function setup(): Promise<Fixture<Table<SimpleTableRecord>>> {
     return fixture<Table<SimpleTableRecord>>(
         html`<nimble-table id-field-name="id">
-            <nimble-table-column-text id="first-column" field-name="stringData1"></nimble-table-column-text>
-            <nimble-table-column-text id="second-column" field-name="stringData2"></nimble-table-column-text>
-            <nimble-table-column-text id="third-column" field-name="stringData3"></nimble-table-column-text>
+            <nimble-table-column-text id="first-column" field-name="stringData1" column-id="column-1"></nimble-table-column-text>
+            <nimble-table-column-text id="second-column" field-name="stringData2" column-id="column-2"></nimble-table-column-text>
+            <nimble-table-column-text id="third-column" field-name="stringData3" column-id="column-3"></nimble-table-column-text>
         </nimble-table>`
     );
 }
@@ -601,6 +602,25 @@ describe('Table sorting', () => {
         expect(column1.columnInternals.currentSortIndex).toEqual(0);
     });
 
+    it('does not emit "column-configuration-change" when sorting changes programmatically', async () => {
+        const data: readonly SimpleTableRecord[] = [
+            { id: '1', stringData1: 'foo' },
+            { id: '2', stringData1: 'abc' },
+            { id: '3', stringData1: 'zzz' },
+            { id: '4', stringData1: 'hello' }
+        ] as const;
+        await element.setData(data);
+        await connect();
+        await waitForUpdatesAsync();
+
+        const listener = createEventListener(element, 'column-configuration-change');
+        column1.sortDirection = TableColumnSortDirection.ascending;
+        column1.sortIndex = 0;
+        await waitForUpdatesAsync();
+
+        expect(listener.spy).not.toHaveBeenCalled();
+    });
+
     describe('sort index validation', () => {
         it('multiple columns with the same sort index and a sort direction is invalid and does not render rows', async () => {
             const data: readonly SimpleTableRecord[] = [
@@ -967,6 +987,57 @@ describe('Table sorting', () => {
                 TableColumnSortDirection.ascending
             );
             expect(column3.columnInternals.currentSortIndex).toEqual(2);
+        });
+
+        it('emits "column-configuration-change" when sorting is enabled on the column', async () => {
+            await element.setData(data);
+            await connect();
+            await waitForUpdatesAsync();
+
+            const listener = createEventListener(element, 'column-configuration-change');
+            await pageObject.clickColumnHeader(0);
+
+            expect(listener.spy).toHaveBeenCalled();
+            const args = listener.spy.calls.first().args[0] as CustomEvent<TableColumnConfigurationChangeEventDetail>;
+            expect(args.detail).toEqual({
+                columns: [{
+                    columnId: 'column-1',
+                    hidden: false,
+                    sortIndex: 0,
+                    sortDirection: TableColumnSortDirection.ascending,
+                    groupIndex: undefined,
+                    fractionalWidth: 1,
+                    pixelWidth: undefined
+                }, {
+                    columnId: 'column-2',
+                    hidden: false,
+                    sortIndex: undefined,
+                    sortDirection: TableColumnSortDirection.none,
+                    groupIndex: undefined,
+                    fractionalWidth: 1,
+                    pixelWidth: undefined
+                }, {
+                    columnId: 'column-3',
+                    hidden: false,
+                    sortIndex: undefined,
+                    sortDirection: TableColumnSortDirection.none,
+                    groupIndex: undefined,
+                    fractionalWidth: 1,
+                    pixelWidth: undefined
+                }]
+            });
+        });
+
+        it('does not emit "column-configuration-change" when sorting is disabled on the column', async () => {
+            await element.setData(data);
+            column1.sortingDisabled = true;
+            await connect();
+            await waitForUpdatesAsync();
+
+            const listener = createEventListener(element, 'column-configuration-change');
+            await pageObject.clickColumnHeader(0);
+
+            expect(listener.spy).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/nimble-components/src/table/tests/table-sorting.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-sorting.spec.ts
@@ -3,7 +3,11 @@ import type { Table } from '..';
 import type { TableColumnText } from '../../table-column/text';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { type Fixture, fixture } from '../../utilities/tests/fixture';
-import { TableColumnConfigurationChangeEventDetail, TableColumnSortDirection, TableRecord } from '../types';
+import {
+    TableColumnConfigurationChangeEventDetail,
+    TableColumnSortDirection,
+    TableRecord
+} from '../types';
 import { TablePageObject } from '../testing/table.pageobject';
 import { createEventListener } from '../../utilities/tests/component';
 
@@ -613,7 +617,10 @@ describe('Table sorting', () => {
         await connect();
         await waitForUpdatesAsync();
 
-        const listener = createEventListener(element, 'column-configuration-change');
+        const listener = createEventListener(
+            element,
+            'column-configuration-change'
+        );
         column1.sortDirection = TableColumnSortDirection.ascending;
         column1.sortIndex = 0;
         await waitForUpdatesAsync();
@@ -994,37 +1001,45 @@ describe('Table sorting', () => {
             await connect();
             await waitForUpdatesAsync();
 
-            const listener = createEventListener(element, 'column-configuration-change');
+            const listener = createEventListener(
+                element,
+                'column-configuration-change'
+            );
             await pageObject.clickColumnHeader(0);
 
             expect(listener.spy).toHaveBeenCalled();
-            const args = listener.spy.calls.first().args[0] as CustomEvent<TableColumnConfigurationChangeEventDetail>;
+            const args = listener.spy.calls.first()
+                .args[0] as CustomEvent<TableColumnConfigurationChangeEventDetail>;
             expect(args.detail).toEqual({
-                columns: [{
-                    columnId: 'column-1',
-                    hidden: false,
-                    sortIndex: 0,
-                    sortDirection: TableColumnSortDirection.ascending,
-                    groupIndex: undefined,
-                    fractionalWidth: 1,
-                    pixelWidth: undefined
-                }, {
-                    columnId: 'column-2',
-                    hidden: false,
-                    sortIndex: undefined,
-                    sortDirection: TableColumnSortDirection.none,
-                    groupIndex: undefined,
-                    fractionalWidth: 1,
-                    pixelWidth: undefined
-                }, {
-                    columnId: 'column-3',
-                    hidden: false,
-                    sortIndex: undefined,
-                    sortDirection: TableColumnSortDirection.none,
-                    groupIndex: undefined,
-                    fractionalWidth: 1,
-                    pixelWidth: undefined
-                }]
+                columns: [
+                    {
+                        columnId: 'column-1',
+                        hidden: false,
+                        sortIndex: 0,
+                        sortDirection: TableColumnSortDirection.ascending,
+                        groupIndex: undefined,
+                        fractionalWidth: 1,
+                        pixelWidth: undefined
+                    },
+                    {
+                        columnId: 'column-2',
+                        hidden: false,
+                        sortIndex: undefined,
+                        sortDirection: TableColumnSortDirection.none,
+                        groupIndex: undefined,
+                        fractionalWidth: 1,
+                        pixelWidth: undefined
+                    },
+                    {
+                        columnId: 'column-3',
+                        hidden: false,
+                        sortIndex: undefined,
+                        sortDirection: TableColumnSortDirection.none,
+                        groupIndex: undefined,
+                        fractionalWidth: 1,
+                        pixelWidth: undefined
+                    }
+                ]
             });
         });
 
@@ -1034,7 +1049,10 @@ describe('Table sorting', () => {
             await connect();
             await waitForUpdatesAsync();
 
-            const listener = createEventListener(element, 'column-configuration-change');
+            const listener = createEventListener(
+                element,
+                'column-configuration-change'
+            );
             await pageObject.clickColumnHeader(0);
 
             expect(listener.spy).not.toHaveBeenCalled();

--- a/packages/nimble-components/src/table/tests/table.stories.ts
+++ b/packages/nimble-components/src/table/tests/table.stories.ts
@@ -131,7 +131,8 @@ const metadata: Meta<TableArgs> = {
             handles: [
                 'action-menu-beforetoggle',
                 'action-menu-toggle',
-                'selection-change'
+                'selection-change',
+                'column-configuration-change'
             ]
         }
     },

--- a/packages/nimble-components/src/table/types.ts
+++ b/packages/nimble-components/src/table/types.ts
@@ -103,6 +103,11 @@ export interface TableRowSelectionEventDetail {
 
 /**
  * Event detail type for interactive column configuration changes.
+ *
+ * The column-configuration-change event is emitted when a column's configuration
+ * is modified programmatically, such as by clicking on the column's header to sort
+ * the column. The items in the `columns` array are specified in the same order as
+ * the columns are listed in the DOM.
  */
 export interface TableColumnConfigurationChangeEventDetail {
     columns: TableColumnConfiguration[];

--- a/packages/nimble-components/src/table/types.ts
+++ b/packages/nimble-components/src/table/types.ts
@@ -102,6 +102,26 @@ export interface TableRowSelectionEventDetail {
 }
 
 /**
+ * Event detail type for interactive column configuration changes.
+ */
+export interface TableColumnConfigurationChangeEventDetail {
+    columns: TableColumnConfiguration[];
+}
+
+/**
+ * A representation of the current configuration of a column within the table.
+ */
+export interface TableColumnConfiguration {
+    columnId?: string;
+    sortIndex?: number;
+    sortDirection: TableColumnSortDirection;
+    groupIndex?: number;
+    hidden: boolean;
+    fractionalWidth: number;
+    pixelWidth?: number;
+}
+
+/**
  * @internal
  *
  * Internal representation of a row in the table


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Some clients of the nimble-table will need to react to a user interactively changing a column's configuration.

This PR implements the event described in #1240 

## 👩‍💻 Implementation

Add event to the web component and to Blazor.
Export event detail types from Angular.
Added event handler to storybook stories for the table.

## 🧪 Testing

- Manually tested that the event is picked up by our storybook stories
- Manually tested that the Blazor event is fired correctly
- Added a few new unit tests to nimble-components

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
