### PR TITLE
Create page object for nimble-select and add page object CONTRIBUTING docs

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/select/testing/ng-package.json
+++ b/angular-workspace/projects/ni/nimble-angular/select/testing/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+      "entryFile": "public-api.ts"
+    }
+}

--- a/angular-workspace/projects/ni/nimble-angular/select/testing/public-api.ts
+++ b/angular-workspace/projects/ni/nimble-angular/select/testing/public-api.ts
@@ -1,0 +1,1 @@
+export * from './select.pageobject';

--- a/angular-workspace/projects/ni/nimble-angular/select/testing/select.pageobject.ts
+++ b/angular-workspace/projects/ni/nimble-angular/select/testing/select.pageobject.ts
@@ -1,0 +1,3 @@
+import { SelectPageObject } from '@ni/nimble-components/dist/esm/select/testing/select.pageobject';
+
+export { SelectPageObject };

--- a/change/@ni-nimble-angular-8ae4d4bf-1bca-43bf-b127-422b364a523d.json
+++ b/change/@ni-nimble-angular-8ae4d4bf-1bca-43bf-b127-422b364a523d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add page object for nimble-select",
+  "packageName": "@ni/nimble-angular",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-5e3c6ae2-ac56-4071-b4f5-c39dc1bc1479.json
+++ b/change/@ni-nimble-components-5e3c6ae2-ac56-4071-b4f5-c39dc1bc1479.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add page object for nimble-select",
+  "packageName": "@ni/nimble-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/CONTRIBUTING.md
+++ b/packages/nimble-components/CONTRIBUTING.md
@@ -424,6 +424,17 @@ Test utilties located in [`/src/utilities/tests`](/packages/nimble-components/sr
 
 The jasmine unit tests utilize [`fixture.ts`](/packages/nimble-components/src/utilities/tests/fixture.ts) for component tests. The fixture utility gives tools for managing the component lifecycle. For some usage examples see [`fixture.spec.ts`](/packages/nimble-components/src/utilities/tests/fixture.spec.ts).
 
+#### Page objects
+
+Components should expose a page object to simplify interacting with the component and querying its state. Page objects can provide an abstraction for implementation details like these:
+
+-   the component's DOM structure; client tests should never need to inspect a component's shadow DOM
+-   timing details of how a component processes updates; client tests should never need to call `waitForUpdatesAsync()` or `processUpdates()` to wait for state changes to propagate
+-   component interactions; client tests shouldn't need to artificially trigger click or keyboard events to interact with a component
+-   complex component state; client tests may be simplified by helpers that describe things like a component's rows or items
+
+Page objects typically won't need to provide methods for querying simple component state; if the page object's interaction methods are properly constructed then client tests can use the component's public attribute or property API to inspect simple state.
+
 ### Disabling tests
 
 If a test is failing on a specific browser but passing on others, it is possible to temporarily mark it to be skipped for that browser by applying the tag `#SkipFirefox`, `#SkipWebkit`, or `#SkipChrome` to the test name:

--- a/packages/nimble-components/src/select/testing/select.pageobject.ts
+++ b/packages/nimble-components/src/select/testing/select.pageobject.ts
@@ -1,15 +1,22 @@
 import { Select } from '..';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
+import { createEventListener } from '../../utilities/tests/component';
 
 /**
  * Page object for the `nimble-select` component to provide consistent ways
  * of querying and interacting with the component during tests.
  */
 export class SelectPageObject {
-    public constructor(private readonly element: Select) {}
+    public constructor(private readonly select: Select) {}
 
     public async setValue(value: string): Promise<void> {
-        this.element.value = value;
+        this.select.value = value;
         await waitForUpdatesAsync();
+    }
+
+    public async clickAndWaitForOpen(): Promise<void> {
+        const regionLoadedListener = createEventListener(this.select, 'loaded');
+        this.select.click();
+        await regionLoadedListener.promise;
     }
 }

--- a/packages/nimble-components/src/select/testing/select.pageobject.ts
+++ b/packages/nimble-components/src/select/testing/select.pageobject.ts
@@ -1,6 +1,8 @@
-import { Select } from '..';
+import type { Select } from '..';
+import type { ListOption } from '../../list-option';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { createEventListener } from '../../utilities/tests/component';
+import { checkFullyInViewport } from '../../utilities/tests/intersection-observer';
 
 /**
  * Page object for the `nimble-select` component to provide consistent ways
@@ -9,14 +11,73 @@ import { createEventListener } from '../../utilities/tests/component';
 export class SelectPageObject {
     public constructor(private readonly select: Select) {}
 
+    /**
+     * Sets the selected value programmatically
+     * @param value The value of the nimble-list-option to select
+     */
     public async setValue(value: string): Promise<void> {
         this.select.value = value;
         await waitForUpdatesAsync();
     }
 
+    /**
+     * Sets the selected value interactively
+     * @param value The value of the nimble-list-option to select
+     */
+    public async selectValue(value: string): Promise<void> {
+        const option = this.getOptionWithValue(value);
+        if (!option) {
+            throw new Error(`No option found with value ${value}`);
+        }
+        await this.clickAndWaitForOpen();
+        option.click();
+        await waitForUpdatesAsync();
+    }
+
+    /**
+     * Clicks the select to open the drop down
+     */
     public async clickAndWaitForOpen(): Promise<void> {
         const regionLoadedListener = createEventListener(this.select, 'loaded');
         this.select.click();
         await regionLoadedListener.promise;
+    }
+
+    /** Checks if the dropdown is fully visible */
+    public async isDropdownFullyInViewport(): Promise<boolean> {
+        return checkFullyInViewport(this.select.listbox);
+    }
+
+    /**
+     * Gets the child list option element with the given value
+     * @param value The value to search for
+     * @returns The list option element if found and undefined if not
+     */
+    public getOptionWithValue(value: string): ListOption | undefined {
+        return this.select.options.find(o => o.value === value);
+    }
+
+    /**
+     * Gets the value of every child list option
+     * @returns A string array containing each option's value
+     */
+    public getOptionValues(): string[] {
+        return this.select.options.map(o => o.value);
+    }
+
+    /**
+     * Gets the display value of every child list option
+     * @returns A string array containing each option's display value
+     */
+    public getOptionDisplayValues(): string[] {
+        return this.select.options.map(o => o.text.trim());
+    }
+
+    /**
+     * Gets the number of child list options
+     * @returns The number of options
+     */
+    public getOptionCount(): number {
+        return this.select.options.length;
     }
 }

--- a/packages/nimble-components/src/select/testing/select.pageobject.ts
+++ b/packages/nimble-components/src/select/testing/select.pageobject.ts
@@ -1,0 +1,15 @@
+import { Select } from '..';
+import { waitForUpdatesAsync } from '../../testing/async-helpers';
+
+/**
+ * Page object for the `nimble-select` component to provide consistent ways
+ * of querying and interacting with the component during tests.
+ */
+export class SelectPageObject {
+    public constructor(private readonly element: Select) {}
+
+    public async setValue(value: string): Promise<void> {
+        this.element.value = value;
+        await waitForUpdatesAsync();
+    }
+}

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -5,6 +5,7 @@ import { listOptionTag } from '../../list-option';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { createEventListener } from '../../utilities/tests/component';
 import { checkFullyInViewport } from '../../utilities/tests/intersection-observer';
+import { SelectPageObject } from '../testing/select.pageobject';
 
 async function setup(
     position?: string,
@@ -115,9 +116,9 @@ describe('Select', () => {
 
     it('should keep selected value when options change', async () => {
         const { element, connect, disconnect } = await setup();
+        const pageObject = new SelectPageObject(element);
         await connect();
-        element.value = 'two';
-        await waitForUpdatesAsync();
+        await pageObject.setValue('two');
         expect(element.value).toBe('two');
 
         // Add option zero at the top of the options list

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -3,7 +3,6 @@ import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Select, selectTag } from '..';
 import { listOptionTag } from '../../list-option';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
-import { createEventListener } from '../../utilities/tests/component';
 import { checkFullyInViewport } from '../../utilities/tests/intersection-observer';
 import { SelectPageObject } from '../testing/select.pageobject';
 
@@ -22,12 +21,6 @@ async function setup(
         </nimble-select>
     `;
     return fixture<Select>(viewTemplate);
-}
-
-async function clickAndWaitForOpen(select: Select): Promise<void> {
-    const regionLoadedListener = createEventListener(select, 'loaded');
-    select.click();
-    await regionLoadedListener.promise;
 }
 
 describe('Select', () => {
@@ -148,8 +141,9 @@ describe('Select', () => {
 
         it('should limit dropdown height to viewport', async () => {
             const { element, connect, disconnect } = await setup500Options();
+            const pageObject = new SelectPageObject(element);
             await connect();
-            await clickAndWaitForOpen(element);
+            await pageObject.clickAndWaitForOpen();
             const fullyVisible = await checkFullyInViewport(element.listbox);
 
             expect(element.listbox.scrollHeight).toBeGreaterThan(
@@ -177,10 +171,10 @@ describe('Select', () => {
 
         it('should not confine dropdown to div with "overflow: auto"', async () => {
             const { element, connect, disconnect } = await setupInDiv();
-            const select: Select = element.querySelector(selectTag)!;
+            const pageObject = new SelectPageObject(element);
             await connect();
-            await clickAndWaitForOpen(select);
-            const fullyVisible = await checkFullyInViewport(select.listbox);
+            await pageObject.clickAndWaitForOpen();
+            const fullyVisible = await checkFullyInViewport(element);
 
             expect(fullyVisible).toBe(true);
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As part of #265 we would like page objects for all of our components.

## 👩‍💻 Implementation

1. Created a nimble-components page object for nimble-select following standard naming and file location.
3. Added methods that seemed useful after scanning Nimble tests and SLE tests that reference the component
4. Added unit tests to ensure all page object methods are exercised
5. Expose from nimble-angular in a new entry point following standard naming and file location. (Note that I'm NOT migrating the select directives to their own new entry point)
6. Added documentation to CONTRIBUTING to describe a philosophy for what belongs in a page object and what doesn't

## 🧪 Testing

1. New unit tests in nimble-components. I didn't see anywhere in nimble-angular that could leverage it.
2. TODO: use in SLE

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
