### PR TITLE
Table to stable 🎉

### DIFF
--- a/change/@ni-nimble-components-f74550fb-5d06-449c-8a65-2dcb2e317f24.json
+++ b/change/@ni-nimble-components-f74550fb-5d06-449c-8a65-2dcb2e317f24.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Move table out of incubating",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor-matrix.stories.ts
+++ b/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor-matrix.stories.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../theme-provider/design-tokens';
 
 const metadata: Meta = {
-    title: 'Tests/Table Column - Anchor',
+    title: 'Tests/Table Column: Anchor',
     parameters: {
         ...sharedMatrixParameters()
     }

--- a/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.stories.ts
+++ b/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.stories.ts
@@ -1,9 +1,7 @@
 import { html, ref } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import { withActions } from '@storybook/addon-actions/decorator';
-import {
-    createUserSelectedThemeStory
-} from '../../../utilities/tests/storybook';
+import { createUserSelectedThemeStory } from '../../../utilities/tests/storybook';
 import { tableTag } from '../../../table';
 import { tableColumnAnchorTag } from '..';
 import {

--- a/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.stories.ts
+++ b/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.stories.ts
@@ -2,8 +2,7 @@ import { html, ref } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import { withActions } from '@storybook/addon-actions/decorator';
 import {
-    createUserSelectedThemeStory,
-    incubatingWarning
+    createUserSelectedThemeStory
 } from '../../../utilities/tests/storybook';
 import { tableTag } from '../../../table';
 import { tableColumnAnchorTag } from '..';
@@ -17,7 +16,7 @@ import { tableColumnTextTag } from '../../text';
 import { AnchorAppearance } from '../../../anchor/types';
 
 const metadata: Meta<SharedTableArgs> = {
-    title: 'Incubating/Table Column - Anchor',
+    title: 'Components/Table Column: Anchor',
     decorators: [withActions],
     parameters: {
         actions: {
@@ -86,7 +85,6 @@ export const anchorColumn: StoryObj<AnchorColumnTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<AnchorColumnTableArgs>`
-        ${incubatingWarning({ componentName: 'table', statusLink: 'https://github.com/orgs/ni/projects/7/views/21' })}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"

--- a/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
@@ -1,9 +1,7 @@
 import { html, ref, when } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import { withActions } from '@storybook/addon-actions/decorator';
-import {
-    createUserSelectedThemeStory
-} from '../../../utilities/tests/storybook';
+import { createUserSelectedThemeStory } from '../../../utilities/tests/storybook';
 import {
     ExampleColumnFractionalWidthType,
     ExampleGroupingDisabledType,

--- a/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
@@ -2,8 +2,7 @@ import { html, ref, when } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import { withActions } from '@storybook/addon-actions/decorator';
 import {
-    createUserSelectedThemeStory,
-    incubatingWarning
+    createUserSelectedThemeStory
 } from '../../../utilities/tests/storybook';
 import {
     ExampleColumnFractionalWidthType,
@@ -77,11 +76,12 @@ const simpleData = [
 ];
 
 const overviewText = `This page contains information about configuring the columns of a \`nimble-table\`. 
-See **Table** for information about configuring the table itself and **Table Column Types** for 
+See **Table** for information about configuring the table itself and the **Table Column** specific docs for 
 information about specific types of column.`;
 
 const metadata: Meta<SharedTableArgs> = {
-    title: 'Incubating/Table Column Configuration',
+    title: 'Components/Table Column Configuration',
+    tags: ['autodocs'],
     decorators: [withActions],
     parameters: {
         docs: {
@@ -95,7 +95,6 @@ const metadata: Meta<SharedTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<SharedTableArgs>`
-    ${incubatingWarning({ componentName: 'table', statusLink: 'https://github.com/orgs/ni/projects/7/views/21' })}
     <${tableTag}
         ${ref('tableRef')}
         data-unused="${x => x.updateData(x)}"
@@ -169,7 +168,6 @@ export const columnOrder: StoryObj<ColumnOrderTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<ColumnOrderTableArgs>`
-        ${incubatingWarning({ componentName: 'table', statusLink: 'https://github.com/orgs/ni/projects/7/views/21' })}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
@@ -242,7 +240,6 @@ export const headerContent: StoryObj<HeaderContentTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<HeaderContentTableArgs>`
-        ${incubatingWarning({ componentName: 'table', statusLink: 'https://github.com/orgs/ni/projects/7/views/21' })}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
@@ -301,7 +298,6 @@ export const commonAttributes: StoryObj<CommonAttributesTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<CommonAttributesTableArgs>`
-        ${incubatingWarning({ componentName: 'table', statusLink: 'https://github.com/orgs/ni/projects/7/views/21' })}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
@@ -417,7 +413,6 @@ export const sorting: StoryObj<SortingTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<SortingTableArgs>`
-        ${incubatingWarning({ componentName: 'table', statusLink: 'https://github.com/orgs/ni/projects/7/views/21' })}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
@@ -606,7 +601,6 @@ export const grouping: StoryObj<GroupingTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<GroupingTableArgs>`
-        ${incubatingWarning({ componentName: 'table', statusLink: 'https://github.com/orgs/ni/projects/7/views/21' })}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
@@ -731,7 +725,6 @@ export const fractionalWidthColumn: StoryObj<ColumnWidthTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<ColumnWidthTableArgs>`
-        ${incubatingWarning({ componentName: 'table', statusLink: 'https://github.com/orgs/ni/projects/7/views/21' })}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"

--- a/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text-matrix.stories.ts
+++ b/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text-matrix.stories.ts
@@ -14,7 +14,7 @@ import {
 } from '../../../theme-provider/design-tokens';
 
 const metadata: Meta = {
-    title: 'Tests/Table Column - Date Text',
+    title: 'Tests/Table Column: Date Text',
     parameters: {
         ...sharedMatrixParameters()
     }

--- a/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.stories.ts
+++ b/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.stories.ts
@@ -1,9 +1,7 @@
 import { html, ref } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import { withActions } from '@storybook/addon-actions/decorator';
-import {
-    createUserSelectedThemeStory
-} from '../../../utilities/tests/storybook';
+import { createUserSelectedThemeStory } from '../../../utilities/tests/storybook';
 import { tableTag } from '../../../table';
 import { tableColumnDateTextTag } from '..';
 import {

--- a/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.stories.ts
+++ b/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.stories.ts
@@ -2,8 +2,7 @@ import { html, ref } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import { withActions } from '@storybook/addon-actions/decorator';
 import {
-    createUserSelectedThemeStory,
-    incubatingWarning
+    createUserSelectedThemeStory
 } from '../../../utilities/tests/storybook';
 import { tableTag } from '../../../table';
 import { tableColumnDateTextTag } from '..';
@@ -57,8 +56,9 @@ const simpleData = [
 ];
 
 const metadata: Meta<SharedTableArgs> = {
-    title: 'Incubating/Table Column - Date Text',
+    title: 'Components/Table Column: Date Text',
     decorators: [withActions],
+    tags: ['autodocs'],
     parameters: {
         actions: {
             handles: sharedTableActions
@@ -123,10 +123,6 @@ export const dateTextColumn: StoryObj<TextColumnTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<TextColumnTableArgs>`
-        ${incubatingWarning({
-        componentName: 'table',
-        statusLink: 'https://github.com/orgs/ni/projects/7/views/21'
-    })}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"

--- a/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text-matrix.stories.ts
+++ b/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text-matrix.stories.ts
@@ -7,7 +7,7 @@ import { tableColumnEnumTextTag } from '..';
 import { mappingTextTag } from '../../../mapping/text';
 
 const metadata: Meta = {
-    title: 'Tests/Table Column - Enum Text',
+    title: 'Tests/Table Column: Enum Text',
     parameters: {
         ...sharedMatrixParameters()
     }

--- a/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text.stories.ts
+++ b/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text.stories.ts
@@ -1,8 +1,7 @@
 import { html, ref } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import {
-    createUserSelectedThemeStory,
-    incubatingWarning
+    createUserSelectedThemeStory
 } from '../../../utilities/tests/storybook';
 import { tableTag } from '../../../table';
 import { tableColumnEnumTextTag } from '..';
@@ -44,7 +43,7 @@ const enumTextColumnDescription = `The \`nimble-table-column-enum-text\` column 
 ${columnOperationBehavior}`;
 
 const metadata: Meta<EnumTextColumnTableArgs> = {
-    title: 'Incubating/Table Column - Enum Text',
+    title: 'Components/Table Column: Enum Text',
     parameters: {
         docs: {
             description: {
@@ -66,7 +65,6 @@ interface EnumTextColumnTableArgs extends SharedTableArgs {
 export const enumTextColumn: StoryObj<EnumTextColumnTableArgs> = {
     // prettier-ignore
     render: createUserSelectedThemeStory(html<EnumTextColumnTableArgs>`
-        ${incubatingWarning({ componentName: 'table', statusLink: 'https://github.com/orgs/ni/projects/7/views/21' })}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"

--- a/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text.stories.ts
+++ b/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text.stories.ts
@@ -1,8 +1,6 @@
 import { html, ref } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
-import {
-    createUserSelectedThemeStory
-} from '../../../utilities/tests/storybook';
+import { createUserSelectedThemeStory } from '../../../utilities/tests/storybook';
 import { tableTag } from '../../../table';
 import { tableColumnEnumTextTag } from '..';
 import {

--- a/packages/nimble-components/src/table-column/icon/tests/table-column-icon-matrix.stories.ts
+++ b/packages/nimble-components/src/table-column/icon/tests/table-column-icon-matrix.stories.ts
@@ -10,7 +10,7 @@ import { mappingSpinnerTag } from '../../../mapping/spinner';
 import { isChromatic } from '../../../utilities/tests/isChromatic';
 
 const metadata: Meta = {
-    title: 'Tests/Table Column - Icon',
+    title: 'Tests/Table Column: Icon',
     parameters: {
         ...sharedMatrixParameters()
     }

--- a/packages/nimble-components/src/table-column/icon/tests/table-column-icon.stories.ts
+++ b/packages/nimble-components/src/table-column/icon/tests/table-column-icon.stories.ts
@@ -1,8 +1,6 @@
 import { html, ref } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
-import {
-    createUserSelectedThemeStory
-} from '../../../utilities/tests/storybook';
+import { createUserSelectedThemeStory } from '../../../utilities/tests/storybook';
 import { tableTag } from '../../../table';
 import { tableColumnIconTag } from '..';
 import {

--- a/packages/nimble-components/src/table-column/icon/tests/table-column-icon.stories.ts
+++ b/packages/nimble-components/src/table-column/icon/tests/table-column-icon.stories.ts
@@ -1,8 +1,7 @@
 import { html, ref } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import {
-    createUserSelectedThemeStory,
-    incubatingWarning
+    createUserSelectedThemeStory
 } from '../../../utilities/tests/storybook';
 import { tableTag } from '../../../table';
 import { tableColumnIconTag } from '..';
@@ -52,7 +51,7 @@ const iconColumnDescription = `The \`nimble-table-column-icon\` column renders s
 ${columnOperationBehavior}`;
 
 const metadata: Meta<IconColumnTableArgs> = {
-    title: 'Incubating/Table Column - Icon',
+    title: 'Components/Table Column: Icon',
     parameters: {
         docs: {
             description: {
@@ -78,7 +77,6 @@ const validityDescription = `${sharedMappingValidityDescription}
 export const iconColumn: StoryObj<IconColumnTableArgs> = {
     // prettier-ignore
     render: createUserSelectedThemeStory(html<IconColumnTableArgs>`
-        ${incubatingWarning({ componentName: 'table', statusLink: 'https://github.com/orgs/ni/projects/7/views/21' })}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"

--- a/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text-matrix.stories.ts
+++ b/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text-matrix.stories.ts
@@ -15,7 +15,7 @@ import {
 import { NumberTextAlignment } from '../types';
 
 const metadata: Meta = {
-    title: 'Tests/Table Column - Number Text',
+    title: 'Tests/Table Column: Number Text',
     parameters: {
         ...sharedMatrixParameters()
     }

--- a/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.stories.ts
+++ b/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.stories.ts
@@ -2,8 +2,7 @@ import { html, ref } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import { withActions } from '@storybook/addon-actions/decorator';
 import {
-    createUserSelectedThemeStory,
-    incubatingWarning
+    createUserSelectedThemeStory
 } from '../../../utilities/tests/storybook';
 import { tableTag } from '../../../table';
 import { tableColumnNumberTextTag } from '..';
@@ -51,7 +50,7 @@ const simpleData = [
 ];
 
 const metadata: Meta<SharedTableArgs> = {
-    title: 'Incubating/Table Column - Number Text',
+    title: 'Components/Table Column: Number Text',
     decorators: [withActions],
     tags: ['autodocs'],
     parameters: {
@@ -136,10 +135,6 @@ export const numberTextColumn: StoryObj<NumberTextColumnTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<NumberTextColumnTableArgs>`
-        ${incubatingWarning({
-        componentName: 'table',
-        statusLink: 'https://github.com/orgs/ni/projects/7/views/21'
-    })}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"

--- a/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.stories.ts
+++ b/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.stories.ts
@@ -1,9 +1,7 @@
 import { html, ref } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import { withActions } from '@storybook/addon-actions/decorator';
-import {
-    createUserSelectedThemeStory
-} from '../../../utilities/tests/storybook';
+import { createUserSelectedThemeStory } from '../../../utilities/tests/storybook';
 import { tableTag } from '../../../table';
 import { tableColumnNumberTextTag } from '..';
 import {

--- a/packages/nimble-components/src/table-column/text/tests/table-column-text.stories.ts
+++ b/packages/nimble-components/src/table-column/text/tests/table-column-text.stories.ts
@@ -2,8 +2,7 @@ import { html, ref } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import { withActions } from '@storybook/addon-actions/decorator';
 import {
-    createUserSelectedThemeStory,
-    incubatingWarning
+    createUserSelectedThemeStory
 } from '../../../utilities/tests/storybook';
 import { tableTag } from '../../../table';
 import { tableColumnTextTag } from '..';
@@ -41,7 +40,7 @@ const simpleData = [
 ];
 
 const metadata: Meta<SharedTableArgs> = {
-    title: 'Incubating/Table Column - Text',
+    title: 'Components/Table Column: Text',
     decorators: [withActions],
     tags: ['autodocs'],
     parameters: {
@@ -83,10 +82,6 @@ export const textColumn: StoryObj<TextColumnTableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<TextColumnTableArgs>`
-        ${incubatingWarning({
-        componentName: 'table',
-        statusLink: 'https://github.com/orgs/ni/projects/7/views/21'
-    })}
         <${tableTag}
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"

--- a/packages/nimble-components/src/table-column/text/tests/table-column-text.stories.ts
+++ b/packages/nimble-components/src/table-column/text/tests/table-column-text.stories.ts
@@ -1,9 +1,7 @@
 import { html, ref } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import { withActions } from '@storybook/addon-actions/decorator';
-import {
-    createUserSelectedThemeStory
-} from '../../../utilities/tests/storybook';
+import { createUserSelectedThemeStory } from '../../../utilities/tests/storybook';
 import { tableTag } from '../../../table';
 import { tableColumnTextTag } from '..';
 import {

--- a/packages/nimble-components/src/table/tests/table.stories.ts
+++ b/packages/nimble-components/src/table/tests/table.stories.ts
@@ -1,9 +1,7 @@
 import { html, ref } from '@microsoft/fast-element';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj } from '@storybook/html';
-import {
-    createUserSelectedThemeStory
-} from '../../utilities/tests/storybook';
+import { createUserSelectedThemeStory } from '../../utilities/tests/storybook';
 import { ExampleDataType } from './types';
 import { Table, tableTag } from '..';
 import { TableRowSelectionMode } from '../types';

--- a/packages/nimble-components/src/table/tests/table.stories.ts
+++ b/packages/nimble-components/src/table/tests/table.stories.ts
@@ -2,8 +2,7 @@ import { html, ref } from '@microsoft/fast-element';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj } from '@storybook/html';
 import {
-    createUserSelectedThemeStory,
-    incubatingWarning
+    createUserSelectedThemeStory
 } from '../../utilities/tests/storybook';
 import { ExampleDataType } from './types';
 import { Table, tableTag } from '..';
@@ -126,7 +125,7 @@ If a record does not exist in the table's data, it will not be selected. If mult
 mode is \`single\`, only the first record that exists in the table's data will become selected.`;
 
 const metadata: Meta<TableArgs> = {
-    title: 'Incubating/Table',
+    title: 'Components/Table',
     tags: ['autodocs'],
     decorators: [withActions],
     parameters: {
@@ -146,7 +145,6 @@ const metadata: Meta<TableArgs> = {
     },
     // prettier-ignore
     render: createUserSelectedThemeStory(html<TableArgs>`
-        ${incubatingWarning({ componentName: 'table', statusLink: 'https://github.com/orgs/ni/projects/7/views/21' })}
         <${tableTag}
             ${ref('tableRef')}
             selection-mode="${x => TableRowSelectionMode[x.selectionMode]}"

--- a/packages/nimble-components/src/tests/component-status.stories.ts
+++ b/packages/nimble-components/src/tests/component-status.stories.ts
@@ -409,15 +409,15 @@ const components = [
     },
     {
         componentName: 'Table',
-        componentHref: './?path=/docs/incubating-table--docs',
+        componentHref: './?path=/docs/components-table--docs',
         designHref:
             'https://xd.adobe.com/view/5b476816-dad1-4671-b20a-efe796631c72-0e14/screen/d389dc1e-da4f-4a63-957b-f8b3cc9591b4/specs/',
         designLabel: 'XD',
         issueHref: 'https://github.com/orgs/ni/projects/11',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.incubating,
-        angularStatus: ComponentFrameworkStatus.incubating,
-        blazorStatus: ComponentFrameworkStatus.incubating
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.ready
     },
     {
         componentName: 'Tabs',
@@ -518,8 +518,8 @@ const components = [
         issueHref: 'https://github.com/ni/nimble/issues/924',
         issueLabel: 'Issue',
         componentStatus: ComponentFrameworkStatus.incubating,
-        angularStatus: ComponentFrameworkStatus.incubating,
-        blazorStatus: ComponentFrameworkStatus.incubating
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist
     }
 ] as const;
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Switch the table documentation to specifying that it is stable.

## 👩‍💻 Implementation

- Removed the incubating warning from stories
- Moved the stories to `/Incubating`
- Updated the component status table (also snuck in some wafer map corrections)
- Made sure each table story exposes either `autodocs` or `mdx` docs
- Got clever and changed the `Table Column - ` prefix to `Table Column:` so they come after `Table Column Configuration` alphabetically as `:` is before `space` in ASCII. Doesn't show up in the URL so think it's fine.

## 🧪 Testing

Manually looked through the stories.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
