### PR TITLE
Configure Renovate to rebase PRs less frequently

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
   ],
   "enabledManagers": ["npm"],
   "rangeStrategy": "update-lockfile",
+  "rebaseWhen": "conflicted",
   "schedule": [
     "monthly"
   ],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,7 +181,7 @@ npm install @ni/nimble-tokens --workspace=@ni/nimble-components
 
 This repository uses [Renovate](https://docs.renovatebot.com/) to automatically create pull requests that bump the version of dependencies on a schedule. Renovate is configured via [`renovate.json`](./.github/renovate.json).
 
-Code owners are responsible for completing or rejecting Renovate PRs. Completing a PR currently requires manually adding a beachball change file to the branch. The change `type` will typically be `none` if only `package-lock.json` is changing and `patch` if any `package.json` is changing. The `comment` should summarize which set of dependencies are being updated.
+Code owners are responsible for completing or rejecting Renovate PRs. Completing a PR may require manually adding a beachball change file to the branch. The change `type` will typically be `patch` if any `package.json` is changing. The `comment` should summarize which set of dependencies are being updated. To complete a PR you may need to manually trigger a rebase by clicking the checkbox in the PR description.
 
 ## Handling intermittent test failures
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Once Renovate has created PRs it currently updates them any time something else changes in the repo. This is annoying because it uses lots of build resources and makes it hard to track down a completed build for the PR, for example to inspect Storybook.

In [a PR discussion](https://github.com/ni/nimble/pull/1634#discussion_r1379067152) we decided to switch to manually triggering the rebase before merging the PR.

## 👩‍💻 Implementation

1. Update renovate.json to `rebaseWhen: conflicts`. This seems more helpful than `never` but hopefully less noisy than `auto`.
2. Update CONTRIBUTING to mention that owners may need to manually trigger the rebase


## 🧪 Testing

We'll see if it works the next time Renovate creates PRs.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
