### PR TITLE
Add rowRecordId to TableCell, TableCellView, and delegated event details

### DIFF
--- a/change/@ni-nimble-components-30319fbf-4709-43b2-9ab5-378704cc1cff.json
+++ b/change/@ni-nimble-components-30319fbf-4709-43b2-9ab5-378704cc1cff.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add rowRecordId to TableCell, TableCellView, and delegated event details",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table-column/base/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/base/cell-view/index.ts
@@ -26,6 +26,9 @@ export abstract class TableCellView<
     @observable
     public column?: TableColumn<TColumnConfig>;
 
+    @observable
+    public rowRecordId?: string;
+
     private delegatedEvents: readonly string[] = [];
 
     /**
@@ -49,7 +52,10 @@ export abstract class TableCellView<
         this.delegatedEventHandler = (event: Event) => {
             this.column?.dispatchEvent(
                 new CustomEvent<DelegatedEventEventDetails>('delegated-event', {
-                    detail: { originalEvent: event }
+                    detail: {
+                        originalEvent: event,
+                        rowRecordId: this.rowRecordId
+                    }
                 })
             );
         };

--- a/packages/nimble-components/src/table-column/base/cell-view/template.ts
+++ b/packages/nimble-components/src/table-column/base/cell-view/template.ts
@@ -25,6 +25,7 @@ export const createCellViewTemplate = (
             :cellRecord="${y => y.cellState?.cellRecord}"
             :columnConfig="${y => y.cellState?.columnConfig}"
             :column="${y => y.column}"
+            :rowRecordId="${y => y.rowRecordId}"
             class="cell-view"
         >
         </${cellViewTag}>

--- a/packages/nimble-components/src/table-column/base/types.ts
+++ b/packages/nimble-components/src/table-column/base/types.ts
@@ -24,6 +24,7 @@ export interface TableColumnWithPlaceholderColumnConfig {
  */
 export interface DelegatedEventEventDetails {
     originalEvent: Event;
+    rowRecordId?: string;
 }
 
 /**

--- a/packages/nimble-components/src/table/components/cell/index.ts
+++ b/packages/nimble-components/src/table/components/cell/index.ts
@@ -29,6 +29,9 @@ export class TableCell<
     @observable
     public column?: TableColumn;
 
+    @observable
+    public rowRecordId?: string;
+
     @attr({ attribute: 'has-action-menu', mode: 'boolean' })
     public hasActionMenu = false;
 

--- a/packages/nimble-components/src/table/components/row/template.ts
+++ b/packages/nimble-components/src/table/components/row/template.ts
@@ -30,6 +30,7 @@ export const template = html<TableRow>`
                         :cellState="${x => x.cellState}"
                         :cellViewTemplate="${x => x.column.columnInternals.cellViewTemplate}"
                         :column="${x => x.column}"
+                        :rowRecordId="${(_x, c) => c.parent.recordId}"
                         ?has-action-menu="${x => !!x.column.actionMenuSlot}"
                         action-menu-label="${x => x.column.actionMenuLabel}"
                         @cell-action-menu-beforetoggle="${(x, c) => c.parent.onCellActionMenuBeforeToggle(c.event as CustomEvent<MenuButtonToggleEventDetail>, x.column)}"


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This is a precursor to adding Angular router support to the anchor column. We want to be able to pass a clicked link's row id as part of the event details of the delegated click event.

## 👩‍💻 Implementation

The delegated event is fired from the TableCellView, so it needs access to the row id. To get it there, we also need to add it to the TableCell. The row id gets propagated through the templates.

## 🧪 Testing

Tested in prototype of Angular router support for anchor column.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
