### PR TITLE
Angular support for @mention configuration and user mapping

### DIFF
--- a/angular-workspace/projects/example-client-app/src/app/app.module.ts
+++ b/angular-workspace/projects/example-client-app/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { NimbleLabelProviderRichTextModule } from '@ni/nimble-angular/label-prov
 import { NimbleLabelProviderTableModule } from '@ni/nimble-angular/label-provider/table';
 import { NimbleMappingTextModule } from '@ni/nimble-angular/mapping/text';
 import { NimbleMappingIconModule } from '@ni/nimble-angular/mapping/icon';
+import { NimbleMappingUserModule } from '@ni/nimble-angular/mapping/user';
 import { NimbleMappingSpinnerModule } from '@ni/nimble-angular/mapping/spinner';
 import { NimbleTableModule } from '@ni/nimble-angular/table';
 import { NimbleTableColumnTextModule } from '@ni/nimble-angular/table-column/text';
@@ -27,6 +28,7 @@ import { NimbleTableColumnNumberTextModule } from '@ni/nimble-angular/table-colu
 import { NimbleTableColumnDurationTextModule } from '@ni/nimble-angular/table-column/duration-text';
 import { NimbleRichTextViewerModule } from '@ni/nimble-angular/rich-text/viewer';
 import { NimbleRichTextEditorModule } from '@ni/nimble-angular/rich-text/editor';
+import { NimbleRichTextMentionUsersModule } from '@ni/nimble-angular/rich-text-mention/users';
 import { AppComponent } from './app.component';
 import { CustomAppComponent } from './customapp/customapp.component';
 import { HeaderComponent } from './header/header.component';
@@ -96,6 +98,8 @@ import { HeaderComponent } from './header/header.component';
         NimbleRichTextEditorModule,
         NimbleTableColumnIconModule,
         NimbleMappingIconModule,
+        NimbleMappingUserModule,
+        NimbleRichTextMentionUsersModule,
         NimbleMappingSpinnerModule,
         RouterModule.forRoot(
             [

--- a/angular-workspace/projects/example-client-app/src/app/customapp/customapp.component.html
+++ b/angular-workspace/projects/example-client-app/src/app/customapp/customapp.component.html
@@ -186,7 +186,11 @@
         <div class="sub-container">
             <div class="container-label">Rich Text Editor</div>
             <div class="rich-text-editor-container">
-                <nimble-rich-text-editor placeholder="Rich text editor" #editor>
+                <nimble-rich-text-editor class="rich-text-editor" placeholder="Rich text editor" #editor>
+                    <nimble-rich-text-mention-users pattern="^user:(.*)">
+                        <nimble-mapping-user key="user:1" display-name="John Doe"></nimble-mapping-user>
+                        <nimble-mapping-user key="user:2" display-name="Mary Wilson"></nimble-mapping-user>
+                    </nimble-rich-text-mention-users>
                     <nimble-button slot="footer-actions" (click)="loadRichTextEditorContent()">Load Content</nimble-button>
                 </nimble-rich-text-editor>
             </div>
@@ -194,7 +198,12 @@
         <div class="sub-container">
             <div class="container-label">Rich Text Viewer</div>
             <div class="rich-text-viewer-container">
-                <nimble-rich-text-viewer [markdown]="viewerMarkdownString"></nimble-rich-text-viewer>
+                <nimble-rich-text-viewer [markdown]="markdownString">
+                    <nimble-rich-text-mention-users pattern="^user:(.*)">
+                        <nimble-mapping-user key="user:1" display-name="John Doe"></nimble-mapping-user>
+                        <nimble-mapping-user key="user:2" display-name="Mary Wilson"></nimble-mapping-user>
+                    </nimble-rich-text-mention-users>
+                </nimble-rich-text-viewer>
             </div>
         </div>
         <div class="sub-container">

--- a/angular-workspace/projects/example-client-app/src/app/customapp/customapp.component.scss
+++ b/angular-workspace/projects/example-client-app/src/app/customapp/customapp.component.scss
@@ -87,6 +87,10 @@ nimble-table {
     padding: $ni-nimble-small-padding;
 }
 
+.rich-text-editor {
+    height: 280px;
+}
+
 .add-table-row-button {
     margin-top: $ni-nimble-small-padding;
 }

--- a/angular-workspace/projects/example-client-app/src/app/customapp/customapp.component.ts
+++ b/angular-workspace/projects/example-client-app/src/app/customapp/customapp.component.ts
@@ -47,7 +47,7 @@ export class CustomAppComponent {
     public selectedRadio = 'mango';
     public activeTabId = 'tab-1';
     public activeAnchorTabId = 'a-tab-2';
-    public viewerMarkdownString = `Supported rich text formatting options:
+    public markdownString = `Supported rich text formatting options:
 1. **Bold**
 2. *Italics*
 3. Numbered lists
@@ -57,17 +57,7 @@ export class CustomAppComponent {
     * Option 1
     * Option 2
 5. Absolute link: <https://nimble.ni.dev/>
-`;
-
-    public editorMarkdownString = `Supported rich text formatting options:
-1. **Bold**
-2. *Italics*
-3. Numbered lists
-    1. Option 1
-    2. Option 2
-4. Bulleted lists
-    * Option 1
-    * Option 2
+6. @mention: <user:1>
 `;
 
     public readonly tableData$: Observable<SimpleTableRecord[]>;
@@ -145,6 +135,6 @@ export class CustomAppComponent {
     }
 
     public loadRichTextEditorContent(): void {
-        this.editor.setMarkdown(this.editorMarkdownString);
+        this.editor.setMarkdown(this.markdownString);
     }
 }

--- a/angular-workspace/projects/ni/nimble-angular/mapping/user/ng-package.json
+++ b/angular-workspace/projects/ni/nimble-angular/mapping/user/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+      "entryFile": "public-api.ts"
+    }
+}

--- a/angular-workspace/projects/ni/nimble-angular/mapping/user/nimble-mapping-user.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/mapping/user/nimble-mapping-user.directive.ts
@@ -12,11 +12,11 @@ export { mappingUserTag };
     selector: 'nimble-mapping-user'
 })
 export class NimbleMappingUserDirective {
-    public get key(): string | undefined {
+    public get key(): MappingUserKey | undefined {
         return this.elementRef.nativeElement.key;
     }
 
-    @Input() public set key(value: string | undefined) {
+    @Input() public set key(value: MappingUserKey | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'key', value);
     }
 

--- a/angular-workspace/projects/ni/nimble-angular/mapping/user/nimble-mapping-user.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/mapping/user/nimble-mapping-user.directive.ts
@@ -1,0 +1,34 @@
+import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
+import { type MappingUser, mappingUserTag } from '@ni/nimble-components/dist/esm/mapping/user';
+import type { MappingUserKey } from '@ni/nimble-components/dist/esm/mapping/base/types';
+
+export type { MappingUser, MappingUserKey };
+export { mappingUserTag };
+
+/**
+ * Directive to provide Angular integration for the mapping user element used by the rich-text-mention-users element.
+ */
+@Directive({
+    selector: 'nimble-mapping-user'
+})
+export class NimbleMappingUserDirective {
+    public get key(): string | undefined {
+        return this.elementRef.nativeElement.key;
+    }
+
+    @Input() public set key(value: string | undefined) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'key', value);
+    }
+
+    public get displayName(): string | undefined {
+        return this.elementRef.nativeElement.displayName;
+    }
+
+    // Renaming because property should have camel casing, but attribute should not
+    // eslint-disable-next-line @angular-eslint/no-input-rename
+    @Input('display-name') public set displayName(value: string | undefined) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'displayName', value);
+    }
+
+    public constructor(protected readonly renderer: Renderer2, protected readonly elementRef: ElementRef<MappingUser>) {}
+}

--- a/angular-workspace/projects/ni/nimble-angular/mapping/user/nimble-mapping-user.module.ts
+++ b/angular-workspace/projects/ni/nimble-angular/mapping/user/nimble-mapping-user.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NimbleMappingUserDirective } from './nimble-mapping-user.directive';
+
+import '@ni/nimble-components/dist/esm/mapping/user';
+
+@NgModule({
+    declarations: [NimbleMappingUserDirective],
+    imports: [CommonModule],
+    exports: [NimbleMappingUserDirective]
+})
+export class NimbleMappingUserModule { }

--- a/angular-workspace/projects/ni/nimble-angular/mapping/user/public-api.ts
+++ b/angular-workspace/projects/ni/nimble-angular/mapping/user/public-api.ts
@@ -1,0 +1,2 @@
+export * from './nimble-mapping-user.directive';
+export * from './nimble-mapping-user.module';

--- a/angular-workspace/projects/ni/nimble-angular/mapping/user/tests/nimble-mapping-user.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/mapping/user/tests/nimble-mapping-user.directive.spec.ts
@@ -1,0 +1,227 @@
+import { Component, ElementRef, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NimbleRichTextMentionUsersModule } from '../../../rich-text-mention/users/nimble-rich-text-mention-users.module';
+import { NimbleRichTextEditorModule } from '../../../rich-text/editor/nimble-rich-text-editor.module';
+import { MappingUser, NimbleMappingUserDirective } from '../nimble-mapping-user.directive';
+import { NimbleMappingUserModule } from '../nimble-mapping-user.module';
+
+describe('NimbleMappingUser', () => {
+    describe('module', () => {
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [NimbleMappingUserModule]
+            });
+        });
+
+        it('custom element is defined', () => {
+            expect(customElements.get('nimble-mapping-user')).not.toBeUndefined();
+        });
+    });
+
+    describe('with no values in template', () => {
+        @Component({
+            template: `
+                <nimble-rich-text-editor>
+                    <nimble-rich-text-mention-users pattern="^user:(.*)">
+                        <nimble-mapping-user #mapping></nimble-mapping-user>
+                    </nimble-rich-text-mention-users>
+                </nimble-rich-text-editor>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('mapping', { read: NimbleMappingUserDirective }) public directive: NimbleMappingUserDirective;
+            @ViewChild('mapping', { read: ElementRef }) public elementRef: ElementRef<MappingUser>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleMappingUserDirective;
+        let nativeElement: MappingUser;
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleMappingUserModule, NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule]
+            });
+
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('will use template string values for key', () => {
+            expect(directive.key).toBeUndefined();
+            expect(nativeElement.key).toBeUndefined();
+        });
+
+        it('will use template string values for display name', () => {
+            expect(directive.displayName).toBeUndefined();
+            expect(nativeElement.displayName).toBeUndefined();
+        });
+    });
+
+    describe('with template string values', () => {
+        @Component({
+            template: `
+                <nimble-rich-text-editor>
+                    <nimble-rich-text-mention-users pattern="^user:(.*)">
+                        <nimble-mapping-user
+                            #mapping
+                            key="user:1"
+                            display-name="name"
+                        >
+                        </nimble-mapping-user>
+                    </nimble-rich-text-mention-users>
+                </nimble-rich-text-editor>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('mapping', { read: NimbleMappingUserDirective }) public directive: NimbleMappingUserDirective;
+            @ViewChild('mapping', { read: ElementRef }) public elementRef: ElementRef<MappingUser>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleMappingUserDirective;
+        let nativeElement: MappingUser;
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleMappingUserModule, NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule]
+            });
+
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('will use template string values for key', () => {
+            expect(directive.key).toBe('user:1');
+            expect(nativeElement.key).toBe('user:1');
+        });
+
+        it('will use template string values for display name', () => {
+            expect(directive.displayName).toBe('name');
+            expect(nativeElement.displayName).toBe('name');
+        });
+    });
+
+    describe('with property bound values', () => {
+        @Component({
+            template: `
+                <nimble-rich-text-editor>
+                    <nimble-rich-text-mention-users pattern="^user:(.*)">
+                        <nimble-mapping-user
+                            #mapping
+                            [key]="key"
+                            [displayName]="displayName"
+                        >
+                        </nimble-mapping-user>
+                    </nimble-rich-text-mention-users>
+                </nimble-rich-text-editor>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('mapping', { read: NimbleMappingUserDirective }) public directive: NimbleMappingUserDirective;
+            @ViewChild('mapping', { read: ElementRef }) public elementRef: ElementRef<MappingUser>;
+            public key = 'user:1';
+            public displayName = 'name';
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleMappingUserDirective;
+        let nativeElement: MappingUser;
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleMappingUserModule, NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule]
+            });
+
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('can be configured with property binding for key', () => {
+            expect(directive.key).toBe('user:1');
+            expect(nativeElement.key).toBe('user:1');
+
+            fixture.componentInstance.key = 'user:2';
+            fixture.detectChanges();
+
+            expect(directive.key).toBe('user:2');
+            expect(nativeElement.key).toBe('user:2');
+        });
+
+        it('can be configured with property binding for display name', () => {
+            expect(directive.displayName).toBe('name');
+            expect(nativeElement.displayName).toBe('name');
+
+            fixture.componentInstance.displayName = 'name change';
+            fixture.detectChanges();
+
+            expect(directive.displayName).toBe('name change');
+            expect(nativeElement.displayName).toBe('name change');
+        });
+    });
+
+    describe('with attribute bound values', () => {
+        @Component({
+            template: `
+                <nimble-rich-text-editor>
+                    <nimble-rich-text-mention-users pattern="^user:(.*)">
+                        <nimble-mapping-user
+                            #mapping
+                            [attr.key]="key"
+                            [attr.display-name]="displayName"
+                        >
+                        </nimble-mapping-user>
+                    </nimble-rich-text-mention-users>
+                </nimble-rich-text-editor>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('mapping', { read: NimbleMappingUserDirective }) public directive: NimbleMappingUserDirective;
+            @ViewChild('mapping', { read: ElementRef }) public elementRef: ElementRef<MappingUser>;
+            public key = 'user:1';
+            public displayName = 'name';
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleMappingUserDirective;
+        let nativeElement: MappingUser;
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleMappingUserModule, NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule]
+            });
+
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('can be configured with attribute binding for key', () => {
+            expect(directive.key).toBe('user:1');
+            expect(nativeElement.key).toBe('user:1');
+
+            fixture.componentInstance.key = 'user:1';
+            fixture.detectChanges();
+
+            expect(directive.key).toBe('user:1');
+            expect(nativeElement.key).toBe('user:1');
+        });
+
+        it('can be configured with attribute binding for display name', () => {
+            expect(directive.displayName).toBe('name');
+            expect(nativeElement.displayName).toBe('name');
+
+            fixture.componentInstance.displayName = 'name change';
+            fixture.detectChanges();
+
+            expect(directive.displayName).toBe('name change');
+            expect(nativeElement.displayName).toBe('name change');
+        });
+    });
+});

--- a/angular-workspace/projects/ni/nimble-angular/rich-text-mention/ng-package.json
+++ b/angular-workspace/projects/ni/nimble-angular/rich-text-mention/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+      "entryFile": "public-api.ts"
+    }
+}

--- a/angular-workspace/projects/ni/nimble-angular/rich-text-mention/nimble-rich-text-mention-base.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/rich-text-mention/nimble-rich-text-mention-base.directive.ts
@@ -1,0 +1,42 @@
+import { Directive, ElementRef, EventEmitter, HostListener, Input, Output, Renderer2 } from '@angular/core';
+import type { RichTextMentionValidity } from '@ni/nimble-components/dist/esm/rich-text-mention/base/models/mention-validator';
+import type { RichTextMention } from '@ni/nimble-components/dist/esm/rich-text-mention/base';
+
+export type { RichTextMentionValidity };
+
+/**
+ * Base class for rich text mention directives
+ */
+@Directive()
+export class NimbleRichTextMentionDirective<T extends RichTextMention> {
+    @Output() public mentionUpdateEvent = new EventEmitter<boolean>();
+
+    @Input() public set pattern(value: string | undefined) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'pattern', value);
+    }
+
+    public get pattern(): string | undefined {
+        return this.elementRef.nativeElement.pattern;
+    }
+
+    public constructor(private readonly renderer: Renderer2, private readonly elementRef: ElementRef<T>) { }
+
+    public checkValidity(): boolean {
+        return this.elementRef.nativeElement.checkValidity();
+    }
+
+    public getMentionedHrefs(): string[] {
+        return this.elementRef.nativeElement.getMentionedHrefs();
+    }
+
+    public get validity(): RichTextMentionValidity {
+        return this.elementRef.nativeElement.validity;
+    }
+
+    @HostListener('mention-update', ['$event'])
+    public onMentionUpdate($event: Event): void {
+        if ($event.target === this.elementRef.nativeElement) {
+            this.mentionUpdateEvent.emit();
+        }
+    }
+}

--- a/angular-workspace/projects/ni/nimble-angular/rich-text-mention/public-api.ts
+++ b/angular-workspace/projects/ni/nimble-angular/rich-text-mention/public-api.ts
@@ -1,0 +1,1 @@
+export * from './nimble-rich-text-mention-base.directive';

--- a/angular-workspace/projects/ni/nimble-angular/rich-text-mention/users/ng-package.json
+++ b/angular-workspace/projects/ni/nimble-angular/rich-text-mention/users/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+      "entryFile": "public-api.ts"
+    }
+}

--- a/angular-workspace/projects/ni/nimble-angular/rich-text-mention/users/nimble-rich-text-mention-users.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/rich-text-mention/users/nimble-rich-text-mention-users.directive.ts
@@ -12,4 +12,4 @@ export { richTextMentionUsersTag };
     selector: 'nimble-rich-text-mention-users'
 })
 
-export class NimbleRichTextMentionUsersDirective extends NimbleRichTextMentionDirective {}
+export class NimbleRichTextMentionUsersDirective extends NimbleRichTextMentionDirective<RichTextMentionUsers> {}

--- a/angular-workspace/projects/ni/nimble-angular/rich-text-mention/users/nimble-rich-text-mention-users.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/rich-text-mention/users/nimble-rich-text-mention-users.directive.ts
@@ -1,0 +1,15 @@
+import { Directive } from '@angular/core';
+import { NimbleRichTextMentionDirective } from '@ni/nimble-angular/rich-text-mention';
+import { type RichTextMentionUsers, richTextMentionUsersTag } from '@ni/nimble-components/dist/esm/rich-text-mention/users';
+
+export type { RichTextMentionUsers };
+export { richTextMentionUsersTag };
+
+/**
+ * Directive to provide Angular integration for the rich text mention users element.
+ */
+@Directive({
+    selector: 'nimble-rich-text-mention-users'
+})
+
+export class NimbleRichTextMentionUsersDirective extends NimbleRichTextMentionDirective {}

--- a/angular-workspace/projects/ni/nimble-angular/rich-text-mention/users/nimble-rich-text-mention-users.module.ts
+++ b/angular-workspace/projects/ni/nimble-angular/rich-text-mention/users/nimble-rich-text-mention-users.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NimbleRichTextMentionUsersDirective } from './nimble-rich-text-mention-users.directive';
+
+import '@ni/nimble-components/dist/esm/rich-text-mention/users/';
+
+@NgModule({
+    declarations: [NimbleRichTextMentionUsersDirective],
+    imports: [CommonModule],
+    exports: [NimbleRichTextMentionUsersDirective]
+})
+export class NimbleRichTextMentionUsersModule { }

--- a/angular-workspace/projects/ni/nimble-angular/rich-text-mention/users/public-api.ts
+++ b/angular-workspace/projects/ni/nimble-angular/rich-text-mention/users/public-api.ts
@@ -1,0 +1,2 @@
+export * from './nimble-rich-text-mention-users.directive';
+export * from './nimble-rich-text-mention-users.module';

--- a/angular-workspace/projects/ni/nimble-angular/rich-text-mention/users/tests/nimble-rich-text-mention-users.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/rich-text-mention/users/tests/nimble-rich-text-mention-users.directive.spec.ts
@@ -1,0 +1,179 @@
+import { Component, ElementRef, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NimbleRichTextMentionUsersModule } from '../nimble-rich-text-mention-users.module';
+import { NimbleRichTextEditorModule } from '../../../rich-text/editor/nimble-rich-text-editor.module';
+import { NimbleRichTextMentionUsersDirective, RichTextMentionUsers } from '../nimble-rich-text-mention-users.directive';
+
+describe('NimbleRichTextMentionUsers', () => {
+    describe('module', () => {
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [NimbleRichTextMentionUsersModule]
+            });
+        });
+
+        it('custom element is defined', () => {
+            expect(customElements.get('nimble-rich-text-mention-users')).not.toBeUndefined();
+        });
+    });
+
+    describe('with no values in template', () => {
+        @Component({
+            template: `
+                <nimble-rich-text-editor>
+                    <nimble-rich-text-mention-users #users></nimble-rich-text-mention-users>
+                </nimble-rich-text-editor>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('users', { read: NimbleRichTextMentionUsersDirective }) public directive: NimbleRichTextMentionUsersDirective;
+            @ViewChild('users', { read: ElementRef }) public elementRef: ElementRef<RichTextMentionUsers>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleRichTextMentionUsersDirective;
+        let nativeElement: RichTextMentionUsers;
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule]
+            });
+
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('will use template string values for pattern', () => {
+            expect(directive.pattern).toBeUndefined();
+            expect(nativeElement.pattern).toBeUndefined();
+        });
+    });
+
+    describe('with template string values', () => {
+        @Component({
+            template: `
+                <nimble-rich-text-editor>
+                    <nimble-rich-text-mention-users pattern="^user:(.*)" #users></nimble-rich-text-mention-users>
+                </nimble-rich-text-editor>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('users', { read: NimbleRichTextMentionUsersDirective }) public directive: NimbleRichTextMentionUsersDirective;
+            @ViewChild('users', { read: ElementRef }) public elementRef: ElementRef<RichTextMentionUsers>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleRichTextMentionUsersDirective;
+        let nativeElement: RichTextMentionUsers;
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule]
+            });
+
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('will use template string values for pattern', () => {
+            expect(directive.pattern).toBe('^user:(.*)');
+            expect(nativeElement.pattern).toBe('^user:(.*)');
+        });
+
+        it('has valid configuration by default', () => {
+            expect(directive.checkValidity()).toBeTrue();
+            expect(nativeElement.checkValidity()).toBeTrue();
+        });
+
+        it('has empty mentioned Hrefs array by default', () => {
+            expect(directive.getMentionedHrefs()).toEqual([]);
+            expect(nativeElement.getMentionedHrefs()).toEqual([]);
+        });
+    });
+
+    describe('with property bound values', () => {
+        @Component({
+            template: `
+                <nimble-rich-text-editor>
+                    <nimble-rich-text-mention-users [pattern]="pattern" #users></nimble-rich-text-mention-users>
+                </nimble-rich-text-editor>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('users', { read: NimbleRichTextMentionUsersDirective }) public directive: NimbleRichTextMentionUsersDirective;
+            @ViewChild('users', { read: ElementRef }) public elementRef: ElementRef<RichTextMentionUsers>;
+            public pattern = '^user:(.*)';
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleRichTextMentionUsersDirective;
+        let nativeElement: RichTextMentionUsers;
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule]
+            });
+
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('can be configured with property binding for pattern', () => {
+            expect(directive.pattern).toBe('^user:(.*)');
+            expect(nativeElement.pattern).toBe('^user:(.*)');
+
+            fixture.componentInstance.pattern = '^https://user/(.*)';
+            fixture.detectChanges();
+
+            expect(directive.pattern).toBe('^https://user/(.*)');
+            expect(nativeElement.pattern).toBe('^https://user/(.*)');
+        });
+    });
+
+    describe('with attribute bound values', () => {
+        @Component({
+            template: `
+                <nimble-rich-text-editor>
+                    <nimble-rich-text-mention-users [attr.pattern]="pattern" #users></nimble-rich-text-mention-users>
+                </nimble-rich-text-editor>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('users', { read: NimbleRichTextMentionUsersDirective }) public directive: NimbleRichTextMentionUsersDirective;
+            @ViewChild('users', { read: ElementRef }) public elementRef: ElementRef<RichTextMentionUsers>;
+            public pattern = '^user:(.*)';
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleRichTextMentionUsersDirective;
+        let nativeElement: RichTextMentionUsers;
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule]
+            });
+
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('can be configured with property binding for pattern', () => {
+            expect(directive.pattern).toBe('^user:(.*)');
+            expect(nativeElement.pattern).toBe('^user:(.*)');
+
+            fixture.componentInstance.pattern = '^https://user/(.*)';
+            fixture.detectChanges();
+
+            expect(directive.pattern).toBe('^https://user/(.*)');
+            expect(nativeElement.pattern).toBe('^https://user/(.*)');
+        });
+    });
+});

--- a/change/@ni-nimble-angular-27988b11-188a-43a4-8e93-f7800b9162b1.json
+++ b/change/@ni-nimble-angular-27988b11-188a-43a4-8e93-f7800b9162b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Angular support for mention configuration and mapping user elements",
+  "packageName": "@ni/nimble-angular",
+  "email": "123377523+vivinkrishna-ni@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

<!---
Provide some background and a description of your work.
What problem does this change solve?

Include links to issues, work items, or other discussions.
-->
[Task 2566806](https://dev.azure.com/ni/DevCentral/_workitems/edit/2566806): PR2 | Angular integration for configuration and mapping element

## 👩‍💻 Implementation

<!---
Describe how the change addresses the problem. Consider factors such as complexity, alternative solutions, performance impact, etc. 

Consider listing files with important changes or comment on them directly in the pull request.
-->
- Added directives for `nimble-rich-text-mention-users` and supporting element `nimble-mapping-user`. Both of these follow the same folder structure as in `nimble-components`
- Added tests for new directives
- Added rich text mention users to example client app

## 🧪 Testing

<!---
Detail the testing done to ensure this submission meets requirements. 

Include automated/manual test additions or modifications, testing done on a local build, private CI run results, and additional testing not covered by automatic pull request validation. If any functionality is not covered by automated testing, provide justification.
-->
Written tests for both the directives

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
