### PR TITLE
Fix bug in table when reordering columns

### DIFF
--- a/change/@ni-nimble-components-2c319a68-618f-4ea0-89c6-e3ef1bfbccd6.json
+++ b/change/@ni-nimble-components-2c319a68-618f-4ea0-89c6-e3ef1bfbccd6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bug in table when reordering columns",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table-column/base/models/column-internals.ts
+++ b/packages/nimble-components/src/table-column/base/models/column-internals.ts
@@ -181,3 +181,15 @@ export class ColumnInternals<TColumnConfig> {
         this.currentPixelWidth = this.pixelWidth;
     }
 }
+
+export function isColumnInternalsProperty(
+    changedProperty: string,
+    ...args: (keyof ColumnInternals<unknown>)[]
+): boolean {
+    for (const arg of args) {
+        if (changedProperty === arg) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.stories.ts
+++ b/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.stories.ts
@@ -32,6 +32,7 @@ import {
     TimeZoneNameFormat,
     WeekdayFormat
 } from '../types';
+import { tableColumnNumberTextTag } from '../../number-text';
 
 const simpleData = [
     {
@@ -161,6 +162,11 @@ export const dateTextColumn: StoryObj<TextColumnTableArgs> = {
             >
             Birthday
             </${tableColumnDateTextTag}>
+            <${tableColumnNumberTextTag}
+                field-name="birthday"
+            >
+            Birthday
+            </${tableColumnNumberTextTag}>
         </${tableTag}>
     `),
     argTypes: {

--- a/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.stories.ts
+++ b/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.stories.ts
@@ -32,7 +32,6 @@ import {
     TimeZoneNameFormat,
     WeekdayFormat
 } from '../types';
-import { tableColumnNumberTextTag } from '../../number-text';
 
 const simpleData = [
     {
@@ -162,11 +161,6 @@ export const dateTextColumn: StoryObj<TextColumnTableArgs> = {
             >
             Birthday
             </${tableColumnDateTextTag}>
-            <${tableColumnNumberTextTag}
-                field-name="birthday"
-            >
-            Birthday
-            </${tableColumnNumberTextTag}>
         </${tableTag}>
     `),
     argTypes: {

--- a/packages/nimble-components/src/table/components/row/index.ts
+++ b/packages/nimble-components/src/table/components/row/index.ts
@@ -59,6 +59,11 @@ export class TableRow<
     @observable
     public dataRecord?: TDataRecord;
 
+    /**
+     * @internal
+     * */
+    public columnNotifiers: Notifier[] = [];
+
     @observable
     public columns: TableColumn[] = [];
 
@@ -99,8 +104,6 @@ export class TableRow<
     // the selection checkbox 'checked' value should be ingored.
     // https://github.com/microsoft/fast/issues/5750
     private ignoreSelectionChangeEvents = false;
-
-    private columnNotifiers?: Notifier[] = [];
 
     @volatile
     public override get ariaSelected(): 'true' | 'false' | null {
@@ -215,7 +218,7 @@ export class TableRow<
     }
 
     private removeColumnObservers(): void {
-        this.columnNotifiers?.forEach(notifier => {
+        this.columnNotifiers.forEach(notifier => {
             notifier.unsubscribe(this);
         });
         this.columnNotifiers = [];

--- a/packages/nimble-components/src/table/components/row/index.ts
+++ b/packages/nimble-components/src/table/components/row/index.ts
@@ -22,7 +22,7 @@ import type {
 import type { TableColumn } from '../../../table-column/base';
 import type { MenuButtonToggleEventDetail } from '../../../menu-button/types';
 import { TableCell } from '../cell';
-import { ColumnInternals } from '../../../table-column/base/models/column-internals';
+import { ColumnInternals, isColumnInternalsProperty } from '../../../table-column/base/models/column-internals';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -68,11 +68,19 @@ export class TableRow<
     @attr({ attribute: 'menu-open', mode: 'boolean' })
     public menuOpen = false;
 
-    /** @internal */
+    /**
+     * @internal
+     * An array that parallels the `columns` array and contains the indent
+     * level of each column's cell.
+     * */
     @observable
     public cellIndentLevels: number[] = [];
 
-    /** @internal */
+    /**
+     * @internal
+     * An array that parallels the `columns` array and contains the cell state
+     * of each column's cell.
+     * */
     @observable
     public cellStates: (TableCellState | undefined)[] = [];
 
@@ -154,23 +162,11 @@ export class TableRow<
         if (
             source instanceof ColumnInternals
             && typeof args === 'string'
-            && (this.isColumnInternalsProperty(args, 'columnConfig')
-                || this.isColumnInternalsProperty(args, 'dataRecordFieldNames'))
+            && (isColumnInternalsProperty(args, 'columnConfig')
+                || isColumnInternalsProperty(args, 'dataRecordFieldNames'))
         ) {
             this.updateCellStates();
         }
-    }
-
-    private isColumnInternalsProperty(
-        changedProperty: string,
-        ...args: (keyof ColumnInternals<unknown>)[]
-    ): boolean {
-        for (const arg of args) {
-            if (changedProperty === arg) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private emitActionMenuToggleEvent(

--- a/packages/nimble-components/src/table/components/row/index.ts
+++ b/packages/nimble-components/src/table/components/row/index.ts
@@ -1,4 +1,10 @@
-import { Notifier, Observable, attr, observable, volatile } from '@microsoft/fast-element';
+import {
+    Notifier,
+    Observable,
+    attr,
+    observable,
+    volatile
+} from '@microsoft/fast-element';
 import {
     Checkbox,
     DesignSystem,
@@ -145,7 +151,12 @@ export class TableRow<
     }
 
     public handleChange(source: unknown, args: unknown): void {
-        if (source instanceof ColumnInternals && typeof args === 'string' && (this.isColumnInternalsProperty(args, 'columnConfig') || this.isColumnInternalsProperty(args, 'dataRecordFieldNames'))) {
+        if (
+            source instanceof ColumnInternals
+            && typeof args === 'string'
+            && (this.isColumnInternalsProperty(args, 'columnConfig')
+                || this.isColumnInternalsProperty(args, 'dataRecordFieldNames'))
+        ) {
             this.updateCellStates();
         }
     }
@@ -184,7 +195,6 @@ export class TableRow<
     }
 
     private dataRecordChanged(): void {
-        this.updateCellIndentLevels();
         this.updateCellStates();
     }
 
@@ -212,9 +222,7 @@ export class TableRow<
         this.removeColumnObservers();
 
         this.columnNotifiers = this.columns.map(column => {
-            const notifier = Observable.getNotifier(
-                column.columnInternals
-            );
+            const notifier = Observable.getNotifier(column.columnInternals);
             notifier.subscribe(this);
             return notifier;
         });

--- a/packages/nimble-components/src/table/components/row/index.ts
+++ b/packages/nimble-components/src/table/components/row/index.ts
@@ -22,7 +22,10 @@ import type {
 import type { TableColumn } from '../../../table-column/base';
 import type { MenuButtonToggleEventDetail } from '../../../menu-button/types';
 import { TableCell } from '../cell';
-import { ColumnInternals, isColumnInternalsProperty } from '../../../table-column/base/models/column-internals';
+import {
+    ColumnInternals,
+    isColumnInternalsProperty
+} from '../../../table-column/base/models/column-internals';
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/nimble-components/src/table/components/row/index.ts
+++ b/packages/nimble-components/src/table/components/row/index.ts
@@ -111,6 +111,7 @@ export class TableRow<
         return null;
     }
 
+    /** @internal */
     public onSelectionChange(event: CustomEvent): void {
         if (this.ignoreSelectionChangeEvents) {
             return;
@@ -126,6 +127,7 @@ export class TableRow<
         this.$emit('row-selection-toggle', detail);
     }
 
+    /** @internal */
     public onCellActionMenuBeforeToggle(
         event: CustomEvent<MenuButtonToggleEventDetail>,
         column: TableColumn
@@ -138,6 +140,7 @@ export class TableRow<
         );
     }
 
+    /** @internal */
     public onCellActionMenuToggle(
         event: CustomEvent<MenuButtonToggleEventDetail>,
         column: TableColumn
@@ -161,6 +164,7 @@ export class TableRow<
         }
     }
 
+    /** @internal */
     public handleChange(source: unknown, args: unknown): void {
         if (
             source instanceof ColumnInternals

--- a/packages/nimble-components/src/table/components/row/template.ts
+++ b/packages/nimble-components/src/table/components/row/template.ts
@@ -1,8 +1,9 @@
 import { html, ref, repeat, when } from '@microsoft/fast-element';
-import type { TableRow, ColumnState } from '.';
+import type { TableRow } from '.';
 import type { MenuButtonToggleEventDetail } from '../../../menu-button/types';
 import { tableCellTag } from '../cell';
 import { checkboxTag } from '../../../checkbox';
+import type { TableColumn } from '../../../table-column/base';
 
 // prettier-ignore
 export const template = html<TableRow>`
@@ -23,31 +24,31 @@ export const template = html<TableRow>`
         <span class="row-front-spacer"></span>
 
         <span ${ref('cellContainer')} class="cell-container">
-            ${repeat(x => x.columnStates, html<ColumnState, TableRow>`
-                ${when(x => !x.column.columnHidden, html<ColumnState, TableRow>`
+            ${repeat(x => x.columns, html<TableColumn, TableRow>`
+                ${when(x => !x.columnHidden, html<TableColumn, TableRow>`
                     <${tableCellTag}
                         class="cell"
-                        :cellState="${x => x.cellState}"
-                        :cellViewTemplate="${x => x.column.columnInternals.cellViewTemplate}"
-                        :column="${x => x.column}"
-                        column-id="${x => x.column.columnId}"
+                        :cellState="${(_, c) => c.parent.cellStates[c.index]}"
+                        :cellViewTemplate="${x => x.columnInternals.cellViewTemplate}"
+                        :column="${x => x}"
+                        column-id="${x => x.columnId}"
                         :recordId="${(_, c) => c.parent.recordId}"
-                        ?has-action-menu="${x => !!x.column.actionMenuSlot}"
-                        action-menu-label="${x => x.column.actionMenuLabel}"
-                        @cell-action-menu-beforetoggle="${(x, c) => c.parent.onCellActionMenuBeforeToggle(c.event as CustomEvent<MenuButtonToggleEventDetail>, x.column)}"
-                        @cell-action-menu-toggle="${(x, c) => c.parent.onCellActionMenuToggle(c.event as CustomEvent<MenuButtonToggleEventDetail>, x.column)}"
-                        :nestingLevel="${x => x.cellIndentLevel};"
+                        ?has-action-menu="${x => !!x.actionMenuSlot}"
+                        action-menu-label="${x => x.actionMenuLabel}"
+                        @cell-action-menu-beforetoggle="${(x, c) => c.parent.onCellActionMenuBeforeToggle(c.event as CustomEvent<MenuButtonToggleEventDetail>, x)}"
+                        @cell-action-menu-toggle="${(x, c) => c.parent.onCellActionMenuToggle(c.event as CustomEvent<MenuButtonToggleEventDetail>, x)}"
+                        :nestingLevel="${(_, c) => c.parent.cellIndentLevels[c.index]};"
                     >
 
-                        ${when((x, c) => ((c.parent as TableRow).currentActionMenuColumn === x.column) && x.column.actionMenuSlot, html<ColumnState, TableRow>`
+                        ${when((x, c) => ((c.parent as TableRow).currentActionMenuColumn === x) && x.actionMenuSlot, html<TableColumn, TableRow>`
                             <slot
-                                name="${x => `row-action-menu-${x.column.actionMenuSlot!}`}"
+                                name="${x => `row-action-menu-${x.actionMenuSlot!}`}"
                                 slot="cellActionMenu"
                             ></slot>
                         `)}
                     </${tableCellTag}>
                 `)}
-            `)}
+            `, { recycle: false, positioning: true })}
         </span>
     </template>
 `;

--- a/packages/nimble-components/src/table/components/row/tests/table-row.spec.ts
+++ b/packages/nimble-components/src/table/components/row/tests/table-row.spec.ts
@@ -15,7 +15,11 @@ import type {
 import { TableRowPageObject } from './table-row.pageobject';
 import { createEventListener } from '../../../../utilities/tests/component';
 import { tableTag, type Table } from '../../..';
-import { TableColumnDateText, TableColumnDateTextCellRecord, tableColumnDateTextTag } from '../../../../table-column/date-text';
+import {
+    TableColumnDateText,
+    TableColumnDateTextCellRecord,
+    tableColumnDateTextTag
+} from '../../../../table-column/date-text';
 
 interface SimpleTableRecord extends TableRecord {
     stringData: string;
@@ -227,7 +231,9 @@ describe('TableRow', () => {
 
         beforeEach(async () => {
             columnReferences = new ColumnReferences();
-            ({ element, connect, disconnect } = await setupTable(columnReferences));
+            ({ element, connect, disconnect } = await setupTable(
+                columnReferences
+            ));
             await connect();
             await element.setData([
                 {
@@ -286,20 +292,27 @@ describe('TableRow', () => {
 
         it('reordering columns reorders cells', async () => {
             // Swap the two columns
-            element.insertBefore(columnReferences.secondColumn, columnReferences.firstColumn);
+            element.insertBefore(
+                columnReferences.secondColumn,
+                columnReferences.firstColumn
+            );
             await waitForUpdatesAsync();
 
             const cell0 = pageObject.getRenderedCell(0)!;
             expect(cell0.cellViewTemplate).toEqual(
                 columnReferences.secondColumn.columnInternals.cellViewTemplate
             );
-            expect(cell0.cellState?.columnConfig).toEqual(columnReferences.secondColumn.columnInternals.columnConfig);
+            expect(cell0.cellState?.columnConfig).toEqual(
+                columnReferences.secondColumn.columnInternals.columnConfig
+            );
 
             const cell1 = pageObject.getRenderedCell(1)!;
             expect(cell1.cellViewTemplate).toEqual(
                 columnReferences.firstColumn.columnInternals.cellViewTemplate
             );
-            expect(cell1.cellState?.columnConfig).toEqual(columnReferences.firstColumn.columnInternals.columnConfig);
+            expect(cell1.cellState?.columnConfig).toEqual(
+                columnReferences.firstColumn.columnInternals.columnConfig
+            );
         });
 
         it('updating column reuses cell', async () => {
@@ -316,7 +329,10 @@ describe('TableRow', () => {
             const originalCell = pageObject.getRenderedCell(0);
 
             // Swap the two columns
-            element.insertBefore(columnReferences.secondColumn, columnReferences.firstColumn);
+            element.insertBefore(
+                columnReferences.secondColumn,
+                columnReferences.firstColumn
+            );
             await waitForUpdatesAsync();
 
             const updatedCell = pageObject.getRenderedCell(0);

--- a/packages/nimble-components/src/table/components/row/tests/table-row.spec.ts
+++ b/packages/nimble-components/src/table/components/row/tests/table-row.spec.ts
@@ -215,8 +215,8 @@ describe('TableRow', () => {
         async function setupTable(source: ColumnReferences): Promise<Fixture<Table<SimpleTableRecord>>> {
             return fixture<Table<SimpleTableRecord>>(
                 html`<${tableTag}>
-                        <${tableColumnTextTag} ${ref('firstColumn')} id="first-column" field-name="stringData" column-id='foo'>Column 1</${tableColumnTextTag}>
-                        <${tableColumnDateTextTag} ${ref('secondColumn')} id="second-column" field-name="numberData" column-id='bar'>Column 2</${tableColumnDateTextTag}>
+                        <${tableColumnTextTag} ${ref('firstColumn')} field-name="stringData" column-id='foo'>Column 1</${tableColumnTextTag}>
+                        <${tableColumnDateTextTag} ${ref('secondColumn')} field-name="numberData" column-id='bar'>Column 2</${tableColumnDateTextTag}>
                     </${tableTag}>`,
                 { source }
             );

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -687,7 +687,7 @@ export class Table<
                 column.columnInternals
             );
             notifierInternals.subscribe(this);
-            this.columnNotifiers.push(notifier);
+            this.columnNotifiers.push(notifierInternals);
         }
     }
 

--- a/packages/nimble-components/src/table/models/table-update-tracker.ts
+++ b/packages/nimble-components/src/table/models/table-update-tracker.ts
@@ -2,24 +2,12 @@ import { DOM } from '@microsoft/fast-element';
 import type { Table } from '..';
 import type { TableColumn } from '../../table-column/base';
 import type { TableRecord } from '../types';
-import type { ColumnInternals } from '../../table-column/base/models/column-internals';
 import { UpdateTracker } from '../../utilities/models/update-tracker';
+import { isColumnInternalsProperty } from '../../table-column/base/models/column-internals';
 
 const isColumnProperty = (
     changedProperty: string,
     ...args: (keyof TableColumn)[]
-): boolean => {
-    for (const arg of args) {
-        if (changedProperty === arg) {
-            return true;
-        }
-    }
-    return false;
-};
-
-const isColumnInternalsProperty = (
-    changedProperty: string,
-    ...args: (keyof ColumnInternals<unknown>)[]
 ): boolean => {
     for (const arg of args) {
         if (changedProperty === arg) {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #1536 

## 👩‍💻 Implementation

The problem that was occurring with the bug is that `cellState` and `cellViewTemplate` binding on the `nimble-table-row` were happening one after another. Because of this the `cellState`, which includes the `cellRecord` and `columnConfig` could get out-of-sync from what the `cellViewTemplate` expected when the order of columns changes. For example, the `cellViewTemplate` for a date-text column could get passed a `cellRecord` and `columnConfig` for the number-text column that used to exist at a given column index.

To solve the problem, I decided the best approach was to have the row's template use a `repeat` directive over the `columns` with `recycle: false`. This means that if the set of columns changes, we won't attempt to reuse `nimble-table-cell` instances for columns that now may be changing types. In order to facilitate this change, I could no longer combine all state that cells need to know about into a single array of type `ColumnState`. Now, there are parallel arrays for `columns`, `cellIndentLevels`, and `cellStates`, which allows the row to distinguish between the cases when the whole cell should be recreated (i.e. the column has been changed) and when something about the cell should be updated (i.e. the indention, configuration, or value has been changed).

## 🧪 Testing

- Manually tested that swapping a number-text column and a date-text column in the DOM doesn't throw an exception anymore
- Unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
