### PR TITLE
Add string test cases for characters from more languages

### DIFF
--- a/change/@ni-nimble-components-0cd25b7c-7dfe-4118-82f7-cfb321759218.json
+++ b/change/@ni-nimble-components-0cd25b7c-7dfe-4118-82f7-cfb321759218.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add test cases for SLE supported languages",
+  "packageName": "@ni/nimble-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/utilities/tests/wacky-strings.ts
+++ b/packages/nimble-components/src/utilities/tests/wacky-strings.ts
@@ -12,6 +12,10 @@ export const wackyStrings = [
     { name: 'Ω' },
     { name: '( ͡° ͜ʖ ͡°)' },
     { name: '😍' },
+    { name: 'Français é, è, ê and ë (French characters)' },
+    { name: 'Doppelgänger ö, ü, ß (German characters)' },
+    { name: '日本語 (Japanese characters)' },
+    { name: '中文 (Chinese characters)' },
     { name: 'Iñtërnâtiônàlizætiøn☃💩' },
     { name: '１' }
 ];


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

There was a question at NITech about support for international characters in the rich text editor. I wanted to be sure that we have test coverage for the cases that our major clients need.

## 👩‍💻 Implementation

Added strings that use French, German, Chinese, and Japanese characters to our shared "wacky strings" constant. These are used for testing the rich text editor, rich text viewer, and several table columns.

## 🧪 Testing

Inspect test output in PR build to ensure new cases are being executed.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
