### PR TITLE
Fix icon color for disabled menu items and disabled text fields

### DIFF
--- a/change/@ni-nimble-components-39e27099-91fe-44c4-8501-23b6e9f4c012.json
+++ b/change/@ni-nimble-components-39e27099-91fe-44c4-8501-23b6e9f4c012.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix icon color for disabled menu items",
+  "comment": "Fix icon color for disabled menu items and disabled text fields",
   "packageName": "@ni/nimble-components",
   "email": "20542556+mollykreis@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@ni-nimble-components-39e27099-91fe-44c4-8501-23b6e9f4c012.json
+++ b/change/@ni-nimble-components-39e27099-91fe-44c4-8501-23b6e9f4c012.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix icon color for disabled menu items",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/anchor-menu-item/styles.ts
+++ b/packages/nimble-components/src/anchor-menu-item/styles.ts
@@ -9,6 +9,7 @@ import {
     controlHeight,
     fillHoverColor,
     fillSelectedColor,
+    iconColor,
     iconSize
 } from '../theme-provider/design-tokens';
 
@@ -71,7 +72,7 @@ export const styles = css`
     }
 
     slot[name='start']::slotted(*) {
-        fill: currentcolor;
+        ${iconColor.cssCustomProperty}: currentcolor;
         width: ${iconSize};
         height: ${iconSize};
     }

--- a/packages/nimble-components/src/menu-item/styles.ts
+++ b/packages/nimble-components/src/menu-item/styles.ts
@@ -10,7 +10,8 @@ import {
     borderHoverColor,
     iconSize,
     bodyFont,
-    bodyDisabledFontColor
+    bodyDisabledFontColor,
+    iconColor
 } from '../theme-provider/design-tokens';
 
 export const styles = css`
@@ -69,7 +70,7 @@ export const styles = css`
         display: contents;
     }
     slot[name='start']::slotted(*) {
-        fill: currentcolor;
+        ${iconColor.cssCustomProperty}: currentcolor;
         width: ${iconSize};
         height: ${iconSize};
     }

--- a/packages/nimble-components/src/menu/tests/menu-matrix.stories.ts
+++ b/packages/nimble-components/src/menu/tests/menu-matrix.stories.ts
@@ -62,7 +62,7 @@ const component = (
                 `)}
             </${menuItemTag}>
             <hr>
-            <${menuItemTag} disabled>Item 2</${menuItemTag}>
+            <${menuItemTag} disabled>${when(() => parentIcon, html`<${iconUserTag} slot="start"></${iconUserTag}>`)}Item 2</${menuItemTag}>
             <${menuItemTag}>${when(() => parentIcon, html`<${iconUserTag} slot="start"></${iconUserTag}>`)}Item 3</${menuItemTag}>
             <${menuItemTag} hidden>Item 4</${menuItemTag}>
             <${anchorMenuItemTag} href='#'>${when(() => parentIcon, html`<${iconUserTag} slot="start"></${iconUserTag}>`)}Anchor item</${anchorMenuItemTag}>

--- a/packages/nimble-components/src/text-field/styles.ts
+++ b/packages/nimble-components/src/text-field/styles.ts
@@ -14,7 +14,8 @@ import {
     bodyFont,
     controlLabelFontColor,
     controlLabelDisabledFontColor,
-    standardPadding
+    standardPadding,
+    iconColor
 } from '../theme-provider/design-tokens';
 import { appearanceBehavior } from '../utilities/style/appearance';
 import { TextFieldAppearance } from './types';
@@ -117,6 +118,7 @@ export const styles = css`
 
     slot[name='start']::slotted(*) {
         flex: none;
+        ${iconColor.cssCustomProperty}: currentcolor;
     }
 
     .control {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #1356 
Also addresses the color of the `start` icon in a disabled text field.

## 👩‍💻 Implementation

The icons in the `start` slot of the `nimble-menu-item`, `nimble-anchor-menu-item`, and `nimble-text-field` did not have the correct color when disabled. I've updated the styling to set `${iconColor.cssCustomProperty}`.

## 🧪 Testing

- Verified locally in storybook that disabled `nimble-menu-item` elements, disabled `nimble-anchor-menu-item` elements, and disabled `nimble-text-field` elements with icons have the correct icon color.
- Updated the matrix test for the menu to have a disabled menu item with an icon. Previously it only had a disabled anchor menu item with an icon.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
