### PR TITLE
Mark 'placeholder' as an @Input on the text column directive

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/table-column/text/nimble-table-column-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/text/nimble-table-column-text.directive.ts
@@ -26,7 +26,7 @@ export class NimbleTableColumnTextDirective extends NimbleTableColumnBaseDirecti
         return this.elementRef.nativeElement.placeholder;
     }
 
-    public set placeholder(value: string | undefined) {
+    @Input() public set placeholder(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'placeholder', value);
     }
 

--- a/change/@ni-nimble-angular-9a9187c6-a422-49ce-849c-51bf9aa974cc.json
+++ b/change/@ni-nimble-angular-9a9187c6-a422-49ce-849c-51bf9aa974cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Mark 'placeholder' as an @Input on the text column directive",
+  "packageName": "@ni/nimble-angular",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

`placeholder` had a setter in the `NimbleTableColumnTextDirective`, but it wasn't marked as an `@Input`. As a result, I cannot bind to it in an Angular app with strict template checking enabled.

## 👩‍💻 Implementation

Mark `placeholder` as an `@Input`.

## 🧪 Testing

Manually verified that I can bind to the column's `placeholder` value from an Angular app when I could not before.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
