### PR TITLE
Improved the prerendering of dies to bucket them based on colors

### DIFF
--- a/change/@ni-nimble-components-085e971f-7cfb-492f-8fdf-95ace3bd7934.json
+++ b/change/@ni-nimble-components-085e971f-7cfb-492f-8fdf-95ace3bd7934.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "changed the prerendering of the dies to cluster them based on colors",
+  "packageName": "@ni/nimble-components",
+  "email": "33986780+munteannatan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/wafer-map/index.ts
+++ b/packages/nimble-components/src/wafer-map/index.ts
@@ -170,20 +170,16 @@ export class WaferMap extends FoundationElement {
             this.eventCoordinator.detachEvents();
             if (this.waferMapUpdateTracker.requiresContainerDimensionsUpdate) {
                 this.dataManager.updateContainerDimensions();
-                this.renderer.updateSortedDiesAndDrawWafer();
             } else if (this.waferMapUpdateTracker.requiresScalesUpdate) {
                 this.dataManager.updateScales();
-                this.renderer.updateSortedDiesAndDrawWafer();
             } else if (
                 this.waferMapUpdateTracker.requiresLabelsFontSizeUpdate
             ) {
                 this.dataManager.updateLabelsFontSize();
-                this.renderer.updateSortedDiesAndDrawWafer();
             } else if (
                 this.waferMapUpdateTracker.requiresDiesRenderInfoUpdate
             ) {
                 this.dataManager.updateDiesRenderInfo();
-                this.renderer.updateSortedDiesAndDrawWafer();
             } else if (this.waferMapUpdateTracker.requiresDrawnWaferUpdate) {
                 this.renderer.drawWafer();
             }

--- a/packages/nimble-components/src/wafer-map/index.ts
+++ b/packages/nimble-components/src/wafer-map/index.ts
@@ -180,9 +180,8 @@ export class WaferMap extends FoundationElement {
                 this.waferMapUpdateTracker.requiresDiesRenderInfoUpdate
             ) {
                 this.dataManager.updateDiesRenderInfo();
-            } else if (this.waferMapUpdateTracker.requiresDrawnWaferUpdate) {
-                this.renderer.drawWafer();
             }
+            this.renderer.drawWafer();
             this.eventCoordinator.attachEvents();
         } else if (this.waferMapUpdateTracker.requiresRenderHoverUpdate) {
             this.renderer.renderHover();

--- a/packages/nimble-components/src/wafer-map/modules/data-manager.ts
+++ b/packages/nimble-components/src/wafer-map/modules/data-manager.ts
@@ -5,9 +5,9 @@ import type { WaferMap } from '..';
 import type {
     Dimensions,
     Margin,
-    DieRenderInfo,
     WaferMapDie,
-    PointCoordinates
+    PointCoordinates,
+    RenderInfo
 } from '../types';
 
 /**
@@ -50,8 +50,8 @@ export class DataManager {
         return this.prerendering.labelsFontSize;
     }
 
-    public get diesRenderInfo(): DieRenderInfo[] {
-        return this.prerendering.diesRenderInfo;
+    public get renderInfo(): RenderInfo {
+        return this.prerendering.renderInfo;
     }
 
     public get data(): Map<string, WaferMapDie> {

--- a/packages/nimble-components/src/wafer-map/modules/prerendering.ts
+++ b/packages/nimble-components/src/wafer-map/modules/prerendering.ts
@@ -57,29 +57,32 @@ export class Prerendering {
         const maxCharacters = this.wafermap.maxCharacters;
         const dieLabelsHidden = this.wafermap.dieLabelsHidden;
         const dieLabelsSuffix = this.wafermap.dieLabelsSuffix;
-        this._renderInfo = this.wafermap.dies.reduce<RenderInfo>((result, die) => {
-            const scaledX = horizontalScale(die.x) ?? 0;
-            const scaledY = verticalScale(die.y) ?? 0;
-            const fillStyle = this.calculateFillStyle(
-                die.value,
-                colorScaleMode,
-                highlightedValues
-            );
-            if (!result[fillStyle]) {
-                result[fillStyle] = [];
-            }
-            result[fillStyle]!.push({
-                x: scaledX + margin.right,
-                y: scaledY + margin.top,
-                text: this.buildLabel(
+        this._renderInfo = this.wafermap.dies.reduce<RenderInfo>(
+            (result, die) => {
+                const scaledX = horizontalScale(die.x) ?? 0;
+                const scaledY = verticalScale(die.y) ?? 0;
+                const fillStyle = this.calculateFillStyle(
                     die.value,
-                    maxCharacters,
-                    dieLabelsHidden,
-                    dieLabelsSuffix
-                )
-            });
-            return result;
-        }, {});
+                    colorScaleMode,
+                    highlightedValues
+                );
+                if (!result[fillStyle]) {
+                    result[fillStyle] = [];
+                }
+                result[fillStyle]!.push({
+                    x: scaledX + margin.right,
+                    y: scaledY + margin.top,
+                    text: this.buildLabel(
+                        die.value,
+                        maxCharacters,
+                        dieLabelsHidden,
+                        dieLabelsSuffix
+                    )
+                });
+                return result;
+            },
+            {}
+        );
     }
 
     private calculateLabelsFontSize(

--- a/packages/nimble-components/src/wafer-map/modules/rendering.ts
+++ b/packages/nimble-components/src/wafer-map/modules/rendering.ts
@@ -106,8 +106,7 @@ export class RenderingModule {
             transformedCanvasMinPoint[1] -= dieHeight;
 
             Object.entries(this.wafermap.dataManager.renderInfo).forEach(
-                ([fillStyle, dies]) => {
-                    context.fillStyle = fillStyle;
+                ([_fillStyle, dies]) => {
                     for (const die of dies) {
                         if (
                             this.isDieVisible(

--- a/packages/nimble-components/src/wafer-map/modules/rendering.ts
+++ b/packages/nimble-components/src/wafer-map/modules/rendering.ts
@@ -119,7 +119,9 @@ export class RenderingModule {
                             context.fillText(
                                 die.text,
                                 die.x + dieWidth / 2,
-                                die.y + dieHeight / 2 + approximateTextHeight.width / 2,
+                                die.y
+                                    + dieHeight / 2
+                                    + approximateTextHeight.width / 2,
                                 dieWidth - (dieWidth / 100) * 20
                             );
                         }

--- a/packages/nimble-components/src/wafer-map/modules/rendering.ts
+++ b/packages/nimble-components/src/wafer-map/modules/rendering.ts
@@ -5,24 +5,9 @@ import { DieRenderInfo, HoverDieOpacity } from '../types';
  * Responsible for drawing the dies inside the wafer map, adding dieText and scaling the canvas
  */
 export class RenderingModule {
-    private dies!: DieRenderInfo[];
     private readonly minDieDim = 50;
 
     public constructor(private readonly wafermap: WaferMap) {}
-
-    public updateSortedDiesAndDrawWafer(): void {
-        this.dies = this.wafermap.dataManager.diesRenderInfo.sort((a, b) => {
-            if (a.fillStyle > b.fillStyle) {
-                return 1;
-            }
-            if (b.fillStyle > a.fillStyle) {
-                return -1;
-            }
-
-            return 0;
-        });
-        this.drawWafer();
-    }
 
     public drawWafer(): void {
         this.wafermap.canvasContext.save();
@@ -76,18 +61,22 @@ export class RenderingModule {
         transformedCanvasMinPoint[0] -= dieWidth;
         transformedCanvasMinPoint[1] -= dieHeight;
 
-        for (const die of this.dies) {
-            if (
-                this.isDieVisible(
-                    die,
-                    transformedCanvasMinPoint,
-                    transformedCanvasMaxPoint
-                )
-            ) {
-                context.fillStyle = die.fillStyle;
-                context.fillRect(die.x, die.y, dieWidth, dieHeight);
+        Object.entries(this.wafermap.dataManager.renderInfo).forEach(
+            ([fillStyle, dies]) => {
+                context.fillStyle = fillStyle;
+                for (const die of dies) {
+                    if (
+                        this.isDieVisible(
+                            die,
+                            transformedCanvasMinPoint,
+                            transformedCanvasMaxPoint
+                        )
+                    ) {
+                        context.fillRect(die.x, die.y, dieWidth, dieHeight);
+                    }
+                }
             }
-        }
+        );
     }
 
     private renderText(): void {
@@ -116,22 +105,27 @@ export class RenderingModule {
             transformedCanvasMinPoint[0] -= dieWidth;
             transformedCanvasMinPoint[1] -= dieHeight;
 
-            for (const die of this.dies) {
-                if (
-                    this.isDieVisible(
-                        die,
-                        transformedCanvasMinPoint,
-                        transformedCanvasMaxPoint
-                    )
-                ) {
-                    context.fillText(
-                        die.text,
-                        die.x + dieWidth / 2,
-                        die.y + dieHeight / 2 + approximateTextHeight.width / 2,
-                        dieWidth - (dieWidth / 100) * 20
-                    );
+            Object.entries(this.wafermap.dataManager.renderInfo).forEach(
+                ([fillStyle, dies]) => {
+                    context.fillStyle = fillStyle;
+                    for (const die of dies) {
+                        if (
+                            this.isDieVisible(
+                                die,
+                                transformedCanvasMinPoint,
+                                transformedCanvasMaxPoint
+                            )
+                        ) {
+                            context.fillText(
+                                die.text,
+                                die.x + dieWidth / 2,
+                                die.y + dieHeight / 2 + approximateTextHeight.width / 2,
+                                dieWidth - (dieWidth / 100) * 20
+                            );
+                        }
+                    }
                 }
-            }
+            );
         }
     }
 

--- a/packages/nimble-components/src/wafer-map/modules/wafer-map-update-tracker.ts
+++ b/packages/nimble-components/src/wafer-map/modules/wafer-map-update-tracker.ts
@@ -65,10 +65,6 @@ export class WaferMapUpdateTracker extends UpdateTracker<typeof trackedItems> {
         );
     }
 
-    public get requiresDrawnWaferUpdate(): boolean {
-        return this.isTracked('transform');
-    }
-
     public get requiresRenderHoverUpdate(): boolean {
         return this.isTracked('hoverDie');
     }

--- a/packages/nimble-components/src/wafer-map/tests/data-manager.spec.ts
+++ b/packages/nimble-components/src/wafer-map/tests/data-manager.spec.ts
@@ -150,7 +150,9 @@ describe('Wafermap Data Manager', () => {
             ([fillStyle, diesRenderInfo]) => {
                 if (!fillStyle.endsWith(',1)')) {
                     for (const dieRenderInfo of diesRenderInfo) {
-                        expect(highlightedValues).not.toContain(dieRenderInfo.text);
+                        expect(highlightedValues).not.toContain(
+                            dieRenderInfo.text
+                        );
                     }
                 }
             }

--- a/packages/nimble-components/src/wafer-map/tests/data-manager.spec.ts
+++ b/packages/nimble-components/src/wafer-map/tests/data-manager.spec.ts
@@ -110,11 +110,13 @@ describe('Wafermap Data Manager', () => {
     });
 
     it('should have as many dies as provided', () => {
+        let length = 0;
         Object.entries(dataManagerModule.renderInfo).forEach(
             ([_fillStyle, diesRenderInfo]) => {
-                expect(diesRenderInfo.length).toEqual(getWaferMapDies().length);
+                length += diesRenderInfo.length;
             }
         );
+        expect(length).toEqual(getWaferMapDies().length);
     });
 
     it('should have label with suffix for each die', () => {

--- a/packages/nimble-components/src/wafer-map/tests/data-manager.spec.ts
+++ b/packages/nimble-components/src/wafer-map/tests/data-manager.spec.ts
@@ -110,53 +110,71 @@ describe('Wafermap Data Manager', () => {
     });
 
     it('should have as many dies as provided', () => {
-        expect(dataManagerModule.diesRenderInfo.length).toEqual(
-            getWaferMapDies().length
+        Object.entries(dataManagerModule.renderInfo).forEach(
+            ([_fillStyle, diesRenderInfo]) => {
+                expect(diesRenderInfo.length).toEqual(getWaferMapDies().length);
+            }
         );
     });
 
     it('should have label with suffix for each die', () => {
-        for (const dieInfo of dataManagerModule.diesRenderInfo) {
-            expect(dieInfo.text).toContain(dieLabelsSuffix);
-        }
+        Object.entries(dataManagerModule.renderInfo).forEach(
+            ([_fillStyle, diesRenderInfo]) => {
+                for (const dieInfo of diesRenderInfo) {
+                    expect(dieInfo.text).toContain(dieLabelsSuffix);
+                }
+            }
+        );
     });
 
     it('should have all dies with full opacity from the highlighted list', () => {
         const highlightedValues = getHighlightedValues().map(
             value => value + dieLabelsSuffix
         );
-        const diesWithFullOpacity = dataManagerModule.diesRenderInfo.filter(x => x.fillStyle.endsWith(',1)'));
-        for (const dieRenderInfo of diesWithFullOpacity) {
-            expect(highlightedValues).toContain(dieRenderInfo.text);
-        }
+        Object.entries(dataManagerModule.renderInfo).forEach(
+            ([fillStyle, diesRenderInfo]) => {
+                if (fillStyle.endsWith(',1)')) {
+                    for (const dieRenderInfo of diesRenderInfo) {
+                        expect(highlightedValues).toContain(dieRenderInfo.text);
+                    }
+                }
+            }
+        );
     });
 
     it('should not have any dies with partial opacity from the highlighted list', () => {
         const highlightedValues = getHighlightedValues().map(
             value => value + dieLabelsSuffix
         );
-        const diesWithPartialOpacity = dataManagerModule.diesRenderInfo.filter(
-            x => !x.fillStyle.endsWith(',1)')
+        Object.entries(dataManagerModule.renderInfo).forEach(
+            ([fillStyle, diesRenderInfo]) => {
+                if (!fillStyle.endsWith(',1)')) {
+                    for (const dieRenderInfo of diesRenderInfo) {
+                        expect(highlightedValues).not.toContain(dieRenderInfo.text);
+                    }
+                }
+            }
         );
-        for (const dieRenderInfo of diesWithPartialOpacity) {
-            expect(highlightedValues).not.toContain(dieRenderInfo.text);
-        }
     });
 
     it('should have all dies inside the canvas with margins', () => {
-        for (const dieRenderInfo of dataManagerModule.diesRenderInfo) {
-            expect(dieRenderInfo.x).toBeGreaterThanOrEqual(0);
-            expect(dieRenderInfo.y).toBeGreaterThanOrEqual(0);
-            expect(dieRenderInfo.x).toBeLessThanOrEqual(
-                canvasDimensions.width
-                    - dataManagerModule.dieDimensions.width
-                    - expectedMargin.left
-            );
-            expect(dieRenderInfo.y).toBeLessThanOrEqual(
-                canvasDimensions.height
-                    - dataManagerModule.dieDimensions.height
-                    - expectedMargin.bottom
-            );
-        }
+        Object.entries(dataManagerModule.renderInfo).forEach(
+            ([_fillStyle, diesRenderInfo]) => {
+                for (const dieRenderInfo of diesRenderInfo) {
+                    expect(dieRenderInfo.x).toBeGreaterThanOrEqual(0);
+                    expect(dieRenderInfo.y).toBeGreaterThanOrEqual(0);
+                    expect(dieRenderInfo.x).toBeLessThanOrEqual(
+                        canvasDimensions.width
+                            - dataManagerModule.dieDimensions.width
+                            - expectedMargin.left
+                    );
+                    expect(dieRenderInfo.y).toBeLessThanOrEqual(
+                        canvasDimensions.height
+                            - dataManagerModule.dieDimensions.height
+                            - expectedMargin.bottom
+                    );
+                }
+            }
+        );
     });
 });

--- a/packages/nimble-components/src/wafer-map/tests/prerendering.coloring.spec.ts
+++ b/packages/nimble-components/src/wafer-map/tests/prerendering.coloring.spec.ts
@@ -255,9 +255,13 @@ describe('Wafermap Prerendering module', () => {
                 Object.entries(prerenderingModule.renderInfo).forEach(
                     ([fillStyle, dies]) => {
                         if (fillStyle === 'rgba(0,0,0,1)') {
-                            expect(dies.length).toEqual(getWaferMapDies().length / 2);
+                            expect(dies.length).toEqual(
+                                getWaferMapDies().length / 2
+                            );
                         } else if (fillStyle === 'rgba(255,0,0,1)') {
-                            expect(dies.length).toEqual(getWaferMapDies().length / 2);
+                            expect(dies.length).toEqual(
+                                getWaferMapDies().length / 2
+                            );
                         }
                     }
                 );
@@ -412,7 +416,9 @@ describe('Wafermap Prerendering module', () => {
                     if (fillStyle === 'rgba(255,0,0,1)') {
                         expect(dies.length).toEqual(1);
                     } else if (fillStyle === 'rgba(255,0,0,0.3)') {
-                        expect(dies.length).toEqual(getWaferMapDies().length - 1);
+                        expect(dies.length).toEqual(
+                            getWaferMapDies().length - 1
+                        );
                     }
                 }
             );

--- a/packages/nimble-components/src/wafer-map/tests/prerendering.coloring.spec.ts
+++ b/packages/nimble-components/src/wafer-map/tests/prerendering.coloring.spec.ts
@@ -51,9 +51,11 @@ describe('Wafermap Prerendering module', () => {
             });
 
             it('should have black fill style for all dies', () => {
-                for (const dieRenderInfo of prerenderingModule.diesRenderInfo) {
-                    expect(dieRenderInfo.fillStyle).toEqual(emptyDieColor);
-                }
+                Object.entries(prerenderingModule.renderInfo).forEach(
+                    ([fillStyle, _dies]) => {
+                        expect(fillStyle).toEqual(emptyDieColor);
+                    }
+                );
             });
         });
 
@@ -99,9 +101,11 @@ describe('Wafermap Prerendering module', () => {
             });
 
             it('should have the same fill style for all dies', () => {
-                for (const dieRenderInfo of prerenderingModule.diesRenderInfo) {
-                    expect(dieRenderInfo.fillStyle).toEqual('rgba(255,0,0,1)');
-                }
+                Object.entries(prerenderingModule.renderInfo).forEach(
+                    ([fillStyle, _dies]) => {
+                        expect(fillStyle).toEqual('rgba(255,0,0,1)');
+                    }
+                );
             });
         });
 
@@ -147,17 +151,11 @@ describe('Wafermap Prerendering module', () => {
             });
 
             it('should have the fill style equally distributed to dies', () => {
-                const waferMapDies = getWaferMapDies();
-                const expectedValues = waferMapDies.map(x => {
-                    return {
-                        fillStyle: `rgba(${(+x.value - 1) * 15},0,0,1)`
-                    };
-                });
-                for (let i = 0; i < waferMapDies.length; i += 1) {
-                    expect(
-                        prerenderingModule.diesRenderInfo[i]!.fillStyle
-                    ).toEqual(expectedValues[i]!.fillStyle);
-                }
+                Object.entries(prerenderingModule.renderInfo).forEach(
+                    ([_fillStyle, dies]) => {
+                        expect(dies.length).toEqual(1);
+                    }
+                );
             });
         });
     });
@@ -204,9 +202,11 @@ describe('Wafermap Prerendering module', () => {
             });
 
             it('should have the same fill style for all dies', () => {
-                for (const dieRenderInfo of prerenderingModule.diesRenderInfo) {
-                    expect(dieRenderInfo.fillStyle).toEqual('rgba(255,0,0,1)');
-                }
+                Object.entries(prerenderingModule.renderInfo).forEach(
+                    ([fillStyle, _dies]) => {
+                        expect(fillStyle).toEqual('rgba(255,0,0,1)');
+                    }
+                );
             });
         });
 
@@ -252,20 +252,15 @@ describe('Wafermap Prerendering module', () => {
             });
 
             it('should have alternating fill style for the dies', () => {
-                const waferMapDies = getWaferMapDies();
-                const expectedValues = waferMapDies.map(x => {
-                    const fillStyle = +x.value % 2 === 1
-                        ? 'rgba(0,0,0,1)'
-                        : 'rgba(255,0,0,1)';
-                    return {
-                        fillStyle
-                    };
-                });
-                for (let i = 0; i < waferMapDies.length; i += 1) {
-                    expect(
-                        prerenderingModule.diesRenderInfo[i]!.fillStyle
-                    ).toEqual(expectedValues[i]!.fillStyle);
-                }
+                Object.entries(prerenderingModule.renderInfo).forEach(
+                    ([fillStyle, dies]) => {
+                        if (fillStyle === 'rgba(0,0,0,1)') {
+                            expect(dies.length).toEqual(getWaferMapDies().length / 2);
+                        } else if (fillStyle === 'rgba(255,0,0,1)') {
+                            expect(dies.length).toEqual(getWaferMapDies().length / 2);
+                        }
+                    }
+                );
             });
         });
     });
@@ -315,9 +310,11 @@ describe('Wafermap Prerendering module', () => {
         });
 
         it('should have NaN color fill style', () => {
-            for (const dieRenderInfo of prerenderingModule.diesRenderInfo) {
-                expect(dieRenderInfo.fillStyle).toEqual(nanDieColor);
-            }
+            Object.entries(prerenderingModule.renderInfo).forEach(
+                ([fillStyle, _dies]) => {
+                    expect(fillStyle).toEqual(nanDieColor);
+                }
+            );
         });
     });
 
@@ -366,9 +363,11 @@ describe('Wafermap Prerendering module', () => {
         });
 
         it('should have empty color fill style', () => {
-            for (const dieRenderInfo of prerenderingModule.diesRenderInfo) {
-                expect(dieRenderInfo.fillStyle).toEqual(emptyDieColor);
-            }
+            Object.entries(prerenderingModule.renderInfo).forEach(
+                ([fillStyle, _dies]) => {
+                    expect(fillStyle).toEqual(emptyDieColor);
+                }
+            );
         });
     });
 
@@ -408,18 +407,15 @@ describe('Wafermap Prerendering module', () => {
         });
 
         it('should have highlighted value with full opacity and the rest with expected opacity', () => {
-            const waferMapDies = getWaferMapDies();
-            const expectedValues = waferMapDies.map(x => {
-                const opacity = x.value === highlightedValue ? 1 : 0.3;
-                return {
-                    fillStyle: `rgba(255,0,0,${opacity})`
-                };
-            });
-            for (let i = 0; i < waferMapDies.length; i += 1) {
-                expect(prerenderingModule.diesRenderInfo[i]!.fillStyle).toEqual(
-                    expectedValues[i]!.fillStyle
-                );
-            }
+            Object.entries(prerenderingModule.renderInfo).forEach(
+                ([fillStyle, dies]) => {
+                    if (fillStyle === 'rgba(255,0,0,1)') {
+                        expect(dies.length).toEqual(1);
+                    } else if (fillStyle === 'rgba(255,0,0,0.3)') {
+                        expect(dies.length).toEqual(getWaferMapDies().length - 1);
+                    }
+                }
+            );
         });
     });
 
@@ -459,9 +455,11 @@ describe('Wafermap Prerendering module', () => {
         });
 
         it('should have all dies with full opacity', () => {
-            for (const dieRenderInfo of prerenderingModule.diesRenderInfo) {
-                expect(dieRenderInfo.fillStyle).toEqual('rgba(255,0,0,1)');
-            }
+            Object.entries(prerenderingModule.renderInfo).forEach(
+                ([fillStyle, _dies]) => {
+                    expect(fillStyle).toEqual('rgba(255,0,0,1)');
+                }
+            );
         });
     });
 });

--- a/packages/nimble-components/src/wafer-map/tests/prerendering.labeling.spec.ts
+++ b/packages/nimble-components/src/wafer-map/tests/prerendering.labeling.spec.ts
@@ -203,7 +203,9 @@ describe('Wafermap Prerendering module', () => {
             Object.entries(prerenderingModule.renderInfo).forEach(
                 ([_fillStyle, diesRenderInfo]) => {
                     for (const dieRenderInfo of diesRenderInfo) {
-                        expect(dieRenderInfo.text).not.toContain(dieLabelsSuffix);
+                        expect(dieRenderInfo.text).not.toContain(
+                            dieLabelsSuffix
+                        );
                         expect(dieRenderInfo.text).toContain('…');
                     }
                 }

--- a/packages/nimble-components/src/wafer-map/tests/prerendering.labeling.spec.ts
+++ b/packages/nimble-components/src/wafer-map/tests/prerendering.labeling.spec.ts
@@ -51,8 +51,12 @@ describe('Wafermap Prerendering module', () => {
         });
 
         it('should have as many dies as provided', () => {
-            expect(prerenderingModule.diesRenderInfo.length).toEqual(
-                getWaferMapDies().length
+            Object.entries(prerenderingModule.renderInfo).forEach(
+                ([_fillStyle, diesRenderInfo]) => {
+                    expect(diesRenderInfo.length).toEqual(
+                        getWaferMapDies().length
+                    );
+                }
             );
         });
 
@@ -147,9 +151,13 @@ describe('Wafermap Prerendering module', () => {
         });
 
         it('should have label suffix for each die', () => {
-            for (const dieRenderInfo of prerenderingModule.diesRenderInfo) {
-                expect(dieRenderInfo.text).toContain(dieLabelsSuffix);
-            }
+            Object.entries(prerenderingModule.renderInfo).forEach(
+                ([_fillStyle, diesRenderInfo]) => {
+                    for (const dieRenderInfo of diesRenderInfo) {
+                        expect(dieRenderInfo.text).toContain(dieLabelsSuffix);
+                    }
+                }
+            );
         });
     });
 
@@ -192,10 +200,14 @@ describe('Wafermap Prerendering module', () => {
         });
 
         it('should not have full label suffix for each die and end in ellipsis', () => {
-            for (const dieRenderInfo of prerenderingModule.diesRenderInfo) {
-                expect(dieRenderInfo.text).not.toContain(dieLabelsSuffix);
-                expect(dieRenderInfo.text).toContain('…');
-            }
+            Object.entries(prerenderingModule.renderInfo).forEach(
+                ([_fillStyle, diesRenderInfo]) => {
+                    for (const dieRenderInfo of diesRenderInfo) {
+                        expect(dieRenderInfo.text).not.toContain(dieLabelsSuffix);
+                        expect(dieRenderInfo.text).toContain('…');
+                    }
+                }
+            );
         });
     });
 
@@ -239,11 +251,15 @@ describe('Wafermap Prerendering module', () => {
 
         it('should have labels equal with values for each die', () => {
             const waferMapDies = getWaferMapDies();
-            for (let i = 0; i < waferMapDies.length; i += 1) {
-                expect(prerenderingModule.diesRenderInfo[i]!.text).toEqual(
-                    waferMapDies[i]!.value
-                );
-            }
+            Object.entries(prerenderingModule.renderInfo).forEach(
+                ([_fillStyle, diesRenderInfo]) => {
+                    for (let i = 0; i < waferMapDies.length; i += 1) {
+                        expect(diesRenderInfo[i]!.text).toEqual(
+                            waferMapDies[i]!.value
+                        );
+                    }
+                }
+            );
         });
     });
 
@@ -287,11 +303,15 @@ describe('Wafermap Prerendering module', () => {
 
         it('should have labels equal with values for each die', () => {
             const waferMapNaNDies = getWaferMapDiesAsNaN();
-            for (let i = 0; i < waferMapNaNDies.length; i += 1) {
-                expect(prerenderingModule.diesRenderInfo[i]!.text).toEqual(
-                    waferMapNaNDies[i]!.value
-                );
-            }
+            Object.entries(prerenderingModule.renderInfo).forEach(
+                ([_fillStyle, diesRenderInfo]) => {
+                    for (let i = 0; i < waferMapNaNDies.length; i += 1) {
+                        expect(diesRenderInfo[i]!.text).toEqual(
+                            waferMapNaNDies[i]!.value
+                        );
+                    }
+                }
+            );
         });
     });
 
@@ -343,11 +363,15 @@ describe('Wafermap Prerendering module', () => {
                         text: `${x.value.substring(0, maxCharacters)}…`
                     };
                 });
-                for (let i = 0; i < waferMapFloatDies.length; i += 1) {
-                    expect(prerenderingModule.diesRenderInfo[i]!.text).toEqual(
-                        expectedValues[i]!.text
-                    );
-                }
+                Object.entries(prerenderingModule.renderInfo).forEach(
+                    ([_fillStyle, diesRenderInfo]) => {
+                        for (let i = 0; i < waferMapFloatDies.length; i += 1) {
+                            expect(diesRenderInfo[i]!.text).toEqual(
+                                expectedValues[i]!.text
+                            );
+                        }
+                    }
+                );
             }
         );
     });
@@ -391,9 +415,13 @@ describe('Wafermap Prerendering module', () => {
         });
 
         it('should have empty label for each die', () => {
-            for (const dieRenderInfo of prerenderingModule.diesRenderInfo) {
-                expect(dieRenderInfo.text).toEqual('');
-            }
+            Object.entries(prerenderingModule.renderInfo).forEach(
+                ([_fillStyle, diesRenderInfo]) => {
+                    for (const dieRenderInfo of diesRenderInfo) {
+                        expect(dieRenderInfo.text).toEqual('');
+                    }
+                }
+            );
         });
     });
 });

--- a/packages/nimble-components/src/wafer-map/tests/prerendering.positioning.spec.ts
+++ b/packages/nimble-components/src/wafer-map/tests/prerendering.positioning.spec.ts
@@ -58,14 +58,18 @@ describe('Wafermap Prerendering module', () => {
                     y: die.y + margin.top
                 };
             });
-            for (let i = 0; i < waferMapDies.length; i += 1) {
-                expect(prerenderingModule.diesRenderInfo[i]!.x).toEqual(
-                    expectedValues[i]!.x
-                );
-                expect(prerenderingModule.diesRenderInfo[i]!.y).toEqual(
-                    expectedValues[i]!.y
-                );
-            }
+            Object.entries(prerenderingModule.renderInfo).forEach(
+                ([_fillStyle, diesRenderInfo]) => {
+                    for (let i = 0; i < waferMapDies.length; i += 1) {
+                        expect(diesRenderInfo[i]!.x).toEqual(
+                            expectedValues[i]!.x
+                        );
+                        expect(diesRenderInfo[i]!.y).toEqual(
+                            expectedValues[i]!.y
+                        );
+                    }
+                }
+            );
         });
     });
 
@@ -121,11 +125,15 @@ describe('Wafermap Prerendering module', () => {
                     x: x.x * 10
                 };
             });
-            for (let i = 0; i < waferMapDies.length; i += 1) {
-                expect(prerenderingModule.diesRenderInfo[i]!.x).toEqual(
-                    expectedValues[i]!.x
-                );
-            }
+            Object.entries(prerenderingModule.renderInfo).forEach(
+                ([_fillStyle, diesRenderInfo]) => {
+                    for (let i = 0; i < waferMapDies.length; i += 1) {
+                        expect(diesRenderInfo[i]!.x).toEqual(
+                            expectedValues[i]!.x
+                        );
+                    }
+                }
+            );
         });
     });
 
@@ -181,11 +189,15 @@ describe('Wafermap Prerendering module', () => {
                     y: x.y * 10
                 };
             });
-            for (let i = 0; i < waferMapDies.length; i += 1) {
-                expect(prerenderingModule.diesRenderInfo[i]!.y).toEqual(
-                    expectedValues[i]!.y
-                );
-            }
+            Object.entries(prerenderingModule.renderInfo).forEach(
+                ([_fillStyle, diesRenderInfo]) => {
+                    for (let i = 0; i < waferMapDies.length; i += 1) {
+                        expect(diesRenderInfo[i]!.y).toEqual(
+                            expectedValues[i]!.y
+                        );
+                    }
+                }
+            );
         });
     });
 });

--- a/packages/nimble-components/src/wafer-map/types.ts
+++ b/packages/nimble-components/src/wafer-map/types.ts
@@ -71,8 +71,11 @@ export interface Margin {
 export interface DieRenderInfo {
     readonly x: number;
     readonly y: number;
-    readonly fillStyle: string;
     readonly text: string;
+}
+
+export interface RenderInfo {
+    [key: string]: DieRenderInfo[];
 }
 
 export interface PointCoordinates {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The die info for rendering was first prepared and then sorted based on the color which costs us a lot of performance.

## 👩‍💻 Implementation

created color buckets to store the values of the dies and rendered them after one cluster after another

## 🧪 Testing

fixed failing tests expecting the previous behavior

observed performance improvements are the time to load has halved
![before](https://github.com/ni/nimble/assets/33986780/2eac8598-3b6b-4491-bd19-81b6567d49da)
![after](https://github.com/ni/nimble/assets/33986780/6e695a4c-8e3d-4ee0-afa4-03cf2a876d23)


## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
