### PR TITLE
Icon table with metadata

### DIFF
--- a/change/@ni-nimble-components-2756e73e-2b29-4dc0-829f-a9a7b1aa2c9d.json
+++ b/change/@ni-nimble-components-2756e73e-2b29-4dc0-829f-a9a7b1aa2c9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update icon story to nimble-table",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/docs/component-status.stories.ts
+++ b/packages/nimble-components/docs/component-status.stories.ts
@@ -506,6 +506,8 @@ const metadata: Meta<TableArgs> = {
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
+            ${/* Make the table big enough to remove vertical scrollbar */ ''}
+            style="height: ${x => x.status === 'active' ? '1200px' : '600px'};"
         >
             <${tableColumnAnchorTag} target="_top"
                 column-id="component-name-column"

--- a/packages/nimble-components/src/icon-base/tests/icon-metadata.ts
+++ b/packages/nimble-components/src/icon-base/tests/icon-metadata.ts
@@ -11,7 +11,7 @@ export const iconMetadata: {
 } = {
     /* eslint-disable @typescript-eslint/naming-convention */
     IconAdd: {
-        tags: ['add-input-field']
+        tags: ['add input field']
     },
     IconArrowDown: {
         tags: ['sort', 'arrow', 'down', 'descending']
@@ -59,7 +59,7 @@ export const iconMetadata: {
         tags: ['sort', 'arrow', 'up', 'ascending']
     },
     IconBars: {
-        tags: ['hamburger-menu']
+        tags: ['hamburger menu']
     },
     IconBell: {
         tags: ['status', 'alarm']
@@ -89,16 +89,16 @@ export const iconMetadata: {
         tags: ['oidc']
     },
     IconChartDiagramChildFocus: {
-        tags: ['managed-systems']
+        tags: ['managed systems']
     },
     IconChartDiagramParentFocus: {
-        tags: ['manager-asset']
+        tags: ['manager asset']
     },
     IconChartDiagramParentFocusTwoChild: {
         tags: ['assets']
     },
     IconCheck: {
-        tags: ['status', 'alarm-acknowledged']
+        tags: ['status', 'alarm acknowledged']
     },
     IconCheckDot: {
         tags: ['status', 'done']
@@ -119,7 +119,7 @@ export const iconMetadata: {
         tags: []
     },
     IconCirclePartialBroken: {
-        tags: ['status', 'partially-connected']
+        tags: ['status', 'partially connected']
     },
     IconCircleSlash: {
         tags: ['status', 'blocked']
@@ -134,13 +134,13 @@ export const iconMetadata: {
         tags: ['time']
     },
     IconClockCog: {
-        tags: ['time-settings']
+        tags: ['time settings']
     },
     IconClockExclamation: {
         tags: ['expire']
     },
     IconClockTriangle: {
-        tags: ['status', 'timed-out']
+        tags: ['status', 'timed out']
     },
     IconClone: {
         tags: ['duplicate']
@@ -152,7 +152,7 @@ export const iconMetadata: {
         tags: []
     },
     IconCloudWithArrow: {
-        tags: ['cloud-connector']
+        tags: ['cloud connector']
     },
     IconCog: {
         tags: ['details', 'settings']
@@ -164,16 +164,16 @@ export const iconMetadata: {
         tags: ['admin', 'administration']
     },
     IconCogSmallCog: {
-        tags: ['system-manager']
+        tags: ['system manager']
     },
     IconCogZoomed: {
-        tags: ['data-indexing']
+        tags: ['data indexing']
     },
     IconComment: {
-        tags: ['notes', 'alarm-notes', 'speech', 'bubble']
+        tags: ['notes', 'alarm notes', 'speech', 'bubble']
     },
     IconComputerAndMonitor: {
-        tags: ['devices-and-interfaces']
+        tags: ['devices and interfaces']
     },
     IconCopy: {
         tags: ['clipboard']
@@ -194,10 +194,10 @@ export const iconMetadata: {
         tags: []
     },
     IconDatabase: {
-        tags: ['measurement-data-analysis']
+        tags: ['measurement data analysis']
     },
     IconDatabaseCheck: {
-        tags: ['system-state-manager']
+        tags: ['system state manager']
     },
     IconDesktop: {
         tags: ['monitor']
@@ -218,7 +218,7 @@ export const iconMetadata: {
         tags: ['import']
     },
     IconElectronicChipZoomed: {
-        tags: ['data-preparation']
+        tags: ['data preparation']
     },
     IconExclamationMark: {
         tags: ['error', 'warning']
@@ -227,19 +227,19 @@ export const iconMetadata: {
         tags: ['details', 'view']
     },
     IconFancyA: {
-        tags: ['tdms-string-channel']
+        tags: ['tdms string channel']
     },
     IconFile: {
-        tags: ['file-tdms']
+        tags: ['file tdms']
     },
     IconFileArrowCurvedRight: {
         tags: ['export', 'extract']
     },
     IconFileDrawer: {
-        tags: ['box', 'repository-manager']
+        tags: ['box', 'repository manager']
     },
     IconFileSearch: {
-        tags: ['file-viewer']
+        tags: ['file viewer']
     },
     IconFilter: {
         tags: []
@@ -248,13 +248,13 @@ export const iconMetadata: {
         tags: ['save']
     },
     IconFloppyDiskCheckmark: {
-        tags: ['save', 'no-unsaved-changed']
+        tags: ['save', 'no unsaved changed']
     },
     IconFloppyDiskStarArrowRight: {
         tags: ['save', 'autosave']
     },
     IconFloppyDiskThreeDots: {
-        tags: ['save', 'in-progress']
+        tags: ['save', 'in progress']
     },
     IconFolder: {
         tags: ['ldap']
@@ -269,7 +269,7 @@ export const iconMetadata: {
         tags: ['knurling']
     },
     IconFunction: {
-        tags: ['data-analyzer']
+        tags: ['data analyzer']
     },
     IconGaugeSimple: {
         tags: ['widget']
@@ -278,7 +278,7 @@ export const iconMetadata: {
         tags: ['chart']
     },
     IconGridTwoByTwo: {
-        tags: ['custom-applications']
+        tags: ['custom applications']
     },
     IconHammer: {
         tags: ['operation']
@@ -305,7 +305,7 @@ export const iconMetadata: {
         tags: []
     },
     IconKey: {
-        tags: ['access-control', 'active-directory']
+        tags: ['access control', 'active directory']
     },
     IconLaptop: {
         tags: []
@@ -314,7 +314,7 @@ export const iconMetadata: {
         tags: ['jobs']
     },
     IconLightningBolt: {
-        tags: ['active-jobs']
+        tags: ['active jobs']
     },
     IconLink: {
         tags: []
@@ -323,13 +323,13 @@ export const iconMetadata: {
         tags: ['unlink']
     },
     IconList: {
-        tags: ['bullet', 'merged-view']
+        tags: ['bullet', 'merged view']
     },
     IconListTree: {
-        tags: ['tree-view']
+        tags: ['tree view']
     },
     IconListTreeDatabase: {
-        tags: ['measurement-data-analysis']
+        tags: ['measurement data analysis']
     },
     IconLock: {
         tags: ['security']
@@ -341,7 +341,7 @@ export const iconMetadata: {
         tags: []
     },
     IconMinus: {
-        tags: ['mixed-checkbox']
+        tags: ['mixed checkbox']
     },
     IconMinusWide: {
         tags: []
@@ -383,7 +383,7 @@ export const iconMetadata: {
         tags: ['insecure']
     },
     IconSignalBars: {
-        tags: ['tdms-channel-group']
+        tags: ['tdms channel group']
     },
     IconSineGraph: {
         tags: ['graph']
@@ -392,13 +392,13 @@ export const iconMetadata: {
         tags: ['status', 'skipped']
     },
     IconSpinner: {
-        tags: ['in-progress']
+        tags: ['in progress']
     },
     IconSquareCheck: {
-        tags: ['test-insights']
+        tags: ['test insights']
     },
     IconSquareT: {
-        tags: ['static-text']
+        tags: ['static text']
     },
     IconT: {
         tags: ['text']
@@ -410,13 +410,13 @@ export const iconMetadata: {
         tags: []
     },
     IconTags: {
-        tags: ['tag-query']
+        tags: ['tag query']
     },
     IconTargetCrosshairs: {
         tags: ['calibrate']
     },
     IconTargetCrosshairsProgress: {
-        tags: ['calibrate', 'self-calibrate']
+        tags: ['calibrate', 'self calibrate']
     },
     IconThreeDotsLine: {
         tags: ['ellipsis', 'options']
@@ -437,25 +437,25 @@ export const iconMetadata: {
         tags: ['clear', 'close', 'delete', 'remove', 'x']
     },
     IconTriangle: {
-        tags: ['status', 'alarm-active']
+        tags: ['status', 'alarm active']
     },
     IconTriangleFilled: {
         tags: ['status']
     },
     IconTrueFalseRectangle: {
-        tags: ['tdms-boolean-channel']
+        tags: ['tdms boolean channel']
     },
     IconTriangleTwoLinesHorizontal: {
-        tags: ['collapse-all']
+        tags: ['collapse all']
     },
     IconTwoSquaresInBrackets: {
-        tags: ['group-by']
+        tags: ['group by']
     },
     IconTwoTrianglesBetweenLines: {
-        tags: ['size-column-to-content']
+        tags: ['size column to content']
     },
     IconUnlink: {
-        tags: ['link-broken']
+        tags: ['link broken']
     },
     IconUnlock: {
         tags: []
@@ -473,7 +473,7 @@ export const iconMetadata: {
         tags: ['status', 'waiting']
     },
     IconWaveform: {
-        tags: ['tdms-waveform-channel']
+        tags: ['tdms waveform channel']
     },
     IconWebviCustom: {
         tags: ['gweb']
@@ -482,7 +482,7 @@ export const iconMetadata: {
         tags: ['gweb']
     },
     IconWindowCode: {
-        tags: ['http-api']
+        tags: ['http api']
     },
     IconWindowText: {
         tags: ['manual']
@@ -494,7 +494,7 @@ export const iconMetadata: {
         tags: ['status', 'fail']
     },
     IconXmarkCheck: {
-        tags: ['self-test']
+        tags: ['self test']
     }
     /* eslint-enable @typescript-eslint/naming-convention */
 };

--- a/packages/nimble-components/src/icon-base/tests/icon-metadata.ts
+++ b/packages/nimble-components/src/icon-base/tests/icon-metadata.ts
@@ -293,7 +293,7 @@ export const iconMetadata: {
         tags: ['history', 'timer']
     },
     IconIndent: {
-        tags: ['increase-list-level', 'indent-right']
+        tags: ['increase list level', 'indent right']
     },
     IconIndeterminantCheckbox: {
         tags: ['selection']
@@ -359,7 +359,7 @@ export const iconMetadata: {
         tags: ['order']
     },
     IconOutdent: {
-        tags: ['decrease-list-level', 'indent-left']
+        tags: ['decrease list level', 'indent left']
     },
     IconPaste: {
         tags: ['clipboard']

--- a/packages/nimble-components/src/icon-base/tests/icons.spec.ts
+++ b/packages/nimble-components/src/icon-base/tests/icons.spec.ts
@@ -41,7 +41,7 @@ describe('Icons', () => {
     describe('can be constructed', () => {
         type IconName = keyof typeof allIconsNamespace;
         const allIconNames = (Object.keys(allIconsNamespace) as IconName[]).map(
-            (x: IconName) => ({ name: x, klass: allIconsNamespace[x] })
+            (x: IconName) => ({ name: x, iconClass: allIconsNamespace[x] })
         );
 
         const focused: IconName[] = [];
@@ -50,11 +50,11 @@ describe('Icons', () => {
             const specType = getSpecTypeByNamedList(icon, focused, disabled);
             // eslint-disable-next-line @typescript-eslint/no-loop-func
             specType(`for icon ${icon.name}`, () => {
-                const tagName = DesignSystem.tagFor(icon.klass);
+                const tagName = DesignSystem.tagFor(icon.iconClass);
                 expect(typeof tagName).toBe('string');
                 expect(tagName.length).toBeGreaterThan(0);
                 expect(document.createElement(tagName)).toBeInstanceOf(
-                    icon.klass
+                    icon.iconClass
                 );
             });
         }

--- a/packages/nimble-components/src/icon-base/tests/icons.stories.ts
+++ b/packages/nimble-components/src/icon-base/tests/icons.stories.ts
@@ -18,9 +18,9 @@ import { tableColumnTextTag } from '../../table-column/text';
 import { iconMetadata } from './icon-metadata';
 
 type IconName = keyof typeof nimbleIconComponentsMap;
-const data = Object.values(nimbleIconComponentsMap).map(klass => ({
-    tag: DesignSystem.tagFor(klass),
-    metaphor: iconMetadata[klass.name as IconName].tags.join(', ')
+const data = Object.values(nimbleIconComponentsMap).map(iconClass => ({
+    tag: DesignSystem.tagFor(iconClass),
+    metaphor: iconMetadata[iconClass.name as IconName].tags.join(', ')
 }));
 
 type Data = (typeof data)[number];

--- a/packages/nimble-components/src/icon-base/tests/icons.stories.ts
+++ b/packages/nimble-components/src/icon-base/tests/icons.stories.ts
@@ -39,10 +39,10 @@ const metadata: Meta<IconArgs> = {
                 component: `Nimble icons can be slotted into other components or used independently. Each icon is available as a custom element. For example, \`<${iconAddTag}></${iconAddTag}>\``
             },
             source: {
-                code: null,
+                code: null
             }
         }
-    },
+    }
 };
 
 export default metadata;

--- a/packages/nimble-components/src/icon-base/tests/icons.stories.ts
+++ b/packages/nimble-components/src/icon-base/tests/icons.stories.ts
@@ -89,7 +89,7 @@ export const icons: StoryObj<IconArgs> = {
         <${tableTag}
             ${ref('tableRef')}
             ${/* Make the table big enough to remove vertical scrollbar */ ''}
-            style="height: 5600px;"
+            style="height: 5800px;"
             data-unused="${x => updateData(x.tableRef)}"
         >
             <${tableColumnIconTag} field-name="tag" key-type="string">

--- a/packages/nimble-components/src/icon-base/tests/icons.stories.ts
+++ b/packages/nimble-components/src/icon-base/tests/icons.stories.ts
@@ -16,6 +16,7 @@ import { tableColumnIconTag } from '../../table-column/icon';
 import { mappingIconTag } from '../../mapping/icon';
 import { tableColumnTextTag } from '../../table-column/text';
 import { iconMetadata } from './icon-metadata';
+import { iconAddTag } from '../../icons/add';
 
 type IconName = keyof typeof nimbleIconComponentsMap;
 const data = Object.values(nimbleIconComponentsMap).map(iconClass => ({
@@ -31,7 +32,17 @@ interface IconArgs {
 }
 
 const metadata: Meta<IconArgs> = {
-    title: 'Components/Icons'
+    title: 'Components/Icons',
+    parameters: {
+        docs: {
+            description: {
+                component: `Nimble icons can be slotted into other components or used independently. Each icon is available as a custom element. For example, \`<${iconAddTag}></${iconAddTag}>\``
+            },
+            source: {
+                code: null,
+            }
+        }
+    },
 };
 
 export default metadata;

--- a/packages/nimble-components/src/theme-provider/tests/color.stories.ts
+++ b/packages/nimble-components/src/theme-provider/tests/color.stories.ts
@@ -60,7 +60,7 @@ const metadata: Meta = {
                 component: overviewText
             },
             source: {
-                code: null,
+                code: null
             }
         }
     }

--- a/packages/nimble-components/src/theme-provider/tests/color.stories.ts
+++ b/packages/nimble-components/src/theme-provider/tests/color.stories.ts
@@ -58,6 +58,9 @@ const metadata: Meta = {
         docs: {
             description: {
                 component: overviewText
+            },
+            source: {
+                code: null,
             }
         }
     }

--- a/packages/nimble-components/src/theme-provider/tests/size-ramp.stories.ts
+++ b/packages/nimble-components/src/theme-provider/tests/size-ramp.stories.ts
@@ -41,7 +41,7 @@ const metadata: Meta = {
                 component: overviewText
             },
             source: {
-                code: null,
+                code: null
             }
         }
     }

--- a/packages/nimble-components/src/theme-provider/tests/size-ramp.stories.ts
+++ b/packages/nimble-components/src/theme-provider/tests/size-ramp.stories.ts
@@ -39,6 +39,9 @@ const metadata: Meta = {
         docs: {
             description: {
                 component: overviewText
+            },
+            source: {
+                code: null,
             }
         }
     }

--- a/packages/nimble-components/src/theme-provider/tests/tokens.stories.ts
+++ b/packages/nimble-components/src/theme-provider/tests/tokens.stories.ts
@@ -37,6 +37,9 @@ const metadata: Meta = {
         docs: {
             description: {
                 component: overviewText
+            },
+            source: {
+                code: null,
             }
         }
     }

--- a/packages/nimble-components/src/theme-provider/tests/tokens.stories.ts
+++ b/packages/nimble-components/src/theme-provider/tests/tokens.stories.ts
@@ -39,7 +39,7 @@ const metadata: Meta = {
                 component: overviewText
             },
             source: {
-                code: null,
+                code: null
             }
         }
     }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Create a table for icons in storybook that shows the tag names and metaphors.

## 👩‍💻 Implementation

- Rendered the icons using the nimble-table
- Show metaphors in a separate column that is not sortable
- Set the height of the table large enough so that all the rows render in the DOM. That way the page is searchable with normal ctrl+f search and there are no nested scrollbars. Can also use normal browser zoom to see the icons bigger.

## 🧪 Testing

Manually checked in storybook

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
