### PR TITLE
Fix bug in number-text column where -0 is sometimes displayed

### DIFF
--- a/change/@ni-nimble-components-5321dfb3-5aee-4682-bf70-1a71971e5c71.json
+++ b/change/@ni-nimble-components-5321dfb3-5aee-4682-bf70-1a71971e5c71.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bug in number-text column when the value rounds to -0",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table-column/number-text/models/decimal-formatter.ts
+++ b/packages/nimble-components/src/table-column/number-text/models/decimal-formatter.ts
@@ -5,6 +5,7 @@ import { NumberFormatter } from './number-formatter';
  */
 export class DecimalFormatter extends NumberFormatter {
     private readonly formatter: Intl.NumberFormat;
+    private readonly tenPowDecimalDigits: number;
 
     public constructor(decimalsToDisplay: number) {
         super();
@@ -13,12 +14,19 @@ export class DecimalFormatter extends NumberFormatter {
             minimumFractionDigits: decimalsToDisplay,
             useGrouping: true
         });
+        this.tenPowDecimalDigits = 10 ** decimalsToDisplay;
     }
 
     protected format(number: number): string {
         // The NumberFormat option of `signDisplay: "negative"` is not supported in all browsers nimble supports.
         // Because that option cannot be used to avoid rendering "-0", coerce the value -0 to 0 prior to formatting.
-        const valueToFormat = number === 0 ? 0 : number;
+        const valueToFormat = this.willRoundToZero(number) ? 0 : number;
         return this.formatter.format(valueToFormat);
+    }
+
+    private willRoundToZero(number: number): boolean {
+        // Multiply the value by 10 raised to decimal-digits so that Math.round can be used to emulate rounding to
+        // decimal-digits decimal places. If that rounded value is 0, then the value will be rendered with only 0s.
+        return Math.round(number * this.tenPowDecimalDigits) === 0;
     }
 }

--- a/packages/nimble-components/src/table-column/number-text/models/tests/decimal-formatter.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/models/tests/decimal-formatter.spec.ts
@@ -33,6 +33,12 @@ describe('DecimalFormatter', () => {
             expectedFormattedValue: '0.00'
         },
         {
+            name: 'does not round to -0',
+            decimalDigits: 2,
+            value: -0.00001,
+            expectedFormattedValue: '0.00'
+        },
+        {
             name: '+0 renders without positive sign',
             decimalDigits: 2,
             value: 0,


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

There are some scenarios in the number-text column when using the `decimal` format where -0 can be displayed even though we attempt to avoid that. Specifically, when the number does not exactly equal -0 but when rounded to show `decimal-digits` decimal places, only zeros will be rendered, then the number will show as `-0.00`.

## 👩‍💻 Implementation

I couldn't find a good way to look at a number and see that it would render only zeros when rounded to `decimal-digits` decimal places. Therefore, the approach I came up with was multiplying the number by 10^decimal-digits and then rounding. If that number is 0, then that means only zeros will be rendered in the number.

## 🧪 Testing

Manually tested
Added new unit test for this case

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
