### PR TITLE
Add partial token for fill hover color

### DIFF
--- a/change/@ni-nimble-components-00eca8d3-4db2-4f8c-b01b-e272c41dbef5.json
+++ b/change/@ni-nimble-components-00eca8d3-4db2-4f8c-b01b-e272c41dbef5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add partial token for fill hover color",
+  "packageName": "@ni/nimble-components",
+  "email": "suriya.sadaiyappan@ni.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/theme-provider/design-token-comments.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-comments.ts
@@ -31,6 +31,8 @@ export const comments: { readonly [key in TokenName]: string | null } = {
     fillHoverSelectedColor:
         'Control fill color when hovering a selected control',
     fillHoverColor: 'Control fill color when hovering component',
+    fillHoverRgbPartialColor:
+        'DEPRECATED: *-partial tokens are used with rgba() to set color transparency in component stylesheets',
     fillDownColor: 'Control fill color when mousedown event occurs',
     borderColor: 'Standard control outline or border color',
     borderRgbPartialColor:

--- a/packages/nimble-components/src/theme-provider/design-token-names.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-names.ts
@@ -25,6 +25,7 @@ export const tokenNames: { readonly [key in TokenName]: string } = {
     fillSelectedRgbPartialColor: 'fill-selected-rgb-partial-color',
     fillHoverSelectedColor: 'fill-hover-selected-color',
     fillHoverColor: 'fill-hover-color',
+    fillHoverRgbPartialColor: 'fill-hover-rgb-partial-color',
     fillDownColor: 'fill-down-color',
     borderColor: 'border-color',
     borderRgbPartialColor: 'border-rgb-partial-color',

--- a/packages/nimble-components/src/theme-provider/design-tokens.ts
+++ b/packages/nimble-components/src/theme-provider/design-tokens.ts
@@ -160,6 +160,10 @@ export const fillHoverColor = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.fillHoverColor)
 ).withDefault((element: HTMLElement) => hexToRgbaCssColor(getFillHoverColorForTheme(element), 0.1));
 
+export const fillHoverRgbPartialColor = DesignToken.create<string>(
+    styleNameFromTokenName(tokenNames.fillHoverRgbPartialColor)
+).withDefault((element: HTMLElement) => hexToRgbPartial(getFillHoverColorForTheme(element)));
+
 export const fillDownColor = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.fillDownColor)
 ).withDefault((element: HTMLElement) => hexToRgbaCssColor(getFillDownColorForTheme(element), 0.15));


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Need to extract rgb part of $ni-nimble-fill-hover-color for using in color-mix. There is no support in CSS currently to extract the rgb from rgba.

## 👩‍💻 Implementation

Added a partial token named `$ni-nimble-fill-hover-rgb-partial-color` containing rgb part of the $ni-nimble-fill-hover-color.

## 🧪 Testing

1. Manually verified in Storybook

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
