### PR TITLE
Tiny: Rollup replace plugin set preventAssignment true

### DIFF
--- a/change/@ni-nimble-components-cf9eaa4d-e512-4d16-b828-bc258b6e892c.json
+++ b/change/@ni-nimble-components-cf9eaa4d-e512-4d16-b828-bc258b6e892c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update component rollup build configuration",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/rollup.config.js
+++ b/packages/nimble-components/rollup.config.js
@@ -7,11 +7,13 @@ import json from '@rollup/plugin-json';
 import nodePolyfills from 'rollup-plugin-polyfill-node';
 
 const umdDevelopmentPlugin = () => replace({
-    'process.env.NODE_ENV': JSON.stringify('development')
+    'process.env.NODE_ENV': JSON.stringify('development'),
+    preventAssignment: true
 });
 
 const umdProductionPlugin = () => replace({
-    'process.env.NODE_ENV': JSON.stringify('production')
+    'process.env.NODE_ENV': JSON.stringify('production'),
+    preventAssignment: true
 });
 
 // eslint-disable-next-line import/no-default-export


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes a minor warning that shows up in builds. [example build](https://github.com/ni/nimble/actions/runs/6109833271/job/16581644062#step:10:139)

Warning message to clean up:
```
(!) Plugin replace: @rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.
```

## 👩‍💻 Implementation

Updated rollup config config.

## 🧪 Testing

Rely on CI.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
