### PR TITLE
Add incubating `nimble-card` component

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,7 @@
 /packages/nimble-components/src/wafer-map @rajsite @jattasNI @DStavilaNI @zszilagy
 /packages/nimble-components/src/rich-text-viewer @rajsite @jattasNI @vikisekarNI
 /packages/nimble-components/src/rich-text-editor @rajsite @jattasNI @vikisekarNI
+/packages/nimble-components/src/card @kjohn1922 @mollykreis
 /packages/nimble-tokens @rajsite @jattasNI @fredvisser
 /packages/site @rajsite @jattasNI
 /packages/xliff-to-json-converter @rajsite @TrevorKarjanis @jattasNI

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,7 @@
 /packages/nimble-components/src/wafer-map @rajsite @jattasNI @DStavilaNI @zszilagy
 /packages/nimble-components/src/rich-text-viewer @rajsite @jattasNI @vikisekarNI
 /packages/nimble-components/src/rich-text-editor @rajsite @jattasNI @vikisekarNI
-/packages/nimble-components/src/card @kjohn1922 @mollykreis
+/packages/nimble-components/src/card @rajsite @jattasNI @kjohn1922 @mollykreis
 /packages/nimble-tokens @rajsite @jattasNI @fredvisser
 /packages/site @rajsite @jattasNI
 /packages/xliff-to-json-converter @rajsite @TrevorKarjanis @jattasNI

--- a/change/@ni-nimble-components-a3500224-7314-4022-aa82-2f4cf29f7866.json
+++ b/change/@ni-nimble-components-a3500224-7314-4022-aa82-2f4cf29f7866.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add an incubating `nimble-card` component",
+  "packageName": "@ni/nimble-components",
+  "email": "35350751+kjohn1922@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/all-components.ts
+++ b/packages/nimble-components/src/all-components.ts
@@ -15,6 +15,7 @@ import './banner';
 import './breadcrumb';
 import './breadcrumb-item';
 import './button';
+import './card';
 import './card-button';
 import './checkbox';
 import './combobox';

--- a/packages/nimble-components/src/card/index.ts
+++ b/packages/nimble-components/src/card/index.ts
@@ -1,4 +1,7 @@
-import { DesignSystem, Card as FastCard } from '@microsoft/fast-foundation';
+import {
+    DesignSystem,
+    Card as FoundationCard
+} from '@microsoft/fast-foundation';
 import { styles } from './styles';
 import { template } from './template';
 
@@ -11,11 +14,11 @@ declare global {
 /**
  * A nimble-styled card
  */
-export class Card extends FastCard {}
+export class Card extends FoundationCard {}
 
 const nimbleCard = Card.compose({
     baseName: 'card',
-    baseClass: FastCard,
+    baseClass: FoundationCard,
     template,
     styles
 });

--- a/packages/nimble-components/src/card/index.ts
+++ b/packages/nimble-components/src/card/index.ts
@@ -1,0 +1,24 @@
+import { DesignSystem, Card as FastCard } from '@microsoft/fast-foundation';
+import { styles } from './styles';
+import { template } from './template';
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'nimble-card': Card;
+    }
+}
+
+/**
+ * A nimble-styled card
+ */
+export class Card extends FastCard {}
+
+const nimbleCard = Card.compose({
+    baseName: 'card',
+    baseClass: FastCard,
+    template,
+    styles
+});
+
+DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleCard());
+export const cardTag = DesignSystem.tagFor(Card);

--- a/packages/nimble-components/src/card/styles.ts
+++ b/packages/nimble-components/src/card/styles.ts
@@ -5,8 +5,8 @@ import {
     bodyFontColor,
     borderColor,
     borderWidth,
-    mediumPadding,
-    sectionBackgroundColor
+    sectionBackgroundColor,
+    standardPadding
 } from '../theme-provider/design-tokens';
 
 export const styles = css`
@@ -17,6 +17,6 @@ export const styles = css`
         color: ${bodyFontColor};
         background-color: ${sectionBackgroundColor};
         border: ${borderWidth} solid ${borderColor};
-        padding: ${mediumPadding};
+        padding: ${standardPadding};
     }
 `;

--- a/packages/nimble-components/src/card/styles.ts
+++ b/packages/nimble-components/src/card/styles.ts
@@ -10,13 +10,15 @@ import {
 } from '../theme-provider/design-tokens';
 
 export const styles = css`
-    ${display('block')}
+    ${display('flex')}
 
     :host {
+        flex-direction: column;
+        gap: ${standardPadding};
+        padding: ${standardPadding};
+        border: ${borderWidth} solid ${borderColor};
         font: ${bodyFont};
         color: ${bodyFontColor};
         background-color: ${sectionBackgroundColor};
-        border: ${borderWidth} solid ${borderColor};
-        padding: ${standardPadding};
     }
 `;

--- a/packages/nimble-components/src/card/styles.ts
+++ b/packages/nimble-components/src/card/styles.ts
@@ -1,48 +1,23 @@
 import { css } from '@microsoft/fast-element';
 import { display } from '@microsoft/fast-foundation';
-import { Theme } from '../theme-provider/types';
-import { themeBehavior } from '../utilities/style/theme';
 import {
     bodyFont,
     bodyFontColor,
-    buttonFillPrimaryColor
+    borderColor,
+    borderWidth,
+    mediumPadding,
+    sectionBackgroundColor
 } from '../theme-provider/design-tokens';
 
+// TODO AB#2542845 Replace placeholder style
 export const styles = css`
     ${display('block')}
 
     :host {
         font: ${bodyFont};
         color: ${bodyFontColor};
-        margin: 10px;
-        padding: 10px;
+        background-color: ${sectionBackgroundColor};
+        border: ${borderWidth} solid ${borderColor};
+        padding: ${mediumPadding};
     }
-`.withBehaviors(
-    themeBehavior(
-        Theme.light,
-        css`
-            :host {
-                background-color: #f0f0f0;
-                border: 2px solid #cccccc;
-            }
-        `
-    ),
-    themeBehavior(
-        Theme.dark,
-        css`
-            :host {
-                background-color: #333333;
-                border: 2px solid #666666;
-            }
-        `
-    ),
-    themeBehavior(
-        Theme.color,
-        css`
-            :host {
-                border: 2px solid ${buttonFillPrimaryColor};
-                background-color: ${buttonFillPrimaryColor};
-            }
-        `
-    )
-);
+`;

--- a/packages/nimble-components/src/card/styles.ts
+++ b/packages/nimble-components/src/card/styles.ts
@@ -9,7 +9,6 @@ import {
     sectionBackgroundColor
 } from '../theme-provider/design-tokens';
 
-// TODO AB#2542845 Replace placeholder style
 export const styles = css`
     ${display('block')}
 

--- a/packages/nimble-components/src/card/styles.ts
+++ b/packages/nimble-components/src/card/styles.ts
@@ -1,0 +1,48 @@
+import { css } from '@microsoft/fast-element';
+import { display } from '@microsoft/fast-foundation';
+import { Theme } from '../theme-provider/types';
+import { themeBehavior } from '../utilities/style/theme';
+import {
+    bodyFont,
+    bodyFontColor,
+    buttonFillPrimaryColor
+} from '../theme-provider/design-tokens';
+
+export const styles = css`
+    ${display('block')}
+
+    :host {
+        font: ${bodyFont};
+        color: ${bodyFontColor};
+        margin: 10px;
+        padding: 10px;
+    }
+`.withBehaviors(
+    themeBehavior(
+        Theme.light,
+        css`
+            :host {
+                background-color: #f0f0f0;
+                border: 2px solid #cccccc;
+            }
+        `
+    ),
+    themeBehavior(
+        Theme.dark,
+        css`
+            :host {
+                background-color: #333333;
+                border: 2px solid #666666;
+            }
+        `
+    ),
+    themeBehavior(
+        Theme.color,
+        css`
+            :host {
+                border: 2px solid ${buttonFillPrimaryColor};
+                background-color: ${buttonFillPrimaryColor};
+            }
+        `
+    )
+);

--- a/packages/nimble-components/src/card/template.ts
+++ b/packages/nimble-components/src/card/template.ts
@@ -1,8 +1,4 @@
 import { html } from '@microsoft/fast-element';
 import type { Card } from '.';
 
-export const template = html<Card>`
-    <template>
-        <slot></slot>
-    </template>
-`;
+export const template = html<Card>`<slot></slot>`;

--- a/packages/nimble-components/src/card/template.ts
+++ b/packages/nimble-components/src/card/template.ts
@@ -1,0 +1,8 @@
+import { html } from '@microsoft/fast-element';
+import type { Card } from '.';
+
+export const template = html<Card>`
+    <template>
+        <slot></slot>
+    </template>
+`;

--- a/packages/nimble-components/src/card/tests/card-matrix.stories.ts
+++ b/packages/nimble-components/src/card/tests/card-matrix.stories.ts
@@ -1,6 +1,5 @@
 import { ViewTemplate, html } from '@microsoft/fast-element';
 import type { Meta, StoryFn } from '@storybook/html';
-import { standardPadding } from '../../theme-provider/design-tokens';
 import {
     createMatrix,
     sharedMatrixParameters

--- a/packages/nimble-components/src/card/tests/card-matrix.stories.ts
+++ b/packages/nimble-components/src/card/tests/card-matrix.stories.ts
@@ -1,0 +1,36 @@
+import { ViewTemplate, html } from '@microsoft/fast-element';
+import type { Meta, StoryFn } from '@storybook/html';
+import { standardPadding } from '../../theme-provider/design-tokens';
+import { loremIpsum } from '../../utilities/tests/lorem-ipsum';
+import {
+    createMatrix,
+    sharedMatrixParameters
+} from '../../utilities/tests/matrix';
+import { createMatrixThemeStory } from '../../utilities/tests/storybook';
+import { buttonTag } from '../../button';
+import { cardTag } from '..';
+
+const metadata: Meta = {
+    title: 'Tests/Card',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
+
+const component = (): ViewTemplate => html`
+<style>
+    .body {
+        margin-bottom: var(${standardPadding.cssCustomProperty});
+    }
+</style>
+<${cardTag}>
+    <div class="body">${loremIpsum}</div>
+    <${buttonTag}>Button</${buttonTag}>
+</${cardTag}>
+`;
+
+export const cardThemeMatrix: StoryFn = createMatrixThemeStory(
+    createMatrix(component)
+);

--- a/packages/nimble-components/src/card/tests/card-matrix.stories.ts
+++ b/packages/nimble-components/src/card/tests/card-matrix.stories.ts
@@ -20,15 +20,15 @@ const metadata: Meta = {
 export default metadata;
 
 const component = (): ViewTemplate => html`
-<style>
-    .body {
-        margin-bottom: var(${standardPadding.cssCustomProperty});
-    }
-</style>
-<${cardTag}>
-    <div class="body">${loremIpsum}</div>
-    <${buttonTag}>Button</${buttonTag}>
-</${cardTag}>
+    <style>
+        .body {
+            margin-bottom: var(${standardPadding.cssCustomProperty});
+        }
+    </style>
+    <${cardTag}>
+        <div class="body">${loremIpsum}</div>
+        <${buttonTag}>Button</${buttonTag}>
+    </${cardTag}>
 `;
 
 export const cardThemeMatrix: StoryFn = createMatrixThemeStory(

--- a/packages/nimble-components/src/card/tests/card-matrix.stories.ts
+++ b/packages/nimble-components/src/card/tests/card-matrix.stories.ts
@@ -1,7 +1,6 @@
 import { ViewTemplate, html } from '@microsoft/fast-element';
 import type { Meta, StoryFn } from '@storybook/html';
 import { standardPadding } from '../../theme-provider/design-tokens';
-import { loremIpsum } from '../../utilities/tests/lorem-ipsum';
 import {
     createMatrix,
     sharedMatrixParameters
@@ -10,9 +9,11 @@ import {
     createMatrixThemeStory,
     createStory
 } from '../../utilities/tests/storybook';
-import { buttonTag } from '../../button';
-import { cardTag } from '..';
 import { hiddenWrapper } from '../../utilities/tests/hidden';
+import { listOptionTag } from '../../list-option';
+import { numberFieldTag } from '../../number-field';
+import { selectTag } from '../../select';
+import { cardTag } from '..';
 
 const metadata: Meta = {
     title: 'Tests/Card',
@@ -24,15 +25,24 @@ const metadata: Meta = {
 export default metadata;
 
 const component = (): ViewTemplate => html`
-    <style>
-        .body {
-            margin-bottom: var(${standardPadding.cssCustomProperty});
-        }
-    </style>
-    <${cardTag}>
-        <div class="body">${loremIpsum}</div>
-        <${buttonTag}>Button</${buttonTag}>
-    </${cardTag}>
+<style>
+    .card-content {
+        display: flex;
+        flex-direction: column;
+        gap: var(${standardPadding.cssCustomProperty});
+    }
+</style>
+<${cardTag}>
+    <div class="card-content">
+        <${numberFieldTag}>Numeric field 1</${numberFieldTag}>
+        <${numberFieldTag}>Numeric field 2</${numberFieldTag}>
+        <${selectTag}>
+            <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            <${listOptionTag} value="2">Option 2</${listOptionTag}>
+            <${listOptionTag} value="3">Option 3</${listOptionTag}>
+        </${selectTag}>
+    </div>
+</${cardTag}>
 `;
 
 export const cardThemeMatrix: StoryFn = createMatrixThemeStory(

--- a/packages/nimble-components/src/card/tests/card-matrix.stories.ts
+++ b/packages/nimble-components/src/card/tests/card-matrix.stories.ts
@@ -6,9 +6,13 @@ import {
     createMatrix,
     sharedMatrixParameters
 } from '../../utilities/tests/matrix';
-import { createMatrixThemeStory } from '../../utilities/tests/storybook';
+import {
+    createMatrixThemeStory,
+    createStory
+} from '../../utilities/tests/storybook';
 import { buttonTag } from '../../button';
 import { cardTag } from '..';
+import { hiddenWrapper } from '../../utilities/tests/hidden';
 
 const metadata: Meta = {
     title: 'Tests/Card',
@@ -33,4 +37,8 @@ const component = (): ViewTemplate => html`
 
 export const cardThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component)
+);
+
+export const hiddenCard: StoryFn = createStory(
+    hiddenWrapper(html`<${cardTag} hidden>Hidden Card</${cardTag}>`)
 );

--- a/packages/nimble-components/src/card/tests/card-matrix.stories.ts
+++ b/packages/nimble-components/src/card/tests/card-matrix.stories.ts
@@ -25,15 +25,7 @@ const metadata: Meta = {
 export default metadata;
 
 const component = (): ViewTemplate => html`
-<style>
-    .card-content {
-        display: flex;
-        flex-direction: column;
-        gap: var(${standardPadding.cssCustomProperty});
-    }
-</style>
-<${cardTag}>
-    <div class="card-content">
+    <${cardTag}>
         <${numberFieldTag}>Numeric field 1</${numberFieldTag}>
         <${numberFieldTag}>Numeric field 2</${numberFieldTag}>
         <${selectTag}>
@@ -41,8 +33,7 @@ const component = (): ViewTemplate => html`
             <${listOptionTag} value="2">Option 2</${listOptionTag}>
             <${listOptionTag} value="3">Option 3</${listOptionTag}>
         </${selectTag}>
-    </div>
-</${cardTag}>
+    </${cardTag}>
 `;
 
 export const cardThemeMatrix: StoryFn = createMatrixThemeStory(

--- a/packages/nimble-components/src/card/tests/card.spec.ts
+++ b/packages/nimble-components/src/card/tests/card.spec.ts
@@ -1,0 +1,11 @@
+import { Card, cardTag } from '..';
+
+describe('Card', () => {
+    it('should export its tag', () => {
+        expect(cardTag).toBe('nimble-card');
+    });
+
+    it('can construct an element instance', () => {
+        expect(document.createElement('nimble-card')).toBeInstanceOf(Card);
+    });
+});

--- a/packages/nimble-components/src/card/tests/card.stories.ts
+++ b/packages/nimble-components/src/card/tests/card.stories.ts
@@ -1,6 +1,5 @@
 import { html } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
-import { standardPadding } from '../../theme-provider/design-tokens';
 import {
     createUserSelectedThemeStory,
     incubatingWarning

--- a/packages/nimble-components/src/card/tests/card.stories.ts
+++ b/packages/nimble-components/src/card/tests/card.stories.ts
@@ -29,12 +29,12 @@ const metadata: Meta = {
         statusLink: 'https://github.com/ni/nimble/issues/296'
     })}
         <style>
-            .body {
+            .card-content {
                 margin-bottom: var(${standardPadding.cssCustomProperty});
             }
         </style>
         <${cardTag}>
-            <div class="body">${loremIpsum}</div>
+            <div class="card-content">${loremIpsum}</div>
             <${buttonTag}>Button</${buttonTag}>
         </${cardTag}>
     `)

--- a/packages/nimble-components/src/card/tests/card.stories.ts
+++ b/packages/nimble-components/src/card/tests/card.stories.ts
@@ -24,7 +24,7 @@ const metadata: Meta = {
         actions: {}
     },
     render: createUserSelectedThemeStory(html`
-        ${incubatingWarning({
+    ${incubatingWarning({
         componentName: 'card',
         statusLink: 'https://github.com/ni/nimble/issues/296'
     })}

--- a/packages/nimble-components/src/card/tests/card.stories.ts
+++ b/packages/nimble-components/src/card/tests/card.stories.ts
@@ -1,5 +1,6 @@
 import { html } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
+import { loremIpsum } from '../../utilities/tests/lorem-ipsum';
 import {
     createUserSelectedThemeStory,
     incubatingWarning
@@ -28,7 +29,7 @@ const metadata: Meta = {
     })}
         <${cardTag}>
             <h2>Title</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maurisscelerisque varius ornare.</p>
+            <p>${loremIpsum}</p>
             <${buttonTag}>Button</${buttonTag}>
         </${cardTag}>
     `)

--- a/packages/nimble-components/src/card/tests/card.stories.ts
+++ b/packages/nimble-components/src/card/tests/card.stories.ts
@@ -1,0 +1,39 @@
+import { html } from '@microsoft/fast-element';
+import type { Meta, StoryObj } from '@storybook/html';
+import {
+    createUserSelectedThemeStory,
+    incubatingWarning
+} from '../../utilities/tests/storybook';
+import { buttonTag } from '../../button';
+import { cardTag } from '..';
+
+const overviewText = `The \`nimble-card\` is a container that is designed to contain arbitrary content that is specified by a client
+application. The \`nimble-card\` is intended for grouping related content.`;
+
+const metadata: Meta = {
+    title: 'Incubating/Card',
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: overviewText
+            }
+        },
+        actions: {}
+    },
+    render: createUserSelectedThemeStory(html`
+        ${incubatingWarning({
+        componentName: 'card',
+        statusLink: 'https://github.com/ni/nimble/issues/296'
+    })}
+        <${cardTag}>
+            <h2>Title</h2>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maurisscelerisque varius ornare.</p>
+            <${buttonTag}>Button</${buttonTag}>
+        </${cardTag}>
+    `)
+};
+
+export default metadata;
+
+export const card: StoryObj = {};

--- a/packages/nimble-components/src/card/tests/card.stories.ts
+++ b/packages/nimble-components/src/card/tests/card.stories.ts
@@ -1,12 +1,13 @@
 import { html } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
 import { standardPadding } from '../../theme-provider/design-tokens';
-import { loremIpsum } from '../../utilities/tests/lorem-ipsum';
 import {
     createUserSelectedThemeStory,
     incubatingWarning
 } from '../../utilities/tests/storybook';
-import { buttonTag } from '../../button';
+import { listOptionTag } from '../../list-option';
+import { numberFieldTag } from '../../number-field';
+import { selectTag } from '../../select';
 import { cardTag } from '..';
 
 const overviewText = `The \`nimble-card\` is a container that is designed to contain arbitrary content that is specified by a client
@@ -30,12 +31,21 @@ const metadata: Meta = {
     })}
         <style>
             .card-content {
-                margin-bottom: var(${standardPadding.cssCustomProperty});
+                display: flex;
+                flex-direction: column;
+                gap: var(${standardPadding.cssCustomProperty});
             }
         </style>
         <${cardTag}>
-            <div class="card-content">${loremIpsum}</div>
-            <${buttonTag}>Button</${buttonTag}>
+            <div class="card-content">
+                <${numberFieldTag}>Numeric field 1</${numberFieldTag}>
+                <${numberFieldTag}>Numeric field 2</${numberFieldTag}>
+                <${selectTag}>
+                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
+                    <${listOptionTag} value="2">Option 2</${listOptionTag}>
+                    <${listOptionTag} value="3">Option 3</${listOptionTag}>
+                </${selectTag}>
+            </div>
         </${cardTag}>
     `)
 };

--- a/packages/nimble-components/src/card/tests/card.stories.ts
+++ b/packages/nimble-components/src/card/tests/card.stories.ts
@@ -1,5 +1,6 @@
 import { html } from '@microsoft/fast-element';
 import type { Meta, StoryObj } from '@storybook/html';
+import { standardPadding } from '../../theme-provider/design-tokens';
 import { loremIpsum } from '../../utilities/tests/lorem-ipsum';
 import {
     createUserSelectedThemeStory,
@@ -27,9 +28,13 @@ const metadata: Meta = {
         componentName: 'card',
         statusLink: 'https://github.com/ni/nimble/issues/296'
     })}
+        <style>
+            .body {
+                margin-bottom: var(${standardPadding.cssCustomProperty});
+            }
+        </style>
         <${cardTag}>
-            <h2>Title</h2>
-            <p>${loremIpsum}</p>
+            <div class="body">${loremIpsum}</div>
             <${buttonTag}>Button</${buttonTag}>
         </${cardTag}>
     `)

--- a/packages/nimble-components/src/card/tests/card.stories.ts
+++ b/packages/nimble-components/src/card/tests/card.stories.ts
@@ -29,23 +29,14 @@ const metadata: Meta = {
         componentName: 'card',
         statusLink: 'https://github.com/ni/nimble/issues/296'
     })}
-        <style>
-            .card-content {
-                display: flex;
-                flex-direction: column;
-                gap: var(${standardPadding.cssCustomProperty});
-            }
-        </style>
         <${cardTag}>
-            <div class="card-content">
-                <${numberFieldTag}>Numeric field 1</${numberFieldTag}>
-                <${numberFieldTag}>Numeric field 2</${numberFieldTag}>
-                <${selectTag}>
-                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
-                    <${listOptionTag} value="2">Option 2</${listOptionTag}>
-                    <${listOptionTag} value="3">Option 3</${listOptionTag}>
-                </${selectTag}>
-            </div>
+            <${numberFieldTag}>Numeric field 1</${numberFieldTag}>
+            <${numberFieldTag}>Numeric field 2</${numberFieldTag}>
+            <${selectTag}>
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+                <${listOptionTag} value="2">Option 2</${listOptionTag}>
+                <${listOptionTag} value="3">Option 3</${listOptionTag}>
+            </${selectTag}>
         </${cardTag}>
     `)
 };

--- a/packages/nimble-components/src/tests/component-status.stories.ts
+++ b/packages/nimble-components/src/tests/component-status.stories.ts
@@ -112,9 +112,9 @@ const components = [
         componentName: 'Card',
         issueHref: 'https://github.com/ni/nimble/issues/296',
         issueLabel: 'Issue',
-        componentStatus: ComponentFrameworkStatus.doesNotExist,
-        angularStatus: ComponentFrameworkStatus.doesNotExist,
-        blazorStatus: ComponentFrameworkStatus.doesNotExist
+        componentStatus: ComponentFrameworkStatus.incubating,
+        angularStatus: ComponentFrameworkStatus.incubating,
+        blazorStatus: ComponentFrameworkStatus.incubating
     },
     {
         componentName: 'Card button',

--- a/packages/nimble-components/src/tests/component-status.stories.ts
+++ b/packages/nimble-components/src/tests/component-status.stories.ts
@@ -110,11 +110,12 @@ const components = [
     },
     {
         componentName: 'Card',
+        componentHref: './?path=/docs/incubating-card--docs',
         issueHref: 'https://github.com/ni/nimble/issues/296',
         issueLabel: 'Issue',
         componentStatus: ComponentFrameworkStatus.incubating,
-        angularStatus: ComponentFrameworkStatus.incubating,
-        blazorStatus: ComponentFrameworkStatus.incubating
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist
     },
     {
         componentName: 'Card button',


### PR DESCRIPTION
# Pull Request

Initial component code for the `nimble-card` component.

See #296 and the [`nimble-card` spec](https://github.com/ni/nimble/blob/main/packages/nimble-components/src/card/specs/README.md) for more information.

## 🤨 Rationale

This adds the initial `nimble-card` component, storybook, and tests.

I will add a "title" slot to the template in a future PR. Future PRs will also add Angular and Blazor support.

The styling in the component right now is intended as a placeholder. We will get styling from our designer and update the styles before releasing the Routines UI with the card component.

## 👩‍💻 Implementation

- Added myself as a code owner for the incubating component, per the contributing instructions
- Marked the component as incubating in the component-status table
- Added index, styles, and template files for the new component, called `nimble-card`


## 🧪 Testing

- Added a storybook page under Incubating with an example
- Added a spec file with a basic unit test

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
