### PR TITLE
Fix keyboard navigation with hidden anchor tabs

### DIFF
--- a/change/@ni-nimble-components-1dd9c055-e2e2-4911-b5bb-84373c149a00.json
+++ b/change/@ni-nimble-components-1dd9c055-e2e2-4911-b5bb-84373c149a00.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix keyboard navigation with hidden anchor tabs",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/anchor-tabs/index.ts
+++ b/packages/nimble-components/src/anchor-tabs/index.ts
@@ -104,8 +104,12 @@ export class AnchorTabs extends FoundationElement {
         return el.getAttribute('aria-disabled') === 'true';
     };
 
+    private readonly isHiddenElement = (el: Element): el is HTMLElement => {
+        return el.getAttribute('hidden') !== null;
+    };
+
     private readonly isFocusableElement = (el: Element): el is HTMLElement => {
-        return !this.isDisabledElement(el);
+        return !this.isDisabledElement(el) && !this.isHiddenElement(el);
     };
 
     private readonly setTabs = (): void => {
@@ -203,7 +207,7 @@ export class AnchorTabs extends FoundationElement {
     };
 
     private focusFirstOrLast(focusLast: boolean): void {
-        const focusableTabs = this.tabs.filter(t => !this.isDisabledElement(t));
+        const focusableTabs = this.tabs.filter(t => this.isFocusableElement(t));
         const focusableIndex = focusLast ? focusableTabs.length - 1 : 0;
         const index = this.tabs.indexOf(focusableTabs[focusableIndex]!);
         if (index > -1) {

--- a/packages/nimble-components/src/anchor-tabs/index.ts
+++ b/packages/nimble-components/src/anchor-tabs/index.ts
@@ -105,7 +105,7 @@ export class AnchorTabs extends FoundationElement {
     };
 
     private readonly isHiddenElement = (el: Element): el is HTMLElement => {
-        return el.getAttribute('hidden') !== null;
+        return el.hasAttribute('hidden');
     };
 
     private readonly isFocusableElement = (el: Element): el is HTMLElement => {

--- a/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
+++ b/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
@@ -122,6 +122,7 @@ describe('AnchorTabs', () => {
     const navigationTests: {
         name: string,
         disabledIndex?: number,
+        hiddenIndex?: number,
         initialFocusIndex: number,
         keyName: string,
         expectedFinalFocusIndex: number
@@ -203,6 +204,20 @@ describe('AnchorTabs', () => {
             initialFocusIndex: 0,
             keyName: keyEnd,
             expectedFinalFocusIndex: 1
+        },
+        {
+            name: 'should skip hidden tab when arrowing right',
+            hiddenIndex: 1,
+            initialFocusIndex: 0,
+            keyName: keyArrowRight,
+            expectedFinalFocusIndex: 2
+        },
+        {
+            name: 'should focus last visible tab when End key pressed',
+            hiddenIndex: 2,
+            initialFocusIndex: 0,
+            keyName: keyEnd,
+            expectedFinalFocusIndex: 1
         }
     ];
     describe('navigation', () => {
@@ -215,6 +230,10 @@ describe('AnchorTabs', () => {
                 await connect();
                 if (test.disabledIndex !== undefined) {
                     tab(test.disabledIndex).disabled = true;
+                    await waitForUpdatesAsync();
+                }
+                if (test.hiddenIndex !== undefined) {
+                    tab(test.hiddenIndex).hidden = true;
                     await waitForUpdatesAsync();
                 }
                 tab(test.initialFocusIndex).focus();

--- a/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
+++ b/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
@@ -213,6 +213,34 @@ describe('AnchorTabs', () => {
             expectedFinalFocusIndex: 2
         },
         {
+            name: 'should skip hidden tab when arrowing left',
+            hiddenIndex: 1,
+            initialFocusIndex: 2,
+            keyName: keyArrowLeft,
+            expectedFinalFocusIndex: 0
+        },
+        {
+            name: 'should skip hidden when arrowing right on last tab',
+            hiddenIndex: 0,
+            initialFocusIndex: 2,
+            keyName: keyArrowRight,
+            expectedFinalFocusIndex: 1
+        },
+        {
+            name: 'should skip hidden when arrowing left on first tab',
+            hiddenIndex: 2,
+            initialFocusIndex: 0,
+            keyName: keyArrowLeft,
+            expectedFinalFocusIndex: 1
+        },
+        {
+            name: 'should focus first visible tab when Home key pressed',
+            hiddenIndex: 0,
+            initialFocusIndex: 2,
+            keyName: keyHome,
+            expectedFinalFocusIndex: 1
+        },
+        {
             name: 'should focus last visible tab when End key pressed',
             hiddenIndex: 2,
             initialFocusIndex: 0,


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Part of #1383
The tabs control needs to be fixed in FAST, but we have similar flawed logic being used for the anchor tabs.


## 👩‍💻 Implementation

The code already handles disabled tabs in the keyboard navigation logic. We just need to expand that to handle hidden tabs the same way. I updated `isFocusableElement()` to also look for the presence of `hidden`.

Also, to make Home/End work properly I had to replace a call to `isDisabledElement()` with `isFocusableElement()` (which used to be equivalent, but now are not).

## 🧪 Testing

Wrote two new test cases and tested manually in Storybook.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
