### PR TITLE
Fix status table Storybook links

### DIFF
--- a/change/@ni-nimble-components-ad5c9d9e-bb19-4dab-843e-e357b0b4ca99.json
+++ b/change/@ni-nimble-components-ad5c9d9e-bb19-4dab-843e-e357b0b4ca99.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update relative link format in Storybook",
+  "packageName": "@ni/nimble-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/docs/component-status.stories.ts
+++ b/packages/nimble-components/docs/component-status.stories.ts
@@ -23,7 +23,7 @@ const components = [
     },
     {
         componentName: 'Anchor',
-        componentHref: '../?path=/docs/components-anchor--docs',
+        componentHref: './?path=/docs/components-anchor--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/bfadf499-caf5-4ca0-9814-e777fbae0d46/',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/324',
@@ -34,7 +34,7 @@ const components = [
     },
     {
         componentName: 'Anchor Button',
-        componentHref: '../?path=/docs/components-anchor-button--docs',
+        componentHref: './?path=/docs/components-anchor-button--docs',
         issueHref: 'https://github.com/ni/nimble/issues/324',
         issueLabel: 'Issue',
         componentStatus: '✅',
@@ -43,7 +43,7 @@ const components = [
     },
     {
         componentName: 'Anchor Tabs',
-        componentHref: '../?path=/docs/components-anchor-tabs--docs',
+        componentHref: './?path=/docs/components-anchor-tabs--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/b2aa2c0c-03b7-4571-8e0d-de88baf0814b',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/479',
@@ -54,7 +54,7 @@ const components = [
     },
     {
         componentName: 'Anchor Tree Item',
-        componentHref: '../?path=/docs/components-tree-view--docs#anchor-tree-item',
+        componentHref: './?path=/docs/components-tree-view--docs#anchor-tree-item',
         issueHref: 'https://github.com/ni/nimble/issues/562',
         issueLabel: 'Issue',
         componentStatus: '✅',
@@ -63,7 +63,7 @@ const components = [
     },
     {
         componentName: 'Banner',
-        componentHref: '../?path=/docs/components-banner--docs',
+        componentHref: './?path=/docs/components-banner--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/29c405f7-08ea-48b6-973f-546970b9dbab',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/305',
@@ -74,7 +74,7 @@ const components = [
     },
     {
         componentName: 'Breadcrumb',
-        componentHref: '../?path=/docs/components-breadcrumb--docs',
+        componentHref: './?path=/docs/components-breadcrumb--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/7b53bb3e-439b-4f13-9d5f-55adc7da8a2e',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/343',
@@ -93,7 +93,7 @@ const components = [
     },
     {
         componentName: 'Card button',
-        componentHref: '../?path=/docs/components-card-button--docs',
+        componentHref: './?path=/docs/components-card-button--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/d4ebeb5d-023c-4ff2-a71c-f6385fffca20',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/643',
@@ -104,7 +104,7 @@ const components = [
     },
     {
         componentName: 'Checkbox',
-        componentHref: '../?path=/docs/components-checkbox--docs',
+        componentHref: './?path=/docs/components-checkbox--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/3698340b-8162-4e5d-bf7a-20194612b3a7',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -123,7 +123,7 @@ const components = [
     },
     {
         componentName: 'Combobox',
-        componentHref: '../?path=/docs/components-combobox--docs',
+        componentHref: './?path=/docs/components-combobox--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/bd6755d9-8fd2-4b97-9709-939ea20680ae',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/341',
@@ -142,7 +142,7 @@ const components = [
     },
     {
         componentName: 'Dialog',
-        componentHref: '../?path=/docs/components-dialog--docs',
+        componentHref: './?path=/docs/components-dialog--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/6f1b5b4d-2e50-4f8d-ad49-e3dac564a006',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/378',
@@ -153,7 +153,7 @@ const components = [
     },
     {
         componentName: 'Drawer',
-        componentHref: '../?path=/docs/components-drawer--docs',
+        componentHref: './?path=/docs/components-drawer--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/730cdeb8-a4b5-4dcc-9fe4-718a75da7aff',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -170,7 +170,7 @@ const components = [
     },
     {
         componentName: 'Icon Button',
-        componentHref: '../?path=/docs/components-button--docs#icon-button',
+        componentHref: './?path=/docs/components-button--docs#icon-button',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/d022d8af-22f4-4bf2-981c-1dc0c61afece',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -179,7 +179,7 @@ const components = [
     },
     {
         componentName: 'Icon Menu Button',
-        componentHref: '../?path=/docs/components-menu-button--docs#icon-button',
+        componentHref: './?path=/docs/components-menu-button--docs#icon-button',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/d022d8af-22f4-4bf2-981c-1dc0c61afece',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/300',
@@ -190,7 +190,7 @@ const components = [
     },
     {
         componentName: 'Icons',
-        componentHref: '../?path=/docs/components-icons--docs',
+        componentHref: './?path=/docs/components-icons--docs',
         componentStatus: '✅',
         angularStatus: '✅',
         blazorStatus: '✅',
@@ -205,7 +205,7 @@ const components = [
     },
     {
         componentName: 'Menu',
-        componentHref: '../?path=/docs/components-menu--docs',
+        componentHref: './?path=/docs/components-menu--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/c098395e-30f8-4bd4-b8c5-394326b59919',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -214,7 +214,7 @@ const components = [
     },
     {
         componentName: 'Menu Button',
-        componentHref: '../?path=/docs/components-menu-button--docs',
+        componentHref: './?path=/docs/components-menu-button--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/42001df1-2969-438e-b353-4327d7a15102',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/300',
@@ -225,7 +225,7 @@ const components = [
     },
     {
         componentName: 'Number Field',
-        componentHref: '../?path=/docs/components-number-field--docs',
+        componentHref: './?path=/docs/components-number-field--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/eaa9ee19-4411-4648-b19d-41f61f9a01cf',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/361',
@@ -244,7 +244,7 @@ const components = [
     },
     {
         componentName: 'Radio',
-        componentHref: '../?path=/docs/components-radio-group--docs',
+        componentHref: './?path=/docs/components-radio-group--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/3698340b-8162-4e5d-bf7a-20194612b3a7',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/297',
@@ -265,7 +265,7 @@ const components = [
     },
     {
         componentName: 'Select (Dropdown)',
-        componentHref: '../?path=/docs/components-select--docs',
+        componentHref: './?path=/docs/components-select--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/6ec70d21-9a59-40cd-a8f4-45cfeed9e01e',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -292,7 +292,7 @@ const components = [
     },
     {
         componentName: 'Spinner',
-        componentHref: '../?path=/docs/components-spinner--docs',
+        componentHref: './?path=/docs/components-spinner--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/ced36959-68d6-440f-a0cc-031bc29d7e98',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/346',
@@ -313,7 +313,7 @@ const components = [
     },
     {
         componentName: 'Switch',
-        componentHref: '../?path=/docs/components-switch--docs',
+        componentHref: './?path=/docs/components-switch--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/3698340b-8162-4e5d-bf7a-20194612b3a7',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/387',
@@ -324,7 +324,7 @@ const components = [
     },
     {
         componentName: 'Table',
-        componentHref: '../?path=/docs/incubating-table--docs',
+        componentHref: './?path=/docs/incubating-table--docs',
         designHref: 'https://xd.adobe.com/view/5b476816-dad1-4671-b20a-efe796631c72-0e14/screen/d389dc1e-da4f-4a63-957b-f8b3cc9591b4/specs/',
         designLabel: 'XD',
         issueHref: 'https://github.com/orgs/ni/projects/11',
@@ -335,7 +335,7 @@ const components = [
     },
     {
         componentName: 'Tabs',
-        componentHref: '../?path=/docs/components-tabs--docs',
+        componentHref: './?path=/docs/components-tabs--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/b2aa2c0c-03b7-4571-8e0d-de88baf0814b',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -344,7 +344,7 @@ const components = [
     },
     {
         componentName: 'Text and Icon Button',
-        componentHref: '../?path=/docs/components-button--docs',
+        componentHref: './?path=/docs/components-button--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/a378bcdb-5c4b-4298-b3b1-28d8b1a37af2',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -353,7 +353,7 @@ const components = [
     },
     {
         componentName: 'Text Button',
-        componentHref: '../?path=/docs/components-button--docs',
+        componentHref: './?path=/docs/components-button--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/42001df1-2969-438e-b353-4327d7a15102',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -362,7 +362,7 @@ const components = [
     },
     {
         componentName: 'Text Area',
-        componentHref: '../?path=/docs/components-text-area--docs',
+        componentHref: './?path=/docs/components-text-area--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/7c146e4b-c7c9-4975-a158-10e6093c522d',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -371,7 +371,7 @@ const components = [
     },
     {
         componentName: 'Text Field',
-        componentHref: '../?path=/docs/components-text-field--docs',
+        componentHref: './?path=/docs/components-text-field--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/842889a5-67ba-4350-91c1-55eee48f4fa2',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -380,7 +380,7 @@ const components = [
     },
     {
         componentName: 'Toggle Icon Button',
-        componentHref: '../?path=/docs/components-toggle-button--docs#icon-button',
+        componentHref: './?path=/docs/components-toggle-button--docs#icon-button',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/d022d8af-22f4-4bf2-981c-1dc0c61afece/',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -389,7 +389,7 @@ const components = [
     },
     {
         componentName: 'Toolbar',
-        componentHref: '../?path=/docs/components-toolbar--docs',
+        componentHref: './?path=/docs/components-toolbar--docs',
         issueHref: 'https://github.com/ni/nimble/issues/411',
         issueLabel: 'Issue',
         componentStatus: '✅',
@@ -398,7 +398,7 @@ const components = [
     },
     {
         componentName: 'Tooltip',
-        componentHref: '../?path=/docs/incubating-tooltip--docs',
+        componentHref: './?path=/docs/incubating-tooltip--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/044414d7-1714-40f2-9679-2ce2c8202d1c',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/309',
@@ -409,7 +409,7 @@ const components = [
     },
     {
         componentName: 'Tree View',
-        componentHref: '../?path=/docs/components-tree-view--docs',
+        componentHref: './?path=/docs/components-tree-view--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/ec5a855a-4174-46ad-947c-3931bbf3e32d',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -418,7 +418,7 @@ const components = [
     },
     {
         componentName: 'Wafer Map',
-        componentHref: '../?path=/docs/incubating-wafer-map--docs',
+        componentHref: './?path=/docs/incubating-wafer-map--docs',
         issueHref: 'https://github.com/ni/nimble/issues/924',
         issueLabel: 'Issue',
         componentStatus: '⚠️',
@@ -438,7 +438,7 @@ const metadata: Meta<TableArgs> = {
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
         >
-            <${tableColumnAnchorTag}
+            <${tableColumnAnchorTag} target="_top"
                 column-id="component-name-column"
                 label-field-name="componentName"
                 href-field-name="componentHref"
@@ -446,14 +446,14 @@ const metadata: Meta<TableArgs> = {
             >
                 Component
             </${tableColumnAnchorTag}>
-            <${tableColumnAnchorTag}
+            <${tableColumnAnchorTag} target="_top"
                 column-id="design-column"
                 label-field-name="designLabel"
                 href-field-name="designHref"
             >
                 Design
             </${tableColumnAnchorTag}>
-            <${tableColumnAnchorTag}
+            <${tableColumnAnchorTag} target="_top"
                 column-id="issue-column"
                 label-field-name="issueLabel"
                 href-field-name="issueHref"

--- a/packages/nimble-components/docs/component-status.stories.ts
+++ b/packages/nimble-components/docs/component-status.stories.ts
@@ -23,7 +23,7 @@ const components = [
     },
     {
         componentName: 'Anchor',
-        componentHref: '/?path=/docs/components-anchor--docs',
+        componentHref: '../?path=/docs/components-anchor--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/bfadf499-caf5-4ca0-9814-e777fbae0d46/',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/324',
@@ -34,7 +34,7 @@ const components = [
     },
     {
         componentName: 'Anchor Button',
-        componentHref: '/?path=/docs/components-anchor-button--docs',
+        componentHref: '../?path=/docs/components-anchor-button--docs',
         issueHref: 'https://github.com/ni/nimble/issues/324',
         issueLabel: 'Issue',
         componentStatus: '✅',
@@ -43,7 +43,7 @@ const components = [
     },
     {
         componentName: 'Anchor Tabs',
-        componentHref: '/?path=/docs/components-anchor-tabs--docs',
+        componentHref: '../?path=/docs/components-anchor-tabs--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/b2aa2c0c-03b7-4571-8e0d-de88baf0814b',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/479',
@@ -54,7 +54,7 @@ const components = [
     },
     {
         componentName: 'Anchor Tree Item',
-        componentHref: '/?path=/docs/components-tree-view--docs#anchor-tree-item',
+        componentHref: '../?path=/docs/components-tree-view--docs#anchor-tree-item',
         issueHref: 'https://github.com/ni/nimble/issues/562',
         issueLabel: 'Issue',
         componentStatus: '✅',
@@ -63,7 +63,7 @@ const components = [
     },
     {
         componentName: 'Banner',
-        componentHref: '/?path=/docs/components-banner--docs',
+        componentHref: '../?path=/docs/components-banner--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/29c405f7-08ea-48b6-973f-546970b9dbab',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/305',
@@ -74,7 +74,7 @@ const components = [
     },
     {
         componentName: 'Breadcrumb',
-        componentHref: '/?path=/docs/components-breadcrumb--docs',
+        componentHref: '../?path=/docs/components-breadcrumb--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/7b53bb3e-439b-4f13-9d5f-55adc7da8a2e',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/343',
@@ -93,7 +93,7 @@ const components = [
     },
     {
         componentName: 'Card button',
-        componentHref: '/?path=/docs/components-card-button--docs',
+        componentHref: '../?path=/docs/components-card-button--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/d4ebeb5d-023c-4ff2-a71c-f6385fffca20',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/643',
@@ -104,7 +104,7 @@ const components = [
     },
     {
         componentName: 'Checkbox',
-        componentHref: '/?path=/docs/components-checkbox--docs',
+        componentHref: '../?path=/docs/components-checkbox--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/3698340b-8162-4e5d-bf7a-20194612b3a7',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -123,7 +123,7 @@ const components = [
     },
     {
         componentName: 'Combobox',
-        componentHref: '/?path=/docs/components-combobox--docs',
+        componentHref: '../?path=/docs/components-combobox--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/bd6755d9-8fd2-4b97-9709-939ea20680ae',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/341',
@@ -142,7 +142,7 @@ const components = [
     },
     {
         componentName: 'Dialog',
-        componentHref: '/?path=/docs/components-dialog--docs',
+        componentHref: '../?path=/docs/components-dialog--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/6f1b5b4d-2e50-4f8d-ad49-e3dac564a006',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/378',
@@ -153,7 +153,7 @@ const components = [
     },
     {
         componentName: 'Drawer',
-        componentHref: '/?path=/docs/components-drawer--docs',
+        componentHref: '../?path=/docs/components-drawer--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/730cdeb8-a4b5-4dcc-9fe4-718a75da7aff',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -170,7 +170,7 @@ const components = [
     },
     {
         componentName: 'Icon Button',
-        componentHref: '/?path=/docs/components-button--docs#icon-button',
+        componentHref: '../?path=/docs/components-button--docs#icon-button',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/d022d8af-22f4-4bf2-981c-1dc0c61afece',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -179,7 +179,7 @@ const components = [
     },
     {
         componentName: 'Icon Menu Button',
-        componentHref: '/?path=/docs/components-menu-button--docs#icon-button',
+        componentHref: '../?path=/docs/components-menu-button--docs#icon-button',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/d022d8af-22f4-4bf2-981c-1dc0c61afece',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/300',
@@ -190,7 +190,7 @@ const components = [
     },
     {
         componentName: 'Icons',
-        componentHref: '/?path=/docs/components-icons--docs',
+        componentHref: '../?path=/docs/components-icons--docs',
         componentStatus: '✅',
         angularStatus: '✅',
         blazorStatus: '✅',
@@ -205,7 +205,7 @@ const components = [
     },
     {
         componentName: 'Menu',
-        componentHref: '/?path=/docs/components-menu--docs',
+        componentHref: '../?path=/docs/components-menu--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/c098395e-30f8-4bd4-b8c5-394326b59919',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -214,7 +214,7 @@ const components = [
     },
     {
         componentName: 'Menu Button',
-        componentHref: '/?path=/docs/components-menu-button--docs',
+        componentHref: '../?path=/docs/components-menu-button--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/42001df1-2969-438e-b353-4327d7a15102',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/300',
@@ -225,7 +225,7 @@ const components = [
     },
     {
         componentName: 'Number Field',
-        componentHref: '/?path=/docs/components-number-field--docs',
+        componentHref: '../?path=/docs/components-number-field--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/eaa9ee19-4411-4648-b19d-41f61f9a01cf',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/361',
@@ -244,7 +244,7 @@ const components = [
     },
     {
         componentName: 'Radio',
-        componentHref: '/?path=/docs/components-radio-group--docs',
+        componentHref: '../?path=/docs/components-radio-group--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/3698340b-8162-4e5d-bf7a-20194612b3a7',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/297',
@@ -265,7 +265,7 @@ const components = [
     },
     {
         componentName: 'Select (Dropdown)',
-        componentHref: '/?path=/docs/components-select--docs',
+        componentHref: '../?path=/docs/components-select--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/6ec70d21-9a59-40cd-a8f4-45cfeed9e01e',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -292,7 +292,7 @@ const components = [
     },
     {
         componentName: 'Spinner',
-        componentHref: '/?path=/docs/components-spinner--docs',
+        componentHref: '../?path=/docs/components-spinner--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/ced36959-68d6-440f-a0cc-031bc29d7e98',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/346',
@@ -313,7 +313,7 @@ const components = [
     },
     {
         componentName: 'Switch',
-        componentHref: '/?path=/docs/components-switch--docs',
+        componentHref: '../?path=/docs/components-switch--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/3698340b-8162-4e5d-bf7a-20194612b3a7',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/387',
@@ -324,7 +324,7 @@ const components = [
     },
     {
         componentName: 'Table',
-        componentHref: '/?path=/docs/incubating-table--docs',
+        componentHref: '../?path=/docs/incubating-table--docs',
         designHref: 'https://xd.adobe.com/view/5b476816-dad1-4671-b20a-efe796631c72-0e14/screen/d389dc1e-da4f-4a63-957b-f8b3cc9591b4/specs/',
         designLabel: 'XD',
         issueHref: 'https://github.com/orgs/ni/projects/11',
@@ -335,7 +335,7 @@ const components = [
     },
     {
         componentName: 'Tabs',
-        componentHref: '/?path=/docs/components-tabs--docs',
+        componentHref: '../?path=/docs/components-tabs--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/b2aa2c0c-03b7-4571-8e0d-de88baf0814b',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -344,7 +344,7 @@ const components = [
     },
     {
         componentName: 'Text and Icon Button',
-        componentHref: '/?path=/docs/components-button--docs',
+        componentHref: '../?path=/docs/components-button--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/a378bcdb-5c4b-4298-b3b1-28d8b1a37af2',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -353,7 +353,7 @@ const components = [
     },
     {
         componentName: 'Text Button',
-        componentHref: '/?path=/docs/components-button--docs',
+        componentHref: '../?path=/docs/components-button--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/42001df1-2969-438e-b353-4327d7a15102',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -362,7 +362,7 @@ const components = [
     },
     {
         componentName: 'Text Area',
-        componentHref: '/?path=/docs/components-text-area--docs',
+        componentHref: '../?path=/docs/components-text-area--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/7c146e4b-c7c9-4975-a158-10e6093c522d',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -371,7 +371,7 @@ const components = [
     },
     {
         componentName: 'Text Field',
-        componentHref: '/?path=/docs/components-text-field--docs',
+        componentHref: '../?path=/docs/components-text-field--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/842889a5-67ba-4350-91c1-55eee48f4fa2',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -380,7 +380,7 @@ const components = [
     },
     {
         componentName: 'Toggle Icon Button',
-        componentHref: '/?path=/docs/components-toggle-button--docs#icon-button',
+        componentHref: '../?path=/docs/components-toggle-button--docs#icon-button',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/d022d8af-22f4-4bf2-981c-1dc0c61afece/',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -389,7 +389,7 @@ const components = [
     },
     {
         componentName: 'Toolbar',
-        componentHref: '/?path=/docs/components-toolbar--docs',
+        componentHref: '../?path=/docs/components-toolbar--docs',
         issueHref: 'https://github.com/ni/nimble/issues/411',
         issueLabel: 'Issue',
         componentStatus: '✅',
@@ -398,7 +398,7 @@ const components = [
     },
     {
         componentName: 'Tooltip',
-        componentHref: '/?path=/docs/incubating-tooltip--docs',
+        componentHref: '../?path=/docs/incubating-tooltip--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/044414d7-1714-40f2-9679-2ce2c8202d1c',
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/309',
@@ -409,7 +409,7 @@ const components = [
     },
     {
         componentName: 'Tree View',
-        componentHref: '/?path=/docs/components-tree-view--docs',
+        componentHref: '../?path=/docs/components-tree-view--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/ec5a855a-4174-46ad-947c-3931bbf3e32d',
         designLabel: 'XD',
         componentStatus: '✅',
@@ -418,7 +418,7 @@ const components = [
     },
     {
         componentName: 'Wafer Map',
-        componentHref: '/?path=/docs/incubating-wafer-map--docs',
+        componentHref: '../?path=/docs/incubating-wafer-map--docs',
         issueHref: 'https://github.com/ni/nimble/issues/924',
         issueLabel: 'Issue',
         componentStatus: '⚠️',

--- a/packages/nimble-components/docs/creating-storybook-component-documentation.md
+++ b/packages/nimble-components/docs/creating-storybook-component-documentation.md
@@ -27,11 +27,11 @@ If the component has a [W3C ARIA description](https://w3c.github.io/aria-practic
 
 ### Markdown
 
-The description supports Markdown, so can link to other documents or components. E.g.
+The description supports Markdown, so can link to other documents or components. Note the specific form of relative link that is necessary due to [Storybook URL behavior](https://github.com/storybookjs/storybook/issues/8618#issuecomment-1401988950).
 
 ```md
-[Links to a specific documentation page](?path=/docs/some--id)
-[Links to a specific story canvas](?path=/story/some--id)
+[Links to a specific documentation page](../?path=/docs/some--id)
+[Links to a specific story canvas](../?path=/story/some--id)
 ```
 
 All other Markdown formatting is supported. See any [Markdown Cheatsheet](https://www.markdownguide.org/cheat-sheet/) for more information.

--- a/packages/nimble-components/docs/creating-storybook-component-documentation.md
+++ b/packages/nimble-components/docs/creating-storybook-component-documentation.md
@@ -27,11 +27,17 @@ If the component has a [W3C ARIA description](https://w3c.github.io/aria-practic
 
 ### Markdown
 
-The description supports Markdown, so can link to other documents or components. Note the specific form of relative link that is necessary due to [Storybook URL behavior](https://github.com/storybookjs/storybook/issues/8618#issuecomment-1401988950).
+The description supports Markdown, so can link to other documents or components. E.g.
 
 ```md
-[Links to a specific documentation page](../?path=/docs/some--id)
-[Links to a specific story canvas](../?path=/story/some--id)
+[Links to a specific documentation page](?path=/docs/some--id)
+[Links to a specific story canvas](?path=/story/some--id)
+```
+
+Note: if linking in a story via a native or Nimble anchor component, use the following syntax:
+
+```html
+<a href="./?path=/docs/some--id" target="_top">Link</a>
 ```
 
 All other Markdown formatting is supported. See any [Markdown Cheatsheet](https://www.markdownguide.org/cheat-sheet/) for more information.


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

I noticed that the links from the [component status table](https://nimble.ni.dev/storybook/?path=/docs/component-status--docs) to component stories were broken on `https://nimble.ni.dev/storybook`. They worked fine in local builds and Chromatic PR builds.

They should look like this:
`https://nimble.ni.dev/storybook/?path=/docs/components-anchor--docs`

But instead they look like this:
`https://nimble.ni.dev/?path=/docs/components-anchor--docs`

## 👩‍💻 Implementation

Changed status table relative links from this form, which is relative to the root of the site:
`/?path=/docs/components-anchor--docs`

to this form, which is relative to the current document: 
`./?path=/docs/components-anchor--docs`

and added `target="_top"` to the anchor columns to escape the storybook iframe context.

Also updated the docs where we describe how to link to stories from anchor tags and scanned for other stories with relative links (there weren't any).

## 🧪 Testing

I tested links in a local storybook build, a local site build, and in the Chromatic PR build. But we won't know for sure whether this fixes the issue in production until we've completed the PR and I can test on nimble.ni.dev/storybook.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
