### PR TITLE
Add mobile guidance to toolbar story

### DIFF
--- a/change/@ni-nimble-components-0f40786a-0fb8-49ff-861d-c111f5517d4c.json
+++ b/change/@ni-nimble-components-0f40786a-0fb8-49ff-861d-c111f5517d4c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add mobile usage guidance to toolbar story",
+  "packageName": "@ni/nimble-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/toolbar/tests/toolbar.mdx
+++ b/packages/nimble-components/src/toolbar/tests/toolbar.mdx
@@ -1,0 +1,27 @@
+import {
+    Controls,
+    DocsStory,
+    Meta,
+    Stories,
+    Title,
+    Description
+} from '@storybook/blocks';
+import * as toolbarStories from './toolbar.stories';
+
+<Meta of={toolbarStories} />
+
+<Title of={toolbarStories} />
+<Description of={toolbarStories} />
+
+<DocsStory of={toolbarStories.toolbar} expanded={false} />
+
+# Usage Docs
+
+## Mobile Usage
+
+When the width available to the toolbar is insufficient to display all the toolbar items,
+consider moving less important items to a `nimble-menu-button`.
+The `nimble-toolbar` cannot detect this situation automatically, but applications can
+do so using CSS media queries or container queries.
+
+<DocsStory of={toolbarStories.mobileToolbar} expanded={false} />

--- a/packages/nimble-components/src/toolbar/tests/toolbar.stories.ts
+++ b/packages/nimble-components/src/toolbar/tests/toolbar.stories.ts
@@ -3,10 +3,14 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { createUserSelectedThemeStory } from '../../utilities/tests/storybook';
 import { toolbarTag } from '..';
 import { buttonTag } from '../../button';
+import { menuTag } from '../../menu';
+import { menuButtonTag } from '../../menu-button';
+import { menuItemTag } from '../../menu-item';
 import { iconCogTag } from '../../icons/cog';
 import { iconEyeTag } from '../../icons/eye';
 import { iconFilterTag } from '../../icons/filter';
 import { iconPencilTag } from '../../icons/pencil';
+import { iconThreeDotsLineTag } from '../../icons/three-dots-line';
 import { iconTrashTag } from '../../icons/trash';
 
 const overviewText = `Per [W3C](https://w3c.github.io/aria-practices/#toolbar) - A toolbar is a container
@@ -25,14 +29,18 @@ ${toolbarTag}::part(positioning-region) {
 
 const metadata: Meta = {
     title: 'Components/Toolbar',
-    tags: ['autodocs'],
     parameters: {
         docs: {
             description: {
                 component: overviewText
             }
         }
-    },
+    }
+};
+
+export default metadata;
+
+export const toolbar: StoryObj = {
     // prettier-ignore
     render: createUserSelectedThemeStory(html`
         <${toolbarTag}>
@@ -61,6 +69,26 @@ const metadata: Meta = {
     `)
 };
 
-export default metadata;
-
-export const toolbar: StoryObj = {};
+export const mobileToolbar: StoryObj = {
+    // prettier-ignore
+    render: createUserSelectedThemeStory(html`
+        <div style="width: 350px; height: 200px;">
+            <${toolbarTag}>
+                <${buttonTag} appearance="ghost" slot="start">
+                    <${iconEyeTag} slot="start"></${iconEyeTag}>
+                    View
+                </${buttonTag}>
+                <${menuButtonTag} appearance="ghost" slot="end" content-hidden title="More">
+                    More
+                    <${iconThreeDotsLineTag} slot="start"></${iconThreeDotsLineTag}>
+                    <${menuTag} slot="menu">
+                        <${menuItemTag}>Delete</${menuItemTag}>
+                        <${menuItemTag}>Edit</${menuItemTag}>
+                        <${menuItemTag}>Settings</${menuItemTag}>
+                        <${menuItemTag}>Filter</${menuItemTag}>
+                    </${menuTag}>
+                </${menuButtonTag}>
+            </${toolbarTag}>
+        </div>
+    `)
+};


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Addresses #1436 

## 👩‍💻 Implementation

The IxD guidance is that content in the toolbar should move to an overflow menu when there is insufficient screen width to display it in toolbar buttons (see comment on linked issue). This is not something Nimble can easily detect, so I'm adding guidance and an example to the toolbar documentation in Storybook.

## 🧪 Testing

Viewed rendered storybook locally.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
