### PR TITLE
Fix nuget Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,6 @@
     "config:base"
   ],
   "enabledManagers": ["npm", "nuget"],
-  "rangeStrategy": "update-lockfile",
   "rebaseWhen": "conflicted",
   "schedule": [
     "monthly"
@@ -16,6 +15,8 @@
     },
     {
       "groupName": "npm dependencies",
+      "matchManagers": ["npm"],
+      "rangeStrategy": "update-lockfile",
       "matchDepTypes": ["dependencies"],
       "matchPackagePatterns":[
         "^@microsoft/fast",
@@ -29,17 +30,14 @@
     },
     {
       "groupName": "npm dev dependencies",
+      "matchManagers": ["npm"],
+      "rangeStrategy": "update-lockfile",
       "matchDepTypes": ["devDependencies"],
       "matchPackagePatterns":[
         "^@ni/eslint-config",
         "beachball",
         "storybook"
       ],
-      "enabled": true
-    },
-    {
-      "groupName": "Nuget dependencies",
-      "rangeStrategy": "auto",
       "enabled": true
     }
   ]


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

After #1673, Renovate created #1674 saying the config I set was invalid. The issue is that the `packageRule` I created for nuget didn't contain any `match*` or `exclude*` rules so Renovate can't figure out what it applies to.

Resolves #1674 (hopefully)

## 👩‍💻 Implementation

I had only created that rule to try to set the update strategy to `auto` for nuget. Other than that we want to start out with the default configuration of updating all nugets. So I 
1. removed the place where we were globally changing update strategy to `lockfile-only`
2. set it on npm package rules instead (and also made it more explicit that those were npm rules)
3. deleted the nuget package rule

## 🧪 Testing

We'll see what Renovate does with this after I submit.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
