### PR TITLE
Improve cell view typing

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/table-column/anchor/nimble-table-column-anchor-navigation-guard.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/anchor/nimble-table-column-anchor-navigation-guard.directive.ts
@@ -33,11 +33,11 @@ export class NimbleTableColumnAnchorNavigationGuardDirective {
 
         const cellView = delegatedEvent.target as TableColumnAnchorCellView;
         // Based on: https://github.com/angular/angular/blob/35a3fde5b71ef3b50282fe6f7b37ca1c92b8d2a0/packages/router/src/directives/router_link.ts#L457
-        if (typeof cellView.columnConfig.target === 'string' && cellView.columnConfig.target !== '_self') {
+        if (typeof cellView.columnConfig?.target === 'string' && cellView.columnConfig.target !== '_self') {
             return;
         }
 
-        const href = cellView.cellRecord.href;
+        const href = cellView.cellRecord?.href;
         if (!href) {
             return;
         }

--- a/change/@ni-nimble-angular-5a418d34-9cb8-42e9-8967-bca73957ddc8.json
+++ b/change/@ni-nimble-angular-5a418d34-9cb8-42e9-8967-bca73957ddc8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve typing for cell view",
+  "packageName": "@ni/nimble-angular",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-badfdbd0-70cb-45b2-9d9c-050629cf4404.json
+++ b/change/@ni-nimble-components-badfdbd0-70cb-45b2-9d9c-050629cf4404.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve typing for cell view",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table-column/anchor/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/anchor/cell-view/index.ts
@@ -31,10 +31,10 @@ TableColumnAnchorColumnConfig
 
     @volatile
     public get text(): string {
-        if (typeof this.cellRecord.label === 'string') {
+        if (typeof this.cellRecord?.label === 'string') {
             return this.cellRecord.label;
         }
-        if (typeof this.cellRecord.href === 'string') {
+        if (typeof this.cellRecord?.href === 'string') {
             return this.cellRecord.href;
         }
         return '';

--- a/packages/nimble-components/src/table-column/anchor/cell-view/template.ts
+++ b/packages/nimble-components/src/table-column/anchor/cell-view/template.ts
@@ -8,31 +8,31 @@ import { overflow } from '../../../utilities/directive/overflow';
 export const template = html<TableColumnAnchorCellView>`
     <template
         @click="${(x, c) => {
-            if (typeof x.cellRecord.href === 'string') {
+            if (typeof x.cellRecord?.href === 'string') {
                 c.event.stopPropagation();
             }
             return true;
         }}"
     >
-        ${when(x => typeof x.cellRecord.href === 'string', html<TableColumnAnchorCellView>`
+        ${when(x => typeof x.cellRecord?.href === 'string', html<TableColumnAnchorCellView>`
             <${anchorTag}
                 ${ref('anchor')}
                 ${overflow('hasOverflow')}
-                href="${x => x.cellRecord.href}"
-                hreflang="${x => x.columnConfig.hreflang}"
-                ping="${x => x.columnConfig.ping}"
-                referrerpolicy="${x => x.columnConfig.referrerpolicy}"
-                rel="${x => x.columnConfig.rel}"
-                target="${x => x.columnConfig.target}"
-                type="${x => x.columnConfig.type}"
-                download="${x => x.columnConfig.download}"
-                underline-hidden="${x => x.columnConfig.underlineHidden}"
-                appearance="${x => x.columnConfig.appearance}"
+                href="${x => x.cellRecord?.href}"
+                hreflang="${x => x.columnConfig?.hreflang}"
+                ping="${x => x.columnConfig?.ping}"
+                referrerpolicy="${x => x.columnConfig?.referrerpolicy}"
+                rel="${x => x.columnConfig?.rel}"
+                target="${x => x.columnConfig?.target}"
+                type="${x => x.columnConfig?.type}"
+                download="${x => x.columnConfig?.download}"
+                underline-hidden="${x => x.columnConfig?.underlineHidden}"
+                appearance="${x => x.columnConfig?.appearance}"
                 title=${x => (x.hasOverflow ? x.text : null)}
             >
                 ${x => x.text}
             </${anchorTag}>`)}
-        ${when(x => typeof x.cellRecord.href !== 'string', html<TableColumnAnchorCellView>`
+        ${when(x => typeof x.cellRecord?.href !== 'string', html<TableColumnAnchorCellView>`
             <span
                 ${overflow('hasOverflow')}
                 title=${x => (x.hasOverflow ? x.text : null)}

--- a/packages/nimble-components/src/table-column/base/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/base/cell-view/index.ts
@@ -18,10 +18,10 @@ export abstract class TableCellView<
     extends FoundationElement
     implements TableCellState<TCellRecord, TColumnConfig> {
     @observable
-    public cellRecord!: TCellRecord;
+    public cellRecord?: TCellRecord;
 
     @observable
-    public columnConfig!: TColumnConfig;
+    public columnConfig?: TColumnConfig;
 
     @observable
     public column?: TableColumn<TColumnConfig>;

--- a/packages/nimble-components/src/table-column/base/group-header-view/index.ts
+++ b/packages/nimble-components/src/table-column/base/group-header-view/index.ts
@@ -6,7 +6,7 @@ export interface TableGroupHeaderState<
     TGroupValue = TableFieldValue,
     TColumnConfig = unknown
 > {
-    groupHeaderValue: TGroupValue;
+    groupHeaderValue?: TGroupValue;
     columnConfig?: TColumnConfig;
 }
 
@@ -22,7 +22,7 @@ export abstract class TableGroupHeaderView<
     extends FoundationElement
     implements TableGroupHeaderState<TGroupValue, TColumnConfig> {
     @observable
-    public groupHeaderValue!: TGroupValue;
+    public groupHeaderValue?: TGroupValue;
 
     @observable
     public columnConfig?: TColumnConfig;

--- a/packages/nimble-components/src/table-column/base/types.ts
+++ b/packages/nimble-components/src/table-column/base/types.ts
@@ -11,8 +11,8 @@ export interface TableCellState<
     TCellRecord extends TableCellRecord = TableCellRecord,
     TColumnConfig = unknown
 > {
-    cellRecord: TCellRecord;
-    columnConfig: TColumnConfig;
+    cellRecord?: TCellRecord;
+    columnConfig?: TColumnConfig;
 }
 
 /**

--- a/packages/nimble-components/src/table-column/date-text/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/cell-view/index.ts
@@ -33,7 +33,7 @@ TableColumnDateTextColumnConfig
         if (this.columnConfig?.formatter) {
             this.text = formatNumericDate(
                 this.columnConfig.formatter,
-                this.cellRecord.value
+                this.cellRecord?.value
             );
         } else {
             this.text = '';

--- a/packages/nimble-components/src/table-column/enum-text/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/enum-text/cell-view/index.ts
@@ -30,7 +30,7 @@ TableColumnEnumColumnConfig
     }
 
     private updateText(): void {
-        const value = this.cellRecord.value;
+        const value = this.cellRecord?.value;
         if (value === undefined || value === null) {
             this.text = '';
             return;

--- a/packages/nimble-components/src/table-column/text/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/text/cell-view/index.ts
@@ -21,7 +21,7 @@ TableColumnTextCellRecord,
 TableColumnTextColumnConfig
 > {
     private cellRecordChanged(): void {
-        this.text = typeof this.cellRecord.value === 'string'
+        this.text = typeof this.cellRecord?.value === 'string'
             ? this.cellRecord.value
             : '';
     }

--- a/packages/nimble-components/src/table/components/row/index.ts
+++ b/packages/nimble-components/src/table/components/row/index.ts
@@ -25,7 +25,7 @@ declare global {
 
 export interface ColumnState {
     column: TableColumn;
-    cellState: TableCellState;
+    cellState?: TableCellState;
     cellIndentLevel: number;
 }
 
@@ -84,7 +84,7 @@ export class TableRow<
     public get columnStates(): ColumnState[] {
         return this.columns.map((column, i) => {
             const fieldNames = column.columnInternals.dataRecordFieldNames;
-            let cellState: TableCellState;
+            let cellState: TableCellState | undefined;
             if (this.hasValidFieldNames(fieldNames) && this.dataRecord) {
                 const cellDataValues = fieldNames.map(
                     field => this.dataRecord![field]
@@ -95,15 +95,10 @@ export class TableRow<
                         cellDataValues[j]
                     ])
                 );
-                const columnConfig = column.columnInternals.columnConfig ?? {};
+                const columnConfig = column.columnInternals.columnConfig;
                 cellState = {
                     cellRecord,
                     columnConfig
-                };
-            } else {
-                cellState = {
-                    cellRecord: {},
-                    columnConfig: {}
                 };
             }
             const cellIndentLevel = i === 0 && this.nestingLevel > 0 ? this.nestingLevel - 1 : 0;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

There were a few typing inconsistencies related to creating a cell view for the nimble-table. This PR addresses those inconsistencies and updates usages accordingly.

The problems with the cell view that are fixed in this PR are:
1. The cell view used the non-null (`!`) assertion when declaring `columnConfig`, which isn't correct. Within `ColumnInternals`, `columnConfig` is declared as `public columnConfig?: TColumnConfig;`, so it is valid for the `columnConfig` to be `undefined`. Therefore, we should make sure the cell view type reflects that possibility.
2. When a row's record didn't contain the expected fields, the cell state would be set to `{ cellRecord: {}, columnConfig: {} }`. This leads to both the `cellRecord` and the `columnConfig` on the cell view to be empty objects, which shouldn't be allowed given the typing. This also forces cell view implementations to check for scenarios that shouldn't be allowed given the configured TypeScript types.

## 👩‍💻 Implementation

To fix the problems described above, a few type changes were made:
1. Make `cellRecord` and `columnConfig` both optional within the `TableCellState` interface and in the base `TableCellView` class.
2. Update the code that validates a row's record to set an undefined `TableCellState` on the cell if the record doesn't contain the expected fields rather than creating a `TableCellState` object with `cellRecord` and `columnConfig` both set to `{}`.
3. Update usages to ensure they are correctly handling the possibility of an `undefined` `cellRecord` and `columnConfig`.

## 🧪 Testing

Ran existing auto tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
