### PR TITLE
Follow new guidance for incubating components, mark table NOT incubating, add sections to Storybook

### DIFF
--- a/packages/nimble-components/.storybook/preview.js
+++ b/packages/nimble-components/.storybook/preview.js
@@ -15,7 +15,13 @@ export const parameters = {
     options: {
         storySort: {
             method: 'alphabetical',
-            order: ['Getting Started']
+            order: [
+                'Getting Started',
+                'Components',
+                'Incubating',
+                'Tokens',
+                'Tests'
+            ]
         }
     },
     controls: {

--- a/packages/nimble-components/docs/incubating.mdx
+++ b/packages/nimble-components/docs/incubating.mdx
@@ -1,0 +1,19 @@
+import { Story, Meta } from '@storybook/addon-docs';
+
+<Meta title="Incubating/Docs" />
+
+# Incubating components
+
+Components are marked as **Incubating** when they're not yet ready for general use.
+A component could be in this state if any of the following are true:
+
+-   It is still in development.
+-   It is currently experimental or application-specific and hasn't yet been generalized for broader use.
+-   It is missing important features like interaction design, visual design, accessibility, or framework integration.
+
+See the issue linked from each component's documentation for more information about what it's missing.
+
+## Using incubating components
+
+Please talk to the Nimble team before using incubating components in production.
+Note that incubating components may make breaking changes without a corresponding `major` version bump.

--- a/packages/nimble-components/src/anchor-button/tests/anchor-button.stories.ts
+++ b/packages/nimble-components/src/anchor-button/tests/anchor-button.stories.ts
@@ -31,7 +31,7 @@ interface AnchorButtonArgs {
 }
 
 const metadata: Meta<AnchorButtonArgs> = {
-    title: 'Anchor Button',
+    title: 'Components/Anchor Button',
     tags: ['autodocs'],
     parameters: {
         docs: {

--- a/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.stories.ts
+++ b/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.stories.ts
@@ -19,7 +19,7 @@ represents a different URL to navigate to. Use the standard tabs component when 
 tab panels hosted on the same page.`;
 
 const metadata: Meta<TabsArgs> = {
-    title: 'Anchor Tabs',
+    title: 'Components/Anchor Tabs',
     tags: ['autodocs'],
     parameters: {
         docs: {

--- a/packages/nimble-components/src/anchor/tests/anchor.stories.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor.stories.ts
@@ -19,7 +19,7 @@ interface AnchorArgs {
 }
 
 const metadata: Meta<AnchorArgs> = {
-    title: 'Anchor',
+    title: 'Components/Anchor',
     tags: ['autodocs'],
     parameters: {
         docs: {

--- a/packages/nimble-components/src/banner/tests/banner.stories.ts
+++ b/packages/nimble-components/src/banner/tests/banner.stories.ts
@@ -41,7 +41,7 @@ should be spaced apart using the \`${bannerGapSize.cssCustomProperty}\` design t
 `;
 
 const metadata: Meta<BannerArgs> = {
-    title: 'Banner',
+    title: 'Components/Banner',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/breadcrumb/tests/breadcrumb.stories.ts
+++ b/packages/nimble-components/src/breadcrumb/tests/breadcrumb.stories.ts
@@ -28,7 +28,7 @@ See the [nimble-angular Readme](https://github.com/ni/nimble/blob/main/angular-w
 for information on using this component in Angular with RouterLink directives.`;
 
 const metadata: Meta<BreadcrumbArgs> = {
-    title: 'Breadcrumb',
+    title: 'Components/Breadcrumb',
     tags: ['autodocs'],
     parameters: {
         docs: {

--- a/packages/nimble-components/src/button/tests/button.stories.ts
+++ b/packages/nimble-components/src/button/tests/button.stories.ts
@@ -31,7 +31,7 @@ a dialog is to append "…" (ellipsis) to the button label, e.g., "Save as…".
 If you want a button that triggers navigation to a URL, use the \`nimble-anchor-button\` instead.`;
 
 const metadata: Meta<ButtonArgs> = {
-    title: 'Button',
+    title: 'Components/Button',
     decorators: [withActions],
     parameters: {
         docs: {

--- a/packages/nimble-components/src/card-button/tests/card-button.stories.ts
+++ b/packages/nimble-components/src/card-button/tests/card-button.stories.ts
@@ -17,7 +17,7 @@ application. The \`nimble-card-button\` is intended to be larger and more promin
 Note: The styling for the "Color" theme is not complete.`;
 
 const metadata: Meta<CardButtonArgs> = {
-    title: 'Card Button',
+    title: 'Components/Card Button',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/checkbox/tests/checkbox.stories.ts
+++ b/packages/nimble-components/src/checkbox/tests/checkbox.stories.ts
@@ -12,7 +12,7 @@ interface CheckboxArgs {
 }
 
 const metadata: Meta<CheckboxArgs> = {
-    title: 'Checkbox',
+    title: 'Components/Checkbox',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/combobox/tests/combobox.stories.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox.stories.ts
@@ -31,7 +31,7 @@ interface OptionArgs {
 }
 
 const metadata: Meta<ComboboxArgs> = {
-    title: 'Combobox',
+    title: 'Components/Combobox',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/dialog/tests/dialog.stories.ts
+++ b/packages/nimble-components/src/dialog/tests/dialog.stories.ts
@@ -50,7 +50,7 @@ const content = {
 } as const;
 
 const metadata: Meta<DialogArgs> = {
-    title: 'Dialog',
+    title: 'Components/Dialog',
     tags: ['autodocs'],
     parameters: {
         docs: {

--- a/packages/nimble-components/src/drawer/tests/drawer.stories.ts
+++ b/packages/nimble-components/src/drawer/tests/drawer.stories.ts
@@ -114,7 +114,7 @@ ${overrideWarning('Drawer Width', widthDescriptionOverride)}
 `;
 
 const metadata: Meta<DrawerArgs> = {
-    title: 'Drawer',
+    title: 'Components/Drawer',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/icon-base/tests/icons.stories.ts
+++ b/packages/nimble-components/src/icon-base/tests/icons.stories.ts
@@ -20,7 +20,7 @@ interface IconArgs {
 }
 
 const metadata: Meta<IconArgs> = {
-    title: 'Icons',
+    title: 'Components/Icons',
     tags: ['autodocs']
 };
 

--- a/packages/nimble-components/src/menu-button/tests/menu-button.stories.ts
+++ b/packages/nimble-components/src/menu-button/tests/menu-button.stories.ts
@@ -32,7 +32,7 @@ This icon will be hidden when \`contentHidden\` is set to \`true\`
 .`;
 
 const metadata: Meta<MenuButtonArgs> = {
-    title: 'Menu Button',
+    title: 'Components/Menu Button',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/menu/tests/menu.stories.ts
+++ b/packages/nimble-components/src/menu/tests/menu.stories.ts
@@ -39,7 +39,7 @@ The \`nimble-menu\` supports several child elements including \`<header>\`, \`<h
 and will format them and any Nimble icons added as children of \`<nimble-menu-item>\` or \`<nimble-anchor-menu-item>\`.`;
 
 const metadata: Meta<MenuArgs> = {
-    title: 'Menu',
+    title: 'Components/Menu',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/number-field/tests/number-field.stories.ts
+++ b/packages/nimble-components/src/number-field/tests/number-field.stories.ts
@@ -18,7 +18,7 @@ interface NumberFieldArgs {
 }
 
 const metadata: Meta<NumberFieldArgs> = {
-    title: 'Number Field',
+    title: 'Components/Number Field',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/radio-group/tests/radio-group.stories.ts
+++ b/packages/nimble-components/src/radio-group/tests/radio-group.stories.ts
@@ -15,7 +15,7 @@ interface RadioGroupArgs {
 }
 
 const metadata: Meta<RadioGroupArgs> = {
-    title: 'Radio Group',
+    title: 'Components/Radio Group',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/select/tests/select.stories.ts
+++ b/packages/nimble-components/src/select/tests/select.stories.ts
@@ -25,7 +25,7 @@ interface OptionArgs {
 }
 
 const metadata: Meta<SelectArgs> = {
-    title: 'Select',
+    title: 'Components/Select',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/spinner/tests/spinner.stories.ts
+++ b/packages/nimble-components/src/spinner/tests/spinner.stories.ts
@@ -29,7 +29,7 @@ const overviewText = '<p>The `nimble-spinner` is an animating indicator that can
     + '<p>See the `size` argument details for information on customizing the spinner size.</p>';
 
 const metadata: Meta<SpinnerArgs> = {
-    title: 'Spinner',
+    title: 'Components/Spinner',
     tags: ['autodocs'],
     parameters: {
         docs: {

--- a/packages/nimble-components/src/switch/tests/switch.stories.ts
+++ b/packages/nimble-components/src/switch/tests/switch.stories.ts
@@ -20,7 +20,7 @@ be checked or not checked and can optionally also allow for a partially checked 
 pressed or not pressed and can optionally allow for a partially pressed state.`;
 
 const metadata: Meta<SwitchArgs> = {
-    title: 'Switch',
+    title: 'Components/Switch',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.stories.ts
+++ b/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.stories.ts
@@ -21,7 +21,7 @@ See the **Table** page for information about configuring the table itself and th
 information about common column configuration.`;
 
 const metadata: Meta<SharedTableArgs> = {
-    title: 'Table Column Types',
+    title: 'Components/Table Column Types',
     decorators: [withActions],
     tags: ['autodocs'],
     parameters: {

--- a/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.stories.ts
+++ b/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.stories.ts
@@ -1,10 +1,7 @@
 import { html, ref } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import { withActions } from '@storybook/addon-actions/decorator';
-import {
-    createUserSelectedThemeStory,
-    usageWarning
-} from '../../../utilities/tests/storybook';
+import { createUserSelectedThemeStory } from '../../../utilities/tests/storybook';
 import { tableTag } from '../../../table';
 import { tableColumnAnchorTag } from '..';
 import {
@@ -106,7 +103,6 @@ export const anchorColumn: StoryObj<AnchorColumnTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<AnchorColumnTableArgs>`
-        ${usageWarning('table')}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"

--- a/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
@@ -1,10 +1,7 @@
 import { html, ref, when } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import { withActions } from '@storybook/addon-actions/decorator';
-import {
-    createUserSelectedThemeStory,
-    usageWarning
-} from '../../../utilities/tests/storybook';
+import { createUserSelectedThemeStory } from '../../../utilities/tests/storybook';
 import {
     ExampleColumnFractionalWidthType,
     ExampleGroupingDisabledType,
@@ -95,7 +92,6 @@ const metadata: Meta<SharedTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<SharedTableArgs>`
-    ${usageWarning('table')}
     <${tableTag}
         ${ref('tableRef')}
         data-unused="${x => x.updateData(x)}"
@@ -169,7 +165,6 @@ export const columnOrder: StoryObj<ColumnOrderTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<ColumnOrderTableArgs>`
-        ${usageWarning('table')}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
@@ -242,7 +237,6 @@ export const headerContent: StoryObj<HeaderContentTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<HeaderContentTableArgs>`
-        ${usageWarning('table')}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
@@ -301,7 +295,6 @@ export const commonAttributes: StoryObj<CommonAttributesTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<CommonAttributesTableArgs>`
-        ${usageWarning('table')}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
@@ -417,7 +410,6 @@ export const sorting: StoryObj<SortingTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<SortingTableArgs>`
-        ${usageWarning('table')}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
@@ -604,7 +596,6 @@ export const grouping: StoryObj<GroupingTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<GroupingTableArgs>`
-        ${usageWarning('table')}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
@@ -728,7 +719,6 @@ export const fractionalWidthColumn: StoryObj<ColumnWidthTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<ColumnWidthTableArgs>`
-        ${usageWarning('table')}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"

--- a/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
@@ -81,7 +81,7 @@ See **Table** for information about configuring the table itself and **Table Col
 information about specific types of column.`;
 
 const metadata: Meta<SharedTableArgs> = {
-    title: 'Table Column Configuration',
+    title: 'Components/Table Column Configuration',
     decorators: [withActions],
     parameters: {
         docs: {

--- a/packages/nimble-components/src/table-column/text/tests/table-column-text.stories.ts
+++ b/packages/nimble-components/src/table-column/text/tests/table-column-text.stories.ts
@@ -45,7 +45,7 @@ See the **Table** page for information about configuring the table itself and th
 information about common column configuration.`;
 
 const metadata: Meta<SharedTableArgs> = {
-    title: 'Table Column Types',
+    title: 'Components/Table Column Types',
     decorators: [withActions],
     parameters: {
         docs: {

--- a/packages/nimble-components/src/table-column/text/tests/table-column-text.stories.ts
+++ b/packages/nimble-components/src/table-column/text/tests/table-column-text.stories.ts
@@ -1,10 +1,7 @@
 import { html, ref } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import { withActions } from '@storybook/addon-actions/decorator';
-import {
-    createUserSelectedThemeStory,
-    usageWarning
-} from '../../../utilities/tests/storybook';
+import { createUserSelectedThemeStory } from '../../../utilities/tests/storybook';
 import { tableTag } from '../../../table';
 import { tableColumnTextTag } from '..';
 import {
@@ -92,7 +89,6 @@ export const textColumn: StoryObj<TextColumnTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<TextColumnTableArgs>`
-        ${usageWarning('table')}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"

--- a/packages/nimble-components/src/table/tests/table.stories.ts
+++ b/packages/nimble-components/src/table/tests/table.stories.ts
@@ -1,10 +1,7 @@
 import { html, ref } from '@microsoft/fast-element';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj } from '@storybook/html';
-import {
-    createUserSelectedThemeStory,
-    usageWarning
-} from '../../utilities/tests/storybook';
+import { createUserSelectedThemeStory } from '../../utilities/tests/storybook';
 import { ExampleDataType } from './types';
 import { Table, tableTag } from '..';
 import { TableRowSelectionMode } from '../types';
@@ -140,7 +137,6 @@ const metadata: Meta<TableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<TableArgs>`
-        ${usageWarning('table')}
         <${tableTag}
             ${ref('tableRef')}
             selection-mode="${x => TableRowSelectionMode[x.selectionMode]}"

--- a/packages/nimble-components/src/table/tests/table.stories.ts
+++ b/packages/nimble-components/src/table/tests/table.stories.ts
@@ -120,7 +120,7 @@ If a record does not exist in the table's data, it will not be selected. If mult
 mode is \`single\`, only the first record that exists in the table's data will become selected.`;
 
 const metadata: Meta<TableArgs> = {
-    title: 'Table',
+    title: 'Components/Table',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/tabs/tests/tabs.stories.ts
+++ b/packages/nimble-components/src/tabs/tests/tabs.stories.ts
@@ -25,7 +25,7 @@ horizontal scrolling. Content may be any height; the tab panel will display a ve
 If you want a sequence of tabs that navigate to different URLs, use the Anchor Tabs component instead.`;
 
 const metadata: Meta<TabsArgs> = {
-    title: 'Tabs',
+    title: 'Components/Tabs',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/text-area/tests/text-area.stories.ts
+++ b/packages/nimble-components/src/text-area/tests/text-area.stories.ts
@@ -29,7 +29,7 @@ If you configure your text area to be resizable (with the \`resize\` attribute) 
 `;
 
 const metadata: Meta<TextAreaArgs> = {
-    title: 'Text Area',
+    title: 'Components/Text Area',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/text-field/tests/text-field.stories.ts
+++ b/packages/nimble-components/src/text-field/tests/text-field.stories.ts
@@ -32,7 +32,7 @@ consuming application must implement that functionality.
 `;
 
 const metadata: Meta<TextFieldArgs> = {
-    title: 'Text Field',
+    title: 'Components/Text Field',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/toggle-button/tests/toggle-button.stories.ts
+++ b/packages/nimble-components/src/toggle-button/tests/toggle-button.stories.ts
@@ -29,7 +29,7 @@ not change when its state changes. In this example, when the pressed state is tr
 screen reader would say something like "Mute toggle button pressed".`;
 
 const metadata: Meta<ToggleButtonArgs> = {
-    title: 'Toggle Button',
+    title: 'Components/Toggle Button',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/toolbar/tests/toolbar.stories.ts
+++ b/packages/nimble-components/src/toolbar/tests/toolbar.stories.ts
@@ -24,7 +24,7 @@ ${toolbarTag}::part(positioning-region) {
 \``;
 
 const metadata: Meta = {
-    title: 'Toolbar',
+    title: 'Components/Toolbar',
     tags: ['autodocs'],
     parameters: {
         docs: {

--- a/packages/nimble-components/src/tooltip/tests/tooltip.stories.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip.stories.ts
@@ -4,7 +4,7 @@ import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj } from '@storybook/html';
 import {
     createUserSelectedThemeStory,
-    usageWarning
+    incubatingWarning
 } from '../../utilities/tests/storybook';
 import {
     borderColor,
@@ -109,7 +109,10 @@ const metadata: Meta<TooltipArgs> = {
         }
     },
     render: createUserSelectedThemeStory(html<TooltipArgs>`
-        ${usageWarning('tooltip', 'https://github.com/ni/nimble/issues/309')}
+        ${incubatingWarning(
+        'tooltip',
+        'https://github.com/ni/nimble/issues/309'
+    )}
         <div ${ref('anchorRef')} id="${x => x.getUniqueId(x.anchorRef)}">
             Hover here to see ${x => x.content} tooltip
         </div>

--- a/packages/nimble-components/src/tooltip/tests/tooltip.stories.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip.stories.ts
@@ -91,7 +91,7 @@ const complexContent = html<TooltipArgs>`
 `;
 
 const metadata: Meta<TooltipArgs> = {
-    title: 'Tooltip',
+    title: 'Incubating/Tooltip',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/tooltip/tests/tooltip.stories.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip.stories.ts
@@ -2,7 +2,10 @@ import { html, ref } from '@microsoft/fast-element';
 import type { AutoUpdateMode } from '@microsoft/fast-foundation';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj } from '@storybook/html';
-import { createUserSelectedThemeStory } from '../../utilities/tests/storybook';
+import {
+    createUserSelectedThemeStory,
+    usageWarning
+} from '../../utilities/tests/storybook';
 import {
     borderColor,
     bodyFont,
@@ -106,10 +109,7 @@ const metadata: Meta<TooltipArgs> = {
         }
     },
     render: createUserSelectedThemeStory(html<TooltipArgs>`
-        <div id="usage-warning">
-            WARNING - The tooltip is still in development and considered
-            experimental. It is not recommended for application use.
-        </div>
+        ${usageWarning('tooltip', 'https://github.com/ni/nimble/issues/309')}
         <div ${ref('anchorRef')} id="${x => x.getUniqueId(x.anchorRef)}">
             Hover here to see ${x => x.content} tooltip
         </div>
@@ -130,10 +130,6 @@ const metadata: Meta<TooltipArgs> = {
                 color: var(${bodyFontColor.cssCustomProperty});
                 width: 80px;
                 height: 60px;
-            }
-            #usage-warning {
-                color: red;
-                font: var(${bodyFont.cssCustomProperty});
             }
         </style>
     `),

--- a/packages/nimble-components/src/tree-view/tests/tree-view.stories.ts
+++ b/packages/nimble-components/src/tree-view/tests/tree-view.stories.ts
@@ -53,7 +53,7 @@ In addition to \`href\`, all other attributes of \`<a>\` are also supported, e.g
 `;
 
 const metadata: Meta<TreeArgs> = {
-    title: 'Tree View',
+    title: 'Components/Tree View',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {

--- a/packages/nimble-components/src/utilities/tests/storybook.ts
+++ b/packages/nimble-components/src/utilities/tests/storybook.ts
@@ -146,14 +146,17 @@ Overrides of properties are not recommended and are not theme-aware by default. 
 ${howToOverride}
 </details>`;
 
-export const usageWarning = (componentName: string, issueLink: string): string => `
+export const incubatingWarning = (
+    componentName: string,
+    issueLink: string
+): string => `
 <style class="code-hide">
-#usage-warning {
+#incubating-warning {
     color: red;
     font: var(${bodyFont.cssCustomProperty});
 }
 </style>
-<div id="usage-warning" class="code-hide">
+<div id="incubating-warning" class="code-hide">
 WARNING - The ${componentName} is still incubating. It is not recommended for application use. 
 For more information on its status, see <a href="${issueLink}">this issue</a>.
 </div>`;

--- a/packages/nimble-components/src/utilities/tests/storybook.ts
+++ b/packages/nimble-components/src/utilities/tests/storybook.ts
@@ -146,7 +146,7 @@ Overrides of properties are not recommended and are not theme-aware by default. 
 ${howToOverride}
 </details>`;
 
-export const usageWarning = (componentName: string): string => `
+export const usageWarning = (componentName: string, issueLink: string): string => `
 <style class="code-hide">
 #usage-warning {
     color: red;
@@ -154,8 +154,8 @@ export const usageWarning = (componentName: string): string => `
 }
 </style>
 <div id="usage-warning" class="code-hide">
-WARNING - The ${componentName} is still in development and considered
-experimental. It is not recommended for application use.
+WARNING - The ${componentName} is still incubating. It is not recommended for application use. 
+For more information on its status, see <a href="${issueLink}">this issue</a>.
 </div>`;
 
 // On Firefox, on the Docs page, there is a div with a scale(1) transform that causes the dropdown

--- a/packages/nimble-components/src/wafer-map/tests/wafer-map-matrix.stories.ts
+++ b/packages/nimble-components/src/wafer-map/tests/wafer-map-matrix.stories.ts
@@ -12,7 +12,7 @@ import {
 import { waferMapTag } from '..';
 
 const metadata: Meta = {
-    title: 'Tests/WaferMap',
+    title: 'Tests/Wafer Map',
     parameters: {
         ...sharedMatrixParameters()
     }

--- a/packages/nimble-components/src/wafer-map/tests/wafer-map.stories.ts
+++ b/packages/nimble-components/src/wafer-map/tests/wafer-map.stories.ts
@@ -3,7 +3,7 @@ import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj } from '@storybook/html';
 import {
     createUserSelectedThemeStory,
-    usageWarning
+    incubatingWarning
 } from '../../utilities/tests/storybook';
 import { generateWaferData } from './data-generator';
 import { goodValueGenerator, badValueGenerator } from './value-generator';
@@ -99,7 +99,10 @@ const metadata: Meta<WaferMapArgs> = {
         }
     },
     render: createUserSelectedThemeStory(html`
-        ${usageWarning('wafer map', 'https://github.com/ni/nimble/issues/924')}
+        ${incubatingWarning(
+        'wafer map',
+        'https://github.com/ni/nimble/issues/924'
+    )}
         <${waferMapTag}
             id="wafer-map"
             colors-scale-mode="${x => x.colorScaleMode}"

--- a/packages/nimble-components/src/wafer-map/tests/wafer-map.stories.ts
+++ b/packages/nimble-components/src/wafer-map/tests/wafer-map.stories.ts
@@ -99,7 +99,7 @@ const metadata: Meta<WaferMapArgs> = {
         }
     },
     render: createUserSelectedThemeStory(html`
-        ${usageWarning('wafer map')}
+        ${usageWarning('wafer map', 'https://github.com/ni/nimble/issues/924')}
         <${waferMapTag}
             id="wafer-map"
             colors-scale-mode="${x => x.colorScaleMode}"

--- a/packages/nimble-components/src/wafer-map/tests/wafer-map.stories.ts
+++ b/packages/nimble-components/src/wafer-map/tests/wafer-map.stories.ts
@@ -84,7 +84,7 @@ const getHighLightedValueSets = (
 };
 
 const metadata: Meta<WaferMapArgs> = {
-    title: 'WaferMap',
+    title: 'Incubating/Wafer Map',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Following the guidance agreed upon in #1249, we want to promote the "Incubating" terminology to describe components that aren't ready for general use.

## 👩‍💻 Implementation

1. Add sections to Storybook for **Incubating** and **Components**. The latter was proposed in #1230 so it seems like a good direction for multiple reasons.
2. Add MDX docs for the Incubating section.
3. Add a link to the corresponding component issue from incubating stories. Update tooltip to use standard incubating header.
4. Rename WaferMap stories to "Wafer Map" to match other components which English naming not code naming (and since this change was already going to cause a Chromatic diff)

## 🧪 Testing

<!---
Detail the testing done to ensure this submission meets requirements. 

Include automated/manual test additions or modifications, testing done on a local build, private CI run results, and additional testing not covered by automatic pull request validation.
-->

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
