### PR TITLE
Rich text viewer | Fix for escape characters parsing in markdown

### DIFF
--- a/change/@ni-nimble-components-54559267-8991-4065-b1bd-cb315fba44f2.json
+++ b/change/@ni-nimble-components-54559267-8991-4065-b1bd-cb315fba44f2.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Added support for using escape character(\\) in rich text editor",
+  "comment": "Added support for using escape character(backslash) in rich text editor",
   "packageName": "@ni/nimble-components",
   "email": "123591928+saikrishnan-ni@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@ni-nimble-components-54559267-8991-4065-b1bd-cb315fba44f2.json
+++ b/change/@ni-nimble-components-54559267-8991-4065-b1bd-cb315fba44f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added support for using escape character(\\) in rich text editor",
+  "packageName": "@ni/nimble-components",
+  "email": "123591928+saikrishnan-ni@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-54559267-8991-4065-b1bd-cb315fba44f2.json
+++ b/change/@ni-nimble-components-54559267-8991-4065-b1bd-cb315fba44f2.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Added support for using escape character(backslash) in rich text viewer",
+  "comment": "Render special characters properly without unnecessary backslashes",
   "packageName": "@ni/nimble-components",
   "email": "123591928+saikrishnan-ni@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@ni-nimble-components-54559267-8991-4065-b1bd-cb315fba44f2.json
+++ b/change/@ni-nimble-components-54559267-8991-4065-b1bd-cb315fba44f2.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Added support for using escape character(backslash) in rich text editor",
+  "comment": "Added support for using escape character(backslash) in rich text viewer",
   "packageName": "@ni/nimble-components",
   "email": "123591928+saikrishnan-ni@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@ni-nimble-components-54559267-8991-4065-b1bd-cb315fba44f2.json
+++ b/change/@ni-nimble-components-54559267-8991-4065-b1bd-cb315fba44f2.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Render special characters properly without unnecessary backslashes",
+  "comment": "Rich-text viewer should recognize escape characters in markdown",
   "packageName": "@ni/nimble-components",
   "email": "123591928+saikrishnan-ni@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/nimble-components/src/rich-text/models/markdown-parser.ts
+++ b/packages/nimble-components/src/rich-text/models/markdown-parser.ts
@@ -43,7 +43,8 @@ export class RichTextMarkdownParser {
         const supportedTokenizerRules = zeroTokenizerConfiguration.enable([
             'emphasis',
             'list',
-            'autolink'
+            'autolink',
+            'escape'
         ]);
 
         return new MarkdownParser(

--- a/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
+++ b/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
@@ -279,11 +279,27 @@ describe('Markdown parser', () => {
             { name: r`\*\*bold\*\*`, tags: ['P'], textContent: ['**bold**'] },
             { name: r`\*italics\*`, tags: ['P'], textContent: ['*italics*'] },
             { name: r`\# test1`, tags: ['P'], textContent: ['# test1'] },
-            { name: r`\> blockquote`, tags: ['P'], textContent: ['> blockquote'] },
+            {
+                name: r`\> blockquote`,
+                tags: ['P'],
+                textContent: ['> blockquote']
+            },
             { name: r`\`code\``, tags: ['P'], textContent: ['`code`'] },
-            { name: r`\~\~strikethrough\~\~`, tags: ['P'], textContent: ['~~strikethrough~~'] },
-            { name: r`\## heading 2`, tags: ['P'], textContent: ['## heading 2'] },
-            { name: r`\[link\](url)`, tags: ['P'], textContent: ['[link](url)'] }
+            {
+                name: r`\~\~strikethrough\~\~`,
+                tags: ['P'],
+                textContent: ['~~strikethrough~~']
+            },
+            {
+                name: r`\## heading 2`,
+                tags: ['P'],
+                textContent: ['## heading 2']
+            },
+            {
+                name: r`\[link\](url)`,
+                tags: ['P'],
+                textContent: ['[link](url)']
+            }
         ];
 
         for (const value of testsWithEscapeCharacters) {

--- a/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
+++ b/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
@@ -244,7 +244,11 @@ describe('Markdown parser', () => {
             );
 
             expect(getTagsFromElement(doc)).toEqual(['P', 'P', 'P']);
-            expect(getLeafContentsFromElement(doc)).toEqual([r`1.\ item 1`, r`2. item 2`, r`3.\item 3`]);
+            expect(getLeafContentsFromElement(doc)).toEqual([
+                r`1.\ item 1`,
+                r`2. item 2`,
+                r`3.\item 3`
+            ]);
         });
 
         it('bullet list with escape character should be parsed as string and not as list', () => {
@@ -258,14 +262,16 @@ describe('Markdown parser', () => {
             );
 
             expect(getTagsFromElement(doc)).toEqual(['P', 'P', 'P']);
-            expect(getLeafContentsFromElement(doc)).toEqual([r`-\ item 1`, r`-\ item 2`, r`-\item 3`]);
+            expect(getLeafContentsFromElement(doc)).toEqual([
+                r`-\ item 1`,
+                r`-\ item 2`,
+                r`-\item 3`
+            ]);
         });
 
         it('escape character should not be parsed and return only non escape character<\\*>', () => {
             const r = String.raw;
-            const doc = RichTextMarkdownParser.parseMarkdownToDOM(
-                r`\*`
-            );
+            const doc = RichTextMarkdownParser.parseMarkdownToDOM(r`\*`);
 
             expect(getTagsFromElement(doc)).toEqual(['P']);
             expect(getLeafContentsFromElement(doc)).toEqual(['*']);

--- a/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
+++ b/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
@@ -233,7 +233,7 @@ describe('Markdown parser', () => {
             ]);
         });
 
-        it('numbers with escape character should be parsed as string and not as list', () => {
+        it('numbers with escape character should be parsed as paragraph', () => {
             const r = String.raw;
             const doc = RichTextMarkdownParser.parseMarkdownToDOM(
                 r`1\.\ item 1
@@ -251,7 +251,7 @@ describe('Markdown parser', () => {
             ]);
         });
 
-        it('bullet list with escape character should be parsed as string and not as list', () => {
+        it('bullet list with escape character should be parsed as paragraph', () => {
             const r = String.raw;
             const doc = RichTextMarkdownParser.parseMarkdownToDOM(
                 r`-\ item 1
@@ -268,34 +268,41 @@ describe('Markdown parser', () => {
                 r`-\item 3`
             ]);
         });
+    });
 
-        it('escape character should not be parsed and return only non escape character<\\*>', () => {
-            const r = String.raw;
-            const doc = RichTextMarkdownParser.parseMarkdownToDOM(r`\*`);
+    describe('various escape characters should be parsed properly', () => {
+        const focused: string[] = [];
+        const disabled: string[] = [];
+        const r = String.raw;
+        const testsWithEscapeCharacters = [
+            { name: r`\*`, tags: ['P'], textContent: ['*'] },
+            { name: r`\*\*bold\*\*`, tags: ['P'], textContent: ['**bold**'] },
+            { name: r`\*italics\*`, tags: ['P'], textContent: ['*italics*'] },
+            { name: r`\# test1`, tags: ['P'], textContent: ['# test1'] },
+            { name: r`\> blockquote`, tags: ['P'], textContent: ['> blockquote'] },
+            { name: r`\`code\``, tags: ['P'], textContent: ['`code`'] },
+            { name: r`\~\~strikethrough\~\~`, tags: ['P'], textContent: ['~~strikethrough~~'] },
+            { name: r`\## heading 2`, tags: ['P'], textContent: ['## heading 2'] },
+            { name: r`\[link\](url)`, tags: ['P'], textContent: ['[link](url)'] }
+        ];
 
-            expect(getTagsFromElement(doc)).toEqual(['P']);
-            expect(getLeafContentsFromElement(doc)).toEqual(['*']);
-        });
+        for (const value of testsWithEscapeCharacters) {
+            const specType = getSpecTypeByNamedList(value, focused, disabled);
+            specType(
+                `"${value.name}"`,
+                // eslint-disable-next-line @typescript-eslint/no-loop-func
+                () => {
+                    const doc = RichTextMarkdownParser.parseMarkdownToDOM(
+                        value.name
+                    );
 
-        it('escape character should not be parsed and return only non escape character<\\*\\*Bold\\*\\*>', () => {
-            const r = String.raw;
-            const doc = RichTextMarkdownParser.parseMarkdownToDOM(
-                r`\*\*bold\*\*`
+                    expect(getTagsFromElement(doc)).toEqual(value.tags);
+                    expect(getLeafContentsFromElement(doc)).toEqual(
+                        value.textContent
+                    );
+                }
             );
-
-            expect(getTagsFromElement(doc)).toEqual(['P']);
-            expect(getLeafContentsFromElement(doc)).toEqual([r`**bold**`]);
-        });
-
-        it('escape character should not be parsed and return only non escape character<\\*Italics\\*>', () => {
-            const r = String.raw;
-            const doc = RichTextMarkdownParser.parseMarkdownToDOM(
-                r`\*italics\*`
-            );
-
-            expect(getTagsFromElement(doc)).toEqual(['P']);
-            expect(getLeafContentsFromElement(doc)).toEqual([r`*italics*`]);
-        });
+        }
     });
 
     describe('various not supported markdown string values render as unchanged strings', () => {

--- a/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
+++ b/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
@@ -232,6 +232,64 @@ describe('Markdown parser', () => {
                 'Bulleted list with bold and italics'
             ]);
         });
+
+        it('numbers with escape character should be parsed as string and not as list', () => {
+            const r = String.raw;
+            const doc = RichTextMarkdownParser.parseMarkdownToDOM(
+                r`1\.\ item 1
+                
+                2\. item 2
+                
+                3\.\item 3`
+            );
+
+            expect(getTagsFromElement(doc)).toEqual(['P', 'P', 'P']);
+            expect(getLeafContentsFromElement(doc)).toEqual([r`1.\ item 1`, r`2. item 2`, r`3.\item 3`]);
+        });
+
+        it('bullet list with escape character should be parsed as string and not as list', () => {
+            const r = String.raw;
+            const doc = RichTextMarkdownParser.parseMarkdownToDOM(
+                r`-\ item 1
+                
+                -\ item 2
+                
+                -\item 3`
+            );
+
+            expect(getTagsFromElement(doc)).toEqual(['P', 'P', 'P']);
+            expect(getLeafContentsFromElement(doc)).toEqual([r`-\ item 1`, r`-\ item 2`, r`-\item 3`]);
+        });
+
+        it('escape character should not be parsed and return only non escape character<\\*>', () => {
+            const r = String.raw;
+            const doc = RichTextMarkdownParser.parseMarkdownToDOM(
+                r`\*`
+            );
+
+            expect(getTagsFromElement(doc)).toEqual(['P']);
+            expect(getLeafContentsFromElement(doc)).toEqual(['*']);
+        });
+
+        it('escape character should not be parsed and return only non escape character<\\*\\*Bold\\*\\*>', () => {
+            const r = String.raw;
+            const doc = RichTextMarkdownParser.parseMarkdownToDOM(
+                r`\*\*bold\*\*`
+            );
+
+            expect(getTagsFromElement(doc)).toEqual(['P']);
+            expect(getLeafContentsFromElement(doc)).toEqual([r`**bold**`]);
+        });
+
+        it('escape character should not be parsed and return only non escape character<\\*Italics\\*>', () => {
+            const r = String.raw;
+            const doc = RichTextMarkdownParser.parseMarkdownToDOM(
+                r`\*italics\*`
+            );
+
+            expect(getTagsFromElement(doc)).toEqual(['P']);
+            expect(getLeafContentsFromElement(doc)).toEqual([r`*italics*`]);
+        });
     });
 
     describe('various not supported markdown string values render as unchanged strings', () => {

--- a/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
+++ b/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
@@ -295,35 +295,35 @@ describe('Markdown parser', () => {
 
         it('special character `.` should be parsed properly (number list test)', () => {
             const doc = RichTextMarkdownParser.parseMarkdownToDOM(
-                r`1\.\ item 1
+                r`1\. item 1
                 
                 2\. item 2
                 
-                3\.\item 3`
+                3\. item 3`
             );
 
             expect(getTagsFromElement(doc)).toEqual(['P', 'P', 'P']);
             expect(getLeafContentsFromElement(doc)).toEqual([
-                r`1.\ item 1`,
+                r`1. item 1`,
                 r`2. item 2`,
-                r`3.\item 3`
+                r`3. item 3`
             ]);
         });
 
-        it('special character `.` should be parsed properly (bullet list test)', () => {
+        it('special character `-` should be parsed properly (bullet list test)', () => {
             const doc = RichTextMarkdownParser.parseMarkdownToDOM(
-                r`-\ item 1
+                r`\- item 1
                 
-                -\ item 2
+                \- item 2
                 
-                -\item 3`
+                \- item 3`
             );
 
             expect(getTagsFromElement(doc)).toEqual(['P', 'P', 'P']);
             expect(getLeafContentsFromElement(doc)).toEqual([
-                r`-\ item 1`,
-                r`-\ item 2`,
-                r`-\item 3`
+                r`- item 1`,
+                r`- item 2`,
+                r`- item 3`
             ]);
         });
 
@@ -335,7 +335,7 @@ describe('Markdown parser', () => {
         });
 
         it('\\ double backslash should render a single backslash', () => {
-            const doc = RichTextMarkdownParser.parseMarkdownToDOM('\\');
+            const doc = RichTextMarkdownParser.parseMarkdownToDOM(r`\\`);
 
             expect(getTagsFromElement(doc)).toEqual(['P']);
             expect(getLeafContentsFromElement(doc)).toEqual(['\\']);

--- a/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
+++ b/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
@@ -232,45 +232,9 @@ describe('Markdown parser', () => {
                 'Bulleted list with bold and italics'
             ]);
         });
-
-        it('numbers with escape character should be parsed as paragraph', () => {
-            const r = String.raw;
-            const doc = RichTextMarkdownParser.parseMarkdownToDOM(
-                r`1\.\ item 1
-                
-                2\. item 2
-                
-                3\.\item 3`
-            );
-
-            expect(getTagsFromElement(doc)).toEqual(['P', 'P', 'P']);
-            expect(getLeafContentsFromElement(doc)).toEqual([
-                r`1.\ item 1`,
-                r`2. item 2`,
-                r`3.\item 3`
-            ]);
-        });
-
-        it('bullet list with escape character should be parsed as paragraph', () => {
-            const r = String.raw;
-            const doc = RichTextMarkdownParser.parseMarkdownToDOM(
-                r`-\ item 1
-                
-                -\ item 2
-                
-                -\item 3`
-            );
-
-            expect(getTagsFromElement(doc)).toEqual(['P', 'P', 'P']);
-            expect(getLeafContentsFromElement(doc)).toEqual([
-                r`-\ item 1`,
-                r`-\ item 2`,
-                r`-\item 3`
-            ]);
-        });
     });
 
-    describe('various escape characters should be parsed properly', () => {
+    describe('escape backslashes should be ignored while parsing', () => {
         const focused: string[] = [];
         const disabled: string[] = [];
         const r = String.raw;
@@ -299,6 +263,15 @@ describe('Markdown parser', () => {
                 name: r`\[link\](url)`,
                 tags: ['P'],
                 textContent: ['[link](url)']
+            },
+            { name: r`\---`, tags: ['P'], textContent: ['---'] },
+            { name: r`\*\*\*`, tags: ['P'], textContent: ['***'] },
+            { name: r`\_\_\_`, tags: ['P'], textContent: ['___'] },
+            { name: r`\-Infinity`, tags: ['P'], textContent: ['-Infinity'] },
+            {
+                name: r`\-2147483648/-1`,
+                tags: ['P'],
+                textContent: ['-2147483648/-1']
             }
         ];
 
@@ -319,6 +292,40 @@ describe('Markdown parser', () => {
                 }
             );
         }
+
+        it('special character `.` should be parsed properly (number list test)', () => {
+            const doc = RichTextMarkdownParser.parseMarkdownToDOM(
+                r`1\.\ item 1
+                
+                2\. item 2
+                
+                3\.\item 3`
+            );
+
+            expect(getTagsFromElement(doc)).toEqual(['P', 'P', 'P']);
+            expect(getLeafContentsFromElement(doc)).toEqual([
+                r`1.\ item 1`,
+                r`2. item 2`,
+                r`3.\item 3`
+            ]);
+        });
+
+        it('special character `.` should be parsed properly (bullet list test)', () => {
+            const doc = RichTextMarkdownParser.parseMarkdownToDOM(
+                r`-\ item 1
+                
+                -\ item 2
+                
+                -\item 3`
+            );
+
+            expect(getTagsFromElement(doc)).toEqual(['P', 'P', 'P']);
+            expect(getLeafContentsFromElement(doc)).toEqual([
+                r`-\ item 1`,
+                r`-\ item 2`,
+                r`-\item 3`
+            ]);
+        });
     });
 
     describe('various not supported markdown string values render as unchanged strings', () => {

--- a/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
+++ b/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
@@ -326,6 +326,20 @@ describe('Markdown parser', () => {
                 r`-\item 3`
             ]);
         });
+
+        it('\n backslash<n> should render a new line', () => {
+            const doc = RichTextMarkdownParser.parseMarkdownToDOM(r`\n`);
+
+            expect(getTagsFromElement(doc)).toEqual(['P']);
+            expect(getLeafContentsFromElement(doc)).toEqual([r`\n`]);
+        });
+
+        it('\\ double backslash should render a single backslash', () => {
+            const doc = RichTextMarkdownParser.parseMarkdownToDOM('\\');
+
+            expect(getTagsFromElement(doc)).toEqual(['P']);
+            expect(getLeafContentsFromElement(doc)).toEqual(['\\']);
+        });
     });
 
     describe('various not supported markdown string values render as unchanged strings', () => {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
- As markdown serialization from editor includes escaping markdown syntax characters and some special characters with a backslash `\`, viewer markdown parser needs to understand the escape backslashes to render the rich text output properly

## 👩‍💻 Implementation

- Added support for understanding escape backslashes in markdown parser logic


  For the below markdown
  ![image](https://github.com/ni/nimble/assets/123591928/7eaf1b09-8835-4dc4-a32e-e9b525387fee)

  #### Expected Behavior
  - Should ignore escape backslashes
  ![image](https://github.com/ni/nimble/assets/123591928/423a7449-7262-4fb7-8ba3-266d508813c5)

  #### Actual Behavior
  - Renders escape backslashes 
  ![image](https://github.com/ni/nimble/assets/123591928/367381f2-70d2-4049-a9da-4bc2eebaa171)

## 🧪 Testing

- Added unit test cases in `markdown-parser.spec.ts`

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
