### PR TITLE
Style unused slots to be hidden

### DIFF
--- a/change/@ni-nimble-components-f58de85c-8a74-4a0b-b1c4-fdab36bfa94f.json
+++ b/change/@ni-nimble-components-f58de85c-8a74-4a0b-b1c4-fdab36bfa94f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "hide unused slots",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/anchor-menu-item/styles.ts
+++ b/packages/nimble-components/src/anchor-menu-item/styles.ts
@@ -76,7 +76,7 @@ export const styles = css`
         height: ${iconSize};
     }
 
-    :host(.indent-1) .start {
+    :host(.indent-1) [part='start'] {
         grid-column: 1;
     }
 

--- a/packages/nimble-components/src/anchor-tabs/styles.ts
+++ b/packages/nimble-components/src/anchor-tabs/styles.ts
@@ -10,6 +10,10 @@ export const styles = css`
         grid-template-rows: auto 1fr;
     }
 
+    [part='start'] {
+        display: none;
+    }
+
     .tablist {
         display: grid;
         grid-template-rows: auto auto;

--- a/packages/nimble-components/src/anchor-tree-item/styles.ts
+++ b/packages/nimble-components/src/anchor-tree-item/styles.ts
@@ -113,7 +113,7 @@ export const styles = css`
         height: ${iconSize};
     }
 
-    [part="end"] {
+    [part='end'] {
         display: none;
     }
 `;

--- a/packages/nimble-components/src/anchor-tree-item/styles.ts
+++ b/packages/nimble-components/src/anchor-tree-item/styles.ts
@@ -96,7 +96,7 @@ export const styles = css`
     ${
         /* this rule keeps children without an icon text aligned with parents */ ''
     }
-    span[part="start"] {
+    [part="start"] {
         width: ${iconSize};
     }
 
@@ -113,10 +113,7 @@ export const styles = css`
         height: ${iconSize};
     }
 
-    ${/* the end class is applied when the corresponding slot is filled */ ''}
-    .end {
-        display: flex;
-        fill: currentcolor;
-        margin-inline-start: ${iconSize};
+    [part="end"] {
+        display: none;
     }
 `;

--- a/packages/nimble-components/src/anchor-tree-item/tests/anchor-tree-item.spec.ts
+++ b/packages/nimble-components/src/anchor-tree-item/tests/anchor-tree-item.spec.ts
@@ -114,15 +114,11 @@ describe('Anchor Tree Item', () => {
             expect(element.end.assignedElements()[0]).toBe(model.checkIcon);
         });
 
-        it('should set start and end slots visible', async () => {
+        it('should set start slot visible', async () => {
             await connect();
             expect(
                 getComputedStyle(element.start).display === 'none'
                     || getComputedStyle(element.startContainer).display === 'none'
-            ).toBeFalse();
-            expect(
-                getComputedStyle(element.end).display === 'none'
-                    || getComputedStyle(element.endContainer).display === 'none'
             ).toBeFalse();
         });
     });

--- a/packages/nimble-components/src/breadcrumb-item/styles.ts
+++ b/packages/nimble-components/src/breadcrumb-item/styles.ts
@@ -59,12 +59,7 @@ export const styles = css`
 
     .start,
     .end {
-        display: flex;
-        align-items: center;
-    }
-
-    .start {
-        margin-inline-end: 4px;
+        display: none;
     }
 
     slot[name='separator'] {

--- a/packages/nimble-components/src/breadcrumb-item/styles.ts
+++ b/packages/nimble-components/src/breadcrumb-item/styles.ts
@@ -57,8 +57,11 @@ export const styles = css`
         text-decoration: underline;
     }
 
-    .start,
-    .end {
+    [part='end'] {
+        display: none;
+    }
+
+    [part='end'] {
         display: none;
     }
 

--- a/packages/nimble-components/src/card-button/styles.ts
+++ b/packages/nimble-components/src/card-button/styles.ts
@@ -119,11 +119,11 @@ export const styles = css`
         display: contents;
     }
 
-    slot[name='start'] {
+    [part='start'] {
         display: none;
     }
 
-    slot[name='end'] {
+    [part='end'] {
         display: none;
     }
 `.withBehaviors(

--- a/packages/nimble-components/src/list-option/styles.ts
+++ b/packages/nimble-components/src/list-option/styles.ts
@@ -22,6 +22,10 @@ export const styles = css`
         height: ${controlHeight};
     }
 
+    [part='start'] {
+        display: none;
+    }
+
     .content {
         padding: 8px 4px;
     }
@@ -65,5 +69,9 @@ export const styles = css`
     .content[disabled] {
         box-shadow: none;
         outline: none;
+    }
+
+    [part='end'] {
+        display: none;
     }
 `;

--- a/packages/nimble-components/src/menu-item/styles.ts
+++ b/packages/nimble-components/src/menu-item/styles.ts
@@ -73,7 +73,7 @@ export const styles = css`
         width: ${iconSize};
         height: ${iconSize};
     }
-    :host(.indent-1) .start {
+    :host(.indent-1) [part='start'] {
         grid-column: 1;
     }
     :host(.indent-1) .content {

--- a/packages/nimble-components/src/number-field/styles.ts
+++ b/packages/nimble-components/src/number-field/styles.ts
@@ -112,7 +112,7 @@ export const styles = css`
     }
 
     [part='start'] {
-        display: contents;
+        display: none;
     }
 
     .control {

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -101,6 +101,10 @@ export const styles = css`
     :host([disabled]:hover)::after {
         width: 0px;
     }
+    
+    [part='start'] {
+        display: none;
+    }
 
     .control {
         align-items: center;

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -101,7 +101,7 @@ export const styles = css`
     :host([disabled]:hover)::after {
         width: 0px;
     }
-    
+
     [part='start'] {
         display: none;
     }

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -211,7 +211,7 @@ export const styles = css`
         fill: ${bodyDisabledFontColor};
     }
 
-    .end {
+    [part='end'] {
         margin-inline-start: auto;
     }
 

--- a/packages/nimble-components/src/select/styles.ts
+++ b/packages/nimble-components/src/select/styles.ts
@@ -25,7 +25,7 @@ export const styles = css`
         order: 2;
     }
 
-    .end {
+    [part='end'] {
         display: contents;
     }
 `.withBehaviors(

--- a/packages/nimble-components/src/tabs/styles.ts
+++ b/packages/nimble-components/src/tabs/styles.ts
@@ -10,6 +10,10 @@ export const styles = css`
         grid-template-rows: auto 1fr;
     }
 
+    [part='start'] {
+        display: none;
+    }
+
     .tablist {
         display: grid;
         grid-template-rows: auto auto;

--- a/packages/nimble-components/src/tree-item/styles.ts
+++ b/packages/nimble-components/src/tree-item/styles.ts
@@ -130,7 +130,7 @@ export const styles = css`
     ${
         /* this rule keeps children without an icon text aligned with parents */ ''
     }
-    span[part="start"] {
+    [part="start"] {
         width: ${iconSize};
     }
 

--- a/packages/nimble-components/src/tree-item/styles.ts
+++ b/packages/nimble-components/src/tree-item/styles.ts
@@ -156,11 +156,8 @@ export const styles = css`
         );
     }
 
-    ${/* the end class is applied when the corresponding slots is filled */ ''}
-    .end {
-        display: flex;
-        fill: currentcolor;
-        margin-inline-start: ${iconSize};
+    [part='end'] {
+        display: none;
     }
 
     .items {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #451 

Components with functional differences:
- anchor-tabs - Updated to hide the `start` slot
- anchor-tree-item - Updated to hide `end` slot
- breadcrumb-item - Updated to hide `start` and `end` slots
- combobox - Updated to hide `start` slot (in shared dropdown styles)
- list-option - Updated to hide `start` and `end` slots
- number-field - Updated to hide `start` slot
- select - Updated to hide `start` slot (in shared dropdown styles)
- tabs - Updated to hide `start` slot
- tree-item - Updated to hide `end` slot

## 👩‍💻 Implementation

- Updating the styling of some slots
- Standardize on selectors of `[part='start']` and `[part='end']`

## 🧪 Testing

- For each new hidden slot, manually tested that an element put in that slot isn't rendered in the component

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
