### PR TITLE
Rich text editor | Setting height in storybook docs

### DIFF
--- a/change/@ni-nimble-components-8d042e30-91cd-421a-99af-5d4bb68493b0.json
+++ b/change/@ni-nimble-components-8d042e30-91cd-421a-99af-5d4bb68493b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Setting height for rich text editor component in storybook docs and tests",
+  "packageName": "@ni/nimble-components",
+  "email": "123377523+vivinkrishna-ni@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-8d042e30-91cd-421a-99af-5d4bb68493b0.json
+++ b/change/@ni-nimble-components-8d042e30-91cd-421a-99af-5d4bb68493b0.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "none",
   "comment": "Setting height for rich text editor component in storybook docs and tests",
   "packageName": "@ni/nimble-components",
   "email": "123377523+vivinkrishna-ni@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-matrix.stories.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-matrix.stories.ts
@@ -63,7 +63,7 @@ const component = (
         ${() => footerHiddenName} ${() => errorStateName} ${() => placeholderName} ${() => disabledName} 
     </p>
     <${richTextEditorTag}
-        style="margin: 5px 0px; width: 500px;"
+        style="margin: 5px 0px; width: 500px; height: 100px;"
         ?disabled="${() => disabled}"
         ?footer-hidden="${() => footerHidden}"
         ?error-visible="${() => isError}"

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.stories.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.stories.ts
@@ -86,6 +86,7 @@ const metadata: Meta<RichTextEditorArgs> = {
     })}
     <${richTextEditorTag}
         ${ref('editorRef')}
+        style="height: 160px;"
         data-unused="${x => x.setMarkdownData(x)}"
         ?disabled="${x => x.disabled}"
         ?footer-hidden="${x => x.footerHidden}"


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

<!---
Provide some background and a description of your work.
What problem does this change solve?

Include links to issues, work items, or other discussions.
-->
1. To provide more spacing and facilitate the exploration of various functionalities of the rich text editor, setting a default height in storybook docs until enabling the `fit-to-content` attribute.
2. To make the content, such as the links (https://github.com/ni/nimble/pull/1496#discussion_r1322114329), visible if any are added as part of the test, height is added for storybook tests. 

## 👩‍💻 Implementation

<!---
Describe how the change addresses the problem. Consider factors such as complexity, alternative solutions, performance impact, etc. 

Consider listing files with important changes or comment on them directly in the pull request.
-->
1. Add `height: 160px;` to the rich text editor storybook doc.
2. Add height for the theme matrix test to isolate the Chromatic test difference from the https://github.com/ni/nimble/pull/1496 PR.

## 🧪 Testing

<!---
Detail the testing done to ensure this submission meets requirements. 

Include automated/manual test additions or modifications, testing done on a local build, private CI run results, and additional testing not covered by automatic pull request validation. If any functionality is not covered by automated testing, provide justification.
-->
Verified manually the differences in the height of the component in storybook docs and tests.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
