### PR TITLE
Add sizing to spec templates

### DIFF
--- a/specs/templates/custom-component.md
+++ b/specs/templates/custom-component.md
@@ -50,7 +50,7 @@
 - *Methods*
 - *Events*
 - *CSS Classes and CSS Custom Properties that affect the component*
-- *Built-in CSS Properties that affect the component. In particular, how is it sized?*
+- *How native CSS Properties (height, width, etc.) affect the component*
 
 *Consider high and low-level APIs. Attempt to design a powerful and extensible low-level API with a high-level API for developer/designer ergonomics and simplicity.*
 

--- a/specs/templates/custom-component.md
+++ b/specs/templates/custom-component.md
@@ -50,6 +50,7 @@
 - *Methods*
 - *Events*
 - *CSS Classes and CSS Custom Properties that affect the component*
+- *Built-in CSS Properties that affect the component. In particular, how is it sized?*
 
 *Consider high and low-level APIs. Attempt to design a powerful and extensible low-level API with a high-level API for developer/designer ergonomics and simplicity.*
 

--- a/specs/templates/fast-based-component.md
+++ b/specs/templates/fast-based-component.md
@@ -31,7 +31,7 @@
 - *Methods*
 - *Events*
 - *CSS Classes and Custom Properties that affect the component*
-- *Built-in CSS Properties that affect the component (e.g. width/max-width)*
+- *Built-in CSS Properties that affect the component. In particular, how is it sized?*
 - *Slots*
 
 ### Angular integration 

--- a/specs/templates/fast-based-component.md
+++ b/specs/templates/fast-based-component.md
@@ -31,6 +31,7 @@
 - *Methods*
 - *Events*
 - *CSS Classes and Custom Properties that affect the component*
+- *Built-in CSS Properties that affect the component (e.g. width/max-width)*
 - *Slots*
 
 ### Angular integration 

--- a/specs/templates/fast-based-component.md
+++ b/specs/templates/fast-based-component.md
@@ -31,7 +31,7 @@
 - *Methods*
 - *Events*
 - *CSS Classes and Custom Properties that affect the component*
-- *Built-in CSS Properties that affect the component. In particular, how is it sized?*
+- *How native CSS Properties (height, width, etc.) affect the component*
 - *Slots*
 
 ### Angular integration 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

We've had several discussions lately about how existing and new components should be sized, including questions about default sizes, intrinsic sizes to fit all of a component's data, and respecting min/max sizes. Many of these conversations were triggered by bugs or feature requests. It would be good to think them through earlier in the component development process.

## 👩‍💻 Implementation

Added a checklist item about sizing (and more generally about response to all css properties) to the new component spec templates.

## 🧪 Testing

N/A

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
