### PR TITLE
New icons for indent and outdent list level

### DIFF
--- a/change/@ni-nimble-components-1e27b7b7-63b9-49f6-a22a-791c536ee2a2.json
+++ b/change/@ni-nimble-components-1e27b7b7-63b9-49f6-a22a-791c536ee2a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "New icons for indent and outdent list level",
+  "packageName": "@ni/nimble-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-tokens-e07efc8f-4b41-496d-8ea1-03c2eba3b7d2.json
+++ b/change/@ni-nimble-tokens-e07efc8f-4b41-496d-8ea1-03c2eba3b7d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "New icons for indent and outdent list level",
+  "packageName": "@ni/nimble-tokens",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/icon-base/tests/icon-metadata.ts
+++ b/packages/nimble-components/src/icon-base/tests/icon-metadata.ts
@@ -293,7 +293,7 @@ export const iconMetadata: {
         tags: ['history', 'timer']
     },
     IconIndent: {
-        tags: ['increase-list-level', 'right-arrow-three-lines']
+        tags: ['increase-list-level']
     },
     IconIndeterminantCheckbox: {
         tags: ['selection']

--- a/packages/nimble-components/src/icon-base/tests/icon-metadata.ts
+++ b/packages/nimble-components/src/icon-base/tests/icon-metadata.ts
@@ -293,7 +293,7 @@ export const iconMetadata: {
         tags: ['history', 'timer']
     },
     IconIndent: {
-        tags: ['increase-list-level']
+        tags: ['increase-list-level', 'indent-right']
     },
     IconIndeterminantCheckbox: {
         tags: ['selection']
@@ -359,7 +359,7 @@ export const iconMetadata: {
         tags: ['order']
     },
     IconOutdent: {
-        tags: ['decrease-list-level']
+        tags: ['decrease-list-level', 'indent-left']
     },
     IconPaste: {
         tags: ['clipboard']

--- a/packages/nimble-components/src/icon-base/tests/icon-metadata.ts
+++ b/packages/nimble-components/src/icon-base/tests/icon-metadata.ts
@@ -292,6 +292,9 @@ export const iconMetadata: {
     IconHourglass: {
         tags: ['history', 'timer']
     },
+    IconIndent: {
+        tags: ['increase-list-level', 'right-arrow-three-lines']
+    },
     IconIndeterminantCheckbox: {
         tags: ['selection']
     },
@@ -354,6 +357,9 @@ export const iconMetadata: {
     },
     IconNumberList: {
         tags: ['order']
+    },
+    IconOutdent: {
+        tags: ['decrease-list-level']
     },
     IconPaste: {
         tags: ['clipboard']

--- a/packages/nimble-tokens/CONTRIBUTING.md
+++ b/packages/nimble-tokens/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Tokens are generated using the [Style Dictionary](https://amzn.github.io/style-d
 
 ### Icon naming
 
-Use [FontAwesome](https://fontawesome.com) names for icons. If FontAweseome doesn't contain an equivalent icon, minimize the use of metaphors; choose descriptive and unambiguous names instead.
+Use [Font Awesome](https://fontawesome.com) names for icons. If Font Awesome doesn't contain an equivalent icon, minimize the use of metaphors; choose descriptive and unambiguous names instead.
 
 | ✅ Descriptive name    | ❌ Metaphor            |
 |------------------------|------------------------|
@@ -38,7 +38,7 @@ Use [FontAwesome](https://fontawesome.com) names for icons. If FontAweseome does
 | `cog`                  | `system-configuration` |
 | `arrow-left-from-line` | `logout`               |
 
-Add all appropriate metaphors and synonyms to the `icon-metadata.ts` file, so clients can quickly find icons in Storybook. You can find ideas for synonyms in the [FontAwesome metadata](https://github.com/FortAwesome/Font-Awesome/blob/master/metadata/icons.yml).
+Add all appropriate metaphors and synonyms to the `icon-metadata.ts` file, so clients can quickly find icons in Storybook. You can find ideas for synonyms in the [Font Awesome metadata](https://github.com/FortAwesome/Font-Awesome/blob/master/metadata/icons.yml).
 
 ### Extract icons from Adobe Illustrator
 

--- a/packages/nimble-tokens/CONTRIBUTING.md
+++ b/packages/nimble-tokens/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Tokens are generated using the [Style Dictionary](https://amzn.github.io/style-d
 
 ### Icon naming
 
-Prefer [FontAwesome](https://fontawesome.com) names for icons. I.e. Minimize the use of metaphors; choose descriptive and unambiguous names instead.
+Use [FontAwesome](https://fontawesome.com) names for icons. If FontAweseome doesn't contain an equivalent icon, minimize the use of metaphors; choose descriptive and unambiguous names instead.
 
 | ✅ Descriptive name    | ❌ Metaphor            |
 |------------------------|------------------------|
@@ -38,7 +38,7 @@ Prefer [FontAwesome](https://fontawesome.com) names for icons. I.e. Minimize the
 | `cog`                  | `system-configuration` |
 | `arrow-left-from-line` | `logout`               |
 
-Add all appropriate metaphors and synonyms to the `icon-metadata.ts` file, so clients can quickly find icons in Storybook.
+Add all appropriate metaphors and synonyms to the `icon-metadata.ts` file, so clients can quickly find icons in Storybook. You can find ideas for synonyms in the [FontAwesome metadata](https://github.com/FortAwesome/Font-Awesome/blob/master/metadata/icons.yml).
 
 ### Extract icons from Adobe Illustrator
 

--- a/packages/nimble-tokens/dist/icons/svg/indent_16x16.svg
+++ b/packages/nimble-tokens/dist/icons/svg/indent_16x16.svg
@@ -1,2 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><defs><style>.cls-1{fill:#161617;stroke-width:0px;}</style></defs><polygon class="cls-1" points="2 5 2 11 5 8.0022 2 5"/><rect class="cls-1" x="6" y="3" width="8" height="2"/><rect class="cls-1" x="6" y="7" width="8" height="2"/><rect class="cls-1" x="6" y="11" width="8" height="2"/></svg>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+    <defs>
+        <style>.cls-1{fill:#161617;stroke-width:0px;}</style>
+    </defs>
+    <polygon class="cls-1" points="2 5 2 11 5 8.0022 2 5" />
+    <rect class="cls-1" x="6" y="3" width="8" height="2" />
+    <rect class="cls-1" x="6" y="7" width="8" height="2" />
+    <rect class="cls-1" x="6" y="11" width="8" height="2" />
+</svg>

--- a/packages/nimble-tokens/dist/icons/svg/indent_16x16.svg
+++ b/packages/nimble-tokens/dist/icons/svg/indent_16x16.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><defs><style>.cls-1{fill:#161617;stroke-width:0px;}</style></defs><polygon class="cls-1" points="2 5 2 11 5 8.0022 2 5"/><rect class="cls-1" x="6" y="3" width="8" height="2"/><rect class="cls-1" x="6" y="7" width="8" height="2"/><rect class="cls-1" x="6" y="11" width="8" height="2"/></svg>

--- a/packages/nimble-tokens/dist/icons/svg/indent_16x16.svg
+++ b/packages/nimble-tokens/dist/icons/svg/indent_16x16.svg
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-    <defs>
-        <style>.cls-1{fill:#161617;stroke-width:0px;}</style>
-    </defs>
     <polygon class="cls-1" points="2 5 2 11 5 8.0022 2 5" />
     <rect class="cls-1" x="6" y="3" width="8" height="2" />
     <rect class="cls-1" x="6" y="7" width="8" height="2" />

--- a/packages/nimble-tokens/dist/icons/svg/indent_16x16.svg
+++ b/packages/nimble-tokens/dist/icons/svg/indent_16x16.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-    <polygon class="cls-1" points="2 5 2 11 5 8.0022 2 5" />
-    <rect class="cls-1" x="6" y="3" width="8" height="2" />
-    <rect class="cls-1" x="6" y="7" width="8" height="2" />
-    <rect class="cls-1" x="6" y="11" width="8" height="2" />
+    <polygon class="cls-1" points="2.5 7.5 3.5 10 2.5 12.5 7.5 10 2.5 7.5" />
+    <rect class="cls-1" x="2" y="3" width="12" height="2" />
+    <rect class="cls-1" x="9" y="7" width="5" height="2" />
+    <rect class="cls-1" x="9" y="11" width="5" height="2" />
 </svg>

--- a/packages/nimble-tokens/dist/icons/svg/outdent_16x16.svg
+++ b/packages/nimble-tokens/dist/icons/svg/outdent_16x16.svg
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-    <defs>
-        <style>.cls-1{fill:#161617;stroke-width:0px;}</style>
-    </defs>
     <polygon class="cls-1" points="5 11 5 5 2 7.9978 5 11" />
     <rect class="cls-1" x="6" y="3" width="8" height="2" />
     <rect class="cls-1" x="6" y="7" width="8" height="2" />

--- a/packages/nimble-tokens/dist/icons/svg/outdent_16x16.svg
+++ b/packages/nimble-tokens/dist/icons/svg/outdent_16x16.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-    <polygon class="cls-1" points="5 11 5 5 2 7.9978 5 11" />
-    <rect class="cls-1" x="6" y="3" width="8" height="2" />
-    <rect class="cls-1" x="6" y="7" width="8" height="2" />
-    <rect class="cls-1" x="6" y="11" width="8" height="2" />
+    <polygon class="cls-1" points="7.5 12.5 6.5 10 7.5 7.5 2.5 10 7.5 12.5" />
+    <rect class="cls-1" x="2" y="3" width="12" height="2" />
+    <rect class="cls-1" x="9" y="7" width="5" height="2" />
+    <rect class="cls-1" x="9" y="11" width="5" height="2" />
 </svg>

--- a/packages/nimble-tokens/dist/icons/svg/outdent_16x16.svg
+++ b/packages/nimble-tokens/dist/icons/svg/outdent_16x16.svg
@@ -1,2 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><defs><style>.cls-1{fill:#161617;stroke-width:0px;}</style></defs><polygon class="cls-1" points="5 11 5 5 2 7.9978 5 11"/><rect class="cls-1" x="6" y="3" width="8" height="2"/><rect class="cls-1" x="6" y="7" width="8" height="2"/><rect class="cls-1" x="6" y="11" width="8" height="2"/></svg>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+    <defs>
+        <style>.cls-1{fill:#161617;stroke-width:0px;}</style>
+    </defs>
+    <polygon class="cls-1" points="5 11 5 5 2 7.9978 5 11" />
+    <rect class="cls-1" x="6" y="3" width="8" height="2" />
+    <rect class="cls-1" x="6" y="7" width="8" height="2" />
+    <rect class="cls-1" x="6" y="11" width="8" height="2" />
+</svg>

--- a/packages/nimble-tokens/dist/icons/svg/outdent_16x16.svg
+++ b/packages/nimble-tokens/dist/icons/svg/outdent_16x16.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><defs><style>.cls-1{fill:#161617;stroke-width:0px;}</style></defs><polygon class="cls-1" points="5 11 5 5 2 7.9978 5 11"/><rect class="cls-1" x="6" y="3" width="8" height="2"/><rect class="cls-1" x="6" y="7" width="8" height="2"/><rect class="cls-1" x="6" y="11" width="8" height="2"/></svg>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #1531 

## 👩‍💻 Implementation

Followed the CONTRIBUTING instructions for adding icons. I also updated them to capture the results of a discussion about icon name.

I chose the file names "indent" and "outdent" based on FontAwesome's equivalent icons [indent](https://fontawesome.com/search?q=indent&o=r) and [outdent](https://fontawesome.com/search?q=outdent&o=r). I added synonyms for "increase list level" and "decrease list level" and for "indent left" and "indent right".

## 🧪 Testing

Verified icon severity affects the color as expected.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
