### PR TITLE
Remove Playwright from Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,7 +35,6 @@
       "matchPackagePatterns":[
         "^@ni/eslint-config",
         "beachball",
-        "playwright",
         "storybook"
       ],
       "enabled": true


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

[Milan pointed out](https://github.com/ni/nimble/pull/1542#discussion_r1327685887) Renovate will fail to update Playwright because:
1. there is no Nuget version corresponding to the latest NPM version
2. there was a breaking change between 1.37 and 1.38

This will block automatic updates for all of our devDependencies.

## 👩‍💻 Implementation

1. Remove Playwright from the list of dev dependencies updated by Renovate
2. Filed tech debt #1544 to address this

## 🧪 Testing

Once this goes in I'll inspect #1537 to ensure it no longer lists Playwright

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
