### PR TITLE
Update TypeScript dependency to 4.8

### DIFF
--- a/angular-workspace/package.json
+++ b/angular-workspace/package.json
@@ -57,6 +57,6 @@
     "ng-packagr": "^14.1.0",
     "playwright": "^1.30.0",
     "rollup": "^3.10.1",
-    "typescript": "~4.8.0"
+    "typescript": "~4.8.2"
   }
 }

--- a/angular-workspace/package.json
+++ b/angular-workspace/package.json
@@ -57,6 +57,6 @@
     "ng-packagr": "^14.1.0",
     "playwright": "^1.30.0",
     "rollup": "^3.10.1",
-    "typescript": "~4.7.4"
+    "typescript": "~4.8.0"
   }
 }

--- a/change/@ni-nimble-components-d702380f-0104-4e61-82f2-d552a31ebfe2.json
+++ b/change/@ni-nimble-components-d702380f-0104-4e61-82f2-d552a31ebfe2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update TypeScript dependency to 4.8",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-tokens-148dc7c4-7518-44b7-8298-113820a13dce.json
+++ b/change/@ni-nimble-tokens-148dc7c4-7518-44b7-8298-113820a13dce.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update TypeScript dependency to 4.8",
+  "packageName": "@ni/nimble-tokens",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-xliff-to-json-converter-f6cdaa7e-d001-497f-9bc9-e7f2a788ef9a.json
+++ b/change/@ni-xliff-to-json-converter-f6cdaa7e-d001-497f-9bc9-e7f2a788ef9a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update TypeScript dependency to 4.8",
+  "packageName": "@ni/xliff-to-json-converter",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "ng-packagr": "^14.1.0",
         "playwright": "^1.30.0",
         "rollup": "^3.10.1",
-        "typescript": "~4.7.4"
+        "typescript": "~4.8.0"
       }
     },
     "angular-workspace/node_modules/@types/node": {
@@ -5570,9 +5570,9 @@
       "integrity": "sha512-gQutuDHPKNxUEcQ4pypZT4Wmrbapus+P9s3bR/SEOLsMbNqNoXigGImITygI5zhb+aA5rzflM6O8YWkmRbGkPA=="
     },
     "node_modules/@microsoft/fast-foundation": {
-      "version": "2.49.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.49.1.tgz",
-      "integrity": "sha512-dSajlZeX+lkqjg4108XbIIhVLECgJTCG32bE8P6rNgo8XCPHVJBDiBejrF34lv5pO9Z2uGORZjeip/N0fPib+g==",
+      "version": "2.49.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.49.2.tgz",
+      "integrity": "sha512-xA7WP/Td33SW0zkpHRH5LUDxyLOPnPQQXieRxc080uLWxoGXhVxo6Rz7b6qwiL+e2IadNCm7X7KcrgsUhJwvBg==",
       "dependencies": {
         "@microsoft/fast-element": "^1.12.0",
         "@microsoft/fast-web-utilities": "^5.4.1",
@@ -32809,9 +32809,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -34819,7 +34819,7 @@
       "dependencies": {
         "@microsoft/fast-colors": "^5.3.1",
         "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "^2.49.1",
+        "@microsoft/fast-foundation": "^2.49.2",
         "@microsoft/fast-web-utilities": "^6.0.0",
         "@ni/nimble-tokens": "^6.4.0",
         "@tanstack/table-core": "^8.9.3",
@@ -34906,7 +34906,7 @@
         "rollup-plugin-sourcemaps": "^0.6.3",
         "storybook": "^7.4.0",
         "ts-loader": "^9.2.5",
-        "typescript": "~4.7.4",
+        "typescript": "~4.8.0",
         "webpack": "^5.75.0",
         "webpack-cli": "^5.0.1",
         "webpack-dev-middleware": "^6.0.1"
@@ -35221,7 +35221,7 @@
         "style-dictionary": "3.7.2",
         "svg-to-ts": "^9.0.0",
         "to-ico": "^1.1.5",
-        "typescript": "~4.7.4"
+        "typescript": "~4.8.0"
       }
     },
     "packages/nimble-tokens/node_modules/brace-expansion": {
@@ -35269,7 +35269,7 @@
       },
       "devDependencies": {
         "@11ty/eleventy": "^1.0.2",
-        "typescript": "~4.7.4",
+        "typescript": "~4.8.0",
         "vite": "^4.0.4"
       }
     },
@@ -35291,7 +35291,7 @@
         "@types/yargs": "^17.0.10",
         "jasmine": "^4.2.0",
         "jasmine-core": "^4.5.0",
-        "typescript": "~4.7.4"
+        "typescript": "~4.8.0"
       }
     },
     "packages/xliff-to-json-converter/node_modules/ansi-regex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "ng-packagr": "^14.1.0",
         "playwright": "^1.30.0",
         "rollup": "^3.10.1",
-        "typescript": "~4.8.0"
+        "typescript": "~4.8.2"
       }
     },
     "angular-workspace/node_modules/@types/node": {
@@ -34906,7 +34906,7 @@
         "rollup-plugin-sourcemaps": "^0.6.3",
         "storybook": "^7.4.0",
         "ts-loader": "^9.2.5",
-        "typescript": "~4.8.0",
+        "typescript": "~4.8.2",
         "webpack": "^5.75.0",
         "webpack-cli": "^5.0.1",
         "webpack-dev-middleware": "^6.0.1"
@@ -35221,7 +35221,7 @@
         "style-dictionary": "3.7.2",
         "svg-to-ts": "^9.0.0",
         "to-ico": "^1.1.5",
-        "typescript": "~4.8.0"
+        "typescript": "~4.8.2"
       }
     },
     "packages/nimble-tokens/node_modules/brace-expansion": {
@@ -35269,7 +35269,7 @@
       },
       "devDependencies": {
         "@11ty/eleventy": "^1.0.2",
-        "typescript": "~4.8.0",
+        "typescript": "~4.8.2",
         "vite": "^4.0.4"
       }
     },
@@ -35291,7 +35291,7 @@
         "@types/yargs": "^17.0.10",
         "jasmine": "^4.2.0",
         "jasmine-core": "^4.5.0",
-        "typescript": "~4.8.0"
+        "typescript": "~4.8.2"
       }
     },
     "packages/xliff-to-json-converter/node_modules/ansi-regex": {

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@microsoft/fast-colors": "^5.3.1",
     "@microsoft/fast-element": "^1.12.0",
-    "@microsoft/fast-foundation": "^2.49.1",
+    "@microsoft/fast-foundation": "^2.49.2",
     "@microsoft/fast-web-utilities": "^6.0.0",
     "@ni/nimble-tokens": "^6.4.0",
     "@tanstack/table-core": "^8.9.3",
@@ -146,7 +146,7 @@
     "rollup-plugin-sourcemaps": "^0.6.3",
     "storybook": "^7.4.0",
     "ts-loader": "^9.2.5",
-    "typescript": "~4.7.4",
+    "typescript": "~4.8.0",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
     "webpack-dev-middleware": "^6.0.1"

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -146,7 +146,7 @@
     "rollup-plugin-sourcemaps": "^0.6.3",
     "storybook": "^7.4.0",
     "ts-loader": "^9.2.5",
-    "typescript": "~4.8.0",
+    "typescript": "~4.8.2",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
     "webpack-dev-middleware": "^6.0.1"

--- a/packages/nimble-tokens/package.json
+++ b/packages/nimble-tokens/package.json
@@ -41,7 +41,7 @@
     "style-dictionary": "3.7.2",
     "svg-to-ts": "^9.0.0",
     "to-ico": "^1.1.5",
-    "typescript": "~4.7.4"
+    "typescript": "~4.8.0"
   },
   "files": [
     "dist/styledictionary/css/**",

--- a/packages/nimble-tokens/package.json
+++ b/packages/nimble-tokens/package.json
@@ -41,7 +41,7 @@
     "style-dictionary": "3.7.2",
     "svg-to-ts": "^9.0.0",
     "to-ico": "^1.1.5",
-    "typescript": "~4.8.0"
+    "typescript": "~4.8.2"
   },
   "files": [
     "dist/styledictionary/css/**",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -17,7 +17,7 @@
     },
     "devDependencies": {
         "@11ty/eleventy": "^1.0.2",
-        "typescript": "~4.7.4",
+        "typescript": "~4.8.0",
         "vite": "^4.0.4"
     },
     "files": [

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -17,7 +17,7 @@
     },
     "devDependencies": {
         "@11ty/eleventy": "^1.0.2",
-        "typescript": "~4.8.0",
+        "typescript": "~4.8.2",
         "vite": "^4.0.4"
     },
     "files": [

--- a/packages/xliff-to-json-converter/package.json
+++ b/packages/xliff-to-json-converter/package.json
@@ -31,7 +31,7 @@
     "@types/yargs": "^17.0.10",
     "jasmine": "^4.2.0",
     "jasmine-core": "^4.5.0",
-    "typescript": "~4.7.4"
+    "typescript": "~4.8.0"
   },
   "dependencies": {
     "xliff": "^6.0.3",

--- a/packages/xliff-to-json-converter/package.json
+++ b/packages/xliff-to-json-converter/package.json
@@ -31,7 +31,7 @@
     "@types/yargs": "^17.0.10",
     "jasmine": "^4.2.0",
     "jasmine-core": "^4.5.0",
-    "typescript": "~4.8.0"
+    "typescript": "~4.8.2"
   },
   "dependencies": {
     "xliff": "^6.0.3",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #810 

## 👩‍💻 Implementation

- Update dependency of `@microsoft/fast-foundation` to the new version that supports TypeScript 4.8
- Update dependency of TypesScript to 4.8

## 🧪 Testing

- Ran the nimble pipeline
- Used a locally built version of nimble to build SystemLinkShared to verify an upgrade to a new version of nimble will not immediately cause any build errors
- Used a locally built version of nimble to build SystemLinkShared with TypeScript 4.8 to verify that SystemLinkShared can update to TS 4.8 with this change

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
