### PR TITLE
Update nimble-card styling to match visual design

### DIFF
--- a/packages/nimble-components/src/card/styles.ts
+++ b/packages/nimble-components/src/card/styles.ts
@@ -1,14 +1,14 @@
 import { css } from '@microsoft/fast-element';
 import { display } from '@microsoft/fast-foundation';
 import {
+    bodyEmphasizedFontWeight,
     bodyFont,
     bodyFontColor,
-    borderColor,
-    borderWidth,
-    sectionBackgroundColor,
+    mediumPadding,
+    cardBorderColor,
     standardPadding,
-    titleFont,
-    titleFontColor
+    subtitleFontColor,
+    subtitlePlus1Font
 } from '../theme-provider/design-tokens';
 
 export const styles = css`
@@ -17,11 +17,11 @@ export const styles = css`
     :host {
         flex-direction: column;
         gap: ${standardPadding};
-        padding: ${standardPadding};
-        border: ${borderWidth} solid ${borderColor};
+        padding: 24px;
+        border: 2px solid ${cardBorderColor};
+        border-radius: 8px;
         font: ${bodyFont};
         color: ${bodyFontColor};
-        background-color: ${sectionBackgroundColor};
     }
 
     section {
@@ -29,7 +29,10 @@ export const styles = css`
     }
 
     slot[name='title'] {
-        font: ${titleFont};
-        color: ${titleFontColor};
+        display: inline-block;
+        margin-bottom: ${mediumPadding};
+        font: ${subtitlePlus1Font};
+        font-weight: ${bodyEmphasizedFontWeight};
+        color: ${subtitleFontColor};
     }
 `;

--- a/packages/nimble-components/src/theme-provider/design-token-comments.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-comments.ts
@@ -48,6 +48,7 @@ export const comments: { readonly [key in TokenName]: string | null } = {
     iconColor: 'Equivalent to the font color for icons',
     modalBackdropColor: 'Color of background overlay behind modal dialog boxes',
     popupBorderColor: 'Border color for menus and dialog boxes',
+    cardBorderColor: 'Border color for cards',
     controlHeight:
         'Standard layout height for all controls. Add "labelHeight" for labels on top.',
     controlSlimHeight:

--- a/packages/nimble-components/src/theme-provider/design-token-names.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-names.ts
@@ -37,6 +37,7 @@ export const tokenNames: { readonly [key in TokenName]: string } = {
     iconColor: 'icon-color',
     modalBackdropColor: 'modal-backdrop-color',
     popupBorderColor: 'popup-border-color',
+    cardBorderColor: 'card-border-color',
     controlHeight: 'control-height',
     controlSlimHeight: 'control-slim-height',
     smallPadding: 'small-padding',

--- a/packages/nimble-components/src/theme-provider/design-tokens.ts
+++ b/packages/nimble-components/src/theme-provider/design-tokens.ts
@@ -209,6 +209,10 @@ export const popupBorderColor = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.popupBorderColor)
 ).withDefault((element: HTMLElement) => hexToRgbaCssColor(getColorForTheme(element, Black91, Black15, White), 0.3));
 
+export const cardBorderColor = DesignToken.create<string>(
+    styleNameFromTokenName(tokenNames.cardBorderColor)
+).withDefault((element: HTMLElement) => hexToRgbaCssColor(getColorForTheme(element, Black91, Black15, White), 0.1));
+
 export const graphGridlineColor = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.graphGridlineColor)
 ).withDefault((element: HTMLElement) => hexToRgbaCssColor(getColorForTheme(element, Black91, Black15, White), 0.2));


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The `nimble-card` has placeholder styling. We now have a visual design to apply to the component: [Figma visual design](https://www.figma.com/file/PO9mFOu5BCl8aJvFchEeuN/Nimble_Components?type=design&node-id=5069%3A8503&mode=design&t=JAnIPq8DWZJ0PBzU-1)

## 👩‍💻 Implementation

Here are the relevant attributes from the visual design, applied to the CSS for the `nimble-card` component:

| Property         | Light value             | Dark value              | Color value           | Token                |
| ---------------- | ----------------------- | ----------------------- | --------------------- | -------------------- |
| title font color | #161617 (Black91 100%)  | #F1F1F2 (Black 15 100%) | #FFFFFF (White 100%)  | `subtitleFontColor`    |
| border color     | #1616171A (Black91 10%) | #F1F1F21A (Black15 10%) | #FFFFFF1A (White 10%) | **new: `cardBorderColor`** |

| Property            | Value                                    | Token                                                        |
| ------------------- | ---------------------------------------- | ------------------------------------------------------------ |
| title font          | BodyEmphasized_XT-Large, Source Sans Pro | `subtitlePlus1Font`                                            |
| title font size     | 16px                                     | `subtitlePlus1Font`                                            |
| title font weight   | 600                                      | `bodyEmphasizedFontWeight`                                     |
| title bottom margin | 24px                                     | `standardPadding` (from `gap`) + `mediumPadding` (`margin-bottom`) |
| border thickness    | 2px                                      | **none**                                                         |
| border radius       | 8px                                      | **none**                                                         |
| border padding      | 24px                                     | **none**                                                         |
| background color    | transparent                              | N/A                                                          |

No design token exists for a 10% opacity border color, so create `cardBorderColor`.

## 🧪 Testing
Storybook testing:
![image](https://github.com/ni/nimble/assets/35350751/7333999d-0ffa-4fa4-b8e0-07e5f8cb1e1c)

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
