### PR TITLE
Switch columnInternals to property initialization

### DIFF
--- a/change/@ni-nimble-components-61e0d8ea-1b0e-4848-9741-6cd9aaba8460.json
+++ b/change/@ni-nimble-components-61e0d8ea-1b0e-4848-9741-6cd9aaba8460.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Move ColumnInternals to abstract property",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table-column/anchor/index.ts
+++ b/packages/nimble-components/src/table-column/anchor/index.ts
@@ -10,6 +10,7 @@ import type { TableStringField } from '../../table/types';
 import { tableColumnAnchorCellViewTag } from './cell-view';
 import { tableColumnTextGroupHeaderTag } from '../text/group-header-view';
 import type { AnchorAppearance } from '../../anchor/types';
+import { ColumnInternals } from '../base/models/column-internals';
 
 export type TableColumnAnchorCellRecord = TableStringField<'label' | 'href'>;
 export interface TableColumnAnchorColumnConfig {
@@ -73,15 +74,13 @@ export class TableColumnAnchor extends mixinGroupableColumnAPI(
     @attr
     public download?: string;
 
-    public constructor() {
-        super({
-            cellRecordFieldNames: ['label', 'href'],
-            cellViewTag: tableColumnAnchorCellViewTag,
-            groupHeaderViewTag: tableColumnTextGroupHeaderTag,
-            delegatedEvents: ['click']
-        });
-        this.columnInternals.sortOperation = TableColumnSortOperation.localeAwareCaseSensitive;
-    }
+    override columnInternals = new ColumnInternals<TableColumnAnchorColumnConfig>({
+        cellRecordFieldNames: ['label', 'href'],
+        cellViewTag: tableColumnAnchorCellViewTag,
+        groupHeaderViewTag: tableColumnTextGroupHeaderTag,
+        delegatedEvents: ['click'],
+        sortOperation: TableColumnSortOperation.localeAwareCaseSensitive
+    });
 
     protected labelFieldNameChanged(): void {
         this.columnInternals.dataRecordFieldNames = [

--- a/packages/nimble-components/src/table-column/anchor/index.ts
+++ b/packages/nimble-components/src/table-column/anchor/index.ts
@@ -10,7 +10,7 @@ import type { TableStringField } from '../../table/types';
 import { tableColumnAnchorCellViewTag } from './cell-view';
 import { tableColumnTextGroupHeaderTag } from '../text/group-header-view';
 import type { AnchorAppearance } from '../../anchor/types';
-import { ColumnInternals } from '../base/models/column-internals';
+import type { ColumnInternalsOptions } from '../base/models/column-internals';
 
 export type TableColumnAnchorCellRecord = TableStringField<'label' | 'href'>;
 export interface TableColumnAnchorColumnConfig {
@@ -74,13 +74,15 @@ export class TableColumnAnchor extends mixinGroupableColumnAPI(
     @attr
     public download?: string;
 
-    public override columnInternals = new ColumnInternals<TableColumnAnchorColumnConfig>({
-        cellRecordFieldNames: ['label', 'href'],
-        cellViewTag: tableColumnAnchorCellViewTag,
-        groupHeaderViewTag: tableColumnTextGroupHeaderTag,
-        delegatedEvents: ['click'],
-        sortOperation: TableColumnSortOperation.localeAwareCaseSensitive
-    });
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+        return {
+            cellRecordFieldNames: ['label', 'href'],
+            cellViewTag: tableColumnAnchorCellViewTag,
+            groupHeaderViewTag: tableColumnTextGroupHeaderTag,
+            delegatedEvents: ['click'],
+            sortOperation: TableColumnSortOperation.localeAwareCaseSensitive
+        };
+    }
 
     protected labelFieldNameChanged(): void {
         this.columnInternals.dataRecordFieldNames = [

--- a/packages/nimble-components/src/table-column/anchor/index.ts
+++ b/packages/nimble-components/src/table-column/anchor/index.ts
@@ -74,7 +74,7 @@ export class TableColumnAnchor extends mixinGroupableColumnAPI(
     @attr
     public download?: string;
 
-    override columnInternals = new ColumnInternals<TableColumnAnchorColumnConfig>({
+    public override columnInternals = new ColumnInternals<TableColumnAnchorColumnConfig>({
         cellRecordFieldNames: ['label', 'href'],
         cellViewTag: tableColumnAnchorCellViewTag,
         groupHeaderViewTag: tableColumnTextGroupHeaderTag,

--- a/packages/nimble-components/src/table-column/base/index.ts
+++ b/packages/nimble-components/src/table-column/base/index.ts
@@ -1,7 +1,7 @@
 import { attr, nullableNumberConverter } from '@microsoft/fast-element';
 import { FoundationElement } from '@microsoft/fast-foundation';
 import { TableColumnSortDirection } from '../../table/types';
-import type { ColumnInternals } from './models/column-internals';
+import { ColumnInternals, ColumnInternalsOptions } from './models/column-internals';
 
 /**
  * The base class for table columns
@@ -35,7 +35,9 @@ export abstract class TableColumn<
      *
      * Column properties configurable by plugin authors
      */
-    public abstract readonly columnInternals: ColumnInternals<TColumnConfig>;
+    public readonly columnInternals: ColumnInternals<TColumnConfig> = new ColumnInternals(this.getColumnInternalsOptions());
+
+    protected abstract getColumnInternalsOptions(): ColumnInternalsOptions;
 
     protected sortDirectionChanged(): void {
         if (!this.sortingDisabled) {

--- a/packages/nimble-components/src/table-column/base/index.ts
+++ b/packages/nimble-components/src/table-column/base/index.ts
@@ -1,7 +1,10 @@
 import { attr, nullableNumberConverter } from '@microsoft/fast-element';
 import { FoundationElement } from '@microsoft/fast-foundation';
 import { TableColumnSortDirection } from '../../table/types';
-import { ColumnInternals, ColumnInternalsOptions } from './models/column-internals';
+import {
+    ColumnInternals,
+    ColumnInternalsOptions
+} from './models/column-internals';
 
 /**
  * The base class for table columns

--- a/packages/nimble-components/src/table-column/base/index.ts
+++ b/packages/nimble-components/src/table-column/base/index.ts
@@ -1,9 +1,7 @@
 import { attr, nullableNumberConverter } from '@microsoft/fast-element';
 import { FoundationElement } from '@microsoft/fast-foundation';
 import { TableColumnSortDirection } from '../../table/types';
-import type {
-    ColumnInternals
-} from './models/column-internals';
+import type { ColumnInternals } from './models/column-internals';
 
 /**
  * The base class for table columns

--- a/packages/nimble-components/src/table-column/base/index.ts
+++ b/packages/nimble-components/src/table-column/base/index.ts
@@ -1,8 +1,7 @@
 import { attr, nullableNumberConverter } from '@microsoft/fast-element';
 import { FoundationElement } from '@microsoft/fast-foundation';
 import { TableColumnSortDirection } from '../../table/types';
-import {
-    ColumnInternalsOptions,
+import type {
     ColumnInternals
 } from './models/column-internals';
 
@@ -38,19 +37,7 @@ export abstract class TableColumn<
      *
      * Column properties configurable by plugin authors
      */
-    public readonly columnInternals: ColumnInternals<TColumnConfig>;
-
-    public constructor(options: ColumnInternalsOptions) {
-        super();
-        if (!options) {
-            throw new Error(
-                'ColumnInternalsOptions must be provided to constructor'
-            );
-        }
-        this.columnInternals = new ColumnInternals(options);
-        this.columnInternals.currentSortDirection = this.sortDirection;
-        this.columnInternals.currentSortIndex = this.sortIndex;
-    }
+    public abstract readonly columnInternals: ColumnInternals<TColumnConfig>;
 
     protected sortDirectionChanged(): void {
         if (!this.sortingDisabled) {
@@ -65,15 +52,12 @@ export abstract class TableColumn<
     }
 
     protected sortingDisabledChanged(): void {
-        // Ignore the default value sortingDisabled initialization from undefined to false (which runs before columnInternals is initialized)
-        if (this.columnInternals) {
-            if (this.sortingDisabled) {
-                this.columnInternals.currentSortDirection = TableColumnSortDirection.none;
-                this.columnInternals.currentSortIndex = undefined;
-            } else {
-                this.columnInternals.currentSortDirection = this.sortDirection;
-                this.columnInternals.currentSortIndex = this.sortIndex;
-            }
+        if (this.sortingDisabled) {
+            this.columnInternals.currentSortDirection = TableColumnSortDirection.none;
+            this.columnInternals.currentSortIndex = undefined;
+        } else {
+            this.columnInternals.currentSortDirection = this.sortDirection;
+            this.columnInternals.currentSortIndex = this.sortIndex;
         }
     }
 }

--- a/packages/nimble-components/src/table-column/base/index.ts
+++ b/packages/nimble-components/src/table-column/base/index.ts
@@ -9,6 +9,13 @@ import { ColumnInternals, ColumnInternalsOptions } from './models/column-interna
 export abstract class TableColumn<
     TColumnConfig = unknown
 > extends FoundationElement {
+    /**
+     * @internal
+     *
+     * Column properties configurable by plugin authors
+     */
+    public readonly columnInternals: ColumnInternals<TColumnConfig> = new ColumnInternals(this.getColumnInternalsOptions());
+
     @attr({ attribute: 'column-id' })
     public columnId?: string;
 
@@ -29,13 +36,6 @@ export abstract class TableColumn<
 
     @attr({ attribute: 'sorting-disabled', mode: 'boolean' })
     public sortingDisabled = false;
-
-    /**
-     * @internal
-     *
-     * Column properties configurable by plugin authors
-     */
-    public readonly columnInternals: ColumnInternals<TColumnConfig> = new ColumnInternals(this.getColumnInternalsOptions());
 
     protected abstract getColumnInternalsOptions(): ColumnInternalsOptions;
 

--- a/packages/nimble-components/src/table-column/base/models/column-internals.ts
+++ b/packages/nimble-components/src/table-column/base/models/column-internals.ts
@@ -1,6 +1,6 @@
 import { uniqueId } from '@microsoft/fast-web-utilities';
 import { ViewTemplate, observable } from '@microsoft/fast-element';
-import type {
+import {
     TableColumnSortDirection,
     TableFieldName
 } from '../../../table/types';
@@ -37,6 +37,11 @@ export interface ColumnInternalsOptions {
      * The names of events that should be delegated from the cell view to the column.
      */
     readonly delegatedEvents: readonly string[];
+
+    /**
+     * The sort operation to use for the column (defaults to TableColumnSortOperation.basic)
+     */
+    readonly sortOperation?: TableColumnSortOperation;
 }
 
 /**
@@ -153,7 +158,7 @@ export class ColumnInternals<TColumnConfig> {
      * the resolved value of the sortDirection after programmatic or interactive updates.
      */
     @observable
-    public currentSortDirection: TableColumnSortDirection;
+    public currentSortDirection: TableColumnSortDirection = TableColumnSortDirection.none;
 
     public constructor(options: ColumnInternalsOptions) {
         this.cellRecordFieldNames = options.cellRecordFieldNames;
@@ -162,6 +167,7 @@ export class ColumnInternals<TColumnConfig> {
             options.groupHeaderViewTag
         );
         this.delegatedEvents = options.delegatedEvents;
+        this.sortOperation = options.sortOperation ?? TableColumnSortOperation.basic;
     }
 
     protected fractionalWidthChanged(): void {

--- a/packages/nimble-components/src/table-column/base/models/column-internals.ts
+++ b/packages/nimble-components/src/table-column/base/models/column-internals.ts
@@ -1,9 +1,6 @@
 import { uniqueId } from '@microsoft/fast-web-utilities';
 import { ViewTemplate, observable } from '@microsoft/fast-element';
-import {
-    TableColumnSortDirection,
-    TableFieldName
-} from '../../../table/types';
+import { TableColumnSortDirection, TableFieldName } from '../../../table/types';
 import type { TableCell } from '../../../table/components/cell';
 import {
     TableColumnSortOperation,

--- a/packages/nimble-components/src/table-column/base/tests/table-cell-view.spec.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-cell-view.spec.ts
@@ -12,6 +12,7 @@ import {
     TableColumnEmpty,
     tableColumnEmptyGroupHeaderViewTag
 } from './table-column.fixtures';
+import type { ColumnInternalsOptions } from '../models/column-internals';
 
 async function setup(): Promise<Fixture<TableCellView>> {
     return fixture(tableColumnEmptyCellViewTag);
@@ -30,13 +31,13 @@ describe('TableCellView', () => {
         name: tableColumnDelegatesClickAndKeydownTag
     })
     class TableColumnDelegatesClickAndKeydown extends TableColumn {
-        public constructor() {
-            super({
+        protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+            return {
                 cellRecordFieldNames: [],
                 cellViewTag: tableColumnEmptyCellViewTag,
                 groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
                 delegatedEvents: ['click', 'keydown']
-            });
+            };
         }
     }
 

--- a/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
@@ -4,7 +4,7 @@ import { customElement } from '@microsoft/fast-element';
 import { TableCellView } from '../cell-view';
 import { TableGroupHeaderView } from '../group-header-view';
 import { TableColumn } from '..';
-import { ColumnInternals } from '../models/column-internals';
+import type { ColumnInternalsOptions } from '../models/column-internals';
 
 export const tableColumnEmptyCellViewTag = 'nimble-test-table-column-empty-cell-view';
 /**
@@ -32,12 +32,14 @@ export const tableColumnEmptyTag = 'nimble-test-table-column-empty';
     name: tableColumnEmptyTag
 })
 export class TableColumnEmpty extends TableColumn {
-    public override columnInternals = new ColumnInternals({
-        cellRecordFieldNames: [],
-        cellViewTag: tableColumnEmptyCellViewTag,
-        groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-        delegatedEvents: []
-    });
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+        return {
+            cellRecordFieldNames: [],
+            cellViewTag: tableColumnEmptyCellViewTag,
+            groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
+            delegatedEvents: []
+        };
+    }
 }
 
 export const tableColumnDelegatesClickAndKeydownTag = 'nimble-test-table-column-delegates';
@@ -48,10 +50,12 @@ export const tableColumnDelegatesClickAndKeydownTag = 'nimble-test-table-column-
     name: tableColumnDelegatesClickAndKeydownTag
 })
 export class TableColumnDelegatesClickAndKeydown extends TableColumn {
-    public override columnInternals = new ColumnInternals({
-        cellRecordFieldNames: [],
-        cellViewTag: tableColumnEmptyCellViewTag,
-        groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-        delegatedEvents: ['click', 'keydown']
-    });
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+        return {
+            cellRecordFieldNames: [],
+            cellViewTag: tableColumnEmptyCellViewTag,
+            groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
+            delegatedEvents: ['click', 'keydown']
+        };
+    }
 }

--- a/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
@@ -4,7 +4,10 @@ import { attr, customElement } from '@microsoft/fast-element';
 import { TableCellView } from '../cell-view';
 import { TableGroupHeaderView } from '../group-header-view';
 import { TableColumn } from '..';
-import type { ColumnInternalsOptions, ColumnInternals } from '../models/column-internals';
+import type {
+    ColumnInternalsOptions,
+    ColumnInternals
+} from '../models/column-internals';
 import { ColumnValidator } from '../models/column-validator';
 
 export const tableColumnEmptyCellViewTag = 'nimble-test-table-column-empty-cell-view';

--- a/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
@@ -4,6 +4,7 @@ import { customElement } from '@microsoft/fast-element';
 import { TableCellView } from '../cell-view';
 import { TableGroupHeaderView } from '../group-header-view';
 import { TableColumn } from '..';
+import { ColumnInternals } from '../models/column-internals';
 
 export const tableColumnEmptyCellViewTag = 'nimble-test-table-column-empty-cell-view';
 /**
@@ -31,14 +32,12 @@ export const tableColumnEmptyTag = 'nimble-test-table-column-empty';
     name: tableColumnEmptyTag
 })
 export class TableColumnEmpty extends TableColumn {
-    public constructor() {
-        super({
-            cellRecordFieldNames: [],
-            cellViewTag: tableColumnEmptyCellViewTag,
-            groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-            delegatedEvents: []
-        });
-    }
+    override columnInternals = new ColumnInternals({
+        cellRecordFieldNames: [],
+        cellViewTag: tableColumnEmptyCellViewTag,
+        groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
+        delegatedEvents: []
+    });
 }
 
 export const tableColumnDelegatesClickAndKeydownTag = 'nimble-test-table-column-delegates';
@@ -49,12 +48,10 @@ export const tableColumnDelegatesClickAndKeydownTag = 'nimble-test-table-column-
     name: tableColumnDelegatesClickAndKeydownTag
 })
 export class TableColumnDelegatesClickAndKeydown extends TableColumn {
-    public constructor() {
-        super({
-            cellRecordFieldNames: [],
-            cellViewTag: tableColumnEmptyCellViewTag,
-            groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-            delegatedEvents: ['click', 'keydown']
-        });
-    }
+    override columnInternals = new ColumnInternals({
+        cellRecordFieldNames: [],
+        cellViewTag: tableColumnEmptyCellViewTag,
+        groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
+        delegatedEvents: ['click', 'keydown']
+    });
 }

--- a/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
@@ -32,7 +32,7 @@ export const tableColumnEmptyTag = 'nimble-test-table-column-empty';
     name: tableColumnEmptyTag
 })
 export class TableColumnEmpty extends TableColumn {
-    override columnInternals = new ColumnInternals({
+    public override columnInternals = new ColumnInternals({
         cellRecordFieldNames: [],
         cellViewTag: tableColumnEmptyCellViewTag,
         groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
@@ -48,7 +48,7 @@ export const tableColumnDelegatesClickAndKeydownTag = 'nimble-test-table-column-
     name: tableColumnDelegatesClickAndKeydownTag
 })
 export class TableColumnDelegatesClickAndKeydown extends TableColumn {
-    override columnInternals = new ColumnInternals({
+    public override columnInternals = new ColumnInternals({
         cellRecordFieldNames: [],
         cellViewTag: tableColumnEmptyCellViewTag,
         groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,

--- a/packages/nimble-components/src/table-column/base/tests/table-column.spec.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.spec.ts
@@ -13,6 +13,7 @@ import {
 } from './table-column.fixtures';
 import { TableColumn } from '..';
 import { TableColumnSortDirection } from '../../../table/types';
+import { ColumnInternals } from '../models/column-internals';
 
 async function setup(): Promise<Fixture<TableColumnEmpty>> {
     return fixture(tableColumnEmptyTag);
@@ -104,27 +105,6 @@ describe('TableColumn', () => {
             return spy as unknown as jasmine.Spy<(err: Error) => void>;
         }
 
-        describe('that is a default constructor without ColumnInternalsOptions', () => {
-            const columnName = uniqueElementName();
-            @customElement({
-                name: columnName
-            })
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            class TestTableColumn extends TableColumn {}
-
-            it('throws when instantiated', async () => {
-                await jasmine.spyOnGlobalErrorsAsync(async globalErrorSpy => {
-                    const spy = castSpy(globalErrorSpy);
-                    document.createElement(columnName);
-                    await Promise.resolve();
-                    expect(spy).toHaveBeenCalledTimes(1);
-                    expect(spy.calls.first().args[0].message).toMatch(
-                        'ColumnInternalsOptions must be provided'
-                    );
-                });
-            });
-        });
-
         describe('that passes an invalid cellViewTag', () => {
             const columnName = uniqueElementName();
             @customElement({
@@ -132,14 +112,12 @@ describe('TableColumn', () => {
             })
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             class TestTableColumn extends TableColumn {
-                public constructor() {
-                    super({
-                        cellRecordFieldNames: [],
-                        cellViewTag: 'div',
-                        groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-                        delegatedEvents: []
-                    });
-                }
+                override columnInternals = new ColumnInternals({
+                    cellRecordFieldNames: [],
+                    cellViewTag: 'div',
+                    groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
+                    delegatedEvents: []
+                });
             }
 
             it('throws when instantiated', async () => {
@@ -162,14 +140,12 @@ describe('TableColumn', () => {
             })
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             class TestTableColumn extends TableColumn {
-                public constructor() {
-                    super({
-                        cellRecordFieldNames: [],
-                        cellViewTag: tableColumnEmptyCellViewTag,
-                        groupHeaderViewTag: 'div',
-                        delegatedEvents: []
-                    });
-                }
+                override columnInternals = new ColumnInternals({
+                    cellRecordFieldNames: [],
+                    cellViewTag: tableColumnEmptyCellViewTag,
+                    groupHeaderViewTag: 'div',
+                    delegatedEvents: []
+                });
             }
 
             it('throws when instantiated', async () => {

--- a/packages/nimble-components/src/table-column/base/tests/table-column.spec.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.spec.ts
@@ -13,7 +13,7 @@ import {
 } from './table-column.fixtures';
 import { TableColumn } from '..';
 import { TableColumnSortDirection } from '../../../table/types';
-import { ColumnInternals } from '../models/column-internals';
+import type { ColumnInternalsOptions } from '../models/column-internals';
 
 async function setup(): Promise<Fixture<TableColumnEmpty>> {
     return fixture(tableColumnEmptyTag);
@@ -112,12 +112,14 @@ describe('TableColumn', () => {
             })
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             class TestTableColumn extends TableColumn {
-                public override columnInternals = new ColumnInternals({
-                    cellRecordFieldNames: [],
-                    cellViewTag: 'div',
-                    groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-                    delegatedEvents: []
-                });
+                protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+                    return {
+                        cellRecordFieldNames: [],
+                        cellViewTag: 'div',
+                        groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
+                        delegatedEvents: []
+                    };
+                }
             }
 
             it('throws when instantiated', async () => {
@@ -140,12 +142,14 @@ describe('TableColumn', () => {
             })
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             class TestTableColumn extends TableColumn {
-                public override columnInternals = new ColumnInternals({
-                    cellRecordFieldNames: [],
-                    cellViewTag: tableColumnEmptyCellViewTag,
-                    groupHeaderViewTag: 'div',
-                    delegatedEvents: []
-                });
+                protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+                    return {
+                        cellRecordFieldNames: [],
+                        cellViewTag: tableColumnEmptyCellViewTag,
+                        groupHeaderViewTag: 'div',
+                        delegatedEvents: []
+                    };
+                }
             }
 
             it('throws when instantiated', async () => {

--- a/packages/nimble-components/src/table-column/base/tests/table-column.spec.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.spec.ts
@@ -112,7 +112,7 @@ describe('TableColumn', () => {
             })
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             class TestTableColumn extends TableColumn {
-                override columnInternals = new ColumnInternals({
+                public override columnInternals = new ColumnInternals({
                     cellRecordFieldNames: [],
                     cellViewTag: 'div',
                     groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
@@ -140,7 +140,7 @@ describe('TableColumn', () => {
             })
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             class TestTableColumn extends TableColumn {
-                override columnInternals = new ColumnInternals({
+                public override columnInternals = new ColumnInternals({
                     cellRecordFieldNames: [],
                     cellViewTag: tableColumnEmptyCellViewTag,
                     groupHeaderViewTag: 'div',

--- a/packages/nimble-components/src/table-column/mixins/tests/fractional-width-column.spec.ts
+++ b/packages/nimble-components/src/table-column/mixins/tests/fractional-width-column.spec.ts
@@ -11,19 +11,21 @@ import {
     tableColumnEmptyCellViewTag,
     tableColumnEmptyGroupHeaderViewTag
 } from '../../base/tests/table-column.fixtures';
-import { ColumnInternals } from '../../base/models/column-internals';
+import type { ColumnInternalsOptions } from '../../base/models/column-internals';
 
 const columnName = uniqueElementName();
 @customElement({
     name: columnName
 })
 class TestTableColumn extends mixinFractionalWidthColumnAPI(TableColumn) {
-    public override columnInternals = new ColumnInternals({
-        cellRecordFieldNames: [],
-        cellViewTag: tableColumnEmptyCellViewTag,
-        groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-        delegatedEvents: []
-    });
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+        return {
+            cellRecordFieldNames: [],
+            cellViewTag: tableColumnEmptyCellViewTag,
+            groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
+            delegatedEvents: []
+        };
+    }
 }
 
 // prettier-ignore

--- a/packages/nimble-components/src/table-column/mixins/tests/fractional-width-column.spec.ts
+++ b/packages/nimble-components/src/table-column/mixins/tests/fractional-width-column.spec.ts
@@ -18,7 +18,7 @@ const columnName = uniqueElementName();
     name: columnName
 })
 class TestTableColumn extends mixinFractionalWidthColumnAPI(TableColumn) {
-    override columnInternals = new ColumnInternals({
+    public override columnInternals = new ColumnInternals({
         cellRecordFieldNames: [],
         cellViewTag: tableColumnEmptyCellViewTag,
         groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,

--- a/packages/nimble-components/src/table-column/mixins/tests/fractional-width-column.spec.ts
+++ b/packages/nimble-components/src/table-column/mixins/tests/fractional-width-column.spec.ts
@@ -11,20 +11,19 @@ import {
     tableColumnEmptyCellViewTag,
     tableColumnEmptyGroupHeaderViewTag
 } from '../../base/tests/table-column.fixtures';
+import { ColumnInternals } from '../../base/models/column-internals';
 
 const columnName = uniqueElementName();
 @customElement({
     name: columnName
 })
 class TestTableColumn extends mixinFractionalWidthColumnAPI(TableColumn) {
-    public constructor() {
-        super({
-            cellRecordFieldNames: [],
-            cellViewTag: tableColumnEmptyCellViewTag,
-            groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-            delegatedEvents: []
-        });
-    }
+    override columnInternals = new ColumnInternals({
+        cellRecordFieldNames: [],
+        cellViewTag: tableColumnEmptyCellViewTag,
+        groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
+        delegatedEvents: []
+    });
 }
 
 // prettier-ignore

--- a/packages/nimble-components/src/table-column/mixins/tests/groupable-column.spec.ts
+++ b/packages/nimble-components/src/table-column/mixins/tests/groupable-column.spec.ts
@@ -11,20 +11,19 @@ import {
     tableColumnEmptyCellViewTag,
     tableColumnEmptyGroupHeaderViewTag
 } from '../../base/tests/table-column.fixtures';
+import { ColumnInternals } from '../../base/models/column-internals';
 
 const columnName = uniqueElementName();
 @customElement({
     name: columnName
 })
 class TestTableColumn extends mixinGroupableColumnAPI(TableColumn) {
-    public constructor() {
-        super({
-            cellRecordFieldNames: [],
-            cellViewTag: tableColumnEmptyCellViewTag,
-            groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-            delegatedEvents: []
-        });
-    }
+    override columnInternals = new ColumnInternals({
+        cellRecordFieldNames: [],
+        cellViewTag: tableColumnEmptyCellViewTag,
+        groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
+        delegatedEvents: []
+    });
 }
 
 // prettier-ignore

--- a/packages/nimble-components/src/table-column/mixins/tests/groupable-column.spec.ts
+++ b/packages/nimble-components/src/table-column/mixins/tests/groupable-column.spec.ts
@@ -11,19 +11,21 @@ import {
     tableColumnEmptyCellViewTag,
     tableColumnEmptyGroupHeaderViewTag
 } from '../../base/tests/table-column.fixtures';
-import { ColumnInternals } from '../../base/models/column-internals';
+import type { ColumnInternalsOptions } from '../../base/models/column-internals';
 
 const columnName = uniqueElementName();
 @customElement({
     name: columnName
 })
 class TestTableColumn extends mixinGroupableColumnAPI(TableColumn) {
-    public override columnInternals = new ColumnInternals({
-        cellRecordFieldNames: [],
-        cellViewTag: tableColumnEmptyCellViewTag,
-        groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-        delegatedEvents: []
-    });
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+        return {
+            cellRecordFieldNames: [],
+            cellViewTag: tableColumnEmptyCellViewTag,
+            groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
+            delegatedEvents: []
+        };
+    }
 }
 
 // prettier-ignore

--- a/packages/nimble-components/src/table-column/mixins/tests/groupable-column.spec.ts
+++ b/packages/nimble-components/src/table-column/mixins/tests/groupable-column.spec.ts
@@ -18,7 +18,7 @@ const columnName = uniqueElementName();
     name: columnName
 })
 class TestTableColumn extends mixinGroupableColumnAPI(TableColumn) {
-    override columnInternals = new ColumnInternals({
+    public override columnInternals = new ColumnInternals({
         cellRecordFieldNames: [],
         cellViewTag: tableColumnEmptyCellViewTag,
         groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,

--- a/packages/nimble-components/src/table-column/text/index.ts
+++ b/packages/nimble-components/src/table-column/text/index.ts
@@ -26,7 +26,7 @@ declare global {
  * The table column for displaying string fields as text.
  */
 export class TableColumnText extends TableColumnTextBase {
-    override columnInternals = new ColumnInternals<TableColumnTextColumnConfig>({
+    public override columnInternals = new ColumnInternals<TableColumnTextColumnConfig>({
         cellRecordFieldNames: ['value'],
         cellViewTag: tableColumnTextCellViewTag,
         groupHeaderViewTag: tableColumnTextGroupHeaderTag,

--- a/packages/nimble-components/src/table-column/text/index.ts
+++ b/packages/nimble-components/src/table-column/text/index.ts
@@ -9,6 +9,7 @@ import {
 } from '../base/types';
 import { tableColumnTextGroupHeaderTag } from './group-header-view';
 import { tableColumnTextCellViewTag } from './cell-view';
+import { ColumnInternals } from '../base/models/column-internals';
 
 export type TableColumnTextCellRecord = TableStringField<'value'>;
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -25,15 +26,13 @@ declare global {
  * The table column for displaying string fields as text.
  */
 export class TableColumnText extends TableColumnTextBase {
-    public constructor() {
-        super({
-            cellRecordFieldNames: ['value'],
-            cellViewTag: tableColumnTextCellViewTag,
-            groupHeaderViewTag: tableColumnTextGroupHeaderTag,
-            delegatedEvents: []
-        });
-        this.columnInternals.sortOperation = TableColumnSortOperation.localeAwareCaseSensitive;
-    }
+    override columnInternals = new ColumnInternals<TableColumnTextColumnConfig>({
+        cellRecordFieldNames: ['value'],
+        cellViewTag: tableColumnTextCellViewTag,
+        groupHeaderViewTag: tableColumnTextGroupHeaderTag,
+        delegatedEvents: [],
+        sortOperation: TableColumnSortOperation.localeAwareCaseSensitive
+    });
 }
 
 const nimbleTableColumnText = TableColumnText.compose({

--- a/packages/nimble-components/src/table-column/text/index.ts
+++ b/packages/nimble-components/src/table-column/text/index.ts
@@ -9,7 +9,7 @@ import {
 } from '../base/types';
 import { tableColumnTextGroupHeaderTag } from './group-header-view';
 import { tableColumnTextCellViewTag } from './cell-view';
-import { ColumnInternals } from '../base/models/column-internals';
+import type { ColumnInternalsOptions } from '../base/models/column-internals';
 
 export type TableColumnTextCellRecord = TableStringField<'value'>;
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -26,13 +26,15 @@ declare global {
  * The table column for displaying string fields as text.
  */
 export class TableColumnText extends TableColumnTextBase {
-    public override columnInternals = new ColumnInternals<TableColumnTextColumnConfig>({
-        cellRecordFieldNames: ['value'],
-        cellViewTag: tableColumnTextCellViewTag,
-        groupHeaderViewTag: tableColumnTextGroupHeaderTag,
-        delegatedEvents: [],
-        sortOperation: TableColumnSortOperation.localeAwareCaseSensitive
-    });
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+        return {
+            cellRecordFieldNames: ['value'],
+            cellViewTag: tableColumnTextCellViewTag,
+            groupHeaderViewTag: tableColumnTextGroupHeaderTag,
+            delegatedEvents: [],
+            sortOperation: TableColumnSortOperation.localeAwareCaseSensitive
+        };
+    }
 }
 
 const nimbleTableColumnText = TableColumnText.compose({

--- a/packages/nimble-components/src/table/specs/table-column-specs/table-column-formatted-text.md
+++ b/packages/nimble-components/src/table/specs/table-column-specs/table-column-formatted-text.md
@@ -97,13 +97,13 @@ Both clients and Nimble itself will derive from these base classes to specify th
 
 ```ts
 export class MyAppProgressColumn extends TableColumnTextBase {
-    public constructor() {
-        super({
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+        return {
             cellRecordFieldNames: ['value'],
             cellViewTag: tableColumnNumericTextCellViewTag,
-            groupHeaderViewTag: tableColumnNumericTextGroupHeaderTag
-        });
-        this.columnInternals.sortOperation = TableColumnSortOperation.basic;
+            groupHeaderViewTag: tableColumnNumericTextGroupHeaderTag,
+            sortOperation: TableColumnSortOperation.basic
+        };
     }
 }
 

--- a/packages/nimble-components/src/table/specs/table-column-specs/table-column-text-field.md
+++ b/packages/nimble-components/src/table/specs/table-column-specs/table-column-text-field.md
@@ -75,10 +75,12 @@ public class TableColumnText extends TableColumn<TableColumnTextCellRecord, Tabl
     }
 
     constuctor() {
-        super({
-            cellRecordFieldNames: ['value'],
-            ...
-        })
+        protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+            return {
+                cellRecordFieldNames: ['value'],
+                ...
+            };
+        }
     }
     ...
 }

--- a/packages/nimble-components/src/table/specs/table-column-specs/table-column-text-field.md
+++ b/packages/nimble-components/src/table/specs/table-column-specs/table-column-text-field.md
@@ -74,13 +74,11 @@ public class TableColumnText extends TableColumn<TableColumnTextCellRecord, Tabl
         this.columnInternals.columnConfig = { placeholder: this.placeholder ?? '' };
     }
 
-    constuctor() {
-        protected override getColumnInternalsOptions(): ColumnInternalsOptions {
-            return {
-                cellRecordFieldNames: ['value'],
-                ...
-            };
-        }
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+        return {
+            cellRecordFieldNames: ['value'],
+            ...
+        };
     }
     ...
 }

--- a/packages/nimble-components/src/table/specs/table-columns-hld.md
+++ b/packages/nimble-components/src/table/specs/table-columns-hld.md
@@ -162,7 +162,7 @@ _Note: The `TableColumn` class may be updated to support other features not cove
 
 ### Column author internal configuration
 
-Column authors have to implement a `getColumnInternalsOptions` returning a `ColumnInternalsOptions` for static configuration and a `columnInternals` object that can be manipulated for dynamic configuration at runtime.
+Column authors have to implement a `getColumnInternalsOptions` method returning a `ColumnInternalsOptions` object for static configuration and a `columnInternals` object that can be manipulated for dynamic configuration at runtime.
 
 ```TS
 export interface ColumnInternalsOptions {

--- a/packages/nimble-components/src/table/specs/table-columns-hld.md
+++ b/packages/nimble-components/src/table/specs/table-columns-hld.md
@@ -124,10 +124,13 @@ This interface could possibly be expanded in the future to communicate relevant 
 
 This abstract class is what a column web component (i.e. a slotted column element) must extend. The attributes added to the `TableColumn` class are intended to be options configurable by client users.
 
-Column authors have additional configuration options to maintain that are configured via the `ColumnInternalsOptions` constructor parameter and the `TableColumn.columnInternals` reference.
+Column authors have additional configuration options to maintain that are configured via implementing the `getColumnInternalsOptions` abstract method and the `TableColumn.columnInternals` reference.
 
 ```TS
 abstract class TableColumn<TColumnConfig = {}> {
+    // @internal Configuration settings for column plugin authors
+    public readonly columnInternals = new ColumnInternals<TColumnConfig>(this.getColumnInternalsOptions());
+
     // An optional ID to associated with the column.
     @attr({ attribute: 'column-id' })
     columnId?: string;
@@ -151,13 +154,7 @@ abstract class TableColumn<TColumnConfig = {}> {
     @attr({ attribute: 'sort-direction' })
     public sortDirection: TableColumnSortDirection = TableColumnSortDirection.none;
 
-    // @internal Configuration settings for column plugin authors
-    public readonly columnInternals: ColumnInternals<TColumnConfig>;
-
-    public constructor(options: ColumnInternalsOptions) {
-        super();
-        this.columnInternals = new ColumnInternals(options);
-    }
+    protected abstract getColumnInternalsOptions(): ColumnInternalsOptions;
 }
 ```
 
@@ -165,7 +162,7 @@ _Note: The `TableColumn` class may be updated to support other features not cove
 
 ### Column author internal configuration
 
-Column authors have a required `ColumnInternalsOptions` constructor parameter argument to define for static configuration and a `columnInternals` object that can be manipulated for dynamic configuration at runtime.
+Column authors have to implement a `getColumnInternalsOptions` returning a `ColumnInternalsOptions` for static configuration and a `columnInternals` object that can be manipulated for dynamic configuration at runtime.
 
 ```TS
 export interface ColumnInternalsOptions {
@@ -259,11 +256,11 @@ public class TableColumnText extends TableColumn<TableColumnTextCellRecord, Tabl
         this.columnInternals.columnConfig = { placeholder: this.placeholder };
     }
 
-    constructor() {
-        super({
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+        return {
             cellViewTag: 'nimble-table-cell-view-text',
             cellRecordFieldNames: ['value']
-        })
+        };
     }
 }
 ```
@@ -331,11 +328,11 @@ public class TableColumnNumberWithUnit extends TableColumn {
         this.columnInternals.dataRecordFieldNames = [this.valueKey, this.unitKey];
     }
 
-    constructor() {
-        super({
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+        return {
             cellViewTag: 'nimble-table-cell-view-number-with-unit',
             cellRecordFieldNames: ['value', 'units']
-        })
+        };
     }
 }
 
@@ -377,12 +374,12 @@ export class ColumnInternals<TColumnConfig> {
     }
 }
 
-AnchorTableColumn extends TableColumn {
-    constructor() {
-        super({
+export class AnchorTableColumn extends TableColumn {
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+        return {
             delegatedEvents: ['click'],
             ...
-        });
+        };
     }
     ...
 }

--- a/packages/nimble-components/src/table/tests/table-delegated-events.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-delegated-events.spec.ts
@@ -12,7 +12,7 @@ import {
 } from '../../utilities/tests/fixture';
 import type { TableRecord } from '../types';
 import { TablePageObject } from '../testing/table.pageobject';
-import { ColumnInternals } from '../../table-column/base/models/column-internals';
+import type { ColumnInternalsOptions } from '../../table-column/base/models/column-internals';
 
 interface SimpleTableRecord extends TableRecord {
     foo: string;
@@ -24,12 +24,14 @@ const columnName = uniqueElementName();
 })
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 class TestTableColumn extends TableColumn {
-    public override columnInternals = new ColumnInternals({
-        cellRecordFieldNames: ['value'],
-        cellViewTag: tableColumnTextCellViewTag,
-        groupHeaderViewTag: tableColumnTextGroupHeaderTag,
-        delegatedEvents: ['click', 'keydown']
-    });
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+        return {
+            cellRecordFieldNames: ['value'],
+            cellViewTag: tableColumnTextCellViewTag,
+            groupHeaderViewTag: tableColumnTextGroupHeaderTag,
+            delegatedEvents: ['click', 'keydown']
+        };
+    }
 }
 
 // prettier-ignore

--- a/packages/nimble-components/src/table/tests/table-delegated-events.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-delegated-events.spec.ts
@@ -24,7 +24,7 @@ const columnName = uniqueElementName();
 })
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 class TestTableColumn extends TableColumn {
-    override columnInternals = new ColumnInternals({
+    public override columnInternals = new ColumnInternals({
         cellRecordFieldNames: ['value'],
         cellViewTag: tableColumnTextCellViewTag,
         groupHeaderViewTag: tableColumnTextGroupHeaderTag,

--- a/packages/nimble-components/src/table/tests/table-delegated-events.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-delegated-events.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '../../utilities/tests/fixture';
 import type { TableRecord } from '../types';
 import { TablePageObject } from '../testing/table.pageobject';
+import { ColumnInternals } from '../../table-column/base/models/column-internals';
 
 interface SimpleTableRecord extends TableRecord {
     foo: string;
@@ -23,14 +24,12 @@ const columnName = uniqueElementName();
 })
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 class TestTableColumn extends TableColumn {
-    public constructor() {
-        super({
-            cellRecordFieldNames: ['value'],
-            cellViewTag: tableColumnTextCellViewTag,
-            groupHeaderViewTag: tableColumnTextGroupHeaderTag,
-            delegatedEvents: ['click', 'keydown']
-        });
-    }
+    override columnInternals = new ColumnInternals({
+        cellRecordFieldNames: ['value'],
+        cellViewTag: tableColumnTextCellViewTag,
+        groupHeaderViewTag: tableColumnTextGroupHeaderTag,
+        delegatedEvents: ['click', 'keydown']
+    });
 }
 
 // prettier-ignore

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -15,7 +15,7 @@ import {
 import { TableColumnSortDirection, TableRecord } from '../types';
 import { TablePageObject } from '../testing/table.pageobject';
 import { tableColumnEmptyGroupHeaderViewTag } from '../../table-column/base/tests/table-column.fixtures';
-import { ColumnInternals } from '../../table-column/base/models/column-internals';
+import type { ColumnInternalsOptions } from '../../table-column/base/models/column-internals';
 
 interface SimpleTableRecord extends TableRecord {
     stringData: string;
@@ -562,15 +562,17 @@ describe('Table', () => {
             })
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             class TestFocusableTableColumn extends TableColumn {
-                public override columnInternals = new ColumnInternals({
-                    cellViewTag: focusableCellViewName,
-                    cellRecordFieldNames: ['value'],
-                    groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-                    delegatedEvents: []
-                });
-
                 @attr({ attribute: 'field-name' })
                 public fieldName?: string;
+
+                protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+                    return {
+                        cellViewTag: focusableCellViewName,
+                        cellRecordFieldNames: ['value'],
+                        groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
+                        delegatedEvents: []
+                    };
+                }
             }
 
             it('to render fewer rows (based on viewport size)', async () => {

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -562,7 +562,7 @@ describe('Table', () => {
             })
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             class TestFocusableTableColumn extends TableColumn {
-                override columnInternals = new ColumnInternals({
+                public override columnInternals = new ColumnInternals({
                     cellViewTag: focusableCellViewName,
                     cellRecordFieldNames: ['value'],
                     groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
@@ -571,7 +571,6 @@ describe('Table', () => {
 
                 @attr({ attribute: 'field-name' })
                 public fieldName?: string;
-
             }
 
             it('to render fewer rows (based on viewport size)', async () => {

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -15,6 +15,7 @@ import {
 import { TableColumnSortDirection, TableRecord } from '../types';
 import { TablePageObject } from '../testing/table.pageobject';
 import { tableColumnEmptyGroupHeaderViewTag } from '../../table-column/base/tests/table-column.fixtures';
+import { ColumnInternals } from '../../table-column/base/models/column-internals';
 
 interface SimpleTableRecord extends TableRecord {
     stringData: string;
@@ -561,17 +562,16 @@ describe('Table', () => {
             })
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             class TestFocusableTableColumn extends TableColumn {
+                override columnInternals = new ColumnInternals({
+                    cellViewTag: focusableCellViewName,
+                    cellRecordFieldNames: ['value'],
+                    groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
+                    delegatedEvents: []
+                });
+
                 @attr({ attribute: 'field-name' })
                 public fieldName?: string;
 
-                public constructor() {
-                    super({
-                        cellViewTag: focusableCellViewName,
-                        cellRecordFieldNames: ['value'],
-                        groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-                        delegatedEvents: []
-                    });
-                }
             }
 
             it('to render fewer rows (based on viewport size)', async () => {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Prior to this change the `TableColumn.columnInternals` property was instantiated in the `TableColumn` constructor. Coupled with the behavior that property initialization runs before constructor execution ([see example jsbin](https://jsbin.com/gikohuxake/edit?js,console)) this would cause the following issue:

1. Attribute default values would be assigned in a class (such as `false` assigned to a hidden attribute)
2. The associated observable change method would run, i.e. `hiddenChanged`
3. If the observable change method would access `columnInternals` the reference would be `undefined`
4. After all property initialization the constructor would run and column Internals would be defined

This change prevents this temporal deadzone of access to `columnInternals` by instantiating it as the first property in the base class.

## 👩‍💻 Implementation

Instantiate the `columnInternals` property in the `TableColumn` base class which retrieves its static configuration via the implementation of a `getColumnInternalsOptions` method which is accessible during property initialization.

## 🧪 Testing

Refactor relying on exisiting testing. Although was able to remove a test that checked an error was reported if `super` was called without a `ColumnInternalsOptions` argument.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
