### PR TITLE
Fully export spinnerTag from nimble-angular

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/src/directives/spinner/nimble-spinner.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/spinner/nimble-spinner.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
-import type { Spinner, spinnerTag } from '@ni/nimble-components/dist/esm/spinner';
+import { type Spinner, spinnerTag } from '@ni/nimble-components/dist/esm/spinner';
 import type { SpinnerAppearance } from '@ni/nimble-components/dist/esm/spinner/types';
 
 export type { Spinner };

--- a/change/@ni-nimble-angular-5e130540-c8ab-4485-a666-7169f1caaa9e.json
+++ b/change/@ni-nimble-angular-5e130540-c8ab-4485-a666-7169f1caaa9e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Fully export spinnerTag from nimble-angular",
+  "packageName": "@ni/nimble-angular",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Can't use `spinnerTag` export from nimble-angular because it was only imported as `type`.

## 👩‍💻 Implementation

Change import to not specify `type`. I also checked all other component tags in nimble-angular to ensure they were being exported properly.

## 🧪 Testing

None.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
