### PR TITLE
Update status table for split buttons

### DIFF
--- a/change/@ni-nimble-components-3e18a537-925f-499b-844f-c89587893a96.json
+++ b/change/@ni-nimble-components-3e18a537-925f-499b-844f-c89587893a96.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update component status table for split buttons",
+  "packageName": "@ni/nimble-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/tests/component-status.stories.ts
+++ b/packages/nimble-components/src/tests/component-status.stories.ts
@@ -377,11 +377,8 @@ const components = [
         blazorStatus: ComponentFrameworkStatus.ready
     },
     {
-        componentName: 'Split Icon Button',
-        designHref:
-            'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/d022d8af-22f4-4bf2-981c-1dc0c61afece',
-        designLabel: 'XD',
-        issueHref: 'https://github.com/ni/nimble/issues/298',
+        componentName: 'Split Button',
+        issueHref: 'https://github.com/ni/nimble/issues/1523',
         issueLabel: 'Issue',
         componentStatus: ComponentFrameworkStatus.doesNotExist,
         angularStatus: ComponentFrameworkStatus.doesNotExist,
@@ -465,6 +462,17 @@ const components = [
             'https://www.figma.com/file/PO9mFOu5BCl8aJvFchEeuN/Nimble_Components?node-id=1295%3A68679&mode=dev',
         designLabel: 'Figma',
         issueHref: 'https://github.com/ni/nimble/issues/513',
+        issueLabel: 'Issue',
+        componentStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist
+    },
+    {
+        componentName: 'Toggle Button Group',
+        designHref:
+            'https://xd.adobe.com/view/33ffad4a-eb2c-4241-b8c5-ebfff1faf6f6-66ac/screen/d022d8af-22f4-4bf2-981c-1dc0c61afece',
+        designLabel: 'XD',
+        issueHref: 'https://github.com/ni/nimble/issues/298',
         issueLabel: 'Issue',
         componentStatus: ComponentFrameworkStatus.doesNotExist,
         angularStatus: ComponentFrameworkStatus.doesNotExist,


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

I recently created #1523 and renamed #298 to use a better name (it used to also be called a split button). The component status table needs equivalent updates.

## 👩‍💻 Implementation

Add the new split button issue and rename/move the old one.

## 🧪 Testing

Storybook build inspection

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
