### PR TITLE
Concrete properties in text-column view base classes

### DIFF
--- a/change/@ni-nimble-components-a91e2528-b7f1-448a-a97a-409d872e2988.json
+++ b/change/@ni-nimble-components-a91e2528-b7f1-448a-a97a-409d872e2988.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Change text-column base class property behavior",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table-column/text-base/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/text-base/cell-view/index.ts
@@ -17,25 +17,22 @@ export abstract class TableColumnTextCellViewBase<
     public textSpan!: HTMLElement;
 
     /**
-     * Returns the text to render in the cell when it contains a valid value (i.e. when shouldUsePlaceholder() is false).
-     * If the implementation has branching code paths then it must be marked with @volatile.
-     * https://www.fast.design/docs/fast-element/observables-and-state/#observable-features
+     * Text to render in the cell when it contains a valid value (i.e. when shouldUsePlaceholder is false).
      */
-    public abstract get text(): string;
+    @observable
+    public text = '';
 
     /**
-     * Returns the text to render in the cell when it contains an invalid value (i.e. when shouldUsePlaceholder() is true).
-     * If the implementation has branching code paths then it must be marked with @volatile.
-     * https://www.fast.design/docs/fast-element/observables-and-state/#observable-features
+     * Text to render in the cell when it contains an invalid value (i.e. when shouldUsePlaceholder is true).
      */
-    public abstract get placeholder(): string;
+    @observable
+    public placeholder = '';
 
     /**
      * Returns whether to display the placeholder value or the text value
-     * If the implementation has branching code paths then it must be marked with @volatile.
-     * https://www.fast.design/docs/fast-element/observables-and-state/#observable-features
-     * */
-    public abstract get shouldUsePlaceholder(): boolean;
+     */
+    @observable
+    public shouldUsePlaceholder = false;
 
     @volatile
     public get content(): string {

--- a/packages/nimble-components/src/table-column/text-base/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/text-base/cell-view/index.ts
@@ -32,7 +32,7 @@ export abstract class TableColumnTextCellViewBase<
      * Returns whether to display the placeholder value or the text value
      */
     @observable
-    public shouldUsePlaceholder = false;
+    public shouldUsePlaceholder = true;
 
     @volatile
     public get content(): string {

--- a/packages/nimble-components/src/table-column/text-base/group-header-view/index.ts
+++ b/packages/nimble-components/src/table-column/text-base/group-header-view/index.ts
@@ -18,25 +18,22 @@ export abstract class TableColumnTextGroupHeaderViewBase<
     public hasOverflow = false;
 
     /**
-     * Returns the text to render in the cell when it contains a valid value (i.e. when shouldUsePlaceholder() is false).
-     * If the implementation has branching code paths then it must be marked with @volatile.
-     * https://www.fast.design/docs/fast-element/observables-and-state/#observable-features
+     * Text to render in the cell when it contains a valid value (i.e. when shouldUsePlaceholder is false).
      */
-    public abstract get text(): string;
+    @observable
+    public text = '';
 
     /**
-     * Returns the text to render in the cell when it contains an invalid value (i.e. when shouldUsePlaceholder() is true).
-     * If the implementation has branching code paths then it must be marked with @volatile.
-     * https://www.fast.design/docs/fast-element/observables-and-state/#observable-features
+     * Text to render in the cell when it contains an invalid value (i.e. when shouldUsePlaceholder is true).
      */
-    public abstract get placeholder(): string;
+    @observable
+    public placeholder = '';
 
     /**
      * Returns whether to display the placeholder value or the text value
-     * If the implementation has branching code paths then it must be marked with @volatile.
-     * https://www.fast.design/docs/fast-element/observables-and-state/#observable-features
-     * */
-    public abstract get shouldUsePlaceholder(): boolean;
+     */
+    @observable
+    public shouldUsePlaceholder = false;
 
     @volatile
     public get content(): string {

--- a/packages/nimble-components/src/table-column/text-base/group-header-view/index.ts
+++ b/packages/nimble-components/src/table-column/text-base/group-header-view/index.ts
@@ -33,7 +33,7 @@ export abstract class TableColumnTextGroupHeaderViewBase<
      * Returns whether to display the placeholder value or the text value
      */
     @observable
-    public shouldUsePlaceholder = false;
+    public shouldUsePlaceholder = true;
 
     @volatile
     public get content(): string {

--- a/packages/nimble-components/src/table-column/text/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/text/cell-view/index.ts
@@ -20,16 +20,17 @@ export class TableColumnTextCellView extends TableColumnTextCellViewBase<
 TableColumnTextCellRecord,
 TableColumnTextColumnConfig
 > {
-    public override get text(): string {
-        return this.cellRecord.value!;
+    private columnConfigChanged(): void {
+        this.placeholder = this.columnConfig.placeholder;
     }
 
-    public override get placeholder(): string {
-        return this.columnConfig.placeholder;
-    }
-
-    public override get shouldUsePlaceholder(): boolean {
-        return typeof this.cellRecord.value !== 'string';
+    private cellRecordChanged(): void {
+        if (typeof this.cellRecord.value === 'string') {
+            this.text = this.cellRecord.value;
+            this.shouldUsePlaceholder = false;
+        } else {
+            this.shouldUsePlaceholder = true;
+        }
     }
 }
 

--- a/packages/nimble-components/src/table-column/text/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/text/cell-view/index.ts
@@ -29,6 +29,7 @@ TableColumnTextColumnConfig
             this.text = this.cellRecord.value;
             this.shouldUsePlaceholder = false;
         } else {
+            this.text = '';
             this.shouldUsePlaceholder = true;
         }
     }

--- a/packages/nimble-components/src/table-column/text/group-header-view/index.ts
+++ b/packages/nimble-components/src/table-column/text/group-header-view/index.ts
@@ -17,16 +17,18 @@ export class TableColumnTextGroupHeaderView extends TableColumnTextGroupHeaderVi
 TableStringFieldValue,
 TableColumnTextColumnConfig
 > {
-    public override get text(): string {
-        return this.groupHeaderValue!;
+    private columnConfigChanged(): void {
+        this.placeholder = this.columnConfig?.placeholder ?? '';
     }
 
-    public override get placeholder(): string {
-        return this.columnConfig?.placeholder ?? '';
-    }
-
-    public override get shouldUsePlaceholder(): boolean {
-        return typeof this.groupHeaderValue !== 'string';
+    private cellRecordChanged(): void {
+        if (typeof this.groupHeaderValue === 'string') {
+            this.text = this.groupHeaderValue;
+            this.shouldUsePlaceholder = false;
+        } else {
+            this.text = '';
+            this.shouldUsePlaceholder = true;
+        }
     }
 }
 

--- a/packages/nimble-components/src/table-column/text/group-header-view/index.ts
+++ b/packages/nimble-components/src/table-column/text/group-header-view/index.ts
@@ -21,7 +21,7 @@ TableColumnTextColumnConfig
         this.placeholder = this.columnConfig?.placeholder ?? '';
     }
 
-    private cellRecordChanged(): void {
+    private groupHeaderValueChanged(): void {
         if (typeof this.groupHeaderValue === 'string') {
             this.text = this.groupHeaderValue;
             this.shouldUsePlaceholder = false;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Changes the text-column cell view and group header view base classes to have concrete observable properties:

  - Is a more "normal" element pattern. Just standard observable properties.
  - Encourages caching results in response to changes instead of calculating new values on accessor request.
    - Cell View elements are configured by the columnConfig and cellRecord/groupHeaderValue. So we can avoid extra work by calculating results only when those change.

## 👩‍💻 Implementation

Changed base class to use observable properties.

## 🧪 Testing

Rely on existing texts.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed. We do keep finding that abstract properties in base class lead to more confusion, not less and end up refactoring away (see columnInternals changes). Not sure if there is general guidance yet.
