### PR TITLE
Add medium padding token and document size ramp

### DIFF
--- a/change/@ni-nimble-components-e37c680c-4d1a-4c38-bd69-dd02b6177e5a.json
+++ b/change/@ni-nimble-components-e37c680c-4d1a-4c38-bd69-dd02b6177e5a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add medium padding token and document size ramp",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/anchor-tab/styles.ts
+++ b/packages/nimble-components/src/anchor-tab/styles.ts
@@ -11,6 +11,7 @@ import {
     fillHoverColor,
     fillHoverSelectedColor,
     smallDelay,
+    mediumPadding,
     standardPadding
 } from '../theme-provider/design-tokens';
 
@@ -52,8 +53,8 @@ export const styles = css`
 
     slot:not([name]) {
         display: block;
-        padding: calc(${standardPadding} / 2) ${standardPadding}
-            calc(${standardPadding} / 2 - ${borderWidth});
+        padding: ${mediumPadding} ${standardPadding}
+            calc(${mediumPadding} - ${borderWidth});
     }
 
     a::before {

--- a/packages/nimble-components/src/menu/styles.ts
+++ b/packages/nimble-components/src/menu/styles.ts
@@ -11,6 +11,7 @@ import {
     groupHeaderTextTransform,
     groupHeaderFontColor,
     smallPadding,
+    mediumPadding,
     elevation2BoxShadow
 } from '../theme-provider/design-tokens';
 import { Theme } from '../theme-provider/types';
@@ -35,7 +36,7 @@ export const styles = css`
     }
 
     :host([slot='submenu']) {
-        margin: 0 calc(${smallPadding} * 2);
+        margin: 0 ${mediumPadding};
     }
 
     ::slotted(*) {

--- a/packages/nimble-components/src/number-field/styles.ts
+++ b/packages/nimble-components/src/number-field/styles.ts
@@ -12,7 +12,8 @@ import {
     smallDelay,
     bodyFont,
     failColor,
-    standardPadding,
+    mediumPadding,
+    smallPadding,
     controlLabelDisabledFontColor
 } from '../theme-provider/design-tokens';
 import { appearanceBehavior } from '../utilities/style/appearance';
@@ -124,7 +125,7 @@ export const styles = css`
         width: 100%;
         border: none;
         padding: 0px;
-        padding-left: calc(${standardPadding} / 2);
+        padding-left: ${mediumPadding};
     }
 
     .control:hover,
@@ -152,7 +153,7 @@ export const styles = css`
     }
     .step-up {
         order: 3;
-        padding-right: calc(${standardPadding} / 4);
+        padding-right: ${smallPadding};
     }
 
     .step-down {
@@ -169,7 +170,7 @@ export const styles = css`
 
     .error-icon {
         order: 1;
-        padding-right: calc(${standardPadding} / 4);
+        padding-right: ${smallPadding};
     }
 `.withBehaviors(
     appearanceBehavior(

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -14,7 +14,7 @@ import {
     smallDelay,
     smallPadding,
     borderRgbPartialColor,
-    standardPadding,
+    mediumPadding,
     failColor,
     elevation2BoxShadow
 } from '../../theme-provider/design-tokens';
@@ -185,7 +185,7 @@ export const styles = css`
         text-overflow: ellipsis;
         overflow: hidden;
         padding: 0px;
-        padding-left: calc(${standardPadding} / 2);
+        padding-left: ${mediumPadding};
     }
 
     .selected-value[disabled]::placeholder {

--- a/packages/nimble-components/src/rich-text/editor/styles.ts
+++ b/packages/nimble-components/src/rich-text/editor/styles.ts
@@ -12,6 +12,7 @@ import {
     failColor,
     iconSize,
     smallDelay,
+    mediumPadding,
     standardPadding,
     linkFontColor
 } from '../../theme-provider/design-tokens';
@@ -268,7 +269,7 @@ export const styles = css`
     :host([error-visible]) .error-icon.scrollbar-width-calculated {
         display: inline-flex;
         position: absolute;
-        top: calc(${standardPadding} / 2);
+        top: ${mediumPadding};
         right: var(--ni-private-rich-text-editor-scrollbar-width);
     }
 `;

--- a/packages/nimble-components/src/tab/styles.ts
+++ b/packages/nimble-components/src/tab/styles.ts
@@ -8,6 +8,7 @@ import {
     controlHeight,
     fillHoverColor,
     fillHoverSelectedColor,
+    mediumPadding,
     standardPadding,
     smallDelay,
     buttonLabelFont
@@ -56,8 +57,8 @@ export const styles = css`
 
     slot:not([name]) {
         display: block;
-        padding: calc(${standardPadding} / 2) ${standardPadding}
-            calc(${standardPadding} / 2 - ${borderWidth});
+        padding: ${mediumPadding} ${standardPadding}
+            calc(${mediumPadding} - ${borderWidth});
     }
 
     :host::before {

--- a/packages/nimble-components/src/table/components/cell/styles.ts
+++ b/packages/nimble-components/src/table/components/cell/styles.ts
@@ -2,7 +2,7 @@ import { css } from '@microsoft/fast-element';
 import { display } from '@microsoft/fast-foundation';
 import {
     controlSlimHeight,
-    smallPadding,
+    mediumPadding,
     standardPadding
 } from '../../../theme-provider/design-tokens';
 
@@ -11,9 +11,9 @@ export const styles = css`
 
     :host {
         --ni-private-table-cell-nesting-level: 0;
-        padding: 0px calc(${standardPadding} / 2);
+        padding: 0px ${mediumPadding};
         padding-left: calc(
-            ${smallPadding} * 2 + ${standardPadding} * 2 *
+            ${mediumPadding} + ${standardPadding} * 2 *
                 var(--ni-private-table-cell-nesting-level)
         );
         align-self: center;

--- a/packages/nimble-components/src/table/components/group-row/styles.ts
+++ b/packages/nimble-components/src/table/components/group-row/styles.ts
@@ -8,7 +8,7 @@ import {
     controlSlimHeight,
     fillHoverColor,
     mediumDelay,
-    smallPadding,
+    mediumPadding,
     standardPadding
 } from '../../../theme-provider/design-tokens';
 import { Theme } from '../../../theme-provider/types';
@@ -62,7 +62,7 @@ export const styles = css`
 
     .expand-collapse-button {
         margin-left: calc(
-            ${smallPadding} * 2 + ${standardPadding} * 2 *
+            ${mediumPadding} + ${standardPadding} * 2 *
                 var(--ni-private-table-group-row-indent-level)
         );
         height: ${controlSlimHeight};
@@ -82,7 +82,7 @@ export const styles = css`
     }
 
     .group-header-view {
-        padding-left: calc(${standardPadding} / 2);
+        padding-left: ${mediumPadding};
         ${userSelectNone}
         overflow: hidden;
         display: flex;
@@ -90,7 +90,7 @@ export const styles = css`
 
     .group-row-child-count {
         padding-left: 2px;
-        padding-right: calc(${standardPadding} / 2);
+        padding-right: ${mediumPadding};
         pointer-events: none;
         ${userSelectNone}
     }

--- a/packages/nimble-components/src/table/components/header/styles.ts
+++ b/packages/nimble-components/src/table/components/header/styles.ts
@@ -3,7 +3,7 @@ import { display } from '@microsoft/fast-foundation';
 import {
     controlHeight,
     iconColor,
-    standardPadding,
+    mediumPadding,
     tableHeaderFont,
     tableHeaderFontColor
 } from '../../../theme-provider/design-tokens';
@@ -14,12 +14,12 @@ export const styles = css`
     :host {
         height: ${controlHeight};
         align-items: center;
-        padding: 0px calc(${standardPadding} / 2);
+        padding: 0px ${mediumPadding};
         font: ${tableHeaderFont};
         color: ${tableHeaderFontColor};
         ${iconColor.cssCustomProperty}: ${tableHeaderFontColor};
         text-transform: uppercase;
-        gap: calc(${standardPadding} / 2);
+        gap: ${mediumPadding};
         cursor: default;
     }
 

--- a/packages/nimble-components/src/table/styles.ts
+++ b/packages/nimble-components/src/table/styles.ts
@@ -7,7 +7,7 @@ import {
     bodyFontColor,
     popupBorderColor,
     controlSlimHeight,
-    smallPadding,
+    mediumPadding,
     standardPadding,
     tableRowBorderColor
 } from '../theme-provider/design-tokens';
@@ -83,7 +83,7 @@ export const styles = css`
 
     .collapse-all-button {
         height: ${controlSlimHeight};
-        margin-left: calc(${smallPadding} * 2);
+        margin-left: ${mediumPadding};
         visibility: hidden;
     }
 

--- a/packages/nimble-components/src/tabs-toolbar/styles.ts
+++ b/packages/nimble-components/src/tabs-toolbar/styles.ts
@@ -6,7 +6,8 @@ import {
     borderRgbPartialColor,
     borderWidth,
     controlHeight,
-    standardPadding
+    mediumPadding,
+    smallPadding
 } from '../theme-provider/design-tokens';
 
 export const styles = css`
@@ -25,6 +26,6 @@ export const styles = css`
         height: 24px;
         border-left: calc(${borderWidth} * 2) solid
             rgba(${borderRgbPartialColor}, 0.3);
-        margin: calc(${standardPadding} / 4) calc(${standardPadding} / 2);
+        margin: ${smallPadding} ${mediumPadding};
     }
 `;

--- a/packages/nimble-components/src/text-area/styles.ts
+++ b/packages/nimble-components/src/text-area/styles.ts
@@ -13,7 +13,8 @@ import {
     controlLabelDisabledFontColor,
     iconSize,
     failColor,
-    standardPadding
+    standardPadding,
+    mediumPadding
 } from '../theme-provider/design-tokens';
 import { appearanceBehavior } from '../utilities/style/appearance';
 import { TextAreaAppearance } from './types';
@@ -159,7 +160,7 @@ export const styles = css`
     :host([error-visible]) .error-icon.scrollbar-width-calculated {
         display: inline-flex;
         position: absolute;
-        top: calc(${standardPadding} / 2);
+        top: ${mediumPadding};
         right: var(--ni-private-scrollbar-width);
     }
 `.withBehaviors(

--- a/packages/nimble-components/src/text-field/styles.ts
+++ b/packages/nimble-components/src/text-field/styles.ts
@@ -14,7 +14,7 @@ import {
     bodyFont,
     controlLabelFontColor,
     controlLabelDisabledFontColor,
-    standardPadding,
+    mediumPadding,
     iconColor
 } from '../theme-provider/design-tokens';
 import { appearanceBehavior } from '../utilities/style/appearance';
@@ -63,7 +63,7 @@ export const styles = css`
         align-items: center;
         justify-content: center;
         border: 0px solid rgba(${borderRgbPartialColor}, 0.3);
-        gap: calc(${standardPadding} / 2);
+        gap: ${mediumPadding};
         padding: ${borderWidth};
     }
 

--- a/packages/nimble-components/src/theme-provider/design-token-comments.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-comments.ts
@@ -52,8 +52,9 @@ export const comments: { readonly [key in TokenName]: string | null } = {
         'Standard layout height for all controls. Add "labelHeight" for labels on top.',
     controlSlimHeight:
         'Height of controls that are somewhat shorter than standard height.',
-    smallPadding: 'Small layout padding for components',
-    standardPadding: 'Standard layout padding for components',
+    smallPadding: '4px spacing for component layout',
+    mediumPadding: '8px spacing for component layout',
+    standardPadding: '16px spacing for component layout',
     labelHeight:
         'Standard label height for components. Set the label font rather than explicitly setting the height for a label.',
     borderWidth: 'Standard border width for most components',

--- a/packages/nimble-components/src/theme-provider/design-token-comments.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-comments.ts
@@ -52,9 +52,9 @@ export const comments: { readonly [key in TokenName]: string | null } = {
         'Standard layout height for all controls. Add "labelHeight" for labels on top.',
     controlSlimHeight:
         'Height of controls that are somewhat shorter than standard height.',
-    smallPadding: 'Fixed 4px size token for component layout',
-    mediumPadding: 'Fixed 8px size token for component layout',
-    standardPadding: 'Fixed 16px size token for component layout',
+    smallPadding: 'Fixed 4px size ramp token for component layout',
+    mediumPadding: 'Fixed 8px size ramp token for component layout',
+    standardPadding: 'Fixed 16px size ramp token for component layout',
     labelHeight:
         'Standard label height for components. Set the label font rather than explicitly setting the height for a label.',
     borderWidth: 'Standard border width for most components',

--- a/packages/nimble-components/src/theme-provider/design-token-comments.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-comments.ts
@@ -52,9 +52,9 @@ export const comments: { readonly [key in TokenName]: string | null } = {
         'Standard layout height for all controls. Add "labelHeight" for labels on top.',
     controlSlimHeight:
         'Height of controls that are somewhat shorter than standard height.',
-    smallPadding: '4px spacing for component layout',
-    mediumPadding: '8px spacing for component layout',
-    standardPadding: '16px spacing for component layout',
+    smallPadding: 'Fixed 4px size token for component layout',
+    mediumPadding: 'Fixed 8px size token for component layout',
+    standardPadding: 'Fixed 16px size token for component layout',
     labelHeight:
         'Standard label height for components. Set the label font rather than explicitly setting the height for a label.',
     borderWidth: 'Standard border width for most components',

--- a/packages/nimble-components/src/theme-provider/design-token-names.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-names.ts
@@ -40,6 +40,7 @@ export const tokenNames: { readonly [key in TokenName]: string } = {
     controlHeight: 'control-height',
     controlSlimHeight: 'control-slim-height',
     smallPadding: 'small-padding',
+    mediumPadding: 'medium-padding',
     standardPadding: 'standard-padding',
     labelHeight: 'label-height',
     borderWidth: 'border-width',

--- a/packages/nimble-components/src/theme-provider/design-tokens.ts
+++ b/packages/nimble-components/src/theme-provider/design-tokens.ts
@@ -288,6 +288,9 @@ export const controlSlimHeight = DesignToken.create<string>(
 export const smallPadding = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.smallPadding)
 ).withDefault('4px');
+export const mediumPadding = DesignToken.create<string>(
+    styleNameFromTokenName(tokenNames.smallPadding)
+).withDefault('8px');
 export const standardPadding = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.standardPadding)
 ).withDefault('16px');

--- a/packages/nimble-components/src/theme-provider/design-tokens.ts
+++ b/packages/nimble-components/src/theme-provider/design-tokens.ts
@@ -289,7 +289,7 @@ export const smallPadding = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.smallPadding)
 ).withDefault('4px');
 export const mediumPadding = DesignToken.create<string>(
-    styleNameFromTokenName(tokenNames.smallPadding)
+    styleNameFromTokenName(tokenNames.mediumPadding)
 ).withDefault('8px');
 export const standardPadding = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.standardPadding)

--- a/packages/nimble-components/src/theme-provider/tests/size-ramp.stories.ts
+++ b/packages/nimble-components/src/theme-provider/tests/size-ramp.stories.ts
@@ -26,7 +26,7 @@ const sizeRampTokenNames = (({
 type TokenName = keyof typeof sizeRampTokenNames;
 const tokenNameKeys = Object.keys(sizeRampTokenNames) as TokenName[];
 
-const overviewText = 'Design Tokens representing the range of fixed sizes to use for spacing and layout.';
+const overviewText = 'Design Tokens representing the range of fixed sizes to use for spacing and layout. Use these tokens when no designated token exists for the purpose.';
 
 interface TokenArgs {
     propertyFormat: PropertyFormat;

--- a/packages/nimble-components/src/theme-provider/tests/size-ramp.stories.ts
+++ b/packages/nimble-components/src/theme-provider/tests/size-ramp.stories.ts
@@ -1,0 +1,124 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import { html, repeat, when } from '@microsoft/fast-element';
+import { PropertyFormat } from './types';
+import { createUserSelectedThemeStory } from '../../utilities/tests/storybook';
+import {
+    tokenNames,
+    cssPropertyFromTokenName,
+    scssPropertyFromTokenName
+} from '../design-token-names';
+
+import {
+    bodyFont,
+    bodyFontColor,
+    groupHeaderFont,
+    groupHeaderFontColor,
+    groupHeaderTextTransform
+} from '../design-tokens';
+import { waitForUpdatesAsync } from '../../testing/async-helpers';
+
+const sizeRampTokenNames = (({
+    smallPadding,
+    mediumPadding,
+    standardPadding
+}) => ({ smallPadding, mediumPadding, standardPadding }))(tokenNames);
+
+type TokenName = keyof typeof sizeRampTokenNames;
+const tokenNameKeys = Object.keys(sizeRampTokenNames) as TokenName[];
+
+const overviewText = 'Design Tokens representing the range of fixed sizes to use for spacing and layout.';
+
+interface TokenArgs {
+    propertyFormat: PropertyFormat;
+}
+
+const metadata: Meta = {
+    title: 'Tokens/Size Ramp',
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: overviewText
+            }
+        }
+    }
+};
+
+export default metadata;
+
+const computedCSSValueFromTokenName = (tokenName: string): string => {
+    return getComputedStyle(document.documentElement).getPropertyValue(
+        cssPropertyFromTokenName(tokenName)
+    );
+};
+
+// prettier-ignore
+export const sizeRampTokens: StoryObj<TokenArgs> = {
+    parameters: {
+        controls: { hideNoControlsWarning: true }
+    },
+    args: {
+        propertyFormat: PropertyFormat.scss
+    },
+    argTypes: {
+        propertyFormat: {
+            options: Object.values(PropertyFormat),
+            control: { type: 'radio' },
+            name: 'Property Format'
+        }
+    },
+    render: createUserSelectedThemeStory(html<TokenArgs>`
+        <style>
+            table {
+                font: var(${bodyFont.cssCustomProperty});
+                color: var(${bodyFontColor.cssCustomProperty});
+            }
+            thead {
+                font: var(${groupHeaderFont.cssCustomProperty});
+                color: var(${groupHeaderFontColor.cssCustomProperty});
+                text-transform: var(${groupHeaderTextTransform.cssCustomProperty});
+            }
+            td { 
+                padding: 10px;
+                height: 32px;
+            }
+        </style>
+        <table>
+            <thead>
+                <tr>
+                    <th>${x => x.propertyFormat} Property</th>
+                    <th>Value</th>
+                </tr>
+            </thead>
+            <tbody>
+            ${repeat(() => tokenNameKeys, html<TokenName, TokenArgs>`
+                <tr>
+                    <td>
+                        ${when((_, c) => (c.parent as TokenArgs).propertyFormat === PropertyFormat.css, html<TokenName>`
+                            ${x => cssPropertyFromTokenName(tokenNames[x])}
+                        `)}
+                        ${when((_, c) => (c.parent as TokenArgs).propertyFormat === PropertyFormat.scss, html<TokenName>`
+                            ${x => scssPropertyFromTokenName(tokenNames[x])}
+                        `)}
+                    </td>
+                    <td>
+                        <div style="display: inline-block;">
+                            ${x => computedCSSValueFromTokenName(tokenNames[x])}
+                        </div>
+                    </td>
+                </tr>
+            `)}
+            </tbody>
+        </table>
+    `)
+};
+
+// Setting token default values is done as part of the FAST render queue so it needs to be cleared before reading them
+// https://github.com/microsoft/fast/blob/bbf4e532cf9263727ef1bd8afbc30d79d1104c03/packages/web-components/fast-foundation/src/design-token/custom-property-manager.ts#LL154C3-L154C3
+// This uses Storybook's "loaders" feature to await the queue. https://storybook.js.org/docs/html/writing-stories/loaders
+sizeRampTokens.loaders = [
+    async () => {
+        await waitForUpdatesAsync();
+        return {};
+    }
+];

--- a/packages/nimble-components/src/theme-provider/tests/tokens.stories.ts
+++ b/packages/nimble-components/src/theme-provider/tests/tokens.stories.ts
@@ -19,6 +19,7 @@ import {
     groupHeaderTextTransform
 } from '../design-tokens';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
+import { anchorTag } from '../../anchor';
 
 type TokenName = keyof typeof tokenNames;
 const tokenNameKeys = Object.keys(tokenNames) as TokenName[];
@@ -177,7 +178,14 @@ export const themeAwareTokens: StoryObj<TokenArgs> = {
                         `)}
                     </td>
                     <td>${x => templateForTokenName(x)}</td>
-                    <td>${x => comments[x]}</td>
+                    <td>
+                        ${when(x => comments[x]?.includes('size ramp token'), html<TokenName>`
+                            <${anchorTag} href="./?path=/docs/tokens-size-ramp--docs" target="_top">${x => comments[x]}</${anchorTag}>
+                        `)}
+                        ${when(x => !comments[x]?.includes('size ramp token'), html<TokenName>`
+                            ${x => comments[x]}
+                        `)}
+                    </td>
                 </tr>
             `)}
             </tbody>

--- a/packages/nimble-components/src/theme-provider/tests/tokens.stories.ts
+++ b/packages/nimble-components/src/theme-provider/tests/tokens.stories.ts
@@ -19,7 +19,6 @@ import {
     groupHeaderTextTransform
 } from '../design-tokens';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
-import { anchorTag } from '../../anchor';
 
 type TokenName = keyof typeof tokenNames;
 const tokenNameKeys = Object.keys(tokenNames) as TokenName[];
@@ -178,14 +177,7 @@ export const themeAwareTokens: StoryObj<TokenArgs> = {
                         `)}
                     </td>
                     <td>${x => templateForTokenName(x)}</td>
-                    <td>
-                        ${when(x => comments[x]?.includes('size ramp token'), html<TokenName>`
-                            <${anchorTag} href="./?path=/docs/tokens-size-ramp--docs" target="_top">${x => comments[x]}</${anchorTag}>
-                        `)}
-                        ${when(x => !comments[x]?.includes('size ramp token'), html<TokenName>`
-                            ${x => comments[x]}
-                        `)}
-                    </td>
+                    <td>${x => comments[x]}</td>
                 </tr>
             `)}
             </tbody>

--- a/packages/nimble-components/src/tooltip/styles.ts
+++ b/packages/nimble-components/src/tooltip/styles.ts
@@ -14,7 +14,7 @@ import {
     tooltipCaptionFont,
     tooltipCaptionFontColor,
     borderWidth,
-    standardPadding,
+    mediumPadding,
     smallPadding,
     elevation2BoxShadow
 } from '../theme-provider/design-tokens';
@@ -42,8 +42,8 @@ export const styles = css`
         border: ${borderWidth} solid var(--ni-private-tooltip-border-color);
         background-color: var(--ni-private-tooltip-background-color);
         padding-bottom: 6px;
-        padding-left: calc(${standardPadding} / 2);
-        padding-right: calc(${standardPadding} / 2);
+        padding-left: ${mediumPadding};
+        padding-right: ${mediumPadding};
         padding-top: ${smallPadding};
     }
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #1518

## 👩‍💻 Implementation

- defined new `mediumPadding` token (8px)
- replaced usages of `standardPadding / 2` and `smallPadding * 2` in our stylesheets
- changed token descriptions of `smallPadding` and `standardPadding` to better reflect that they are fixed-size
- created new Size Ramp story under the Tokens section

## 🧪 Testing

None

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
