### PR TITLE
Fix table horizontal scroll issue

### DIFF
--- a/change/@ni-nimble-components-8b2e5179-69e4-4bee-b273-444b66879e93.json
+++ b/change/@ni-nimble-components-8b2e5179-69e4-4bee-b273-444b66879e93.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix for table horizontal scrollbar issue.",
+  "packageName": "@ni/nimble-components",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/models/table-layout-manager.ts
+++ b/packages/nimble-components/src/table/models/table-layout-manager.ts
@@ -163,7 +163,7 @@ export class TableLayoutManager<TData extends TableRecord> {
                 currentDelta
             )
             : delta;
-        const actualDelta = Math.round(allowedDelta);
+        const actualDelta = allowedDelta;
         const leftColumn = this.visibleColumns[leftColumnIndex]!;
         leftColumn.columnInternals.currentPixelWidth! += actualDelta;
 
@@ -186,7 +186,7 @@ export class TableLayoutManager<TData extends TableRecord> {
                 currentDelta
             )
             : delta;
-        const actualDelta = Math.round(allowedDelta);
+        const actualDelta = allowedDelta;
         const rightColumn = this.visibleColumns[rightColumnIndex]!;
         rightColumn.columnInternals.currentPixelWidth! -= actualDelta;
 

--- a/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
@@ -869,4 +869,12 @@ describe('Table Interactive Column Sizing', () => {
         expect(actualFractionalWidths).toEqual(expectedFractionalWidths);
         expect(actualPixelWidths).toEqual(expectedPixelWidths);
     });
+
+    it('sizing to left when columns are all on sub-pixel boundary and just above minimum size, does not cause total column width to change', async () => {
+        await pageObject.sizeTableToGivenRowWidth(202, element); // columns now on half-pixel boundary
+        pageObject.dragSizeColumnByLeftDivider(3, [-1]);
+        await waitForUpdatesAsync();
+        const totalColumnPixelWidth = pageObject.getTotalCellRenderedWidth();
+        expect(totalColumnPixelWidth).toBe(202);
+    });
 });

--- a/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
@@ -872,6 +872,8 @@ describe('Table Interactive Column Sizing', () => {
 
     it('sizing to left when columns are all on sub-pixel boundary and just above minimum size, does not cause total column width to change', async () => {
         await pageObject.sizeTableToGivenRowWidth(202, element); // columns now on half-pixel boundary
+        const expectedColumnSizes = [50.5, 50.5, 50.5, 50.5];
+        expectedColumnSizes.forEach((width, i) => expect(pageObject.getCellRenderedWidth(0, i)).toBe(width));
         pageObject.dragSizeColumnByLeftDivider(3, [-1]);
         await waitForUpdatesAsync();
         const totalColumnPixelWidth = pageObject.getTotalCellRenderedWidth();


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

- #1387

## 👩‍💻 Implementation

Just remove unnecessary calls to `Math.round` on the delta value in the cascade implementations. The current implementation works well with individual columns being given an adjusted pixel size on a sub-pixel boundary.

## 🧪 Testing

Added a unit test.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
