### PR TITLE
Enable Angular combobox to read value & provide more detailed docs

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/src/directives/combobox/nimble-combobox.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/combobox/nimble-combobox.directive.ts
@@ -67,5 +67,9 @@ export class NimbleComboboxDirective {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorVisible', toBooleanProperty(value));
     }
 
+    public get value(): string {
+        return this.elementRef.nativeElement.value;
+    }
+
     public constructor(private readonly renderer: Renderer2, private readonly elementRef: ElementRef<Combobox>) {}
 }

--- a/change/@ni-nimble-angular-8f7b058f-d348-476a-9c47-66a808f3dfd4.json
+++ b/change/@ni-nimble-angular-8f7b058f-d348-476a-9c47-66a808f3dfd4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "enable reading the component value using the combobox directive",
+  "packageName": "@ni/nimble-angular",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-7eda48e3-f14b-4481-bbdc-613b26f5f7c7.json
+++ b/change/@ni-nimble-components-7eda48e3-f14b-4481-bbdc-613b26f5f7c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update combobox docs to include differing behavior across frameworks",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/combobox/tests/combobox.mdx
+++ b/packages/nimble-components/src/combobox/tests/combobox.mdx
@@ -1,0 +1,31 @@
+import {
+    Controls,
+    DocsStory,
+    Meta,
+    Stories,
+    Title,
+    Description
+} from '@storybook/blocks';
+import * as comboboxStories from './combobox.stories';
+
+<Meta of={comboboxStories} />
+
+<Title of={comboboxStories} />
+<Description of={comboboxStories} />
+
+<DocsStory of={comboboxStories.underlineCombobox} expanded={false} />
+<Controls of={comboboxStories.underlineCombobox} />
+
+# Usage Docs
+
+## Combobox value
+
+### Native element and Blazor
+
+The value of the combobox comes from the text content of the selected autocomplete `nimble-list-option`, or, if no matching autocomplete is found, the value is the user-entered text.
+
+### Angular
+
+In Angular, an autocomplete `nimble-list-option` can be created with an `ngValue`. In that case the `ngModel` of the combobox will be the `ngValue` of the matched autocomplete option.
+If no matching autocomplete option is found, the `ngModel` of the combobox will be set to `OPTION_NOT_FOUND`, and if the application needs to access the user-entered text, that should be done
+through the `value` on the `nativeElement` associated with the `nimble-combobox`.

--- a/packages/nimble-components/src/combobox/tests/combobox.mdx
+++ b/packages/nimble-components/src/combobox/tests/combobox.mdx
@@ -28,4 +28,4 @@ The value of the combobox comes from the text content of the selected autocomple
 
 In Angular, an autocomplete `nimble-list-option` can be created with an `ngValue`. In that case the `ngModel` of the combobox will be the `ngValue` of the matched autocomplete option.
 If no matching autocomplete option is found, the `ngModel` of the combobox will be set to `OPTION_NOT_FOUND`, and if the application needs to access the user-entered text, that should be done
-through the `value` on the `nativeElement` associated with the `nimble-combobox`.
+through the `value` property on the `NimbleComboboxDirective`.

--- a/packages/nimble-components/src/combobox/tests/combobox.stories.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox.stories.ts
@@ -32,14 +32,13 @@ interface OptionArgs {
 
 const metadata: Meta<ComboboxArgs> = {
     title: 'Components/Combobox',
-    tags: ['autodocs'],
     decorators: [withActions],
     parameters: {
         docs: {
             description: {
-                component: `Combobox is a list in which the current value is displayed in the element. Upon clicking on the element, the other options are visible. The user can enter aribtrary values in the input area.
-                     The combobox provides 'autocomplete' options that help finding and selecting a particular value. The value of the combobox comes from the text content of the selected list-option, or, if no matching
-                     list option is found, the user-entered text. Whereas with the \`nimble-select\` component, the value property of the list-option is always used for its value.`
+                component: `Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/), a combobox is an input widget that has an associated popup. The popup enables users to choose a value for the input from a collection.
+                The \`nimble-combobox\` provides 'autocomplete' options that can help a user find and select a particular value. Unlike with the \`nimble-select\` component, the \`nimble-combobox\` allows the user to enter
+                arbitrary values in the input area, not just those that exist as autocomplete options.`
             }
         },
         actions: {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

I was given the feedback that our existing docs for the combobox are confusing and misleading because we only document the behavior of the native element without any additional documentation that explains the behavior in our supported frameworks (or even implies that the API behavior might be different). It is also not ideal that our previous "recommended" workflow for reading the value associated with an `OPTION_NOT_FOUND` Angular combobox was through the `nativeElement`. Therefore, I've added a getter for the `value` in Angular.

I expect that at least part of the documentation and implementation will need to be updated when all the issues captured in #1303 are addressed, but I think this change is still good to enable clients to be more successful with the combobox before a more complete fix is in place.

Fixes https://github.com/ni/nimble/issues/682

## 👩‍💻 Implementation

- Add getter for `value` on the Angular combobox directive
- Created `.mdx` story for the comboxbox so that we can create docs with improved formatting.

## 🧪 Testing

- Manually verified that the doc page looks correct.
- New unit tests for reading the `value` of a combobox from Angular

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
