### PR TITLE
Make DateText columnConfig `undefined` when the column is invalid

### DIFF
--- a/change/@ni-nimble-components-9591ab72-7495-41f4-a237-a6322b9238ba.json
+++ b/change/@ni-nimble-components-9591ab72-7495-41f4-a237-a6322b9238ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make DateText columnConfig `undefined` when the column is invalid",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table-column/date-text/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/cell-view/index.ts
@@ -30,7 +30,7 @@ TableColumnDateTextColumnConfig
     }
 
     private updateText(): void {
-        if (this.columnConfig?.formatter) {
+        if (this.columnConfig) {
             this.text = formatNumericDate(
                 this.columnConfig.formatter,
                 this.cellRecord?.value

--- a/packages/nimble-components/src/table-column/date-text/group-header-view/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/group-header-view/index.ts
@@ -27,7 +27,7 @@ TableColumnDateTextColumnConfig
     }
 
     private updateText(): void {
-        if (this.columnConfig?.formatter) {
+        if (this.columnConfig) {
             this.text = formatNumericDate(
                 this.columnConfig.formatter,
                 this.groupHeaderValue

--- a/packages/nimble-components/src/table-column/date-text/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/index.ts
@@ -8,7 +8,7 @@ import { TableColumnSortOperation, TableColumnValidity } from '../base/types';
 import { tableColumnDateTextGroupHeaderViewTag } from './group-header-view';
 import { tableColumnDateTextCellViewTag } from './cell-view';
 import type { ColumnInternalsOptions } from '../base/models/column-internals';
-import type {
+import {
     DateTextFormat,
     LocaleMatcherAlgorithm,
     EraFormat,
@@ -31,7 +31,7 @@ import { optionalBooleanConverter } from '../../utilities/models/converter';
 
 export type TableColumnDateTextCellRecord = TableNumberField<'value'>;
 export interface TableColumnDateTextColumnConfig {
-    formatter?: Intl.DateTimeFormat;
+    formatter: Intl.DateTimeFormat;
 }
 
 declare global {
@@ -210,18 +210,23 @@ export class TableColumnDateText extends TableColumnTextBase {
     }
 
     private updateColumnConfig(): void {
-        const columnConfig: TableColumnDateTextColumnConfig = {
-            formatter: this.createFormatter()
-        };
-        this.columnInternals.columnConfig = columnConfig;
-        this.validator.setCustomOptionsValidity(
-            columnConfig.formatter !== undefined
-        );
+        const formatter = this.createFormatter();
+
+        if (formatter) {
+            const columnConfig: TableColumnDateTextColumnConfig = {
+                formatter
+            };
+            this.columnInternals.columnConfig = columnConfig;
+            this.validator.setCustomOptionsValidity(true);
+        } else {
+            this.columnInternals.columnConfig = undefined;
+            this.validator.setCustomOptionsValidity(false);
+        }
     }
 
     private createFormatter(): Intl.DateTimeFormat | undefined {
         let options: Intl.DateTimeFormatOptions;
-        if (!this.format) {
+        if (this.format === DateTextFormat.default) {
             options = {
                 dateStyle: 'medium',
                 timeStyle: 'medium'


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

After a brief team discussion, we decided that it would make more sense to make the `columnConfig` `undefined` when the date-text column was invalid rather than having the `columnConfig` contain invalid options (i.e. an `undefined` formatter`). This is consistent with the number-text column.

## 👩‍💻 Implementation

Set `columnConfig` to `undefined` when creating the `DateTimeFormat` object throws an exception rather than creating a `columnConfig` object with an `undefined` `formatter`.

## 🧪 Testing

- Ran existing unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
