### PR TITLE
Fix typo causing patterns docs to remain visible on nimble.ni.dev/storybook

### DIFF
--- a/change/@ni-nimble-components-0e6695a2-3a3d-424b-a164-2b142312e542.json
+++ b/change/@ni-nimble-components-0e6695a2-3a3d-424b-a164-2b142312e542.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix typo in hidden patterns docs",
+  "packageName": "@ni/nimble-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/docs/patterns.mdx
+++ b/packages/nimble-components/docs/patterns.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs';
 
-<Meta title="Patterns/Docs" />
+<Meta title="patterns/Docs" />
 
 # Patterns
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

After #1490 I noticed that the MDX file for the "patterns" doc section that we intended to hide was still visible in the publicly hosted https://nimble.ni.dev/storybook/?path=/docs/patterns-docs--docs

## 👩‍💻 Implementation

The filter was excluding "patterns/" but the MDX file was titled "Patterns/". I made it lowercase to match the filter and the folder that contains the patterns.

## 🧪 Testing

Locally modified filter to remove check for nimble.ni.dev and verified that the section is now hidden.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
