### PR TITLE
Enable Renovate for nuget dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:base"
   ],
-  "enabledManagers": ["npm"],
+  "enabledManagers": ["npm", "nuget"],
   "rangeStrategy": "update-lockfile",
   "rebaseWhen": "conflicted",
   "schedule": [
@@ -15,7 +15,7 @@
       "enabled": false
     },
     {
-      "groupName": "Dependencies",
+      "groupName": "npm dependencies",
       "matchDepTypes": ["dependencies"],
       "matchPackagePatterns":[
         "^@microsoft/fast",
@@ -28,13 +28,18 @@
       "enabled": true
     },
     {
-      "groupName": "Dev Dependencies",
+      "groupName": "npm dev dependencies",
       "matchDepTypes": ["devDependencies"],
       "matchPackagePatterns":[
         "^@ni/eslint-config",
         "beachball",
         "storybook"
       ],
+      "enabled": true
+    },
+    {
+      "groupName": "Nuget dependencies",
+      "rangeStrategy": "auto",
       "enabled": true
     }
   ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,7 +181,7 @@ npm install @ni/nimble-tokens --workspace=@ni/nimble-components
 
 This repository uses [Renovate](https://docs.renovatebot.com/) to automatically create pull requests that bump the version of dependencies on a schedule. Renovate is configured via [`renovate.json`](./.github/renovate.json).
 
-Code owners are responsible for completing or rejecting Renovate PRs. Completing a PR may require manually adding a beachball change file to the branch. The change `type` will typically be `patch` if any `package.json` is changing. The `comment` should summarize which set of dependencies are being updated. To complete a PR you may need to manually trigger a rebase by clicking the checkbox in the PR description. **Note:** prefer the checkbox over GitHub's "Update branch" button so that Renovate can remain in control of all commits to its branch.
+Code owners are responsible for completing or rejecting Renovate PRs. Completing a PR may require manually adding a beachball change file to the branch. The change `type` will typically be `patch` if any `package.json` or `.csproj` is changing. The `comment` should summarize which set of dependencies are being updated. To complete a PR you may need to manually trigger a rebase by clicking the checkbox in the PR description. **Note:** prefer the checkbox over GitHub's "Update branch" button so that Renovate can remain in control of all commits to its branch.
 
 ## Handling intermittent test failures
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

We have a few Nuget dependencies that would be good to keep up to date. Some of them have security vulnerabilities as revealed by Snyk PRs like #1670 but we didn't like the way those PRs looked as we'd prefer they be updated in a group.

## 👩‍💻 Implementation

1. Configure Renovate to update Nuget dependencies in addition to npm ones. It [doesn't look like](https://docs.renovatebot.com/configuration-options/#rangestrategy) Renovate supports [lockfile only updates for Nuget](https://devblogs.microsoft.com/nuget/enable-repeatable-package-restores-using-a-lock-file/#:~:text=To%20enable%20the%20use%20of%20lock%20file%20with,%E2%80%93%20packages.lock.json%20file%20at%20the%20project%20root%20directory.) so I think owners will have to push beachball change files to these PRs.
2. Update CONTRIBUTING docs to mention that Renovate might modify `.csproj` files and thus might need beachball change files.

## 🧪 Testing

When this PR completes I'll poke Renovate and see what PRs it creates.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
