### PR TITLE
Rich Text Editor | Revert Firefox workaround for caret disappearing issue

### DIFF
--- a/packages/nimble-components/src/rich-text-editor/index.ts
+++ b/packages/nimble-components/src/rich-text-editor/index.ts
@@ -227,7 +227,6 @@ export class RichTextEditor extends FoundationElement implements ErrorPattern {
      */
     public boldButtonClick(): void {
         this.tiptapEditor.chain().focus().toggleBold().run();
-        this.forceFocusEditor();
     }
 
     /**
@@ -237,7 +236,6 @@ export class RichTextEditor extends FoundationElement implements ErrorPattern {
     public boldButtonKeyDown(event: KeyboardEvent): boolean {
         if (this.keyActivatesButton(event)) {
             this.tiptapEditor.chain().focus().toggleBold().run();
-            this.forceFocusEditor();
             return false;
         }
         return true;
@@ -249,7 +247,6 @@ export class RichTextEditor extends FoundationElement implements ErrorPattern {
      */
     public italicsButtonClick(): void {
         this.tiptapEditor.chain().focus().toggleItalic().run();
-        this.forceFocusEditor();
     }
 
     /**
@@ -259,7 +256,6 @@ export class RichTextEditor extends FoundationElement implements ErrorPattern {
     public italicsButtonKeyDown(event: KeyboardEvent): boolean {
         if (this.keyActivatesButton(event)) {
             this.tiptapEditor.chain().focus().toggleItalic().run();
-            this.forceFocusEditor();
             return false;
         }
         return true;
@@ -271,7 +267,6 @@ export class RichTextEditor extends FoundationElement implements ErrorPattern {
      */
     public bulletListButtonClick(): void {
         this.tiptapEditor.chain().focus().toggleBulletList().run();
-        this.forceFocusEditor();
     }
 
     /**
@@ -281,7 +276,6 @@ export class RichTextEditor extends FoundationElement implements ErrorPattern {
     public bulletListButtonKeyDown(event: KeyboardEvent): boolean {
         if (this.keyActivatesButton(event)) {
             this.tiptapEditor.chain().focus().toggleBulletList().run();
-            this.forceFocusEditor();
             return false;
         }
         return true;
@@ -293,7 +287,6 @@ export class RichTextEditor extends FoundationElement implements ErrorPattern {
      */
     public numberedListButtonClick(): void {
         this.tiptapEditor.chain().focus().toggleOrderedList().run();
-        this.forceFocusEditor();
     }
 
     /**
@@ -303,7 +296,6 @@ export class RichTextEditor extends FoundationElement implements ErrorPattern {
     public numberedListButtonKeyDown(event: KeyboardEvent): boolean {
         if (this.keyActivatesButton(event)) {
             this.tiptapEditor.chain().focus().toggleOrderedList().run();
-            this.forceFocusEditor();
             return false;
         }
         return true;
@@ -565,15 +557,6 @@ export class RichTextEditor extends FoundationElement implements ErrorPattern {
                 }
             }
         });
-    }
-
-    // In Firefox browser, once the editor gets focused, the blinking caret will be visible until we click format buttons (Bold, Italic ...) in the Firefox browser (changing focus).
-    // But once any of the toolbar button is clicked, editor internally has its focus but the blinking caret disappears.
-    // As a workaround, manually triggering blur and setting focus on editor makes the blinking caret to re-appear.
-    // Mozilla issue https://bugzilla.mozilla.org/show_bug.cgi?id=1496769 tracks removal of this workaround.
-    private forceFocusEditor(): void {
-        this.tiptapEditor.commands.blur();
-        this.tiptapEditor.commands.focus();
     }
 }
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Issue Link : https://github.com/ni/nimble/issues/1454

Reverting the workaround made for the above issue of blinking Caret disappeared when clicking on the formatting button in Firefox, As it is fixed with the latest release of Firefox browser ([v117](https://www.mozilla.org/en-US/firefox/117.0/releasenotes/)).

## 👩‍💻 Implementation

Removed `forceFocusEditor()` function on button interaction handlers.

## 🧪 Testing

- Manually tested the behavior by installing the latest firefox browser (v117) and comparing the behaviors with previous versions (v116 and before).

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
