### PR TITLE
Fix the drawer's footer's border to match the visual design spec

### DIFF
--- a/change/@ni-nimble-components-8fc634ea-f7eb-4d79-aab1-42f80536aad0.json
+++ b/change/@ni-nimble-components-8fc634ea-f7eb-4d79-aab1-42f80536aad0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix the drawer's footer's border to match the visual design spec",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/drawer/styles.ts
+++ b/packages/nimble-components/src/drawer/styles.ts
@@ -4,12 +4,11 @@ import {
     applicationBackgroundColor,
     bodyFont,
     bodyFontColor,
-    borderWidth,
-    popupBorderColor,
     standardPadding,
     titlePlus1Font,
     drawerWidth,
-    largeDelay
+    largeDelay,
+    actionRgbPartialColor
 } from '../theme-provider/design-tokens';
 import {
     modalBackdropColorThemeColorStatic,
@@ -153,7 +152,7 @@ export const styles = css`
         flex: none;
         display: flex;
         justify-content: flex-end;
-        border-top: ${borderWidth} solid ${popupBorderColor};
+        border-top: 2px solid rgba(${actionRgbPartialColor}, 0.1);
     }
 `.withBehaviors(
     /*


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The top border of the drawer's footer should be 2px, rather than 1px. It was also not quite the right color. I've updated the border to be styled in an identical fashion to the similar border at the top of the dialog's footer, which is correct.

## 👩‍💻 Implementation

- Minor style update

## 🧪 Testing

- Verified the styling looks correct in storybook

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
