### PR TITLE
Add support for icons in start/end slots of list option

### DIFF
--- a/change/@ni-nimble-components-7b301573-b03c-4f05-ba59-005403744225.json
+++ b/change/@ni-nimble-components-7b301573-b03c-4f05-ba59-005403744225.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for icons in start/end slots of list option",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/combobox/tests/combobox-opened-matrix.stories.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox-opened-matrix.stories.ts
@@ -5,6 +5,7 @@ import { sharedMatrixParameters } from '../../utilities/tests/matrix';
 import { backgroundStates } from '../../utilities/tests/states';
 import { comboboxTag } from '..';
 import { listOptionTag } from '../../list-option';
+import { iconCheckTag } from '../../icons/check';
 
 const metadata: Meta = {
     title: 'Tests/Combobox',
@@ -29,8 +30,8 @@ const component = ([
     positionStyle
 ]: PositionState): ViewTemplate => html`
     <${comboboxTag} open position="${() => position}" style="${() => positionStyle}">
-        <${listOptionTag} value="1">Option 1</${listOptionTag}>
-        <${listOptionTag} value="2" disabled>Option 2</${listOptionTag}>
+        <${listOptionTag} value="1"><${iconCheckTag} slot="start"></${iconCheckTag}>Option 1</${listOptionTag}>
+        <${listOptionTag} value="2" disabled><${iconCheckTag} slot="end"></${iconCheckTag}> Option 2</${listOptionTag}>
         <${listOptionTag} value="3">Option 3</${listOptionTag}>
         <${listOptionTag} value="4" hidden>Option 4</${listOptionTag}>
     </${comboboxTag}>

--- a/packages/nimble-components/src/combobox/tests/combobox.stories.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox.stories.ts
@@ -1,5 +1,5 @@
 import { ComboboxAutocomplete } from '@microsoft/fast-foundation';
-import { html, repeat } from '@microsoft/fast-element';
+import { html, repeat, when } from '@microsoft/fast-element';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj } from '@storybook/html';
 import { listOptionTag } from '../../list-option';
@@ -9,6 +9,7 @@ import {
     DropdownPosition
 } from '../../patterns/dropdown/types';
 import { comboboxTag } from '..';
+import { iconCheckTag } from '../../icons/check';
 
 interface ComboboxArgs {
     disabled: boolean;
@@ -25,6 +26,7 @@ interface ComboboxArgs {
 interface OptionArgs {
     label: string;
     disabled: boolean;
+    iconSlot?: string;
 }
 
 const metadata: Meta<ComboboxArgs> = {
@@ -34,7 +36,7 @@ const metadata: Meta<ComboboxArgs> = {
     parameters: {
         docs: {
             description: {
-                component: `Combobox is a list in which the current value is displayed in the element. Upon clicking on the element, the other options are visible. The user can enter aribtrary values in the input area. 
+                component: `Combobox is a list in which the current value is displayed in the element. Upon clicking on the element, the other options are visible. The user can enter aribtrary values in the input area.
                      The combobox provides 'autocomplete' options that help finding and selecting a particular value. The value of the combobox comes from the text content of the selected list-option, or, if no matching
                      list option is found, the user-entered text. Whereas with the \`nimble-select\` component, the value property of the list-option is always used for its value.`
             }
@@ -56,7 +58,10 @@ const metadata: Meta<ComboboxArgs> = {
             placeholder="${x => x.placeholder}"
         >
             ${repeat(x => x.options, html<OptionArgs>`
-                <${listOptionTag} ?disabled="${x => x.disabled}">${x => x.label}</${listOptionTag}>
+                <${listOptionTag} ?disabled="${x => x.disabled}">
+                    ${when(x => x.iconSlot, html<OptionArgs>`<${iconCheckTag} slot="${x => x.iconSlot}"></${iconCheckTag}>`)}
+                    ${x => x.label}
+                </${listOptionTag}>
             `)}
         </${comboboxTag}>
     `),
@@ -91,8 +96,8 @@ const metadata: Meta<ComboboxArgs> = {
         appearance: DropdownAppearance.underline,
         placeholder: 'Select value...',
         options: [
-            { label: 'Mary', disabled: false },
-            { label: 'Sue', disabled: false },
+            { label: 'Mary', disabled: false, iconSlot: 'start' },
+            { label: 'Sue', disabled: false, iconSlot: 'end' },
             { label: 'Joaquin', disabled: false },
             { label: 'Frank', disabled: false },
             { label: 'Dracula', disabled: true },

--- a/packages/nimble-components/src/list-option/styles.ts
+++ b/packages/nimble-components/src/list-option/styles.ts
@@ -19,6 +19,7 @@ export const styles = css`
         font: ${bodyFont};
         cursor: pointer;
         justify-content: left;
+        align-items: center;
         height: ${controlHeight};
     }
 
@@ -60,6 +61,11 @@ export const styles = css`
     :host([disabled]) {
         color: ${bodyDisabledFontColor};
         cursor: default;
+    }
+
+    [part='start'],
+    [part='end'] {
+        display: contents;
     }
 
     .content[disabled] {

--- a/packages/nimble-components/src/select/tests/select-opened-matrix.stories.ts
+++ b/packages/nimble-components/src/select/tests/select-opened-matrix.stories.ts
@@ -5,6 +5,7 @@ import { sharedMatrixParameters } from '../../utilities/tests/matrix';
 import { backgroundStates } from '../../utilities/tests/states';
 import { selectTag } from '..';
 import { listOptionTag } from '../../list-option';
+import { iconCheckTag } from '../../icons/check';
 
 const metadata: Meta = {
     title: 'Tests/Select',
@@ -27,8 +28,8 @@ const component = ([
     positionStyle
 ]: PositionState): ViewTemplate => html`
     <${selectTag} open position="${() => position}" style="${() => positionStyle}">
-        <${listOptionTag} value="1">Option 1</${listOptionTag}>
-        <${listOptionTag} value="2" disabled>Option 2</${listOptionTag}>
+        <${listOptionTag} value="1"><${iconCheckTag} slot="start"></${iconCheckTag}>Option 1</${listOptionTag}>
+        <${listOptionTag} value="2" disabled><${iconCheckTag} slot="end"></${iconCheckTag}>Option 2</${listOptionTag}>
         <${listOptionTag} value="3">Option 3</${listOptionTag}>
         <${listOptionTag} value="4" hidden>Option 4</${listOptionTag}>
     </${selectTag}>

--- a/packages/nimble-components/src/select/tests/select.stories.ts
+++ b/packages/nimble-components/src/select/tests/select.stories.ts
@@ -1,10 +1,11 @@
-import { html, repeat } from '@microsoft/fast-element';
+import { html, repeat, when } from '@microsoft/fast-element';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj } from '@storybook/html';
 import { createUserSelectedThemeStory } from '../../utilities/tests/storybook';
 import { DropdownAppearance } from '../../patterns/dropdown/types';
 import { selectTag } from '..';
 import { listOptionTag } from '../../list-option';
+import { iconCheckTag } from '../../icons/check';
 
 interface SelectArgs {
     disabled: boolean;
@@ -19,6 +20,7 @@ interface OptionArgs {
     label: string;
     value: string;
     disabled: boolean;
+    iconSlot?: string;
 }
 
 const metadata: Meta<SelectArgs> = {
@@ -50,6 +52,7 @@ const metadata: Meta<SelectArgs> = {
                     value="${x => x.value}"
                     ?disabled="${x => x.disabled}"
                 >
+                    ${when(x => x.iconSlot, html<OptionArgs>`<${iconCheckTag} slot="${x => x.iconSlot}"></${iconCheckTag}>`)}
                     ${x => x.label}
                 </${listOptionTag}>
             `)}
@@ -78,8 +81,13 @@ const metadata: Meta<SelectArgs> = {
         dropDownPosition: 'below',
         appearance: DropdownAppearance.underline,
         options: [
-            { label: 'Option 1', value: '1', disabled: false },
-            { label: 'Option 2', value: '2', disabled: true },
+            {
+                label: 'Option 1',
+                value: '1',
+                disabled: false,
+                iconSlot: 'start'
+            },
+            { label: 'Option 2', value: '2', disabled: true, iconSlot: 'end' },
             { label: 'Option 3', value: '3', disabled: false },
             { label: 'Option 4', value: '4', disabled: false },
             { label: 'Option 5', value: '5', disabled: false },


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #1254 

## 👩‍💻 Implementation

We didn't explictly support adding content to the start and end slots of list options. This PR adds that support by adding a little styling to our shared dropdown styles to center-align the content. I also add examples of start- and end-slotted icons in the select and combobox Storybook stories (including test stories).

Note that icons on disabled options are not displayed differently (e.g. dimmed). This is consistent with the menu item's behavior, but inconsistent with the tree item's.

## 🧪 Testing

Added Chromatic tests.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
