### PR TITLE
Export MappingKeyType fully instead of just as type

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/table-column/enum-text/nimble-table-column-enum-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/enum-text/nimble-table-column-enum-text.directive.ts
@@ -2,9 +2,10 @@ import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
 import { type TableColumnEnumText, tableColumnEnumTextTag } from '@ni/nimble-components/dist/esm/table-column/enum-text';
 import { BooleanValueOrAttribute, NumberValueOrAttribute, toBooleanProperty, toNullableNumberProperty } from '@ni/nimble-angular/internal-utilities';
 import { NimbleTableColumnBaseDirective } from '@ni/nimble-angular/table-column';
-import type { MappingKeyType } from '@ni/nimble-components/dist/esm/table-column/enum-base/types';
+import { MappingKeyType } from '@ni/nimble-components/dist/esm/table-column/enum-base/types';
 
-export type { TableColumnEnumText, MappingKeyType };
+export { MappingKeyType };
+export type { TableColumnEnumText };
 export { tableColumnEnumTextTag };
 
 /**

--- a/change/@ni-nimble-angular-3412dcc2-e65f-46c7-a1d2-598d1e9d709c.json
+++ b/change/@ni-nimble-angular-3412dcc2-e65f-46c7-a1d2-598d1e9d709c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Export MappingKeyType fully instead of just as type",
+  "packageName": "@ni/nimble-angular",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Angular users should be able to use enum values of `MappingKeyType`.

## 👩‍💻 Implementation

Exporting without "type".

## 🧪 Testing

None

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
