### PR TITLE
Set errorOnUnknownElements and errorOnUnknownProperties for Angular tests

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/test.ts
+++ b/angular-workspace/projects/ni/nimble-angular/test.ts
@@ -32,7 +32,6 @@ context.keys().map(context);
 
 // Workaround to make console.error calls fail tests:
 // https://github.com/angular/angular/issues/36430#issuecomment-874772398
-// Might be removable after upgrading to Angular 14:
-// https://github.com/angular/angular/issues/36430#issuecomment-1117801535
+// This can be useful to have even with errorOnUnknownElements and errorOnUnknownProperties set to true.
 // eslint-disable-next-line no-console, @typescript-eslint/no-explicit-any
 console.error = (data: any): void => fail(data);

--- a/angular-workspace/projects/ni/nimble-angular/test.ts
+++ b/angular-workspace/projects/ni/nimble-angular/test.ts
@@ -20,7 +20,9 @@ getTestBed().initTestEnvironment(
     BrowserDynamicTestingModule,
     platformBrowserDynamicTesting(),
     {
-        teardown: { destroyAfterEach: false }
+        teardown: { destroyAfterEach: false },
+        errorOnUnknownElements: true,
+        errorOnUnknownProperties: true
     }
 );
 // Then we find all the tests.

--- a/change/@ni-nimble-angular-686d906d-4904-418e-b084-4115fa73314a.json
+++ b/change/@ni-nimble-angular-686d906d-4904-418e-b084-4115fa73314a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Set errorOnUnknownElements and errorOnUnknownProperties for Angular tests",
+  "packageName": "@ni/nimble-angular",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #270

## 👩‍💻 Implementation

Set two configuration options in `test.ts`.

It was suggested in the issue that these might replace an earlier "workaround" of calling `fail()` for any `console.error` output, however it seems that still has value, as it can catch any number of other errors. I'm leaving that code in.

## 🧪 Testing

Temporarily commented out our code that fails on console.error, then verified that an otherwise passing test fails when a component template includes a bogus element name.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
