### PR TITLE
Suppress Circular Dependencies Warnings related to D3

### DIFF
--- a/change/@ni-nimble-components-b4363203-ef9a-4f2f-a5b0-011890fe1997.json
+++ b/change/@ni-nimble-components-b4363203-ef9a-4f2f-a5b0-011890fe1997.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Filter rollup d3 related warning messages",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/rollup.config.js
+++ b/packages/nimble-components/rollup.config.js
@@ -26,13 +26,14 @@ const onwarn = (warning, defaultHandler) => {
     const ignoredWarnings = [
         {
             code: 'CIRCULAR_DEPENDENCY',
-            file: 'node_modules/d3-',
-        },
+            file: 'node_modules/d3-'
+        }
     ];
 
-    if (!ignoredWarnings.some(({ code, file }) => (
-        warning.code === code
-        && warning.message.includes(file)))
+    if (
+        !ignoredWarnings.some(
+            ({ code, file }) => warning.code === code && warning.message.includes(file)
+        )
     ) {
         defaultHandler(warning);
     }

--- a/packages/nimble-components/rollup.config.js
+++ b/packages/nimble-components/rollup.config.js
@@ -16,6 +16,28 @@ const umdProductionPlugin = () => replace({
     preventAssignment: true
 });
 
+// d3 has circular dependencies it won't remove:
+// https://github.com/d3/d3-selection/issues/168
+// So ignore just d3's circular dependencies following the pattern from:
+// https://github.com/rollup/rollup/issues/1089#issuecomment-635564942
+// Updated to use current onwarn api:
+// https://rollupjs.org/configuration-options/#onwarn
+const onwarn = (warning, defaultHandler) => {
+    const ignoredWarnings = [
+        {
+            code: 'CIRCULAR_DEPENDENCY',
+            file: 'node_modules/d3-',
+        },
+    ];
+
+    if (!ignoredWarnings.some(({ code, file }) => (
+        warning.code === code
+        && warning.message.includes(file)))
+    ) {
+        defaultHandler(warning);
+    }
+};
+
 // eslint-disable-next-line import/no-default-export
 export default [
     {
@@ -32,7 +54,8 @@ export default [
             resolve(),
             commonJS(),
             json()
-        ]
+        ],
+        onwarn
     },
     {
         input: 'dist/esm/all-components.js',
@@ -55,6 +78,7 @@ export default [
             resolve(),
             commonJS(),
             json()
-        ]
+        ],
+        onwarn
     }
 ];


### PR DESCRIPTION

# Pull Request

## 🤨 Rationale

The d3 library chooses to intentionally keep circular dependencies: https://github.com/d3/d3-selection/issues/168

Rollup reports circular dependencies as warnings but to limit verbosity only show the first few so all we see are warnings related to d3. Example:

```
> rollup --bundleConfigAsCjs --config


dist/esm/all-components.js → dist/all-components-bundle.js...
(!) Circular dependencies
../../node_modules/d3-selection/src/selection/index.js -> ../../node_modules/d3-selection/src/selection/select.js -> ../../node_modules/d3-selection/src/selection/index.js
../../node_modules/d3-selection/src/selection/index.js -> ../../node_modules/d3-selection/src/selection/selectAll.js -> ../../node_modules/d3-selection/src/selection/index.js
../../node_modules/d3-selection/src/selection/index.js -> ../../node_modules/d3-selection/src/selection/filter.js -> ../../node_modules/d3-selection/src/selection/index.js
...and 12 more
created dist/all-components-bundle.js in 12.3s
```

If we introduce circular dependencies or add a library that introduces additional circular dpendencies they may be missed.

## 👩‍💻 Implementation

Implemented a rollup onwarn handler that can filter out the d3 libraries circular dependency warnings.

## 🧪 Testing

Validated locally that choosing a more specific prefix like `d3-selection` will filter only warnings for that subset and let others through.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
