### PR TITLE
Update links to W3C ARIA patterns

### DIFF
--- a/change/@ni-nimble-components-886fd7d5-40a6-4934-8e32-0384b9280446.json
+++ b/change/@ni-nimble-components-886fd7d5-40a6-4934-8e32-0384b9280446.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update links to W3C ARIA patterns",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/docs/creating-storybook-component-documentation.md
+++ b/packages/nimble-components/docs/creating-storybook-component-documentation.md
@@ -23,7 +23,7 @@ const metadata: Meta<ComponentArgs> = {
         ...
 ```
 
-If the component has a [W3C ARIA description](https://w3c.github.io/aria-practices/), consider using that to describe the component purpose.
+If the component has a [W3C ARIA description](https://www.w3.org/WAI/ARIA/apg/patterns/), consider using that to describe the component purpose.
 
 ### Markdown
 

--- a/packages/nimble-components/src/anchor/tests/anchor.stories.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor.stories.ts
@@ -24,7 +24,7 @@ const metadata: Meta<AnchorArgs> = {
         docs: {
             description: {
                 component:
-                    'Per [W3C](https://w3c.github.io/aria-practices/#link), an anchor/link widget provides an interactive reference to a resource. The target resource can be either external or local, i.e., either outside or within the current page or application.'
+                    'Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/link/), an anchor/link widget provides an interactive reference to a resource. The target resource can be either external or local, i.e., either outside or within the current page or application.'
             }
         },
         actions: {}

--- a/packages/nimble-components/src/button/tests/button.stories.ts
+++ b/packages/nimble-components/src/button/tests/button.stories.ts
@@ -24,7 +24,7 @@ interface ButtonArgs {
     endIcon: boolean;
 }
 
-const overviewText = `Per [W3C](https://w3c.github.io/aria-practices/#button) - A button is a widget that
+const overviewText = `Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/button/) - A button is a widget that
 enables users to trigger an action or event, such as submitting a form, opening a dialog, canceling an
 action, or performing a delete operation. A common convention for informing users that a button launches
 a dialog is to append "…" (ellipsis) to the button label, e.g., "Save as…".

--- a/packages/nimble-components/src/checkbox/tests/checkbox.stories.ts
+++ b/packages/nimble-components/src/checkbox/tests/checkbox.stories.ts
@@ -19,7 +19,7 @@ const metadata: Meta<CheckboxArgs> = {
         docs: {
             description: {
                 component:
-                    'Per [W3C](https://w3c.github.io/aria-practices/#checkbox) – The dual-state checkbox is the most common type, as it allows the user to toggle between two choices: checked and not checked.'
+                    'Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/) – The dual-state checkbox is the most common type, as it allows the user to toggle between two choices: checked and not checked.'
             }
         },
         actions: {

--- a/packages/nimble-components/src/menu-button/tests/menu-button.stories.ts
+++ b/packages/nimble-components/src/menu-button/tests/menu-button.stories.ts
@@ -23,7 +23,7 @@ interface MenuButtonArgs {
     menuPosition: string;
 }
 
-const overviewText = `Per [W3C](https://w3c.github.io/aria-practices/#menubutton), a menu button is a button that opens a menu. It is
+const overviewText = `Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/), a menu button is a button that opens a menu. It is
 often styled as a typical push button with a downward pointing arrow or triangle to hint that activating the button will display a menu.`;
 
 const endIconDescription = `When including an icon after the text content, set \`slot="end"\` on the icon to ensure proper styling.

--- a/packages/nimble-components/src/menu/tests/menu.stories.ts
+++ b/packages/nimble-components/src/menu/tests/menu.stories.ts
@@ -36,7 +36,7 @@ interface ItemArgs extends MenuItemArgs {
     type: 'nimble-menu-item' | 'header' | 'hr';
 }
 
-const overviewText = `Per [W3C](https://w3c.github.io/aria-practices/#menu) - A menu is a widget that offers a list of choices to the user,
+const overviewText = `Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/) - A menu is a widget that offers a list of choices to the user,
 such as a set of actions or functions. Menu widgets behave like native operating system menus, such as the menus that pull down from the
 menubars commonly found at the top of many desktop application windows. A menu is usually opened, or made visible, by activating a menu button,
 choosing an item in a menu that opens a sub menu, or by invoking a command, such as Shift + F10 in Windows, that opens a context specific menu.

--- a/packages/nimble-components/src/radio-group/tests/radio-group.stories.ts
+++ b/packages/nimble-components/src/radio-group/tests/radio-group.stories.ts
@@ -22,7 +22,7 @@ const metadata: Meta<RadioGroupArgs> = {
         docs: {
             description: {
                 component:
-                    'Per [W3C](https://w3c.github.io/aria-practices/#radiobutton) – A radio group is a set of checkable buttons, known as radio buttons, where no more than one of the buttons can be checked at a time. Some implementations may initialize the set with all buttons in the unchecked state in order to force the user to check one of the buttons before moving past a certain point in the workflow.'
+                    'Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/radio/) – A radio group is a set of checkable buttons, known as radio buttons, where no more than one of the buttons can be checked at a time. Some implementations may initialize the set with all buttons in the unchecked state in order to force the user to check one of the buttons before moving past a certain point in the workflow.'
             }
         },
         actions: {

--- a/packages/nimble-components/src/switch/tests/switch.stories.ts
+++ b/packages/nimble-components/src/switch/tests/switch.stories.ts
@@ -12,7 +12,7 @@ interface SwitchArgs {
     uncheckedMessage: string;
 }
 
-const overviewText = `Per [W3C](https://w3c.github.io/aria-practices/#switch) - A switch is an input widget that
+const overviewText = `Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/switch/) - A switch is an input widget that
 allows users to choose one of two values: on or off. Switches are similar to checkboxes and toggle buttons, which
 can also serve as binary inputs. One difference, however, is that switches can only be used for binary input while
 checkboxes and toggle buttons allow implementations the option of supporting a third middle state. Checkboxes can

--- a/packages/nimble-components/src/table/specs/README.md
+++ b/packages/nimble-components/src/table/specs/README.md
@@ -268,7 +268,7 @@ Placeholder
 
 ### Accessibility
 
-The `nimble-table` should align either to the W3C [grid interaction model](https://w3c.github.io/aria-practices/#grid) or the [table interaction model](https://w3c.github.io/aria-practices/#table) (TBD).
+The `nimble-table` should align either to the W3C [grid interaction model](https://www.w3.org/WAI/ARIA/apg/patterns/grid/) or the [table interaction model](https://www.w3.org/WAI/ARIA/apg/patterns/table/) (TBD).
 
 ### Globalization
 

--- a/packages/nimble-components/src/tabs/tests/tabs.stories.ts
+++ b/packages/nimble-components/src/tabs/tests/tabs.stories.ts
@@ -14,7 +14,7 @@ interface TabsArgs {
     tabDisabled: boolean;
 }
 
-const overviewText = `Per [W3C](https://w3c.github.io/aria-practices/#tabpanel) - Tabs are a set of layered
+const overviewText = `Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) - Tabs are a set of layered
 sections of content, known as tab panels, that display one panel of content at a time. Each tab panel has an
 associated tab element, that when activated, displays the panel. The list of tab elements is arranged along
 one edge of the currently displayed panel, most commonly the top edge.

--- a/packages/nimble-components/src/toggle-button/tests/toggle-button.stories.ts
+++ b/packages/nimble-components/src/toggle-button/tests/toggle-button.stories.ts
@@ -22,7 +22,7 @@ interface ToggleButtonArgs {
     endIcon: boolean;
 }
 
-const overviewText = `Per [W3C](https://w3c.github.io/aria-practices/#button) - A toggle button is a two-state button
+const overviewText = `Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/button/) - A toggle button is a two-state button
 that can be either off (not pressed) or on (pressed). For example, a button labeled mute in an audio player could
 indicate that sound is muted by setting the pressed state true. Important: it is critical the label on a toggle does
 not change when its state changes. In this example, when the pressed state is true, the label remains "Mute" so a

--- a/packages/nimble-components/src/toolbar/tests/toolbar.stories.ts
+++ b/packages/nimble-components/src/toolbar/tests/toolbar.stories.ts
@@ -9,7 +9,7 @@ import { iconFilterTag } from '../../icons/filter';
 import { iconPencilTag } from '../../icons/pencil';
 import { iconTrashTag } from '../../icons/trash';
 
-const overviewText = `Per [W3C](https://w3c.github.io/aria-practices/#toolbar) - A toolbar is a container
+const overviewText = `Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/) - A toolbar is a container
 for grouping a set of controls, such as buttons, menubuttons, or checkboxes.
 
 When a set of controls is visually presented as a group, the toolbar role can be used to communicate the

--- a/packages/nimble-components/src/tooltip/tests/tooltip.stories.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip.stories.ts
@@ -101,7 +101,7 @@ const metadata: Meta<TooltipArgs> = {
         docs: {
             description: {
                 component:
-                    'Per [W3C](https://w3c.github.io/aria-practices/#tooltip) – A tooltip is a popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it. It typically appears after a small delay and disappears when Escape is pressed or on mouse out. <br><br> It is recommended to set up aria-describedby, an accessibility feature that sets the description of another element through ID references. To do this, the anchor element (button, text, icon, etc.) of the tooltip must have `aria-describedby= name` in its attributes. To call it, use `id= name` in the nimble-tooltip attributes. More information can be found in the [aria-describedby docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby).'
+                    'Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/) – A tooltip is a popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it. It typically appears after a small delay and disappears when Escape is pressed or on mouse out. <br><br> It is recommended to set up aria-describedby, an accessibility feature that sets the description of another element through ID references. To do this, the anchor element (button, text, icon, etc.) of the tooltip must have `aria-describedby= name` in its attributes. To call it, use `id= name` in the nimble-tooltip attributes. More information can be found in the [aria-describedby docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby).'
             }
         },
         actions: {

--- a/packages/nimble-components/src/tree-view/tests/tree-view.stories.ts
+++ b/packages/nimble-components/src/tree-view/tests/tree-view.stories.ts
@@ -31,7 +31,7 @@ interface AnchorItemArgs {
     icon: boolean;
 }
 
-const overviewText = `Per [W3C](https://w3c.github.io/aria-practices/#TreeView) - A tree view widget
+const overviewText = `Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/) - A tree view widget
 presents a hierarchical list. Any item in the hierarchy may have child items, and items that have
 children may be expanded or collapsed to show or hide the children. For example, in a file system
 navigator that uses a tree view to display folders and files, an item representing a folder can be


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

I noticed that most of our W3C links were pointing to pages that had been moved. This isn't ideal, so I updated the links to point to the new location of the W3C docs. 

## 👩‍💻 Implementation

Update URLs

## 🧪 Testing

Manually verified that the new links point to the appropriate pages.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
