### PR TITLE
Update resolved version of @babel/traverse to fix critical vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "packages/site"
       ],
       "devDependencies": {
+        "@babel/traverse": "^7.23.2",
         "@lhci/cli": "^0.10.0",
         "beachball": "^2.31.0",
         "cross-env": "^7.0.3",
@@ -4087,9 +4088,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.0.tgz",
-      "integrity": "sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.23.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "packages/site"
       ],
       "devDependencies": {
-        "@babel/traverse": "^7.23.2",
         "@lhci/cli": "^0.10.0",
         "beachball": "^2.31.0",
         "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "packages/site"
   ],
   "devDependencies": {
+    "@babel/traverse": "^7.23.2",
     "@lhci/cli": "^0.10.0",
     "beachball": "^2.31.0",
     "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "packages/site"
   ],
   "devDependencies": {
-    "@babel/traverse": "^7.23.2",
     "@lhci/cli": "^0.10.0",
     "beachball": "^2.31.0",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The `npm audit` step of the repo pipeline is failing due to a critical vulnerability in `@babel/traverse`.

## 👩‍💻 Implementation

`@babel/traverse` is pulled in by Storybook and Angular. New versions of those packages that uptake the patched version of `@babel/traverse` are not yet available.

I performed these steps to get `package-lock.json` to uptake the new version of the sub-dependency without changing any direct dependencies, `package.json` files, or other sub-dependencies:
1. `npm i -D @babel/traverse@latest` to install the patched version at the repo root. This updated `package-lock.json` to resolve just that version, which is compatible with all the packages that pull it in.
2. Modify root `package.json` to remove the dependency that was added in 1.
3. `npm i`. This updated `package-lock.json` to no longer express the direct dependcy but kept the resolved version at the newer patched one.

See alternate approaches in #1602 (just step 1 above) or #1603 (fixing all vulnerabilities). 

## 🧪 Testing

Relying on pipeline

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
