### PR TITLE
Docs improvements for "incubating" status

### DIFF
--- a/change/@ni-nimble-components-5a5cb537-8c17-4509-98de-de0de0eda189.json
+++ b/change/@ni-nimble-components-5a5cb537-8c17-4509-98de-de0de0eda189.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Documentation updates about incubating status",
+  "packageName": "@ni/nimble-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/CONTRIBUTING.md
+++ b/packages/nimble-components/CONTRIBUTING.md
@@ -83,7 +83,7 @@ If a component is not ready for general use, it should be marked as "incubating"
 
 -   It is still in development.
 -   It is currently experimental or application-specific and hasn't yet been generalized for broader use.
--   It is missing important features like interaction design, visual design, accessibility, or framework integration.
+-   It is missing important features like interaction design, visual design, or accessibility.
 
 Incubating contributions may compromise on the above capabilities but they still must abide by other repository requirements. For example:
 
@@ -102,7 +102,7 @@ To mark a component as incubating:
 
 To move a component out of incubating status:
 
-1. Have a conversation with the Nimble team to decide if it is sufficiently complete.
+1. Have a conversation with the Nimble team to decide if it is sufficiently complete. The requirements listed at the top of this section must be met. Some feature gaps like framework integration may be OK as long as we don't anticipate that filling them would cause major breaking changes.
 2. Update the markings described above to indicate that it is now ready for general use!
 
 ### Folder structure

--- a/packages/nimble-components/src/tests/incubating.mdx
+++ b/packages/nimble-components/src/tests/incubating.mdx
@@ -9,7 +9,7 @@ A component could be in this state if any of the following are true:
 
 -   It is still in development.
 -   It is currently experimental or application-specific and hasn't yet been generalized for broader use.
--   It is missing important features like interaction design, visual design, accessibility, or framework integration.
+-   It is missing important features like interaction design, visual design, or accessibility.
 
 See the issue linked from each component's documentation for more information about what it's missing.
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

We've had more conversations about what it takes to move a component out of incubating. We want to capture that nuance in our docs.

## 👩‍💻 Implementation

Updated CONTRIBUTING and storybook docs for Incubating to mention that feature gaps like missing framework integration are OK as long as they won't cause breaking changes.

## 🧪 Testing

N/A

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [X] I have updated the project documentation to reflect my changes or determined no changes are needed.
