### PR TITLE
Fix table bug where shift-selecting rows would highlight all cell content

### DIFF
--- a/change/@ni-nimble-components-40354720-a6bd-433f-a845-772c70bb5180.json
+++ b/change/@ni-nimble-components-40354720-a6bd-433f-a845-772c70bb5180.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix table bug where shift-selecting rows would highlight all cell content",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -198,6 +198,7 @@ export class Table<
     @observable
     public tableScrollableMinWidth = 0;
 
+    @observable
     public documentShiftKeyDown = false;
 
     private readonly table: TanStackTable<TData>;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fix a bug in the `nimble-table` where shift-selecting rows would incorrectly highlight all cell content within the selection range.

## 👩‍💻 Implementation

Mark `documentShiftKeyDown` as `@observable` on the `Table`. This appears to have been accidentally removed in #1321.

## 🧪 Testing

Manually tested that shift-selecting rows no longer selects the text in cells.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
