### PR TITLE
Update component status table to use nimble icons

### DIFF
--- a/change/@ni-nimble-components-b6e8c4d8-f216-44f2-b5dc-ab0dd5454759.json
+++ b/change/@ni-nimble-components-b6e8c4d8-f216-44f2-b5dc-ab0dd5454759.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update component status table to use nimble icons",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/docs/component-status.mdx
+++ b/packages/nimble-components/docs/component-status.mdx
@@ -20,9 +20,9 @@ Here are components that are either implemented or on the roadmap for Nimble. So
 
 | Icon | Description                                                                                                                                                              |
 | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| ✅   | The component is ready for general use.                                                                                                                                  |
-| ⚠️   | The component is "[incubating](/docs/incubating-docs--docs)". These are not ready for general use and may make breaking changes without a "major" semantic version bump. |
-| ⭕   | The component doesn't exist yet. Please submit requests by commenting on the linked issue.                                                                               |
+| <${iconCheckTag} severity="success"></${iconCheckTag}>   | The component is ready for general use.                                                                                                                                  |
+| <${iconTriangleTag} severity="warning"></${iconTriangleTag}>   | The component is "[incubating](/docs/incubating-docs--docs)". These are not ready for general use and may make breaking changes without a "major" semantic version bump. |
+| <${iconXmarkTag} severity="error"></${iconXmarkTag}>   | The component doesn't exist yet. Please submit requests by commenting on the linked issue.                                                                               |
 
 ## Future work
 

--- a/packages/nimble-components/docs/component-status.mdx
+++ b/packages/nimble-components/docs/component-status.mdx
@@ -20,9 +20,9 @@ Here are components that are either implemented or on the roadmap for Nimble. So
 
 | Icon | Description                                                                                                                                                              |
 | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| <${iconCheckTag} severity="success"></${iconCheckTag}>   | The component is ready for general use.                                                                                                                                  |
-| <${iconTriangleTag} severity="warning"></${iconTriangleTag}>   | The component is "[incubating](/docs/incubating-docs--docs)". These are not ready for general use and may make breaking changes without a "major" semantic version bump. |
-| <${iconXmarkTag} severity="error"></${iconXmarkTag}>   | The component doesn't exist yet. Please submit requests by commenting on the linked issue.                                                                               |
+| <nimble-icon-check severity="success"></nimble-icon-check>   | The component is ready for general use.                                                                                                                                  |
+| <nimble-icon-triangle severity="warning"></nimble-icon-triangle>   | The component is "[incubating](/docs/incubating-docs--docs)". These are not ready for general use and may make breaking changes without a "major" semantic version bump. |
+| <nimble-icon-xmark severity="error"></nimble-icon-xmark>   | The component doesn't exist yet. Please submit requests by commenting on the linked issue.                                                                               |
 
 ## Future work
 

--- a/packages/nimble-components/docs/component-status.mdx
+++ b/packages/nimble-components/docs/component-status.mdx
@@ -18,11 +18,11 @@ Here are components that are either implemented or on the roadmap for Nimble. So
 
 ### Legend
 
-| Icon | Description                                                                                                                                                              |
-| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| <nimble-icon-check severity="success"></nimble-icon-check>   | The component is ready for general use.                                                                                                                                  |
-| <nimble-icon-triangle severity="warning"></nimble-icon-triangle>   | The component is "[incubating](/docs/incubating-docs--docs)". These are not ready for general use and may make breaking changes without a "major" semantic version bump. |
-| <nimble-icon-xmark severity="error"></nimble-icon-xmark>   | The component doesn't exist yet. Please submit requests by commenting on the linked issue.                                                                               |
+| Icon                                                             | Description                                                                                                                                                              |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| <nimble-icon-check severity="success"></nimble-icon-check>       | The component is ready for general use.                                                                                                                                  |
+| <nimble-icon-triangle severity="warning"></nimble-icon-triangle> | The component is "[incubating](/docs/incubating-docs--docs)". These are not ready for general use and may make breaking changes without a "major" semantic version bump. |
+| <nimble-icon-xmark severity="error"></nimble-icon-xmark>         | The component doesn't exist yet. Please submit requests by commenting on the linked issue.                                                                               |
 
 ## Future work
 

--- a/packages/nimble-components/docs/component-status.mdx
+++ b/packages/nimble-components/docs/component-status.mdx
@@ -3,6 +3,9 @@ import {
     componentStatus,
     componentStatusFuture
 } from './component-status.stories';
+import '../src/icons/check';
+import '../src/icons/triangle';
+import '../src/icons/xmark';
 
 <Meta title="Component Status" />
 

--- a/packages/nimble-components/docs/component-status.stories.ts
+++ b/packages/nimble-components/docs/component-status.stories.ts
@@ -5,7 +5,6 @@ import {
 } from '../src/utilities/tests/storybook';
 import { Table, tableTag } from '../src/table';
 import { tableColumnAnchorTag } from '../src/table-column/anchor';
-import { tableColumnTextTag } from '../src/table-column/text';
 import { tableColumnIconTag } from '../src/table-column/icon';
 import { mappingIconTag } from '../src/mapping/icon';
 import { iconCheckTag } from '../src/icons/check';
@@ -28,9 +27,9 @@ const components = [
         designLabel: 'Figma',
         issueHref: 'https://github.com/ni/nimble/issues/533',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.notReady,
-        angularStatus: ComponentFrameworkStatus.notReady,
-        blazorStatus: ComponentFrameworkStatus.notReady,
+        componentStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Anchor',
@@ -78,9 +77,9 @@ const components = [
         componentName: 'Badge',
         issueHref: 'https://github.com/ni/nimble/issues/1428',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.notReady,
-        angularStatus: ComponentFrameworkStatus.notReady,
-        blazorStatus: ComponentFrameworkStatus.notReady,
+        componentStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Banner',
@@ -108,9 +107,9 @@ const components = [
         componentName: 'Card',
         issueHref: 'https://github.com/ni/nimble/issues/296',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.notReady,
-        angularStatus: ComponentFrameworkStatus.notReady,
-        blazorStatus: ComponentFrameworkStatus.notReady,
+        componentStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Card button',
@@ -147,17 +146,17 @@ const components = [
         componentName: 'Date picker',
         issueHref: 'https://github.com/ni/nimble/issues/342',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.notReady,
-        angularStatus: ComponentFrameworkStatus.notReady,
-        blazorStatus: ComponentFrameworkStatus.notReady,
+        componentStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Date Time Text',
         issueHref: 'https://github.com/ni/nimble/issues/294',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.notReady,
-        angularStatus: ComponentFrameworkStatus.notReady,
-        blazorStatus: ComponentFrameworkStatus.notReady,
+        componentStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Dialog',
@@ -183,9 +182,9 @@ const components = [
         componentName: 'Filter Builder (Query Builder)',
         issueHref: 'https://github.com/ni/nimble/issues/310',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.notReady,
-        angularStatus: ComponentFrameworkStatus.notReady,
-        blazorStatus: ComponentFrameworkStatus.notReady,
+        componentStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Icon Button',
@@ -218,9 +217,9 @@ const components = [
         componentName: 'Label',
         issueHref: 'https://github.com/ni/nimble/issues/312',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.notReady,
-        angularStatus: ComponentFrameworkStatus.notReady,
-        blazorStatus: ComponentFrameworkStatus.notReady,
+        componentStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Menu',
@@ -259,25 +258,25 @@ const components = [
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/458',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.notReady,
-        angularStatus: ComponentFrameworkStatus.notReady,
-        blazorStatus: ComponentFrameworkStatus.notReady,
+        componentStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Progress Bar',
         issueHref: 'https://github.com/ni/nimble/issues/304',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.notReady,
-        angularStatus: ComponentFrameworkStatus.notReady,
-        blazorStatus: ComponentFrameworkStatus.notReady,
+        componentStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Query Builder',
         issueHref: 'https://github.com/ni/nimble/issues/506',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.notReady,
-        angularStatus: ComponentFrameworkStatus.notReady,
-        blazorStatus: ComponentFrameworkStatus.notReady,
+        componentStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Radio',
@@ -297,7 +296,7 @@ const components = [
         issueLabel: 'Issue',
         componentStatus: ComponentFrameworkStatus.incubating,
         angularStatus: ComponentFrameworkStatus.incubating,
-        blazorStatus: ComponentFrameworkStatus.incubating,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Rich Text Viewer',
@@ -306,7 +305,7 @@ const components = [
         issueLabel: 'Issue',
         componentStatus: ComponentFrameworkStatus.incubating,
         angularStatus: ComponentFrameworkStatus.incubating,
-        blazorStatus: ComponentFrameworkStatus.incubating,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Search Field',
@@ -314,9 +313,9 @@ const components = [
         designLabel: 'Figma',
         issueHref: 'https://github.com/ni/nimble/issues/299',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.notReady,
-        angularStatus: ComponentFrameworkStatus.notReady,
-        blazorStatus: ComponentFrameworkStatus.notReady,
+        componentStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Select (Dropdown)',
@@ -331,9 +330,9 @@ const components = [
         componentName: 'Skeleton',
         issueHref: 'https://github.com/ni/nimble/issues/762',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.notReady,
-        angularStatus: ComponentFrameworkStatus.notReady,
-        blazorStatus: ComponentFrameworkStatus.notReady,
+        componentStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Slider',
@@ -341,9 +340,9 @@ const components = [
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/295',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.notReady,
-        angularStatus: ComponentFrameworkStatus.notReady,
-        blazorStatus: ComponentFrameworkStatus.notReady,
+        componentStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Spinner',
@@ -362,17 +361,17 @@ const components = [
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/298',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.notReady,
-        angularStatus: ComponentFrameworkStatus.notReady,
-        blazorStatus: ComponentFrameworkStatus.notReady,
+        componentStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Stepper',
         issueHref: 'https://github.com/ni/nimble/issues/624',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.notReady,
-        angularStatus: ComponentFrameworkStatus.notReady,
-        blazorStatus: ComponentFrameworkStatus.notReady,
+        componentStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Switch',
@@ -438,9 +437,9 @@ const components = [
         designLabel: 'Figma',
         issueHref: 'https://github.com/ni/nimble/issues/513',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.notReady,
-        angularStatus: ComponentFrameworkStatus.notReady,
-        blazorStatus: ComponentFrameworkStatus.notReady,
+        componentStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
     },
     {
         componentName: 'Toggle Icon Button',
@@ -494,7 +493,7 @@ const components = [
 const iconMappings = html`
     <${mappingIconTag} key="${ComponentFrameworkStatus.ready}" text="Ready" icon="${iconCheckTag}" severity="success"></${mappingIconTag}>
     <${mappingIconTag} key="${ComponentFrameworkStatus.incubating}" text="Incubating" icon="${iconTriangleTag}" severity="warning"></${mappingIconTag}>
-    <${mappingIconTag} key="${ComponentFrameworkStatus.notReady}" text="Not ready" icon="${iconXmarkTag}" severity="error"></${mappingIconTag}>
+    <${mappingIconTag} key="${ComponentFrameworkStatus.doesNotExist}" text="Does not exist" icon="${iconXmarkTag}" severity="error"></${mappingIconTag}>
 `;
 
 const metadata: Meta<TableArgs> = {
@@ -536,6 +535,7 @@ const metadata: Meta<TableArgs> = {
                 ?column-hidden="${x => x.status === 'future'}"
             >
                 Web Component
+                ${iconMappings}
             </${tableColumnIconTag}>
             <${tableColumnIconTag}
                 column-id="angular-status-column"
@@ -543,6 +543,7 @@ const metadata: Meta<TableArgs> = {
                 ?column-hidden="${x => x.status === 'future'}"
             >
                 Angular
+                ${iconMappings}
             </${tableColumnIconTag}>
             <${tableColumnIconTag}
                 column-id="blazor-status-column"
@@ -550,6 +551,7 @@ const metadata: Meta<TableArgs> = {
                 ?column-hidden="${x => x.status === 'future'}"
             >
                 Blazor
+                ${iconMappings}
             </${tableColumnIconTag}>
 
         </${tableTag}>
@@ -580,9 +582,9 @@ const metadata: Meta<TableArgs> = {
                 // but doesn't seem to be upgraded to a custom element yet
                 await customElements.whenDefined('nimble-table');
                 const isFuture = (component: typeof components[number]): boolean =>
-                    component.angularStatus  === ComponentFrameworkStatus.notReady
-                    && component.blazorStatus === ComponentFrameworkStatus.notReady
-                    && component.componentStatus === ComponentFrameworkStatus.notReady;
+                    component.angularStatus  === ComponentFrameworkStatus.doesNotExist
+                    && component.blazorStatus === ComponentFrameworkStatus.doesNotExist
+                    && component.componentStatus === ComponentFrameworkStatus.doesNotExist;
                 const data = components.filter(component => x.status === 'future' ? isFuture(component) : !isFuture(component))
                 await x.tableRef.setData(data);
             })();

--- a/packages/nimble-components/docs/component-status.stories.ts
+++ b/packages/nimble-components/docs/component-status.stories.ts
@@ -6,6 +6,12 @@ import {
 import { Table, tableTag } from '../src/table';
 import { tableColumnAnchorTag } from '../src/table-column/anchor';
 import { tableColumnTextTag } from '../src/table-column/text';
+import { tableColumnIconTag } from '../src/table-column/icon';
+import { mappingIconTag } from '../src/mapping/icon';
+import { iconCheckTag } from '../src/icons/check';
+import { iconTriangleTag } from '../src/icons/triangle';
+import { iconXmarkTag } from '../src/icons/xmark';
+import { ComponentFrameworkStatus } from './types';
 
 const statusOptions = ['active', 'future'] as const;
 
@@ -22,9 +28,9 @@ const components = [
         designLabel: 'Figma',
         issueHref: 'https://github.com/ni/nimble/issues/533',
         issueLabel: 'Issue',
-        componentStatus: '⭕',
-        angularStatus: '⭕',
-        blazorStatus: '⭕',
+        componentStatus: ComponentFrameworkStatus.notReady,
+        angularStatus: ComponentFrameworkStatus.notReady,
+        blazorStatus: ComponentFrameworkStatus.notReady,
     },
     {
         componentName: 'Anchor',
@@ -33,9 +39,9 @@ const components = [
         designLabel: 'Figma',
         issueHref: 'https://github.com/ni/nimble/issues/324',
         issueLabel: 'Issue',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Anchor Button',
@@ -44,9 +50,9 @@ const components = [
         designLabel: 'Figma',
         issueHref: 'https://github.com/ni/nimble/issues/324',
         issueLabel: 'Issue',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Anchor Tabs',
@@ -55,26 +61,26 @@ const components = [
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/479',
         issueLabel: 'Issue',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Anchor Tree Item',
         componentHref: './?path=/docs/components-tree-view--docs#anchor-tree-item',
         issueHref: 'https://github.com/ni/nimble/issues/562',
         issueLabel: 'Issue',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Badge',
         issueHref: 'https://github.com/ni/nimble/issues/1428',
         issueLabel: 'Issue',
-        componentStatus: '⭕',
-        angularStatus: '⭕',
-        blazorStatus: '⭕',
+        componentStatus: ComponentFrameworkStatus.notReady,
+        angularStatus: ComponentFrameworkStatus.notReady,
+        blazorStatus: ComponentFrameworkStatus.notReady,
     },
     {
         componentName: 'Banner',
@@ -83,9 +89,9 @@ const components = [
         designLabel: 'Figma',
         issueHref: 'https://github.com/ni/nimble/issues/305',
         issueLabel: 'Issue',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Breadcrumb',
@@ -94,17 +100,17 @@ const components = [
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/343',
         issueLabel: 'Issue',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Card',
         issueHref: 'https://github.com/ni/nimble/issues/296',
         issueLabel: 'Issue',
-        componentStatus: '⭕',
-        angularStatus: '⭕',
-        blazorStatus: '⭕',
+        componentStatus: ComponentFrameworkStatus.notReady,
+        angularStatus: ComponentFrameworkStatus.notReady,
+        blazorStatus: ComponentFrameworkStatus.notReady,
     },
     {
         componentName: 'Card button',
@@ -113,18 +119,18 @@ const components = [
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/643',
         issueLabel: 'Issue',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Checkbox',
         componentHref: './?path=/docs/components-checkbox--docs',
         designHref: 'https://www.figma.com/file/PO9mFOu5BCl8aJvFchEeuN/Nimble_Components?node-id=1295%3A64589&mode=dev',
         designLabel: 'Figma',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Combobox',
@@ -133,25 +139,25 @@ const components = [
         designLabel: 'Figma',
         issueHref: 'https://github.com/ni/nimble/issues/341',
         issueLabel: 'Issue',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Date picker',
         issueHref: 'https://github.com/ni/nimble/issues/342',
         issueLabel: 'Issue',
-        componentStatus: '⭕',
-        angularStatus: '⭕',
-        blazorStatus: '⭕',
+        componentStatus: ComponentFrameworkStatus.notReady,
+        angularStatus: ComponentFrameworkStatus.notReady,
+        blazorStatus: ComponentFrameworkStatus.notReady,
     },
     {
         componentName: 'Date Time Text',
         issueHref: 'https://github.com/ni/nimble/issues/294',
         issueLabel: 'Issue',
-        componentStatus: '⭕',
-        angularStatus: '⭕',
-        blazorStatus: '⭕',
+        componentStatus: ComponentFrameworkStatus.notReady,
+        angularStatus: ComponentFrameworkStatus.notReady,
+        blazorStatus: ComponentFrameworkStatus.notReady,
     },
     {
         componentName: 'Dialog',
@@ -160,35 +166,35 @@ const components = [
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/378',
         issueLabel: 'Issue',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Drawer',
         componentHref: './?path=/docs/components-drawer--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/730cdeb8-a4b5-4dcc-9fe4-718a75da7aff',
         designLabel: 'XD',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Filter Builder (Query Builder)',
         issueHref: 'https://github.com/ni/nimble/issues/310',
         issueLabel: 'Issue',
-        componentStatus: '⭕',
-        angularStatus: '⭕',
-        blazorStatus: '⭕',
+        componentStatus: ComponentFrameworkStatus.notReady,
+        angularStatus: ComponentFrameworkStatus.notReady,
+        blazorStatus: ComponentFrameworkStatus.notReady,
     },
     {
         componentName: 'Icon Button',
         componentHref: './?path=/docs/components-button--docs#icon-button',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/d022d8af-22f4-4bf2-981c-1dc0c61afece',
         designLabel: 'XD',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Icon Menu Button',
@@ -197,33 +203,33 @@ const components = [
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/300',
         issueLabel: 'Issue',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Icons',
         componentHref: './?path=/docs/components-icons--docs',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Label',
         issueHref: 'https://github.com/ni/nimble/issues/312',
         issueLabel: 'Issue',
-        componentStatus: '⭕',
-        angularStatus: '⭕',
-        blazorStatus: '⭕',
+        componentStatus: ComponentFrameworkStatus.notReady,
+        angularStatus: ComponentFrameworkStatus.notReady,
+        blazorStatus: ComponentFrameworkStatus.notReady,
     },
     {
         componentName: 'Menu',
         componentHref: './?path=/docs/components-menu--docs',
         designHref: 'https://www.figma.com/file/PO9mFOu5BCl8aJvFchEeuN/Nimble_Components?node-id=1317%3A31514&mode=dev',
         designLabel: 'Figma',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Menu Button',
@@ -232,9 +238,9 @@ const components = [
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/300',
         issueLabel: 'Issue',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Number Field',
@@ -243,9 +249,9 @@ const components = [
         designLabel: 'Figma',
         issueHref: 'https://github.com/ni/nimble/issues/361',
         issueLabel: 'Issue',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Picker (Chip/Pill)',
@@ -253,25 +259,25 @@ const components = [
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/458',
         issueLabel: 'Issue',
-        componentStatus: '⭕',
-        angularStatus: '⭕',
-        blazorStatus: '⭕',
+        componentStatus: ComponentFrameworkStatus.notReady,
+        angularStatus: ComponentFrameworkStatus.notReady,
+        blazorStatus: ComponentFrameworkStatus.notReady,
     },
     {
         componentName: 'Progress Bar',
         issueHref: 'https://github.com/ni/nimble/issues/304',
         issueLabel: 'Issue',
-        componentStatus: '⭕',
-        angularStatus: '⭕',
-        blazorStatus: '⭕',
+        componentStatus: ComponentFrameworkStatus.notReady,
+        angularStatus: ComponentFrameworkStatus.notReady,
+        blazorStatus: ComponentFrameworkStatus.notReady,
     },
     {
         componentName: 'Query Builder',
         issueHref: 'https://github.com/ni/nimble/issues/506',
         issueLabel: 'Issue',
-        componentStatus: '⭕',
-        angularStatus: '⭕',
-        blazorStatus: '⭕',
+        componentStatus: ComponentFrameworkStatus.notReady,
+        angularStatus: ComponentFrameworkStatus.notReady,
+        blazorStatus: ComponentFrameworkStatus.notReady,
     },
     {
         componentName: 'Radio',
@@ -280,27 +286,27 @@ const components = [
         designLabel: 'Figma',
         issueHref: 'https://github.com/ni/nimble/issues/297',
         issueLabel: 'Issue',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Rich Text Editor',
         componentHref: './?path=/docs/incubating-rich-text-editor--docs',
         issueHref: 'https://github.com/ni/nimble/issues/1288',
         issueLabel: 'Issue',
-        componentStatus: '⚠️',
-        angularStatus: '⚠️',
-        blazorStatus: '⚠️',
+        componentStatus: ComponentFrameworkStatus.incubating,
+        angularStatus: ComponentFrameworkStatus.incubating,
+        blazorStatus: ComponentFrameworkStatus.incubating,
     },
     {
         componentName: 'Rich Text Viewer',
         componentHref: './?path=/docs/incubating-rich-text-viewer--docs',
         issueHref: 'https://github.com/ni/nimble/issues/1288',
         issueLabel: 'Issue',
-        componentStatus: '⚠️',
-        angularStatus: '⚠️',
-        blazorStatus: '⚠️',
+        componentStatus: ComponentFrameworkStatus.incubating,
+        angularStatus: ComponentFrameworkStatus.incubating,
+        blazorStatus: ComponentFrameworkStatus.incubating,
     },
     {
         componentName: 'Search Field',
@@ -308,26 +314,26 @@ const components = [
         designLabel: 'Figma',
         issueHref: 'https://github.com/ni/nimble/issues/299',
         issueLabel: 'Issue',
-        componentStatus: '⭕',
-        angularStatus: '⭕',
-        blazorStatus: '⭕',
+        componentStatus: ComponentFrameworkStatus.notReady,
+        angularStatus: ComponentFrameworkStatus.notReady,
+        blazorStatus: ComponentFrameworkStatus.notReady,
     },
     {
         componentName: 'Select (Dropdown)',
         componentHref: './?path=/docs/components-select--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/6ec70d21-9a59-40cd-a8f4-45cfeed9e01e',
         designLabel: 'XD',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Skeleton',
         issueHref: 'https://github.com/ni/nimble/issues/762',
         issueLabel: 'Issue',
-        componentStatus: '⭕',
-        angularStatus: '⭕',
-        blazorStatus: '⭕',
+        componentStatus: ComponentFrameworkStatus.notReady,
+        angularStatus: ComponentFrameworkStatus.notReady,
+        blazorStatus: ComponentFrameworkStatus.notReady,
     },
     {
         componentName: 'Slider',
@@ -335,9 +341,9 @@ const components = [
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/295',
         issueLabel: 'Issue',
-        componentStatus: '⭕',
-        angularStatus: '⭕',
-        blazorStatus: '⭕',
+        componentStatus: ComponentFrameworkStatus.notReady,
+        angularStatus: ComponentFrameworkStatus.notReady,
+        blazorStatus: ComponentFrameworkStatus.notReady,
     },
     {
         componentName: 'Spinner',
@@ -346,9 +352,9 @@ const components = [
         designLabel: 'Figma',
         issueHref: 'https://github.com/ni/nimble/issues/346',
         issueLabel: 'Issue',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Split Icon Button',
@@ -356,17 +362,17 @@ const components = [
         designLabel: 'XD',
         issueHref: 'https://github.com/ni/nimble/issues/298',
         issueLabel: 'Issue',
-        componentStatus: '⭕',
-        angularStatus: '⭕',
-        blazorStatus: '⭕',
+        componentStatus: ComponentFrameworkStatus.notReady,
+        angularStatus: ComponentFrameworkStatus.notReady,
+        blazorStatus: ComponentFrameworkStatus.notReady,
     },
     {
         componentName: 'Stepper',
         issueHref: 'https://github.com/ni/nimble/issues/624',
         issueLabel: 'Issue',
-        componentStatus: '⭕',
-        angularStatus: '⭕',
-        blazorStatus: '⭕',
+        componentStatus: ComponentFrameworkStatus.notReady,
+        angularStatus: ComponentFrameworkStatus.notReady,
+        blazorStatus: ComponentFrameworkStatus.notReady,
     },
     {
         componentName: 'Switch',
@@ -375,9 +381,9 @@ const components = [
         designLabel: 'Figma',
         issueHref: 'https://github.com/ni/nimble/issues/387',
         issueLabel: 'Issue',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Table',
@@ -386,45 +392,45 @@ const components = [
         designLabel: 'XD',
         issueHref: 'https://github.com/orgs/ni/projects/11',
         issueLabel: 'Issue',
-        componentStatus: '⚠️',
-        angularStatus: '⚠️',
-        blazorStatus: '⚠️',
+        componentStatus: ComponentFrameworkStatus.incubating,
+        angularStatus: ComponentFrameworkStatus.incubating,
+        blazorStatus: ComponentFrameworkStatus.incubating,
     },
     {
         componentName: 'Tabs',
         componentHref: './?path=/docs/components-tabs--docs',
         designHref: 'https://www.figma.com/file/PO9mFOu5BCl8aJvFchEeuN/Nimble_Components?node-id=1295%3A70711&mode=dev',
         designLabel: 'Figma',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Text Button',
         componentHref: './?path=/docs/components-button--docs',
         designHref: 'https://www.figma.com/file/PO9mFOu5BCl8aJvFchEeuN/Nimble_Components?node-id=1295%3A82309&mode=dev',
         designLabel: 'Figma',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Text Area',
         componentHref: './?path=/docs/components-text-area--docs',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/7c146e4b-c7c9-4975-a158-10e6093c522d',
         designLabel: 'XD',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Text Field',
         componentHref: './?path=/docs/components-text-field--docs',
         designHref: 'https://www.figma.com/file/PO9mFOu5BCl8aJvFchEeuN/Nimble_Components?node-id=1295%3A47516&mode=dev',
         designLabel: 'Figma',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Toast',
@@ -432,27 +438,27 @@ const components = [
         designLabel: 'Figma',
         issueHref: 'https://github.com/ni/nimble/issues/513',
         issueLabel: 'Issue',
-        componentStatus: '⭕',
-        angularStatus: '⭕',
-        blazorStatus: '⭕',
+        componentStatus: ComponentFrameworkStatus.notReady,
+        angularStatus: ComponentFrameworkStatus.notReady,
+        blazorStatus: ComponentFrameworkStatus.notReady,
     },
     {
         componentName: 'Toggle Icon Button',
         componentHref: './?path=/docs/components-toggle-button--docs#icon-button',
         designHref: 'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/d022d8af-22f4-4bf2-981c-1dc0c61afece/',
         designLabel: 'XD',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Toolbar',
         componentHref: './?path=/docs/components-toolbar--docs',
         issueHref: 'https://github.com/ni/nimble/issues/411',
         issueLabel: 'Issue',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Tooltip',
@@ -461,29 +467,35 @@ const components = [
         designLabel: 'Figma',
         issueHref: 'https://github.com/ni/nimble/issues/309',
         issueLabel: 'Issue',
-        componentStatus: '⚠️',
-        angularStatus: '⚠️',
-        blazorStatus: '⚠️',
+        componentStatus: ComponentFrameworkStatus.incubating,
+        angularStatus: ComponentFrameworkStatus.incubating,
+        blazorStatus: ComponentFrameworkStatus.incubating,
     },
     {
         componentName: 'Tree View',
         componentHref: './?path=/docs/components-tree-view--docs',
         designHref: 'https://www.figma.com/file/PO9mFOu5BCl8aJvFchEeuN/Nimble_Components?node-id=1372%3A32423&mode=dev',
         designLabel: 'Figma',
-        componentStatus: '✅',
-        angularStatus: '✅',
-        blazorStatus: '✅',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready,
     },
     {
         componentName: 'Wafer Map',
         componentHref: './?path=/docs/incubating-wafer-map--docs',
         issueHref: 'https://github.com/ni/nimble/issues/924',
         issueLabel: 'Issue',
-        componentStatus: '⚠️',
-        angularStatus: '⚠️',
-        blazorStatus: '⚠️',
+        componentStatus: ComponentFrameworkStatus.incubating,
+        angularStatus: ComponentFrameworkStatus.incubating,
+        blazorStatus: ComponentFrameworkStatus.incubating,
     }
 ] as const;
+
+const iconMappings = html`
+    <${mappingIconTag} key="${ComponentFrameworkStatus.ready}" text="Ready" icon="${iconCheckTag}" severity="success"></${mappingIconTag}>
+    <${mappingIconTag} key="${ComponentFrameworkStatus.incubating}" text="Incubating" icon="${iconTriangleTag}" severity="warning"></${mappingIconTag}>
+    <${mappingIconTag} key="${ComponentFrameworkStatus.notReady}" text="Not ready" icon="${iconXmarkTag}" severity="error"></${mappingIconTag}>
+`;
 
 const metadata: Meta<TableArgs> = {
     title: 'Internal/Component Status',
@@ -518,27 +530,27 @@ const metadata: Meta<TableArgs> = {
             >
                 Issue
             </${tableColumnAnchorTag}>
-            <${tableColumnTextTag}
+            <${tableColumnIconTag}
                 column-id="component-status-column"
                 field-name="componentStatus"
                 ?column-hidden="${x => x.status === 'future'}"
             >
                 Web Component
-            </${tableColumnTextTag}>
-            <${tableColumnTextTag}
+            </${tableColumnIconTag}>
+            <${tableColumnIconTag}
                 column-id="angular-status-column"
                 field-name="angularStatus"
                 ?column-hidden="${x => x.status === 'future'}"
             >
                 Angular
-            </${tableColumnTextTag}>
-            <${tableColumnTextTag}
+            </${tableColumnIconTag}>
+            <${tableColumnIconTag}
                 column-id="blazor-status-column"
                 field-name="blazorStatus"
                 ?column-hidden="${x => x.status === 'future'}"
             >
                 Blazor
-            </${tableColumnTextTag}>
+            </${tableColumnIconTag}>
 
         </${tableTag}>
     `),
@@ -568,9 +580,9 @@ const metadata: Meta<TableArgs> = {
                 // but doesn't seem to be upgraded to a custom element yet
                 await customElements.whenDefined('nimble-table');
                 const isFuture = (component: typeof components[number]): boolean =>
-                    component.angularStatus  === '⭕'
-                    && component.blazorStatus === '⭕'
-                    && component.componentStatus === '⭕';
+                    component.angularStatus  === ComponentFrameworkStatus.notReady
+                    && component.blazorStatus === ComponentFrameworkStatus.notReady
+                    && component.componentStatus === ComponentFrameworkStatus.notReady;
                 const data = components.filter(component => x.status === 'future' ? isFuture(component) : !isFuture(component))
                 await x.tableRef.setData(data);
             })();

--- a/packages/nimble-components/docs/types.ts
+++ b/packages/nimble-components/docs/types.ts
@@ -1,0 +1,7 @@
+export const ComponentFrameworkStatus = {
+    ready: 'ready',
+    incubating: 'incubating',
+    notReady: 'not_ready'
+} as const;
+export type ComponentFrameworkStatus =
+    (typeof ComponentFrameworkStatus)[keyof typeof ComponentFrameworkStatus];

--- a/packages/nimble-components/docs/types.ts
+++ b/packages/nimble-components/docs/types.ts
@@ -1,7 +1,7 @@
 export const ComponentFrameworkStatus = {
     ready: 'ready',
     incubating: 'incubating',
-    notReady: 'not_ready'
+    doesNotExist: 'does_not_exist'
 } as const;
 export type ComponentFrameworkStatus =
     (typeof ComponentFrameworkStatus)[keyof typeof ComponentFrameworkStatus];


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Update the component status table to use the `nimble-table-column-icon` rather than emoji icons.

## 👩‍💻 Implementation

- Update component status table to use icon column
- Update markdown table that is the legend for the icons
- Add an enum for framework-specific status to avoid hard-coding strings

## 🧪 Testing

Verified that the storybook docs looked correct

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
