### PR TITLE
Set build locale to en_US.UTF-8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ on:
 env:
   GITHUB_SERVICE_USER: "rajsite"
   GITHUB_SERVICE_EMAIL: "rajsite@users.noreply.github.com"
+  LC_ALL: "en_US.UTF-8"
+  LANG: "en_US.UTF-8"
+  LANGUAGE: "en_US.UTF-8"
 
 jobs:
   build:

--- a/change/@ni-nimble-components-9b1f20f7-121c-4ddc-b57e-32723a4d281d.json
+++ b/change/@ni-nimble-components-9b1f20f7-121c-4ddc-b57e-32723a4d281d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Be more specific about desired locale for testing",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/karma.conf.js
+++ b/packages/nimble-components/karma.conf.js
@@ -29,7 +29,7 @@ const commonChromeFlags = [
     '--disable-infobars',
     '--disable-translate',
     '--force-prefers-reduced-motion',
-    '--lang=en'
+    '--lang=en-US'
 ];
 
 // Create a webpack environment plugin to use while running tests so that


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

In another PR for the date-text column, I included some tests that are sensitive to the machine's locale and expect it to be some form of 'en'. While it seems all GitHub's hosted runners are in the US and would therefore have a compatible default locale, it is safer to explicitly set the locale.

## 👩‍💻 Implementation

Setting the env variables LC_ALL, LANG, and LANGUAGE is supposed to be sufficient.

## 🧪 Testing

Build succeeds.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
