### PR TITLE
Mapping base class make generic and remove text property

### DIFF
--- a/change/@ni-nimble-components-f7f47d9d-f5d5-4ad0-b573-a1ab40586bfd.json
+++ b/change/@ni-nimble-components-f7f47d9d-f5d5-4ad0-b573-a1ab40586bfd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update internal mapping base class to be generic",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/mapping/base/index.ts
+++ b/packages/nimble-components/src/mapping/base/index.ts
@@ -10,13 +10,4 @@ export abstract class Mapping<T> extends FoundationElement {
      */
     @attr()
     public key?: T;
-
-    /**
-     * In the case of a mapping that maps to text, this is that mapped text.
-     * For mappings to non-textual representations, this is a string that can
-     * be displayed in contexts such as group headers or tooltips and used as
-     * an accessible label.
-     */
-    @attr()
-    public text?: string;
 }

--- a/packages/nimble-components/src/mapping/base/index.ts
+++ b/packages/nimble-components/src/mapping/base/index.ts
@@ -1,16 +1,15 @@
 import { attr } from '@microsoft/fast-element';
 import { FoundationElement } from '@microsoft/fast-foundation';
-import type { MappingKey } from './types';
 
 /**
  * Base class for mapping configuration elements
  */
-export abstract class Mapping extends FoundationElement {
+export abstract class Mapping<T> extends FoundationElement {
     /**
      * The data value that is mapped to another representation
      */
     @attr()
-    public key?: MappingKey;
+    public key?: T;
 
     /**
      * In the case of a mapping that maps to text, this is that mapped text.

--- a/packages/nimble-components/src/mapping/icon/index.ts
+++ b/packages/nimble-components/src/mapping/icon/index.ts
@@ -4,6 +4,7 @@ import { Mapping } from '../base';
 import { template } from '../base/template';
 import type { IconSeverity } from '../../icon-base/types';
 import { Icon } from '../../icon-base';
+import type { MappingKey } from '../base/types';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -20,7 +21,7 @@ function isIconClass(elementClass: CustomElementConstructor): boolean {
  * One or more may be added as children of a nimble-table-column-icon element to define
  * how specific data values should be displayed as icons in that column's cells.
  */
-export class MappingIcon extends Mapping {
+export class MappingIcon extends Mapping<MappingKey> {
     @attr()
     public icon?: string;
 

--- a/packages/nimble-components/src/mapping/icon/index.ts
+++ b/packages/nimble-components/src/mapping/icon/index.ts
@@ -28,6 +28,9 @@ export class MappingIcon extends Mapping<MappingKey> {
     @attr()
     public severity: IconSeverity;
 
+    @attr()
+    public text?: string;
+
     /**
      * @internal
      * Calculated asynchronously by the icon mapping based on the configured icon value.

--- a/packages/nimble-components/src/mapping/spinner/index.ts
+++ b/packages/nimble-components/src/mapping/spinner/index.ts
@@ -1,6 +1,7 @@
 import { DesignSystem } from '@microsoft/fast-foundation';
 import { Mapping } from '../base';
 import { template } from '../base/template';
+import type { MappingKey } from '../base/types';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -13,7 +14,7 @@ declare global {
  * One or more may be added as children of a nimble-table-column-icon element to define
  * which specific data values should be displayed as spinners in that column's cells.
  */
-export class MappingSpinner extends Mapping {}
+export class MappingSpinner extends Mapping<MappingKey> {}
 
 const spinnerMapping = MappingSpinner.compose({
     baseName: 'mapping-spinner',

--- a/packages/nimble-components/src/mapping/spinner/index.ts
+++ b/packages/nimble-components/src/mapping/spinner/index.ts
@@ -1,4 +1,5 @@
 import { DesignSystem } from '@microsoft/fast-foundation';
+import { attr } from '@microsoft/fast-element';
 import { Mapping } from '../base';
 import { template } from '../base/template';
 import type { MappingKey } from '../base/types';
@@ -14,7 +15,10 @@ declare global {
  * One or more may be added as children of a nimble-table-column-icon element to define
  * which specific data values should be displayed as spinners in that column's cells.
  */
-export class MappingSpinner extends Mapping<MappingKey> {}
+export class MappingSpinner extends Mapping<MappingKey> {
+    @attr()
+    public text?: string;
+}
 
 const spinnerMapping = MappingSpinner.compose({
     baseName: 'mapping-spinner',

--- a/packages/nimble-components/src/mapping/text/index.ts
+++ b/packages/nimble-components/src/mapping/text/index.ts
@@ -1,6 +1,7 @@
 import { DesignSystem } from '@microsoft/fast-foundation';
 import { Mapping } from '../base';
 import { template } from '../base/template';
+import type { MappingKey } from '../base/types';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -13,7 +14,7 @@ declare global {
  * One or more may be added as children of a nimble-table-column-enum-text element to define
  * how a specific data value should be displayed as text in that column's cells.
  */
-export class MappingText extends Mapping {}
+export class MappingText extends Mapping<MappingKey> {}
 
 const textMapping = MappingText.compose({
     baseName: 'mapping-text',

--- a/packages/nimble-components/src/mapping/text/index.ts
+++ b/packages/nimble-components/src/mapping/text/index.ts
@@ -1,4 +1,5 @@
 import { DesignSystem } from '@microsoft/fast-foundation';
+import { attr } from '@microsoft/fast-element';
 import { Mapping } from '../base';
 import { template } from '../base/template';
 import type { MappingKey } from '../base/types';
@@ -14,7 +15,10 @@ declare global {
  * One or more may be added as children of a nimble-table-column-enum-text element to define
  * how a specific data value should be displayed as text in that column's cells.
  */
-export class MappingText extends Mapping<MappingKey> {}
+export class MappingText extends Mapping<MappingKey> {
+    @attr()
+    public text?: string;
+}
 
 const textMapping = MappingText.compose({
     baseName: 'mapping-text',

--- a/packages/nimble-components/src/table-column/enum-base/index.ts
+++ b/packages/nimble-components/src/table-column/enum-base/index.ts
@@ -71,7 +71,9 @@ export abstract class TableColumnEnumBase<
     /**
      * Implementations should throw an error if an invalid Mapping is passed.
      */
-    protected abstract createMappingConfig(mapping: Mapping<unknown>): MappingConfig;
+    protected abstract createMappingConfig(
+        mapping: Mapping<unknown>
+    ): MappingConfig;
 
     protected abstract createColumnConfig(
         mappingConfigs: MappingConfigs

--- a/packages/nimble-components/src/table-column/enum-base/index.ts
+++ b/packages/nimble-components/src/table-column/enum-base/index.ts
@@ -46,7 +46,7 @@ export abstract class TableColumnEnumBase<
 
     /** @internal */
     @observable
-    public mappings: Mapping[] = [];
+    public mappings: Mapping<unknown>[] = [];
 
     @attr({ attribute: 'field-name' })
     public fieldName?: string;
@@ -71,7 +71,7 @@ export abstract class TableColumnEnumBase<
     /**
      * Implementations should throw an error if an invalid Mapping is passed.
      */
-    protected abstract createMappingConfig(mapping: Mapping): MappingConfig;
+    protected abstract createMappingConfig(mapping: Mapping<unknown>): MappingConfig;
 
     protected abstract createColumnConfig(
         mappingConfigs: MappingConfigs

--- a/packages/nimble-components/src/table-column/enum-base/models/mapping-key-resolver.ts
+++ b/packages/nimble-components/src/table-column/enum-base/models/mapping-key-resolver.ts
@@ -8,7 +8,7 @@ import type { MappingKeyType } from '../types';
  * values in the table data.
  */
 export const resolveKeyWithType = (
-    key: MappingKey | undefined,
+    key: unknown,
     keyType: MappingKeyType
 ): MappingKey | undefined => {
     if (keyType === 'number') {

--- a/packages/nimble-components/src/table-column/enum-base/models/table-column-enum-base-validator.ts
+++ b/packages/nimble-components/src/table-column/enum-base/models/table-column-enum-base-validator.ts
@@ -8,8 +8,7 @@ export const enumBaseValidityFlagNames = [
     'invalidMappingKeyValueForType',
     'unsupportedMappingType',
     'duplicateMappingKey',
-    'missingKeyValue',
-    'missingTextValue'
+    'missingKeyValue'
 ] as const;
 
 /**
@@ -38,7 +37,6 @@ export abstract class TableColumnEnumBaseValidator<
         this.validateMappingTypes(mappings);
         this.validateUniqueKeys(keys, keyType);
         this.validateNoMissingKeys(mappings);
-        this.validateNoMissingText(mappings);
     }
 
     private validateKeyValuesForType(
@@ -71,10 +69,5 @@ export abstract class TableColumnEnumBaseValidator<
     private validateNoMissingKeys(mappings: Mapping<unknown>[]): void {
         const invalid = mappings.some(mapping => mapping.key === undefined);
         this.setConditionValue('missingKeyValue', invalid);
-    }
-
-    private validateNoMissingText(mappings: Mapping<unknown>[]): void {
-        const invalid = mappings.some(mapping => mapping.text === undefined);
-        this.setConditionValue('missingTextValue', invalid);
     }
 }

--- a/packages/nimble-components/src/table-column/enum-base/models/table-column-enum-base-validator.ts
+++ b/packages/nimble-components/src/table-column/enum-base/models/table-column-enum-base-validator.ts
@@ -28,7 +28,10 @@ export abstract class TableColumnEnumBaseValidator<
         super(columnInternals, configValidityKeys);
     }
 
-    public validate(mappings: Mapping<unknown>[], keyType: MappingKeyType): void {
+    public validate(
+        mappings: Mapping<unknown>[],
+        keyType: MappingKeyType
+    ): void {
         this.untrackAll();
         const keys = mappings.map(mapping => mapping.key);
         this.validateKeyValuesForType(keys, keyType);
@@ -39,7 +42,7 @@ export abstract class TableColumnEnumBaseValidator<
     }
 
     private validateKeyValuesForType(
-        keys: (unknown)[],
+        keys: unknown[],
         keyType: MappingKeyType
     ): void {
         // Ignore undefined keys, because validateNoMissingKeys covers that case.
@@ -59,10 +62,7 @@ export abstract class TableColumnEnumBaseValidator<
         this.setConditionValue('unsupportedMappingType', !valid);
     }
 
-    private validateUniqueKeys(
-        keys: (unknown)[],
-        keyType: MappingKeyType
-    ): void {
+    private validateUniqueKeys(keys: unknown[], keyType: MappingKeyType): void {
         const typedKeys = keys.map(x => resolveKeyWithType(x, keyType));
         const invalid = new Set(typedKeys).size !== typedKeys.length;
         this.setConditionValue('duplicateMappingKey', invalid);

--- a/packages/nimble-components/src/table-column/enum-base/models/table-column-enum-base-validator.ts
+++ b/packages/nimble-components/src/table-column/enum-base/models/table-column-enum-base-validator.ts
@@ -1,7 +1,6 @@
 import { ColumnValidator } from '../../base/models/column-validator';
 import type { ColumnInternals } from '../../base/models/column-internals';
 import type { Mapping } from '../../../mapping/base';
-import type { MappingKey } from '../../../mapping/base/types';
 import type { MappingKeyType } from '../types';
 import { resolveKeyWithType } from './mapping-key-resolver';
 
@@ -24,12 +23,12 @@ export abstract class TableColumnEnumBaseValidator<
     public constructor(
         columnInternals: ColumnInternals<unknown>,
         configValidityKeys: ValidityFlagNames,
-        private readonly supportedMappingElements: readonly (typeof Mapping)[]
+        private readonly supportedMappingElements: readonly (typeof Mapping<unknown>)[]
     ) {
         super(columnInternals, configValidityKeys);
     }
 
-    public validate(mappings: Mapping[], keyType: MappingKeyType): void {
+    public validate(mappings: Mapping<unknown>[], keyType: MappingKeyType): void {
         this.untrackAll();
         const keys = mappings.map(mapping => mapping.key);
         this.validateKeyValuesForType(keys, keyType);
@@ -40,7 +39,7 @@ export abstract class TableColumnEnumBaseValidator<
     }
 
     private validateKeyValuesForType(
-        keys: (MappingKey | undefined)[],
+        keys: (unknown)[],
         keyType: MappingKeyType
     ): void {
         // Ignore undefined keys, because validateNoMissingKeys covers that case.
@@ -53,7 +52,7 @@ export abstract class TableColumnEnumBaseValidator<
         this.setConditionValue('invalidMappingKeyValueForType', invalid);
     }
 
-    private validateMappingTypes(mappings: Mapping[]): void {
+    private validateMappingTypes(mappings: Mapping<unknown>[]): void {
         const valid = mappings.every(mapping => this.supportedMappingElements.some(
             mappingClass => mapping instanceof mappingClass
         ));
@@ -61,7 +60,7 @@ export abstract class TableColumnEnumBaseValidator<
     }
 
     private validateUniqueKeys(
-        keys: (MappingKey | undefined)[],
+        keys: (unknown)[],
         keyType: MappingKeyType
     ): void {
         const typedKeys = keys.map(x => resolveKeyWithType(x, keyType));
@@ -69,12 +68,12 @@ export abstract class TableColumnEnumBaseValidator<
         this.setConditionValue('duplicateMappingKey', invalid);
     }
 
-    private validateNoMissingKeys(mappings: Mapping[]): void {
+    private validateNoMissingKeys(mappings: Mapping<unknown>[]): void {
         const invalid = mappings.some(mapping => mapping.key === undefined);
         this.setConditionValue('missingKeyValue', invalid);
     }
 
-    private validateNoMissingText(mappings: Mapping[]): void {
+    private validateNoMissingText(mappings: Mapping<unknown>[]): void {
         const invalid = mappings.some(mapping => mapping.text === undefined);
         this.setConditionValue('missingTextValue', invalid);
     }

--- a/packages/nimble-components/src/table-column/enum-base/models/table-column-enum-base-validator.ts
+++ b/packages/nimble-components/src/table-column/enum-base/models/table-column-enum-base-validator.ts
@@ -6,7 +6,6 @@ import { resolveKeyWithType } from './mapping-key-resolver';
 
 export const enumBaseValidityFlagNames = [
     'invalidMappingKeyValueForType',
-    'unsupportedMappingType',
     'duplicateMappingKey',
     'missingKeyValue'
 ] as const;
@@ -21,8 +20,7 @@ export abstract class TableColumnEnumBaseValidator<
     > {
     public constructor(
         columnInternals: ColumnInternals<unknown>,
-        configValidityKeys: ValidityFlagNames,
-        private readonly supportedMappingElements: readonly (typeof Mapping<unknown>)[]
+        configValidityKeys: ValidityFlagNames
     ) {
         super(columnInternals, configValidityKeys);
     }
@@ -34,7 +32,6 @@ export abstract class TableColumnEnumBaseValidator<
         this.untrackAll();
         const keys = mappings.map(mapping => mapping.key);
         this.validateKeyValuesForType(keys, keyType);
-        this.validateMappingTypes(mappings);
         this.validateUniqueKeys(keys, keyType);
         this.validateNoMissingKeys(mappings);
     }
@@ -51,13 +48,6 @@ export abstract class TableColumnEnumBaseValidator<
                 && resolveKeyWithType(key, keyType) === undefined
         );
         this.setConditionValue('invalidMappingKeyValueForType', invalid);
-    }
-
-    private validateMappingTypes(mappings: Mapping<unknown>[]): void {
-        const valid = mappings.every(mapping => this.supportedMappingElements.some(
-            mappingClass => mapping instanceof mappingClass
-        ));
-        this.setConditionValue('unsupportedMappingType', !valid);
     }
 
     private validateUniqueKeys(keys: unknown[], keyType: MappingKeyType): void {

--- a/packages/nimble-components/src/table-column/enum-text/index.ts
+++ b/packages/nimble-components/src/table-column/enum-text/index.ts
@@ -61,7 +61,7 @@ export class TableColumnEnumText extends mixinGroupableColumnAPI(
         };
     }
 
-    protected createMappingConfig(mapping: Mapping): MappingConfig {
+    protected createMappingConfig(mapping: Mapping<unknown>): MappingConfig {
         if (mapping instanceof MappingText) {
             return new MappingTextConfig(mapping.text);
         }

--- a/packages/nimble-components/src/table-column/enum-text/models/table-column-enum-text-validator.ts
+++ b/packages/nimble-components/src/table-column/enum-text/models/table-column-enum-text-validator.ts
@@ -46,7 +46,9 @@ export class TableColumnEnumTextValidator extends TableColumnEnumBaseValidator<
     }
 
     private validateMappingTypes(mappings: Mapping<unknown>[]): void {
-        const valid = mappings.every(TableColumnEnumTextValidator.isSupportedMappingElement);
+        const valid = mappings.every(
+            TableColumnEnumTextValidator.isSupportedMappingElement
+        );
         this.setConditionValue('unsupportedMappingType', !valid);
     }
 }

--- a/packages/nimble-components/src/table-column/enum-text/models/table-column-enum-text-validator.ts
+++ b/packages/nimble-components/src/table-column/enum-text/models/table-column-enum-text-validator.ts
@@ -1,11 +1,16 @@
+import type { Mapping } from '../../../mapping/base';
 import { MappingText } from '../../../mapping/text';
 import type { ColumnInternals } from '../../base/models/column-internals';
 import {
     TableColumnEnumBaseValidator,
     enumBaseValidityFlagNames
 } from '../../enum-base/models/table-column-enum-base-validator';
+import type { MappingKeyType } from '../../enum-base/types';
 
-const enumTextValidityFlagNames = [...enumBaseValidityFlagNames] as const;
+const enumTextValidityFlagNames = [
+    ...enumBaseValidityFlagNames,
+    'missingTextValue'
+] as const;
 
 /**
  * Validator for TableColumnEnumText
@@ -15,5 +20,26 @@ export class TableColumnEnumTextValidator extends TableColumnEnumBaseValidator<
 > {
     public constructor(columnInternals: ColumnInternals<unknown>) {
         super(columnInternals, enumTextValidityFlagNames, [MappingText]);
+    }
+
+    private static isSupportedMappingElement(
+        mapping: Mapping<unknown>
+    ): mapping is MappingText {
+        return mapping instanceof MappingText;
+    }
+
+    public override validate(
+        mappings: Mapping<unknown>[],
+        keyType: MappingKeyType
+    ): void {
+        super.validate(mappings, keyType);
+        this.validateNoMissingText(mappings);
+    }
+
+    private validateNoMissingText(mappings: Mapping<unknown>[]): void {
+        const invalid = mappings
+            .filter(TableColumnEnumTextValidator.isSupportedMappingElement)
+            .some(mapping => mapping.text === undefined);
+        this.setConditionValue('missingTextValue', invalid);
     }
 }

--- a/packages/nimble-components/src/table-column/enum-text/models/table-column-enum-text-validator.ts
+++ b/packages/nimble-components/src/table-column/enum-text/models/table-column-enum-text-validator.ts
@@ -9,6 +9,7 @@ import type { MappingKeyType } from '../../enum-base/types';
 
 const enumTextValidityFlagNames = [
     ...enumBaseValidityFlagNames,
+    'unsupportedMappingType',
     'missingTextValue'
 ] as const;
 
@@ -19,7 +20,7 @@ export class TableColumnEnumTextValidator extends TableColumnEnumBaseValidator<
     typeof enumTextValidityFlagNames
 > {
     public constructor(columnInternals: ColumnInternals<unknown>) {
-        super(columnInternals, enumTextValidityFlagNames, [MappingText]);
+        super(columnInternals, enumTextValidityFlagNames);
     }
 
     private static isSupportedMappingElement(
@@ -33,6 +34,7 @@ export class TableColumnEnumTextValidator extends TableColumnEnumBaseValidator<
         keyType: MappingKeyType
     ): void {
         super.validate(mappings, keyType);
+        this.validateMappingTypes(mappings);
         this.validateNoMissingText(mappings);
     }
 
@@ -41,5 +43,10 @@ export class TableColumnEnumTextValidator extends TableColumnEnumBaseValidator<
             .filter(TableColumnEnumTextValidator.isSupportedMappingElement)
             .some(mapping => mapping.text === undefined);
         this.setConditionValue('missingTextValue', invalid);
+    }
+
+    private validateMappingTypes(mappings: Mapping<unknown>[]): void {
+        const valid = mappings.every(TableColumnEnumTextValidator.isSupportedMappingElement);
+        this.setConditionValue('unsupportedMappingType', !valid);
     }
 }

--- a/packages/nimble-components/src/table-column/icon/index.ts
+++ b/packages/nimble-components/src/table-column/icon/index.ts
@@ -63,7 +63,7 @@ export class TableColumnIcon extends mixinGroupableColumnAPI(
         };
     }
 
-    protected createMappingConfig(mapping: Mapping): MappingConfig {
+    protected createMappingConfig(mapping: Mapping<unknown>): MappingConfig {
         if (mapping instanceof MappingIcon) {
             if (!mapping.resolvedIcon) {
                 throw Error('Unresolved icon');

--- a/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
+++ b/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
@@ -10,7 +10,8 @@ import type { MappingKeyType } from '../../enum-base/types';
 
 const iconValidityFlagNames = [
     ...enumBaseValidityFlagNames,
-    'invalidIconName'
+    'invalidIconName',
+    'missingTextValue'
 ] as const;
 
 /**
@@ -23,7 +24,13 @@ export class TableColumnIconValidator extends TableColumnEnumBaseValidator<
         super(columnInternals, iconValidityFlagNames, [
             MappingIcon,
             MappingSpinner
-        ]);
+        ] as const);
+    }
+
+    private static isSupportedMappingElement(
+        mapping: Mapping<unknown>
+    ): mapping is MappingIcon {
+        return mapping instanceof MappingIcon;
     }
 
     public override validate(
@@ -32,15 +39,20 @@ export class TableColumnIconValidator extends TableColumnEnumBaseValidator<
     ): void {
         super.validate(mappings, keyType);
         this.validateIconNames(mappings);
+        this.validateNoMissingText(mappings);
     }
 
     private validateIconNames(mappings: Mapping<unknown>[]): void {
-        const isMappingIcon = (
-            mapping: Mapping<unknown>
-        ): mapping is MappingIcon => mapping instanceof MappingIcon;
         const invalid = mappings
-            .filter(isMappingIcon)
+            .filter(TableColumnIconValidator.isSupportedMappingElement)
             .some(mappingIcon => mappingIcon.resolvedIcon === undefined);
         this.setConditionValue('invalidIconName', invalid);
+    }
+
+    private validateNoMissingText(mappings: Mapping<unknown>[]): void {
+        const invalid = mappings
+            .filter(TableColumnIconValidator.isSupportedMappingElement)
+            .some(mapping => mapping.text === undefined);
+        this.setConditionValue('missingTextValue', invalid);
     }
 }

--- a/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
+++ b/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
@@ -27,10 +27,16 @@ export class TableColumnIconValidator extends TableColumnEnumBaseValidator<
         ] as const);
     }
 
-    private static isSupportedMappingElement(
+    private static isIconMappingElement(
         mapping: Mapping<unknown>
     ): mapping is MappingIcon {
         return mapping instanceof MappingIcon;
+    }
+
+    private static isSupportedMappingElement(
+        mapping: Mapping<unknown>
+    ): mapping is MappingIcon | MappingSpinner {
+        return mapping instanceof MappingIcon || mapping instanceof MappingSpinner;
     }
 
     public override validate(
@@ -44,7 +50,7 @@ export class TableColumnIconValidator extends TableColumnEnumBaseValidator<
 
     private validateIconNames(mappings: Mapping<unknown>[]): void {
         const invalid = mappings
-            .filter(TableColumnIconValidator.isSupportedMappingElement)
+            .filter(TableColumnIconValidator.isIconMappingElement)
             .some(mappingIcon => mappingIcon.resolvedIcon === undefined);
         this.setConditionValue('invalidIconName', invalid);
     }

--- a/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
+++ b/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
@@ -10,6 +10,7 @@ import type { MappingKeyType } from '../../enum-base/types';
 
 const iconValidityFlagNames = [
     ...enumBaseValidityFlagNames,
+    'unsupportedMappingType',
     'invalidIconName',
     'missingTextValue'
 ] as const;
@@ -21,10 +22,7 @@ export class TableColumnIconValidator extends TableColumnEnumBaseValidator<
     typeof iconValidityFlagNames
 > {
     public constructor(columnInternals: ColumnInternals<unknown>) {
-        super(columnInternals, iconValidityFlagNames, [
-            MappingIcon,
-            MappingSpinner
-        ] as const);
+        super(columnInternals, iconValidityFlagNames);
     }
 
     private static isIconMappingElement(
@@ -46,6 +44,7 @@ export class TableColumnIconValidator extends TableColumnEnumBaseValidator<
         keyType: MappingKeyType
     ): void {
         super.validate(mappings, keyType);
+        this.validateMappingTypes(mappings);
         this.validateIconNames(mappings);
         this.validateNoMissingText(mappings);
     }
@@ -62,5 +61,10 @@ export class TableColumnIconValidator extends TableColumnEnumBaseValidator<
             .filter(TableColumnIconValidator.isSupportedMappingElement)
             .some(mapping => mapping.text === undefined);
         this.setConditionValue('missingTextValue', invalid);
+    }
+
+    private validateMappingTypes(mappings: Mapping<unknown>[]): void {
+        const valid = mappings.every(TableColumnIconValidator.isSupportedMappingElement);
+        this.setConditionValue('unsupportedMappingType', !valid);
     }
 }

--- a/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
+++ b/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
@@ -35,7 +35,9 @@ export class TableColumnIconValidator extends TableColumnEnumBaseValidator<
     }
 
     private validateIconNames(mappings: Mapping<unknown>[]): void {
-        const isMappingIcon = (mapping: Mapping<unknown>): mapping is MappingIcon => mapping instanceof MappingIcon;
+        const isMappingIcon = (
+            mapping: Mapping<unknown>
+        ): mapping is MappingIcon => mapping instanceof MappingIcon;
         const invalid = mappings
             .filter(isMappingIcon)
             .some(mappingIcon => mappingIcon.resolvedIcon === undefined);

--- a/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
+++ b/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
@@ -64,7 +64,9 @@ export class TableColumnIconValidator extends TableColumnEnumBaseValidator<
     }
 
     private validateMappingTypes(mappings: Mapping<unknown>[]): void {
-        const valid = mappings.every(TableColumnIconValidator.isSupportedMappingElement);
+        const valid = mappings.every(
+            TableColumnIconValidator.isSupportedMappingElement
+        );
         this.setConditionValue('unsupportedMappingType', !valid);
     }
 }

--- a/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
+++ b/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
@@ -27,15 +27,15 @@ export class TableColumnIconValidator extends TableColumnEnumBaseValidator<
     }
 
     public override validate(
-        mappings: Mapping[],
+        mappings: Mapping<unknown>[],
         keyType: MappingKeyType
     ): void {
         super.validate(mappings, keyType);
         this.validateIconNames(mappings);
     }
 
-    private validateIconNames(mappings: Mapping[]): void {
-        const isMappingIcon = (mapping: Mapping): mapping is MappingIcon => mapping instanceof MappingIcon;
+    private validateIconNames(mappings: Mapping<unknown>[]): void {
+        const isMappingIcon = (mapping: Mapping<unknown>): mapping is MappingIcon => mapping instanceof MappingIcon;
         const invalid = mappings
             .filter(isMappingIcon)
             .some(mappingIcon => mappingIcon.resolvedIcon === undefined);

--- a/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
+++ b/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
@@ -36,7 +36,9 @@ export class TableColumnIconValidator extends TableColumnEnumBaseValidator<
     private static isSupportedMappingElement(
         mapping: Mapping<unknown>
     ): mapping is MappingIcon | MappingSpinner {
-        return mapping instanceof MappingIcon || mapping instanceof MappingSpinner;
+        return (
+            mapping instanceof MappingIcon || mapping instanceof MappingSpinner
+        );
     }
 
     public override validate(

--- a/packages/nimble-components/src/table-column/icon/tests/table-column-icon.spec.ts
+++ b/packages/nimble-components/src/table-column/icon/tests/table-column-icon.spec.ts
@@ -15,6 +15,7 @@ import type { MappingKey } from '../../../mapping/base/types';
 import { IconSeverity } from '../../../icon-base/types';
 import { MappingKeyType } from '../../enum-base/types';
 import { mappingSpinnerTag } from '../../../mapping/spinner';
+import { spinnerTag } from '../../../spinner';
 
 interface SimpleTableRecord extends TableRecord {
     field1?: MappingKey | undefined;
@@ -121,6 +122,28 @@ describe('TableColumnIcon', () => {
                 expect(
                     pageObject.getRenderedIconColumnCellIconTagName(0, 0)
                 ).toBe(iconXmarkTag);
+            });
+        }
+
+        for (const test of dataTypeTests) {
+            const specType = getSpecTypeByNamedList(test, focused, disabled);
+            // eslint-disable-next-line @typescript-eslint/no-loop-func
+            specType(`displays spinner mapped from ${test.name}`, async () => {
+                ({ element, connect, disconnect, model } = await setup(
+                    {
+                        keyType: test.name,
+                        iconMappings: [],
+                        spinnerMappings: [{ key: test.key, text: 'alpha' }]
+                    }
+                ));
+                pageObject = new TablePageObject<SimpleTableRecord>(element);
+                await element.setData([{ field1: test.key }]);
+                await connect();
+                await waitForUpdatesAsync();
+
+                expect(
+                    pageObject.getRenderedIconColumnCellIconTagName(0, 0)
+                ).toBe(spinnerTag);
             });
         }
     });
@@ -502,7 +525,7 @@ describe('TableColumnIcon', () => {
             expect(model.col1.validity.missingKeyValue).toBeTrue();
         });
 
-        it('is invalid with missing text value', async () => {
+        it('is invalid with missing icon text value', async () => {
             ({ element, connect, disconnect, model } = await setup({
                 keyType: MappingKeyType.string,
                 iconMappings: [
@@ -542,6 +565,18 @@ describe('TableColumnIcon', () => {
             await waitForUpdatesAsync();
             expect(model.col1.checkValidity()).toBeFalse();
             expect(model.col1.validity.invalidIconName).toBeTrue();
+        });
+
+        it('is invalid with missing spinner text value', async () => {
+            ({ element, connect, disconnect, model } = await setup({
+                keyType: MappingKeyType.string,
+                iconMappings: [],
+                spinnerMappings: [{ key: 'a' }]
+            }));
+            await connect();
+            await waitForUpdatesAsync();
+            expect(model.col1.checkValidity()).toBeFalse();
+            expect(model.col1.validity.missingTextValue).toBeTrue();
         });
     });
 });

--- a/packages/nimble-components/src/table-column/icon/tests/table-column-icon.spec.ts
+++ b/packages/nimble-components/src/table-column/icon/tests/table-column-icon.spec.ts
@@ -107,13 +107,13 @@ describe('TableColumnIcon', () => {
             const specType = getSpecTypeByNamedList(test, focused, disabled);
             // eslint-disable-next-line @typescript-eslint/no-loop-func
             specType(`displays icon mapped from ${test.name}`, async () => {
-                ({ element, connect, disconnect, model } = await setup(
-                    {
-                        keyType: test.name,
-                        iconMappings: [{ key: test.key, text: 'alpha', icon: iconXmarkTag }],
-                        spinnerMappings: []
-                    }
-                ));
+                ({ element, connect, disconnect, model } = await setup({
+                    keyType: test.name,
+                    iconMappings: [
+                        { key: test.key, text: 'alpha', icon: iconXmarkTag }
+                    ],
+                    spinnerMappings: []
+                }));
                 pageObject = new TablePageObject<SimpleTableRecord>(element);
                 await element.setData([{ field1: test.key }]);
                 await connect();
@@ -129,13 +129,11 @@ describe('TableColumnIcon', () => {
             const specType = getSpecTypeByNamedList(test, focused, disabled);
             // eslint-disable-next-line @typescript-eslint/no-loop-func
             specType(`displays spinner mapped from ${test.name}`, async () => {
-                ({ element, connect, disconnect, model } = await setup(
-                    {
-                        keyType: test.name,
-                        iconMappings: [],
-                        spinnerMappings: [{ key: test.key, text: 'alpha' }]
-                    }
-                ));
+                ({ element, connect, disconnect, model } = await setup({
+                    keyType: test.name,
+                    iconMappings: [],
+                    spinnerMappings: [{ key: test.key, text: 'alpha' }]
+                }));
                 pageObject = new TablePageObject<SimpleTableRecord>(element);
                 await element.setData([{ field1: test.key }]);
                 await connect();
@@ -227,9 +225,7 @@ describe('TableColumnIcon', () => {
     it('changing mapping key updates display', async () => {
         ({ element, connect, disconnect, model } = await setup({
             keyType: MappingKeyType.string,
-            iconMappings: [
-                { key: 'a', text: 'alpha', icon: iconXmarkTag }
-            ],
+            iconMappings: [{ key: 'a', text: 'alpha', icon: iconXmarkTag }],
             spinnerMappings: []
         }));
         pageObject = new TablePageObject<SimpleTableRecord>(element);
@@ -249,9 +245,7 @@ describe('TableColumnIcon', () => {
     it('sets label as title of icon', async () => {
         ({ element, connect, disconnect, model } = await setup({
             keyType: MappingKeyType.string,
-            iconMappings: [
-                { key: 'a', text: 'alpha', icon: iconXmarkTag }
-            ],
+            iconMappings: [{ key: 'a', text: 'alpha', icon: iconXmarkTag }],
             spinnerMappings: []
         }));
         pageObject = new TablePageObject<SimpleTableRecord>(element);
@@ -264,9 +258,7 @@ describe('TableColumnIcon', () => {
     it('sets label as aria-label of icon', async () => {
         ({ element, connect, disconnect, model } = await setup({
             keyType: MappingKeyType.string,
-            iconMappings: [
-                { key: 'a', text: 'alpha', icon: iconXmarkTag }
-            ],
+            iconMappings: [{ key: 'a', text: 'alpha', icon: iconXmarkTag }],
             spinnerMappings: []
         }));
         pageObject = new TablePageObject<SimpleTableRecord>(element);
@@ -514,9 +506,7 @@ describe('TableColumnIcon', () => {
         it('is invalid with missing key value', async () => {
             ({ element, connect, disconnect, model } = await setup({
                 keyType: MappingKeyType.string,
-                iconMappings: [
-                    { text: 'alpha', icon: iconXmarkTag }
-                ],
+                iconMappings: [{ text: 'alpha', icon: iconXmarkTag }],
                 spinnerMappings: []
             }));
             await connect();
@@ -528,9 +518,7 @@ describe('TableColumnIcon', () => {
         it('is invalid with missing icon text value', async () => {
             ({ element, connect, disconnect, model } = await setup({
                 keyType: MappingKeyType.string,
-                iconMappings: [
-                    { key: 'a', icon: iconXmarkTag }
-                ],
+                iconMappings: [{ key: 'a', icon: iconXmarkTag }],
                 spinnerMappings: []
             }));
             await connect();
@@ -542,9 +530,7 @@ describe('TableColumnIcon', () => {
         it('is invalid with non-icon icon value', async () => {
             ({ element, connect, disconnect, model } = await setup({
                 keyType: MappingKeyType.string,
-                iconMappings: [
-                    { key: 'a', text: 'alpha', icon: 'div' }
-                ],
+                iconMappings: [{ key: 'a', text: 'alpha', icon: 'div' }],
                 spinnerMappings: []
             }));
             await connect();
@@ -556,9 +542,7 @@ describe('TableColumnIcon', () => {
         it('is invalid with completely made up icon value', async () => {
             ({ element, connect, disconnect, model } = await setup({
                 keyType: MappingKeyType.string,
-                iconMappings: [
-                    { key: 'a', text: 'alpha', icon: 'foo' }
-                ],
+                iconMappings: [{ key: 'a', text: 'alpha', icon: 'foo' }],
                 spinnerMappings: []
             }));
             await connect();

--- a/packages/nimble-components/src/table-column/icon/tests/table-column-icon.spec.ts
+++ b/packages/nimble-components/src/table-column/icon/tests/table-column-icon.spec.ts
@@ -13,6 +13,8 @@ import { iconXmarkTag } from '../../../icons/xmark';
 import { iconCheckTag } from '../../../icons/check';
 import type { MappingKey } from '../../../mapping/base/types';
 import { IconSeverity } from '../../../icon-base/types';
+import { MappingKeyType } from '../../enum-base/types';
+import { mappingSpinnerTag } from '../../../mapping/spinner';
 
 interface SimpleTableRecord extends TableRecord {
     field1?: MappingKey | undefined;
@@ -23,6 +25,11 @@ interface BasicIconMapping {
     key?: MappingKey;
     text?: string;
     icon: string;
+}
+
+interface BasicSpinnerMapping {
+    key?: MappingKey;
+    text?: string;
 }
 
 class Model {
@@ -40,18 +47,28 @@ describe('TableColumnIcon', () => {
     let model: Model;
 
     // prettier-ignore
-    async function setup(mappings: BasicIconMapping[], keyType = 'string'): Promise<ModelFixture<Table<SimpleTableRecord>>> {
+    async function setup(options: {
+        keyType: MappingKeyType,
+        iconMappings: BasicIconMapping[],
+        spinnerMappings: BasicSpinnerMapping[]
+    }): Promise<ModelFixture<Table<SimpleTableRecord>>> {
         const source = new Model();
         const result = await fixture<Table<SimpleTableRecord>>(html<Model>`
             <${tableTag} style="width: 700px">
-                <${tableColumnIconTag} ${ref('col1')} field-name="field1" key-type="${keyType}">
+                <${tableColumnIconTag} ${ref('col1')} field-name="field1" key-type="${options.keyType}">
                     Column 1
-                    ${repeat(() => mappings, html<BasicIconMapping>`
+                    ${repeat(() => options.iconMappings, html<BasicIconMapping>`
                         <${mappingIconTag}
                             key="${x => x.key}"
                             text="${x => x.text}"
                             icon="${x => x.icon}">
                         </${mappingIconTag}>
+                    `)}
+                    ${repeat(() => options.spinnerMappings, html<BasicSpinnerMapping>`
+                    <${mappingSpinnerTag}
+                        key="${x => x.key}"
+                        text="${x => x.text}"
+                    </${mappingSpinnerTag}>
                     `)}
                 </${tableColumnIconTag}>
             </${tableTag}>`, { source });
@@ -79,9 +96,9 @@ describe('TableColumnIcon', () => {
 
     describe('various key types', () => {
         const dataTypeTests = [
-            { name: 'string', key: 'a' },
-            { name: 'number', key: 10 },
-            { name: 'boolean', key: true }
+            { name: MappingKeyType.string, key: 'a' },
+            { name: MappingKeyType.number, key: 10 },
+            { name: MappingKeyType.boolean, key: true }
         ];
         const focused: string[] = [];
         const disabled: string[] = [];
@@ -90,8 +107,11 @@ describe('TableColumnIcon', () => {
             // eslint-disable-next-line @typescript-eslint/no-loop-func
             specType(`displays icon mapped from ${test.name}`, async () => {
                 ({ element, connect, disconnect, model } = await setup(
-                    [{ key: test.key, text: 'alpha', icon: iconXmarkTag }],
-                    test.name
+                    {
+                        keyType: test.name,
+                        iconMappings: [{ key: test.key, text: 'alpha', icon: iconXmarkTag }],
+                        spinnerMappings: []
+                    }
                 ));
                 pageObject = new TablePageObject<SimpleTableRecord>(element);
                 await element.setData([{ field1: test.key }]);
@@ -106,9 +126,11 @@ describe('TableColumnIcon', () => {
     });
 
     it('displays blank when no matches', async () => {
-        ({ element, connect, disconnect, model } = await setup([
-            { key: 'a', text: 'alpha', icon: iconXmarkTag }
-        ]));
+        ({ element, connect, disconnect, model } = await setup({
+            keyType: MappingKeyType.string,
+            iconMappings: [{ key: 'a', text: 'alpha', icon: iconXmarkTag }],
+            spinnerMappings: []
+        }));
         pageObject = new TablePageObject<SimpleTableRecord>(element);
         await element.setData([{ field1: 'no match' }]);
         await connect();
@@ -118,10 +140,14 @@ describe('TableColumnIcon', () => {
     });
 
     it('changing fieldName updates display', async () => {
-        ({ element, connect, disconnect, model } = await setup([
-            { key: 'a', text: 'alpha', icon: iconXmarkTag },
-            { key: 'b', text: 'bravo', icon: iconCheckTag }
-        ]));
+        ({ element, connect, disconnect, model } = await setup({
+            keyType: MappingKeyType.string,
+            iconMappings: [
+                { key: 'a', text: 'alpha', icon: iconXmarkTag },
+                { key: 'b', text: 'bravo', icon: iconCheckTag }
+            ],
+            spinnerMappings: []
+        }));
         pageObject = new TablePageObject<SimpleTableRecord>(element);
         await element.setData([{ field1: 'a', field2: 'b' }]);
         await connect();
@@ -136,9 +162,11 @@ describe('TableColumnIcon', () => {
     });
 
     it('changing mapping icon updates display', async () => {
-        ({ element, connect, disconnect, model } = await setup([
-            { key: 'a', text: 'alpha', icon: iconXmarkTag }
-        ]));
+        ({ element, connect, disconnect, model } = await setup({
+            keyType: MappingKeyType.string,
+            iconMappings: [{ key: 'a', text: 'alpha', icon: iconXmarkTag }],
+            spinnerMappings: []
+        }));
         pageObject = new TablePageObject<SimpleTableRecord>(element);
         await element.setData([{ field1: 'a' }]);
         await connect();
@@ -154,9 +182,11 @@ describe('TableColumnIcon', () => {
     });
 
     it('changing mapping severity updates display', async () => {
-        ({ element, connect, disconnect, model } = await setup([
-            { key: 'a', text: 'alpha', icon: iconXmarkTag }
-        ]));
+        ({ element, connect, disconnect, model } = await setup({
+            keyType: MappingKeyType.string,
+            iconMappings: [{ key: 'a', text: 'alpha', icon: iconXmarkTag }],
+            spinnerMappings: []
+        }));
         pageObject = new TablePageObject<SimpleTableRecord>(element);
         await element.setData([{ field1: 'a' }]);
         await connect();
@@ -172,9 +202,13 @@ describe('TableColumnIcon', () => {
     });
 
     it('changing mapping key updates display', async () => {
-        ({ element, connect, disconnect, model } = await setup([
-            { key: 'a', text: 'alpha', icon: iconXmarkTag }
-        ]));
+        ({ element, connect, disconnect, model } = await setup({
+            keyType: MappingKeyType.string,
+            iconMappings: [
+                { key: 'a', text: 'alpha', icon: iconXmarkTag }
+            ],
+            spinnerMappings: []
+        }));
         pageObject = new TablePageObject<SimpleTableRecord>(element);
         await element.setData([{ field1: 'b' }]);
         await connect();
@@ -190,9 +224,13 @@ describe('TableColumnIcon', () => {
     });
 
     it('sets label as title of icon', async () => {
-        ({ element, connect, disconnect, model } = await setup([
-            { key: 'a', text: 'alpha', icon: iconXmarkTag }
-        ]));
+        ({ element, connect, disconnect, model } = await setup({
+            keyType: MappingKeyType.string,
+            iconMappings: [
+                { key: 'a', text: 'alpha', icon: iconXmarkTag }
+            ],
+            spinnerMappings: []
+        }));
         pageObject = new TablePageObject<SimpleTableRecord>(element);
         await element.setData([{ field1: 'a' }]);
         await connect();
@@ -201,9 +239,13 @@ describe('TableColumnIcon', () => {
     });
 
     it('sets label as aria-label of icon', async () => {
-        ({ element, connect, disconnect, model } = await setup([
-            { key: 'a', text: 'alpha', icon: iconXmarkTag }
-        ]));
+        ({ element, connect, disconnect, model } = await setup({
+            keyType: MappingKeyType.string,
+            iconMappings: [
+                { key: 'a', text: 'alpha', icon: iconXmarkTag }
+            ],
+            spinnerMappings: []
+        }));
         pageObject = new TablePageObject<SimpleTableRecord>(element);
         await element.setData([{ field1: 'a' }]);
         await connect();
@@ -223,13 +265,17 @@ describe('TableColumnIcon', () => {
                 `data "${value.name}" renders as "${value.name}"`,
                 // eslint-disable-next-line @typescript-eslint/no-loop-func
                 async () => {
-                    ({ element, connect, disconnect, model } = await setup([
-                        {
-                            key: 'a',
-                            text: value.name,
-                            icon: iconXmarkTag
-                        }
-                    ]));
+                    ({ element, connect, disconnect, model } = await setup({
+                        keyType: MappingKeyType.string,
+                        iconMappings: [
+                            {
+                                key: 'a',
+                                text: value.name,
+                                icon: iconXmarkTag
+                            }
+                        ],
+                        spinnerMappings: []
+                    }));
                     pageObject = new TablePageObject<SimpleTableRecord>(
                         element
                     );
@@ -248,9 +294,11 @@ describe('TableColumnIcon', () => {
     });
 
     it('sets group header text to blank when unmatched', async () => {
-        ({ element, connect, disconnect, model } = await setup([
-            { key: 'b', text: 'bravo', icon: iconXmarkTag }
-        ]));
+        ({ element, connect, disconnect, model } = await setup({
+            keyType: MappingKeyType.string,
+            iconMappings: [{ key: 'b', text: 'bravo', icon: iconXmarkTag }],
+            spinnerMappings: []
+        }));
         pageObject = new TablePageObject<SimpleTableRecord>(element);
         await element.setData([{ field1: 'unmatched' }]);
         await connect();
@@ -262,9 +310,11 @@ describe('TableColumnIcon', () => {
     });
 
     it('clears cell when mappings removed', async () => {
-        ({ element, connect, disconnect, model } = await setup([
-            { key: 'a', text: 'alpha', icon: iconXmarkTag }
-        ]));
+        ({ element, connect, disconnect, model } = await setup({
+            keyType: MappingKeyType.string,
+            iconMappings: [{ key: 'a', text: 'alpha', icon: iconXmarkTag }],
+            spinnerMappings: []
+        }));
         pageObject = new TablePageObject<SimpleTableRecord>(element);
         await element.setData([{ field1: 'a' }]);
         await connect();
@@ -279,9 +329,11 @@ describe('TableColumnIcon', () => {
     });
 
     it('clears group header when mappings removed', async () => {
-        ({ element, connect, disconnect, model } = await setup([
-            { key: 'a', text: 'alpha', icon: iconXmarkTag }
-        ]));
+        ({ element, connect, disconnect, model } = await setup({
+            keyType: MappingKeyType.string,
+            iconMappings: [{ key: 'a', text: 'alpha', icon: iconXmarkTag }],
+            spinnerMappings: []
+        }));
         pageObject = new TablePageObject<SimpleTableRecord>(element);
         await element.setData([{ field1: 'a' }]);
         model.col1.groupIndex = 0;
@@ -298,10 +350,11 @@ describe('TableColumnIcon', () => {
 
     describe('validation', () => {
         it('is valid with no mappings', async () => {
-            ({ element, connect, disconnect, model } = await setup(
-                [],
-                'number'
-            ));
+            ({ element, connect, disconnect, model } = await setup({
+                keyType: MappingKeyType.number,
+                iconMappings: [],
+                spinnerMappings: []
+            }));
             await connect();
             await waitForUpdatesAsync();
             const column = model.col1;
@@ -314,16 +367,17 @@ describe('TableColumnIcon', () => {
         });
 
         it('is valid with valid numeric key values', async () => {
-            ({ element, connect, disconnect, model } = await setup(
-                [
+            ({ element, connect, disconnect, model } = await setup({
+                keyType: MappingKeyType.number,
+                iconMappings: [
                     { key: '0', text: 'alpha', icon: iconXmarkTag },
                     { key: '1', text: 'alpha', icon: iconXmarkTag },
                     { key: '1.01', text: 'alpha', icon: iconXmarkTag },
                     { key: '-1.01', text: 'alpha', icon: iconXmarkTag },
                     { key: '-1e3', text: 'alpha', icon: iconXmarkTag }
                 ],
-                'number'
-            ));
+                spinnerMappings: []
+            }));
             await connect();
             await waitForUpdatesAsync();
             expect(model.col1.checkValidity()).toBeTrue();
@@ -348,16 +402,17 @@ describe('TableColumnIcon', () => {
                 );
                 // eslint-disable-next-line @typescript-eslint/no-loop-func
                 specType(` ${test.name}`, async () => {
-                    ({ element, connect, disconnect, model } = await setup(
-                        [
+                    ({ element, connect, disconnect, model } = await setup({
+                        keyType: MappingKeyType.boolean,
+                        iconMappings: [
                             {
                                 key: test.key,
                                 text: 'alpha',
                                 icon: iconXmarkTag
                             }
                         ],
-                        'boolean'
-                    ));
+                        spinnerMappings: []
+                    }));
                     await connect();
                     await waitForUpdatesAsync();
                     expect(model.col1.checkValidity()).toBeFalse();
@@ -369,10 +424,11 @@ describe('TableColumnIcon', () => {
         });
 
         it('is invalid with invalid numeric key values', async () => {
-            ({ element, connect, disconnect, model } = await setup(
-                [{ key: 'a', text: 'alpha', icon: iconXmarkTag }],
-                'number'
-            ));
+            ({ element, connect, disconnect, model } = await setup({
+                keyType: MappingKeyType.number,
+                iconMappings: [{ key: 'a', text: 'alpha', icon: iconXmarkTag }],
+                spinnerMappings: []
+            }));
             await connect();
             await waitForUpdatesAsync();
             expect(model.col1.checkValidity()).toBeFalse();
@@ -403,10 +459,14 @@ describe('TableColumnIcon', () => {
         });
 
         it('is invalid with duplicate key values', async () => {
-            ({ element, connect, disconnect, model } = await setup([
-                { key: 'a', text: 'alpha', icon: iconXmarkTag },
-                { key: 'a', text: 'alpha', icon: iconXmarkTag }
-            ]));
+            ({ element, connect, disconnect, model } = await setup({
+                keyType: MappingKeyType.string,
+                iconMappings: [
+                    { key: 'a', text: 'alpha', icon: iconXmarkTag },
+                    { key: 'a', text: 'alpha', icon: iconXmarkTag }
+                ],
+                spinnerMappings: []
+            }));
             await connect();
             await waitForUpdatesAsync();
             expect(model.col1.checkValidity()).toBeFalse();
@@ -414,13 +474,14 @@ describe('TableColumnIcon', () => {
         });
 
         it('is invalid with equivalent numeric key values', async () => {
-            ({ element, connect, disconnect, model } = await setup(
-                [
+            ({ element, connect, disconnect, model } = await setup({
+                keyType: MappingKeyType.number,
+                iconMappings: [
                     { key: '0', text: 'alpha', icon: iconXmarkTag },
                     { key: '0.0', text: 'alpha', icon: iconXmarkTag }
                 ],
-                'number'
-            ));
+                spinnerMappings: []
+            }));
             await connect();
             await waitForUpdatesAsync();
             expect(model.col1.checkValidity()).toBeFalse();
@@ -428,9 +489,13 @@ describe('TableColumnIcon', () => {
         });
 
         it('is invalid with missing key value', async () => {
-            ({ element, connect, disconnect, model } = await setup([
-                { text: 'alpha', icon: iconXmarkTag }
-            ]));
+            ({ element, connect, disconnect, model } = await setup({
+                keyType: MappingKeyType.string,
+                iconMappings: [
+                    { text: 'alpha', icon: iconXmarkTag }
+                ],
+                spinnerMappings: []
+            }));
             await connect();
             await waitForUpdatesAsync();
             expect(model.col1.checkValidity()).toBeFalse();
@@ -438,9 +503,13 @@ describe('TableColumnIcon', () => {
         });
 
         it('is invalid with missing text value', async () => {
-            ({ element, connect, disconnect, model } = await setup([
-                { key: 'a', icon: iconXmarkTag }
-            ]));
+            ({ element, connect, disconnect, model } = await setup({
+                keyType: MappingKeyType.string,
+                iconMappings: [
+                    { key: 'a', icon: iconXmarkTag }
+                ],
+                spinnerMappings: []
+            }));
             await connect();
             await waitForUpdatesAsync();
             expect(model.col1.checkValidity()).toBeFalse();
@@ -448,9 +517,13 @@ describe('TableColumnIcon', () => {
         });
 
         it('is invalid with non-icon icon value', async () => {
-            ({ element, connect, disconnect, model } = await setup([
-                { key: 'a', text: 'alpha', icon: 'div' }
-            ]));
+            ({ element, connect, disconnect, model } = await setup({
+                keyType: MappingKeyType.string,
+                iconMappings: [
+                    { key: 'a', text: 'alpha', icon: 'div' }
+                ],
+                spinnerMappings: []
+            }));
             await connect();
             await waitForUpdatesAsync();
             expect(model.col1.checkValidity()).toBeFalse();
@@ -458,9 +531,13 @@ describe('TableColumnIcon', () => {
         });
 
         it('is invalid with completely made up icon value', async () => {
-            ({ element, connect, disconnect, model } = await setup([
-                { key: 'a', text: 'alpha', icon: 'foo' }
-            ]));
+            ({ element, connect, disconnect, model } = await setup({
+                keyType: MappingKeyType.string,
+                iconMappings: [
+                    { key: 'a', text: 'alpha', icon: 'foo' }
+                ],
+                spinnerMappings: []
+            }));
             await connect();
             await waitForUpdatesAsync();
             expect(model.col1.checkValidity()).toBeFalse();


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

We would like to use the mapping base class in more contexts. Conceptually the mapping base class represents just a key and specific implementations represent any additional configuration and what types the key supports.

The mapping base class was modified to support generic key types and remove properties not necessarily needed for all mappings. For example the upcoming user mapping represents a key (href: string) and implementation details of a display-name today and others in the future (username, email, etc.)/

## 👩‍💻 Implementation

- Make the key generic on mapping
- Remove text from the mapping base class
- Update the table enum usages for the types

## 🧪 Testing

Relying on existing tests. Did not add additional tests around generic key types. Existing validation in table column implementations are thorough. Addressed testing gap with spinner validation.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
