### PR TITLE
Update Renovate Nuget config to group bunit dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,6 +39,14 @@
         "storybook"
       ],
       "enabled": true
+    },
+    {
+      "groupName": "nuget bunit dependencies",
+      "matchManagers": ["nuget"],
+      "matchPackagePatterns":[
+        "^bunit"
+      ],
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Now that we established Renovate to update nuget deps in #1675 I noticed on the dependency dashboard #1537 that the 3 bunit dependencies will be updated in separate PRs. We want them to be updated together.

Here's what the dependency dashboard showed before this change:

---

  ![image](https://github.com/ni/nimble/assets/10500124/044dbb45-e10a-4359-8e2e-b7b9a64356f3)

---

## 👩‍💻 Implementation

Add a package rule for any nuget package that starts with "bunit".

I considered grouping all minor/patch nuget dependencies in one group to reduce the PR noise, similar to what we did for npm. We may yet decide to do this but I wanted to get some runtime with the default configuration and hear the team's feedback first.

## 🧪 Testing

I will inspect the dashboard when this completes to ensure it works as intended.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
