### PR TITLE
Fix GroupRow component template.

### DIFF
--- a/change/@ni-nimble-components-b13a25d8-6e83-45d2-94a9-48c73a77b23b.json
+++ b/change/@ni-nimble-components-b13a25d8-6e83-45d2-94a9-48c73a77b23b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix GroupRow component template",
+  "packageName": "@ni/nimble-components",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/components/group-row/template.ts
+++ b/packages/nimble-components/src/table/components/group-row/template.ts
@@ -38,7 +38,7 @@ export const template = html<TableGroupRow>`
 
         <div class="group-row-header-content">
             ${x => x.groupColumn?.columnInternals.groupHeaderViewTemplate}
-            <div class="group-row-child-count">(${x => x.leafItemCount})</span>
+            <span class="group-row-child-count">(${x => x.leafItemCount})</span>
         </div>
     </template>
 `;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Noticed a mistake in the template for the `GroupRow` component, and decided to make a quick fix for it. The existing mistake in the template (an incorrect `span` closing tag for a `div` element) is apparently innocuous, as FAST seems to resolve the errant tag to the same element as was used for the start tag.

## 👩‍💻 Implementation

Decided to change the opening tag to match the ending tag, as the `span` layout semantics made sense for what it was being used for.

## 🧪 Testing

Manual.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
