### PR TITLE
Hide inc/dec buttons on numeric from a11y tree

### DIFF
--- a/change/@ni-nimble-components-9da58386-e822-45d9-a191-56fc2717b88b.json
+++ b/change/@ni-nimble-components-9da58386-e822-45d9-a191-56fc2717b88b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Hide inc/dec buttons on numeric from a11y tree",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/number-field/index.ts
+++ b/packages/nimble-components/src/number-field/index.ts
@@ -74,6 +74,7 @@ const nimbleNumberField = NumberField.compose<NumberFieldOptions>({
             appearance="ghost"
             content-hidden
             tabindex="-1"
+            aria-hidden="true"
         >
             ${x => numericDecrementLabel.getValueFor(x)}
             <${iconMinusWideTag}
@@ -88,6 +89,7 @@ const nimbleNumberField = NumberField.compose<NumberFieldOptions>({
             appearance="ghost"
             content-hidden
             tabindex="-1"
+            aria-hidden="true"
         >
             ${x => numericIncrementLabel.getValueFor(x)}
             <${iconAddTag}

--- a/packages/nimble-components/src/number-field/tests/number-field.spec.ts
+++ b/packages/nimble-components/src/number-field/tests/number-field.spec.ts
@@ -23,9 +23,31 @@ describe('NumberField', () => {
     });
 
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-number-field')).toBeInstanceOf(
+        expect(document.createElement(numberFieldTag)).toBeInstanceOf(
             NumberField
         );
+    });
+
+    it('prevents inc/dec buttons from being focusable', () => {
+        const buttons = Array.from(
+            document
+                .createElement(numberFieldTag)
+                .shadowRoot!.querySelectorAll('.step-up-down-button')
+        );
+        expect(
+            buttons.every(x => (x as HTMLElement).tabIndex === -1)
+        ).toBeTrue();
+    });
+
+    it('hides inc/dec buttons from a11y tree', () => {
+        const buttons = Array.from(
+            document
+                .createElement(numberFieldTag)
+                .shadowRoot!.querySelectorAll('.step-up-down-button')
+        );
+        expect(
+            buttons.every(x => (x as HTMLElement).ariaHidden === 'true')
+        ).toBeTrue();
     });
 });
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #1644

## 👩‍💻 Implementation

Added `aria-hidden="true"` to both inc/dec buttons. As these buttons are not focusable, and there are other keyboard interactions (up/down arrow) for incrementing/decrementing the value, these buttons are not interesting to assistive technologies. The `<button>` element implicitly has `focusable=true` for a11y, and this cannot be changed, even if it is removed from the tab order with `tabIndex=-1`. If we want to keep it as an unfocusable button, we must use `aria-hidden`.

## 🧪 Testing

Checked in Storybook.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
