### PR TITLE
Remove `height: auto;` from the nimble-table in the Angular example app

### DIFF
--- a/angular-workspace/projects/example-client-app/src/app/customapp/customapp.component.scss
+++ b/angular-workspace/projects/example-client-app/src/app/customapp/customapp.component.scss
@@ -70,7 +70,6 @@ nimble-drawer {
 }
 
 nimble-table {
-    height: auto;
     max-height: 480px;
 }
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The nimble-table doesn't support being configured with `height: auto`, so this styling should be removed from the example app. With `height: auto`, no rows of the table are rendered in the app. See #1624

## 👩‍💻 Implementation

Remove `height: auto` from the example app's styling. Now the table uses the default height set in the nimble-table's `:host` styling. This is aligned with how the Blazor example app is styled.

## 🧪 Testing

- Verified the rows of the table are now rendered in the Angular example app

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
