### PR TITLE
mention in editor suggested changes

### DIFF
--- a/packages/nimble-components/src/rich-text-mention/base/index.ts
+++ b/packages/nimble-components/src/rich-text-mention/base/index.ts
@@ -17,10 +17,7 @@ import {
 } from './models/mention-internals';
 import { Mapping } from '../../mapping/base';
 import type { RichText } from '../../rich-text/base';
-import type {
-    MappingConfigs,
-    MentionUpdateEventDetail,
-} from './types';
+import type { MappingConfigs, MentionUpdateEventDetail } from './types';
 import type { MentionConfig } from './models/mention-config';
 
 /**

--- a/packages/nimble-components/src/rich-text-mention/base/index.ts
+++ b/packages/nimble-components/src/rich-text-mention/base/index.ts
@@ -92,7 +92,7 @@ export abstract class RichTextMention<
      */
     public handleChange(source: unknown, args: unknown): void {
         if (source instanceof Mapping && typeof args === 'string') {
-            this.updateMentionConfig();
+            this.updateMappingConfigs();
         }
     }
 
@@ -125,17 +125,20 @@ export abstract class RichTextMention<
         return mappingConfigs;
     }
 
-    private updateMentionConfig(): void {
+    private updateMappingConfigs(): void {
         this.validator.validate(this.mappingElements, this.pattern);
-        this.mentionInternals.mappingConfigs = this.getMappingConfigs();
+        this.mentionInternals.mappingConfigs = this.validator.isValid()
+            ? this.getMappingConfigs()
+            : undefined;
     }
 
     private mappingElementsChanged(): void {
-        this.updateMentionConfig();
+        this.updateMappingConfigs();
         this.observeMappingElements();
     }
 
     private patternChanged(): void {
+        this.validator.validate(this.mappingElements, this.pattern);
         this.mentionInternals.pattern = this.pattern;
     }
 

--- a/packages/nimble-components/src/rich-text-mention/base/models/mention-config.ts
+++ b/packages/nimble-components/src/rich-text-mention/base/models/mention-config.ts
@@ -1,0 +1,6 @@
+/**
+ * Base class for Mention-specific configuration
+ */
+// Intentionally empty. Common mention configuration should be represented in MentionInternals
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+export abstract class MentionConfig {}

--- a/packages/nimble-components/src/rich-text-mention/base/models/mention-internals.ts
+++ b/packages/nimble-components/src/rich-text-mention/base/models/mention-internals.ts
@@ -56,7 +56,10 @@ export class MentionInternals {
      */
     public readonly mentionUpdateEmitter: MentionUpdateEmitter;
 
-    public constructor(options: MentionInternalsOptions, mentionUpdateEmitter: MentionUpdateEmitter) {
+    public constructor(
+        options: MentionInternalsOptions,
+        mentionUpdateEmitter: MentionUpdateEmitter
+    ) {
         this.icon = options.icon;
         this.character = options.character;
         this.viewElement = options.viewElement;

--- a/packages/nimble-components/src/rich-text-mention/base/models/mention-internals.ts
+++ b/packages/nimble-components/src/rich-text-mention/base/models/mention-internals.ts
@@ -1,4 +1,6 @@
 import { observable } from '@microsoft/fast-element';
+import type { MentionConfig } from './mention-config';
+import type { MappingConfigs, MentionUpdateEmitter } from '../types';
 
 export interface MentionInternalsOptions {
     readonly icon: string;
@@ -9,12 +11,18 @@ export interface MentionInternalsOptions {
 /**
  * Internal mention state
  */
-export class MentionInternals<TMentionConfig> {
+export class MentionInternals {
     /**
-     * Configuration which will hold mentioning info, character, icon and pattern
+     * Mention-specific configuration. Can be used to, for example, pass mention-specific configuration to views.
      */
     @observable
-    public mentionConfig?: TMentionConfig;
+    public mentionConfig?: MentionConfig;
+
+    /**
+     * Mappings configured for the mention node
+     */
+    @observable
+    public mappingConfigs?: MappingConfigs;
 
     /**
      * Whether this mention has a valid configuration.
@@ -25,6 +33,7 @@ export class MentionInternals<TMentionConfig> {
     /**
      * Regex used to extract user ID from user key (url)
      */
+    @observable
     public pattern?: string;
 
     /**
@@ -42,9 +51,15 @@ export class MentionInternals<TMentionConfig> {
      */
     public readonly viewElement: string;
 
-    public constructor(options: MentionInternalsOptions) {
+    /**
+     * Funtion to invoke to emit a mention-update event
+     */
+    public readonly mentionUpdateEmitter: MentionUpdateEmitter;
+
+    public constructor(options: MentionInternalsOptions, mentionUpdateEmitter: MentionUpdateEmitter) {
         this.icon = options.icon;
         this.character = options.character;
         this.viewElement = options.viewElement;
+        this.mentionUpdateEmitter = mentionUpdateEmitter;
     }
 }

--- a/packages/nimble-components/src/rich-text-mention/base/models/mention-validator.ts
+++ b/packages/nimble-components/src/rich-text-mention/base/models/mention-validator.ts
@@ -127,7 +127,7 @@ export class RichTextMentionValidator<
                 return (
                     href === undefined
                           || typeof href !== 'string'
-                          || !(new RegExp(pattern).test(href))
+                          || !new RegExp(pattern).test(href)
                 );
             });
         this.setConditionValue('mentionHrefDoesNotMatchPattern', invalid);

--- a/packages/nimble-components/src/rich-text-mention/base/models/mention-validator.ts
+++ b/packages/nimble-components/src/rich-text-mention/base/models/mention-validator.ts
@@ -21,10 +21,10 @@ export const baseValidityFlagNames = [
  * Validator for RichTextMention
  */
 export class RichTextMentionValidator<
-    ValidityFlagNames extends readonly string[]
+    ValidityFlagNames extends readonly string[] = typeof baseValidityFlagNames
 > extends Validator<typeof baseValidityFlagNames | ValidityFlagNames> {
     public constructor(
-        private readonly mentionInternals: MentionInternals<unknown>,
+        private readonly mentionInternals: MentionInternals,
         configValidityKeys: ValidityFlagNames,
         private readonly supportedMappingElements: readonly (typeof Mapping<unknown>)[]
     ) {
@@ -86,6 +86,7 @@ export class RichTextMentionValidator<
         );
     }
 
+    // TODO move this to child class like done for table
     private validateMappingTypes(mappings: Mapping<unknown>[]): void {
         const valid = mappings.every(mapping => this.supportedMappingElements.some(
             mappingClass => mapping instanceof mappingClass
@@ -126,7 +127,7 @@ export class RichTextMentionValidator<
                 return (
                     href === undefined
                           || typeof href !== 'string'
-                          || !RegExp(pattern).test(href)
+                          || !(new RegExp(pattern).test(href))
                 );
             });
         this.setConditionValue('mentionHrefDoesNotMatchPattern', invalid);
@@ -144,7 +145,8 @@ export class RichTextMentionValidator<
 
     private isInvalidRegex(pattern: string): boolean {
         try {
-            RegExp(pattern);
+            // eslint-disable-next-line no-new
+            new RegExp(pattern);
             return false;
         } catch (error) {
             return true;

--- a/packages/nimble-components/src/rich-text-mention/base/template.ts
+++ b/packages/nimble-components/src/rich-text-mention/base/template.ts
@@ -2,6 +2,6 @@ import { slotted, html } from '@microsoft/fast-element';
 import type { RichTextMention } from '.';
 
 export const template = html<RichTextMention>`<slot
-    ${slotted('mappings')}
+    ${slotted('mappingElements')}
     name="mapping"
 ></slot>`;

--- a/packages/nimble-components/src/rich-text-mention/base/tests/rich-text-mention.fixtures.ts
+++ b/packages/nimble-components/src/rich-text-mention/base/tests/rich-text-mention.fixtures.ts
@@ -9,7 +9,10 @@ import type {
     MentionInternals,
     MentionInternalsOptions
 } from '../models/mention-internals';
-import { RichTextMentionValidator, baseValidityFlagNames } from '../models/mention-validator';
+import {
+    RichTextMentionValidator,
+    baseValidityFlagNames
+} from '../models/mention-validator';
 import { MentionConfig } from '../models/mention-config';
 
 export const richTextMentionTestTag = 'nimble-rich-text-test-mention';

--- a/packages/nimble-components/src/rich-text-mention/base/tests/rich-text-mention.fixtures.ts
+++ b/packages/nimble-components/src/rich-text-mention/base/tests/rich-text-mention.fixtures.ts
@@ -9,24 +9,29 @@ import type {
     MentionInternals,
     MentionInternalsOptions
 } from '../models/mention-internals';
-import { RichTextMentionValidator } from '../models/mention-validator';
-import type { MappingConfigs, RichTextMentionConfig } from '../types';
+import { RichTextMentionValidator, baseValidityFlagNames } from '../models/mention-validator';
+import { MentionConfig } from '../models/mention-config';
 
 export const richTextMentionTestTag = 'nimble-rich-text-test-mention';
 
 /**
  * validator for testing
  */
-export class RichTextMentionTestValidator extends RichTextMentionValidator<[]> {
-    public constructor(columnInternals: MentionInternals<unknown>) {
-        super(columnInternals, [], [MappingUser]);
+class RichTextMentionTestValidator extends RichTextMentionValidator {
+    public constructor(columnInternals: MentionInternals) {
+        super(columnInternals, baseValidityFlagNames, [MappingUser]);
     }
 }
 
 /**
+ * Mention config for testing
+ */
+class TestMentionConfig extends MentionConfig {}
+
+/**
  * Basic MappingConfig for testing
  */
-export class MappingTestConfig extends MappingConfig {}
+class MappingTestConfig extends MappingConfig {}
 
 /**
  * Simple rich text mention for testing
@@ -34,7 +39,7 @@ export class MappingTestConfig extends MappingConfig {}
 @customElement({
     name: richTextMentionTestTag,
     template: html<RichTextMention>`<slot
-        ${slotted('mappings')}
+        ${slotted('mappingElements')}
         name="mapping"
     ></slot>`
 })
@@ -58,12 +63,8 @@ export class RichTextMentionTest extends RichTextMention {
         };
     }
 
-    protected override createMentionConfig(
-        mappingConfigs: MappingConfigs
-    ): RichTextMentionConfig {
-        return {
-            mappingConfigs
-        };
+    protected override createMentionConfig(): TestMentionConfig {
+        return new TestMentionConfig();
     }
 
     protected createMappingConfig(mapping: Mapping<unknown>): MappingConfig {
@@ -71,5 +72,11 @@ export class RichTextMentionTest extends RichTextMention {
             return new MappingTestConfig(mapping.key, mapping.displayName);
         }
         throw new Error('Unsupported mapping');
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        [richTextMentionTestTag]: RichTextMentionTest;
     }
 }

--- a/packages/nimble-components/src/rich-text-mention/base/types.ts
+++ b/packages/nimble-components/src/rich-text-mention/base/types.ts
@@ -10,6 +10,4 @@ export interface MentionUpdateEventDetail {
 
 export type MappingConfigs = ReadonlyMap<string, MappingConfig>;
 
-export interface RichTextMentionConfig {
-    mappingConfigs: MappingConfigs;
-}
+export type MentionUpdateEmitter = (filter: string) => void;

--- a/packages/nimble-components/src/rich-text-mention/users/index.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/index.ts
@@ -21,9 +21,7 @@ declare global {
 /**
  * Rich Text user mention configuration element which will have MappingMentionUser elements as children
  */
-export class RichTextMentionUsers extends RichTextMention<
-RichTextMentionUsersValidator
-> {
+export class RichTextMentionUsers extends RichTextMention<RichTextMentionUsersValidator> {
     // TODO this isn't a great way to do this. It's mixing configuration element state and parent state which are decoupled asynchronously from each other.
     // I'd prefer to leave it out of nimble for now. The app can know when things have settled and so this themselves.
     // I'm also now wondering how do multiple regexes that happen to match the same url behave...

--- a/packages/nimble-components/src/rich-text-mention/users/index.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/index.ts
@@ -10,8 +10,7 @@ import type { Mapping } from '../../mapping/base';
 import type { MappingUserKey } from '../../mapping/base/types';
 import { RichTextMentionUsersValidator } from './models/rich-text-mention-users-validator';
 import { richTextMentionUsersViewTag } from './view';
-import type { RichTextMentionUserConfig } from './types';
-import type { MappingConfigs, RichTextMentionConfig } from '../base/types';
+import { UserMentionConfig } from './types';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -23,9 +22,13 @@ declare global {
  * Rich Text user mention configuration element which will have MappingMentionUser elements as children
  */
 export class RichTextMentionUsers extends RichTextMention<
-RichTextMentionUserConfig,
 RichTextMentionUsersValidator
 > {
+    // TODO this isn't a great way to do this. It's mixing configuration element state and parent state which are decoupled asynchronously from each other.
+    // I'd prefer to leave it out of nimble for now. The app can know when things have settled and so this themselves.
+    // I'm also now wondering how do multiple regexes that happen to match the same url behave...
+    // I'd expect it to match based on DOM order. So I don't think this is reliable.
+    // At the very very minimum this should be in the base class, it's not mention implementation specific, it should be something the editor knows
     public override getMentionedHrefs(): string[] {
         const regex = new RegExp(this.pattern ?? '');
         return this.richTextParent
@@ -45,12 +48,8 @@ RichTextMentionUsersValidator
         };
     }
 
-    protected override createMentionConfig(
-        mappingConfigs: MappingConfigs
-    ): RichTextMentionConfig {
-        return {
-            mappingConfigs
-        };
+    protected override createMentionConfig(): UserMentionConfig {
+        return new UserMentionConfig();
     }
 
     protected createMappingConfig(

--- a/packages/nimble-components/src/rich-text-mention/users/models/rich-text-mention-users-validator.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/models/rich-text-mention-users-validator.ts
@@ -18,7 +18,7 @@ const usersValidityFlagNames = [
 export class RichTextMentionUsersValidator extends RichTextMentionValidator<
     typeof usersValidityFlagNames
 > {
-    public constructor(columnInternals: MentionInternals<unknown>) {
+    public constructor(columnInternals: MentionInternals) {
         super(columnInternals, usersValidityFlagNames, [MappingUser]);
     }
 

--- a/packages/nimble-components/src/rich-text-mention/users/tests/rich-text-mention-users.spec.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/tests/rich-text-mention-users.spec.ts
@@ -111,8 +111,8 @@ describe('RichTextMentionUsers', () => {
             pattern: 'user:'
         }));
         await connect();
-        const mappingConfigs = element.mentionInternals.mentionConfig!.mappingConfigs;
-        expect(mappingConfigs?.size).toEqual(2);
+        const mappingConfigs = element.mentionInternals.mappingConfigs!;
+        expect(mappingConfigs.size).toEqual(2);
         expect(Array.from(mappingConfigs.keys())).toEqual(['user:1', 'user:2']);
         expect(mappingConfigs.get('user:1')?.displayName).toEqual('user');
         expect(mappingConfigs.get('user:2')?.displayName).toEqual('user');
@@ -126,16 +126,16 @@ describe('RichTextMentionUsers', () => {
             pattern: 'user:'
         }));
         await connect();
-        let mappingConfigs = element.mentionInternals.mentionConfig!.mappingConfigs;
-        expect(mappingConfigs?.size).toEqual(1);
+        let mappingConfigs = element.mentionInternals.mappingConfigs!;
+        expect(mappingConfigs.size).toEqual(1);
         expect(Array.from(mappingConfigs.keys())).toEqual(['user:1']);
         expect(mappingConfigs.get('user:1')?.displayName).toEqual('user');
         expect(mappingConfigs.get('user:1')?.mentionHref).toEqual('user:1');
 
         const newMappingData = [{ key: 'user:3', displayName: 'user-3' }];
         await setUserMappingElements(element, newMappingData);
-        mappingConfigs = element.mentionInternals.mentionConfig!.mappingConfigs;
-        expect(mappingConfigs?.size).toEqual(1);
+        mappingConfigs = element.mentionInternals.mappingConfigs!;
+        expect(mappingConfigs.size).toEqual(1);
         expect(Array.from(mappingConfigs.keys())).toEqual(['user:3']);
         expect(mappingConfigs.get('user:3')?.displayName).toEqual('user-3');
         expect(mappingConfigs.get('user:3')?.mentionHref).toEqual('user:3');
@@ -147,16 +147,16 @@ describe('RichTextMentionUsers', () => {
             pattern: 'user:'
         }));
         await connect();
-        let mappingConfigs = element.mentionInternals.mentionConfig!.mappingConfigs;
-        expect(mappingConfigs?.size).toEqual(1);
+        let mappingConfigs = element.mentionInternals.mappingConfigs!;
+        expect(mappingConfigs.size).toEqual(1);
         expect(Array.from(mappingConfigs.keys())).toEqual(['user:1']);
         expect(mappingConfigs.get('user:1')?.displayName).toEqual('user');
         expect(mappingConfigs.get('user:1')?.mentionHref).toEqual('user:1');
 
         const newMappingData = { key: 'user:3', displayName: 'user-3' };
         await updateFirstUserMappingElement(element, newMappingData);
-        mappingConfigs = element.mentionInternals.mentionConfig!.mappingConfigs;
-        expect(mappingConfigs?.size).toEqual(1);
+        mappingConfigs = element.mentionInternals.mappingConfigs!;
+        expect(mappingConfigs.size).toEqual(1);
         expect(Array.from(mappingConfigs.keys())).toEqual(['user:3']);
         expect(mappingConfigs.get('user:3')?.displayName).toEqual('user-3');
         expect(mappingConfigs.get('user:3')?.mentionHref).toEqual('user:3');
@@ -168,8 +168,8 @@ describe('RichTextMentionUsers', () => {
             pattern: 'user:'
         }));
         await connect();
-        const mappingConfigs = element.mentionInternals.mentionConfig!.mappingConfigs;
-        expect(mappingConfigs?.size).toEqual(1);
+        const mappingConfigs = element.mentionInternals.mappingConfigs!;
+        expect(mappingConfigs.size).toEqual(1);
         expect(Array.from(mappingConfigs.keys())).toEqual(['user:1']);
         expect(mappingConfigs.get('user:1')?.displayName).toEqual('user');
         expect(mappingConfigs.get('user:1')?.mentionHref).toEqual('user:1');
@@ -186,7 +186,7 @@ describe('RichTextMentionUsers', () => {
         }));
         await connect();
         const mappingConfig = new Map([]);
-        expect(element.mentionInternals.mentionConfig?.mappingConfigs).toEqual(
+        expect(element.mentionInternals.mappingConfigs).toEqual(
             mappingConfig
         );
     });
@@ -197,8 +197,8 @@ describe('RichTextMentionUsers', () => {
             pattern: 'user:.*'
         }));
         await connect();
-        const mappingConfigs = element.mentionInternals.mentionConfig!.mappingConfigs;
-        expect(mappingConfigs?.size).toEqual(1);
+        const mappingConfigs = element.mentionInternals.mappingConfigs!;
+        expect(mappingConfigs.size).toEqual(1);
         expect(Array.from(mappingConfigs.keys())).toEqual(['user:1']);
         expect(mappingConfigs.get('user:1')?.displayName).toEqual('user');
         expect(mappingConfigs.get('user:1')?.mentionHref).toEqual('user:1');
@@ -212,8 +212,8 @@ describe('RichTextMentionUsers', () => {
             pattern: 'user:'
         }));
         await connect();
-        const mappingConfigs = element.mentionInternals.mentionConfig!.mappingConfigs;
-        expect(mappingConfigs?.size).toEqual(1);
+        const mappingConfigs = element.mentionInternals.mappingConfigs!;
+        expect(mappingConfigs.size).toEqual(1);
         expect(Array.from(mappingConfigs.keys())).toEqual(['user:1']);
         expect(mappingConfigs.get('user:1')?.displayName).toEqual('user');
         expect(mappingConfigs.get('user:1')?.mentionHref).toEqual('user:1');

--- a/packages/nimble-components/src/rich-text-mention/users/tests/rich-text-mention-users.spec.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/tests/rich-text-mention-users.spec.ts
@@ -186,9 +186,7 @@ describe('RichTextMentionUsers', () => {
         }));
         await connect();
         const mappingConfig = new Map([]);
-        expect(element.mentionInternals.mappingConfigs).toEqual(
-            mappingConfig
-        );
+        expect(element.mentionInternals.mappingConfigs).toEqual(mappingConfig);
     });
 
     it('should have undefined mentionConfig when an invalid pattern is assigned', async () => {

--- a/packages/nimble-components/src/rich-text-mention/users/types.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/types.ts
@@ -1,3 +1,6 @@
-import type { RichTextMentionConfig } from '../base/types';
+import { MentionConfig } from '../base/models/mention-config';
 
-export type RichTextMentionUserConfig = RichTextMentionConfig;
+/**
+ * User Mention custom configuration
+ */
+export class UserMentionConfig extends MentionConfig {}

--- a/packages/nimble-components/src/rich-text/base/index.ts
+++ b/packages/nimble-components/src/rich-text/base/index.ts
@@ -34,7 +34,12 @@ export abstract class RichText extends FoundationElement {
      * @internal
      */
     public handleChange(source: unknown, args: unknown): void {
-        if (source instanceof MentionInternals && MarkdownParserMentionConfiguration.isObservedMentionInternalsProperty(args)) {
+        if (
+            source instanceof MentionInternals
+            && MarkdownParserMentionConfiguration.isObservedMentionInternalsProperty(
+                args
+            )
+        ) {
             this.updateParserMentionConfig();
         }
     }

--- a/packages/nimble-components/src/rich-text/base/index.ts
+++ b/packages/nimble-components/src/rich-text/base/index.ts
@@ -20,6 +20,9 @@ export abstract class RichText extends FoundationElement {
     @observable
     protected mentionElements: RichTextMention[] = [];
 
+    /**
+     * @internal
+     */
     private mentionInternalsNotifiers: Notifier[] = [];
 
     /**
@@ -36,7 +39,10 @@ export abstract class RichText extends FoundationElement {
         }
     }
 
-    protected mentionElementsChanged(): void {
+    protected mentionElementsChanged(old: unknown): void {
+        if (old === undefined) {
+            return;
+        }
         this.observeMentionInternals();
         this.updateParserMentionConfig();
     }
@@ -64,7 +70,10 @@ export abstract class RichText extends FoundationElement {
         this.parserMentionConfig = [];
     }
 
-    private childItemsChanged(): void {
+    private childItemsChanged(old: unknown): void {
+        if (old === undefined) {
+            return;
+        }
         void this.updateMentionElementsFromChildItems();
     }
 

--- a/packages/nimble-components/src/rich-text/base/index.ts
+++ b/packages/nimble-components/src/rich-text/base/index.ts
@@ -11,6 +11,11 @@ export abstract class RichText extends FoundationElement {
     /**
      * @internal
      */
+    public mentionInternalsNotifiers: Notifier[] = [];
+
+    /**
+     * @internal
+     */
     @observable
     public readonly childItems: Element[] = [];
 
@@ -18,12 +23,7 @@ export abstract class RichText extends FoundationElement {
     protected parserMentionConfig?: MarkdownParserMentionConfiguration[];
 
     @observable
-    protected mentionElements: RichTextMention[] = [];
-
-    /**
-     * @internal
-     */
-    private mentionInternalsNotifiers: Notifier[] = [];
+    protected mentionElements!: RichTextMention[];
 
     /**
      * @internal
@@ -39,10 +39,7 @@ export abstract class RichText extends FoundationElement {
         }
     }
 
-    protected mentionElementsChanged(old: unknown): void {
-        if (old === undefined) {
-            return;
-        }
+    protected mentionElementsChanged(_old: unknown, _new: unknown): void {
         this.observeMentionInternals();
         this.updateParserMentionConfig();
     }
@@ -70,10 +67,7 @@ export abstract class RichText extends FoundationElement {
         this.parserMentionConfig = [];
     }
 
-    private childItemsChanged(old: unknown): void {
-        if (old === undefined) {
-            return;
-        }
+    private childItemsChanged(_prev: unknown, _next: unknown): void {
         void this.updateMentionElementsFromChildItems();
     }
 

--- a/packages/nimble-components/src/rich-text/editor/index.ts
+++ b/packages/nimble-components/src/rich-text/editor/index.ts
@@ -5,12 +5,7 @@ import {
     DesignSystem
 } from '@microsoft/fast-foundation';
 import { keyEnter, keySpace } from '@microsoft/fast-web-utilities';
-import {
-    findParentNode,
-    isList,
-    AnyExtension,
-    Extension,
-} from '@tiptap/core';
+import { findParentNode, isList, AnyExtension, Extension } from '@tiptap/core';
 
 import type { PlaceholderOptions } from '@tiptap/extension-placeholder';
 import { template } from './template';
@@ -229,8 +224,8 @@ export class RichTextEditor extends RichText implements ErrorPattern {
      * @internal
      */
     public parserMentionConfigChanged(_prev: unknown, _next: unknown): void {
-        const cuurr = this.getMarkdown();
-        this.setMarkdown(cuurr);
+        const currentStateMarkdown = this.getMarkdown();
+        this.setMarkdown(currentStateMarkdown);
     }
 
     /**
@@ -331,9 +326,6 @@ export class RichTextEditor extends RichText implements ErrorPattern {
      */
     public setMarkdown(markdown: string): void {
         const html = this.getHtmlContent(markdown);
-        // TODO calling setMarkdown when initial markdown <user:2> and then update mention nodes to match changes
-        // html representation from nimble-anchor to a mention view
-        // calling getmarkdown with the mention view causes the content to render as user:2
         this.tiptapEditor.commands.setContent(html);
     }
 
@@ -367,7 +359,10 @@ export class RichTextEditor extends RichText implements ErrorPattern {
         return Array.from(mentionedHrefs);
     }
 
-    protected override mentionElementsChanged(prev: unknown, next: unknown): void {
+    protected override mentionElementsChanged(
+        prev: unknown,
+        next: unknown
+    ): void {
         super.mentionElementsChanged(prev, next);
         this.updateMentionExtensionsConfig();
     }
@@ -380,7 +375,11 @@ export class RichTextEditor extends RichText implements ErrorPattern {
                 mention => mention.mentionInternals.validConfiguration
             )
         ) {
-            this.mentionExtensionConfig = this.mentionElements.map(mentionElement => new MentionExtensionConfiguration(mentionElement.mentionInternals));
+            this.mentionExtensionConfig = this.mentionElements.map(
+                mentionElement => new MentionExtensionConfiguration(
+                    mentionElement.mentionInternals
+                )
+            );
             return;
         }
         this.mentionExtensionConfig = [];
@@ -400,7 +399,10 @@ export class RichTextEditor extends RichText implements ErrorPattern {
         this.unbindEditorUpdateEvent();
         this.unbindNativeInputEvent();
         this.tiptapEditor?.destroy();
-        this.tiptapEditor = createTiptapEditor(this.editor, this.mentionExtensionConfig ?? []);
+        this.tiptapEditor = createTiptapEditor(
+            this.editor,
+            this.mentionExtensionConfig ?? []
+        );
         this.bindEditorTransactionEvent();
         this.bindEditorUpdateEvent();
         this.stopNativeInputEventPropagation();

--- a/packages/nimble-components/src/rich-text/editor/index.ts
+++ b/packages/nimble-components/src/rich-text/editor/index.ts
@@ -6,41 +6,23 @@ import {
 } from '@microsoft/fast-foundation';
 import { keyEnter, keySpace } from '@microsoft/fast-web-utilities';
 import {
-    Editor,
     findParentNode,
     isList,
     AnyExtension,
     Extension,
-    Mark,
-    Node,
-    mergeAttributes
 } from '@tiptap/core';
-import Bold from '@tiptap/extension-bold';
-import BulletList from '@tiptap/extension-bullet-list';
-import Document from '@tiptap/extension-document';
-import History from '@tiptap/extension-history';
-import Italic from '@tiptap/extension-italic';
-import Link, { LinkOptions } from '@tiptap/extension-link';
-import ListItem from '@tiptap/extension-list-item';
-import OrderedList from '@tiptap/extension-ordered-list';
-import Paragraph from '@tiptap/extension-paragraph';
-import Placeholder from '@tiptap/extension-placeholder';
+
 import type { PlaceholderOptions } from '@tiptap/extension-placeholder';
-import Text from '@tiptap/extension-text';
-import Mention, { MentionOptions } from '@tiptap/extension-mention';
-import HardBreak from '@tiptap/extension-hard-break';
-import { Slice, Fragment, Node as FragmentNode } from 'prosemirror-model';
-import { PluginKey } from 'prosemirror-state';
 import { template } from './template';
 import { styles } from './styles';
 import type { ToggleButton } from '../../toggle-button';
-import { MentionExtensionConfig, TipTapNodeName } from './types';
+import { TipTapNodeName, mentionPluginPrefix } from './types';
 import type { ErrorPattern } from '../../patterns/error/types';
 import { RichTextMarkdownParser } from '../models/markdown-parser';
 import { RichTextMarkdownSerializer } from '../models/markdown-serializer';
-import { anchorTag } from '../../anchor';
 import { RichText } from '../base';
 import { MentionExtensionConfiguration } from '../models/mention-extension-configuration';
+import { createTiptapEditor } from './models/create-tiptap-editor';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -60,7 +42,7 @@ export class RichTextEditor extends RichText implements ErrorPattern {
     /**
      * @internal
      */
-    public tiptapEditor = this.createTiptapEditor();
+    public tiptapEditor = createTiptapEditor(this.editor, []);
 
     /**
      * Whether to disable user from editing and interacting with toolbar buttons
@@ -112,18 +94,20 @@ export class RichTextEditor extends RichText implements ErrorPattern {
      */
     public get empty(): boolean {
         // Tiptap [isEmpty](https://tiptap.dev/api/editor#is-empty) returns false even if the editor has only whitespace.
-        // However, the expectation is to return true if the editor is empty or contains only whitespace.
-        // Hence, by retrieving the current text content using Tiptap state docs and then trimming the string to determine whether it is empty or not.
-        // Additionally, for mention nodes where the text content consists solely of white spaces, the name is displayed inside the view element template.
-        // Since the trimming method mentioned above will return true as there are only white spaces in mention nodes, an extra check has been implemented.
-        // This check ensures the presence of mention nodes within the editor document.
-        const editorContentInStringFormat = this.tiptapEditor.state.doc.toString();
-        for (const extensionName of this.getAllMentionExtensionNames()) {
-            if (editorContentInStringFormat.includes(extensionName)) {
-                return false;
-            }
+        // Get the prose mirror textContent of all the nodes with whitespace trimmed to see if it is empty
+        // Mention nodes are formatted as empty text content, so if empty make sure there are no mention nodes remaining
+        if (this.tiptapEditor.state.doc.textContent.trim() === '') {
+            let hasMention = false;
+            this.tiptapEditor.state.doc.descendants(node => {
+                if (node.type.name.startsWith(mentionPluginPrefix)) {
+                    hasMention = true;
+                }
+                const continueDescent = hasMention === false;
+                return continueDescent;
+            });
+            return hasMention;
         }
-        return this.tiptapEditor.state.doc.textContent.trim().length === 0;
+        return false;
     }
 
     /**
@@ -171,7 +155,6 @@ export class RichTextEditor extends RichText implements ErrorPattern {
     private updateScrollbarWidthQueued = false;
 
     private readonly xmlSerializer = new XMLSerializer();
-    private readonly validAbsoluteLinkRegex = /^https?:\/\//i;
 
     /**
      * @internal
@@ -239,25 +222,10 @@ export class RichTextEditor extends RichText implements ErrorPattern {
     /**
      * @internal
      */
-    public mentionExtensionConfigChanged(
-        prev: MentionExtensionConfiguration[] | undefined,
-        next: MentionExtensionConfiguration[]
-    ): void {
-        const prevConfigCharacters = prev
-            ?.map(config => config.character)
-            .sort((a, b) => a.localeCompare(b))
-            .toString();
-        const nextConfigCharacters = next
-            .map(config => config.character)
-            .sort((a, b) => a.localeCompare(b))
-            .toString();
-        if (prevConfigCharacters === nextConfigCharacters) {
-            this.setMarkdown(this.getMarkdown());
-            return;
-        }
+    public mentionExtensionConfigChanged(): void {
         const currentStateMarkdown = this.getMarkdown();
         this.richTextMarkdownSerializer = new RichTextMarkdownSerializer(
-            this.getAllMentionExtensionNames()
+            (this.mentionExtensionConfig ?? []).map(config => config.name)
         );
         this.initializeEditor();
         this.setMarkdown(currentStateMarkdown);
@@ -373,31 +341,29 @@ export class RichTextEditor extends RichText implements ErrorPattern {
     }
 
     public getMentionedHrefs(): string[] {
-        const mentionedHrefs: string[] = [];
+        const mentionedHrefs = new Set<string>();
         this.tiptapEditor.state.doc.descendants(node => {
-            if (this.getAllMentionExtensionNames().includes(node.type.name)) {
-                if (!mentionedHrefs.includes(node.attrs.href as string)) {
-                    mentionedHrefs.push(node.attrs.href as string);
-                }
+            if (node.type.name.startsWith(mentionPluginPrefix)) {
+                mentionedHrefs.add(node.attrs.href as string);
             }
         });
-        return mentionedHrefs;
+        return Array.from(mentionedHrefs);
     }
 
-    protected override updateMentionConfig(): void {
-        super.updateMentionConfig();
+    protected override mentionElementsChanged(): void {
+        super.mentionElementsChanged();
+        this.updateMentionExtensionsConfig();
+    }
+
+    // Currently MentionExtensionConfiguration only depends on static properties on mention instances (non observable mentionInternal propeties)
+    // If MentionExtensionConfiguuration starts to rely on observable properties then override handleChange should be implemented to choose what to observe
+    private updateMentionExtensionsConfig(): void {
         if (
             this.mentionElements.every(
                 mention => mention.mentionInternals.validConfiguration
             )
         ) {
-            this.mentionExtensionConfig = this.mentionElements.map(
-                (mention, index) => new MentionExtensionConfiguration(
-                    mention.mentionInternals,
-                    `mention-plugin-${index}`
-                )
-            );
-
+            this.mentionExtensionConfig = this.mentionElements.map(mentionElement => new MentionExtensionConfiguration(mentionElement.mentionInternals));
             return;
         }
         this.mentionExtensionConfig = [];
@@ -412,272 +378,15 @@ export class RichTextEditor extends RichText implements ErrorPattern {
         return editor;
     }
 
-    /**
-     * This method finds the Link mark in the pasted content and update its Text node.
-     * If there is no text node, pass the node's fragment recursively and updates only node containing Link mark.
-     * If the Text node does not contains Link mark, push the same node to `updatedNodes`.
-     *
-     * @param fragment Fragment containing the pasted content. [Fragment](https://prosemirror.net/docs/ref/#model.Fragment)
-     * @returns modified fragment from the `updatedNode` after updating the valid link text with its href value.
-     */
-    private readonly updateLinkAndMentionNodes = (
-        fragment: Fragment
-    ): Fragment => {
-        const updatedNodes: FragmentNode[] = [];
-
-        fragment.forEach(node => {
-            if (node.isText && node.marks.length > 0) {
-                const linkMark = node.marks.find(
-                    mark => mark.type.name === 'link' && mark.attrs
-                );
-                if (linkMark) {
-                    // Checks if the link is valid link or not
-                    // Needing to separately validate the link on paste is a workaround for a tiptap issue
-                    // See: https://github.com/ni/nimble/issues/1527
-                    if (
-                        this.validAbsoluteLinkRegex.test(
-                            linkMark.attrs.href as string
-                        )
-                    ) {
-                        // The below lines of code is responsible for updating the text content with its href value and creates a new updated text node.
-                        // This code needs an update when the hyperlink support is added.
-                        // See: https://github.com/ni/nimble/issues/1527
-                        updatedNodes.push(
-                            this.tiptapEditor.schema.text(
-                                linkMark.attrs.href as string,
-                                node.marks
-                            )
-                        );
-                    } else {
-                        // If it is a invalid link, creates a new Text node with the same text content and without a Link mark.
-                        updatedNodes.push(
-                            this.tiptapEditor.schema.text(
-                                node.textContent,
-                                linkMark.removeFromSet(node.marks)
-                            )
-                        );
-                    }
-                } else {
-                    updatedNodes.push(node);
-                }
-            } else if (
-                this.getAllMentionExtensionNames().includes(node.type.name)
-            ) {
-                updatedNodes.push(
-                    this.tiptapEditor.schema.text(node.attrs.label as string)
-                );
-            } else {
-                const updatedContent = this.updateLinkAndMentionNodes(
-                    node.content
-                );
-                updatedNodes.push(node.copy(updatedContent));
-            }
-        });
-
-        return Fragment.fromArray(updatedNodes);
-    };
-
-    private createTiptapEditor(): Editor {
-        const customLink = this.getCustomLinkExtension();
-        const mentionExtensions = this.mentionExtensionConfig?.map(config => this.getCustomMentionExtension({
-            name: config.name,
-            character: config.character,
-            key: config.key,
-            viewElement: config.viewElement
-        })) ?? [];
-
-        /**
-         * @param slice contains the Fragment of the copied content. If the content is a link, the slice contains Text node with Link mark.
-         * ProseMirror reference for `transformPasted`: https://prosemirror.net/docs/ref/#view.EditorProps.transformPasted
-         */
-        const transformPasted = (slice: Slice): Slice => {
-            const modifiedFragment = this.updateLinkAndMentionNodes(
-                slice.content
-            );
-            return new Slice(modifiedFragment, slice.openStart, slice.openEnd);
-        };
-
-        /**
-         * For more information on the extensions for the supported formatting options, refer to the links below.
-         * Tiptap marks: https://tiptap.dev/api/marks
-         * Tiptap nodes: https://tiptap.dev/api/nodes
-         */
-        return new Editor({
-            element: this.editor,
-            // The editor will detect markdown syntax for an input only for these items
-            // https://tiptap.dev/api/editor#enable-input-rules
-            enableInputRules: [BulletList, OrderedList],
-            // The editor will not detect markdown syntax when pasting content in any supported items
-            // Lists do not have any default paste rules, they have only input rules, so disabled paste rules
-            // https://tiptap.dev/api/editor#enable-paste-rules
-            enablePasteRules: false,
-            editorProps: {
-                // Validating whether the links in the pasted content belongs to the supported scheme (HTTPS/HTTP),
-                // and rendering it as a link in the editor. If not, rendering it as a plain text.
-                // Also, updating the link text content with its href as we support only the absolute link.
-
-                // `transformPasted` can be updated/removed when hyperlink support added
-                // See: https://github.com/ni/nimble/issues/1527
-                transformPasted
-            },
-            extensions: [
-                Document,
-                Paragraph,
-                Text,
-                BulletList,
-                OrderedList,
-                ListItem,
-                Bold,
-                Italic,
-                History,
-                Placeholder.configure({
-                    placeholder: '',
-                    showOnlyWhenEditable: false
-                }),
-                HardBreak,
-                customLink,
-                ...mentionExtensions
-            ]
-        });
-    }
-
     private initializeEditor(): void {
         this.unbindEditorTransactionEvent();
         this.unbindEditorUpdateEvent();
         this.unbindNativeInputEvent();
         this.tiptapEditor?.destroy();
-        this.tiptapEditor = this.createTiptapEditor();
+        this.tiptapEditor = createTiptapEditor(this.editor, this.mentionExtensionConfig ?? []);
         this.bindEditorTransactionEvent();
         this.bindEditorUpdateEvent();
         this.stopNativeInputEventPropagation();
-    }
-
-    /**
-     * Extending the default link mark schema defined in the TipTap.
-     *
-     * "excludes": https://prosemirror.net/docs/ref/#model.MarkSpec.excludes
-     * "inclusive": https://prosemirror.net/docs/ref/#model.MarkSpec.inclusive
-     * "parseHTML": https://tiptap.dev/guide/custom-extensions#parse-html
-     * "renderHTML": https://tiptap.dev/guide/custom-extensions/#render-html
-     */
-    private getCustomLinkExtension(): Mark<LinkOptions> {
-        return Link.extend({
-            // Excludes can be removed/enabled when hyperlink support added
-            // See: https://github.com/ni/nimble/issues/1527
-            excludes: '_',
-            // Inclusive can be updated when hyperlink support added
-            // See: https://github.com/ni/nimble/issues/1527
-            inclusive: false,
-            parseHTML() {
-                return [
-                    // To load the `nimble-anchor` from the HTML parsed content by markdown-parser as links in the Tiptap editor, the `parseHTML`
-                    // of Link extension should return nimble `anchorTag`.
-                    // This is because the link mark schema in `markdown-parser.ts` file uses `<nimble-anchor>` as anchor tag and not `<a>`.
-                    {
-                        tag: anchorTag
-                    },
-                    // `<a>` tag is added here to support when pasting a link from external source.
-                    {
-                        tag: 'a'
-                    }
-                ];
-            },
-            // HTMLAttribute cannot be in camelCase as we want to match it with the name in Tiptap
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            renderHTML({ HTMLAttributes }) {
-                // The below 'a' tag should be replaced with 'nimble-anchor' once the below issue is fixed.
-                // https://github.com/ni/nimble/issues/1516
-                return ['a', HTMLAttributes];
-            }
-        }).configure({
-            // HTMLAttribute cannot be in camelCase as we want to match it with the name in Tiptap
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            HTMLAttributes: {
-                rel: 'noopener noreferrer',
-                target: null
-            },
-            autolink: true,
-            openOnClick: false,
-            // linkOnPaste can be enabled when hyperlink support added
-            // See: https://github.com/ni/nimble/issues/1527
-            linkOnPaste: false,
-            validate: href => this.validAbsoluteLinkRegex.test(href)
-        });
-    }
-
-    private getCustomMentionExtension(
-        config: MentionExtensionConfig
-    ): Node<MentionOptions> {
-        return Mention.extend({
-            name: config.name,
-            parseHTML() {
-                return [
-                    {
-                        tag: config.viewElement
-                    }
-                ];
-            },
-            addAttributes() {
-                return {
-                    href: {
-                        default: null,
-                        parseHTML: element => element.getAttribute('mention-href'),
-                        renderHTML: attributes => {
-                            return {
-                                'mention-href': attributes.href as string
-                            };
-                        }
-                    },
-
-                    label: {
-                        default: null,
-                        parseHTML: element => element.getAttribute('mention-label'),
-                        renderHTML: attributes => {
-                            return {
-                                'mention-label': attributes.label as string
-                            };
-                        }
-                    }
-                };
-            },
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            renderHTML({ HTMLAttributes }) {
-                return [
-                    config.viewElement,
-                    mergeAttributes(
-                        this.options.HTMLAttributes,
-                        HTMLAttributes,
-                        { 'disable-editing': true }
-                    )
-                ];
-            }
-        }).configure({
-            suggestion: {
-                char: config.character,
-                decorationTag: config.viewElement,
-                pluginKey: new PluginKey(config.key),
-                allowSpaces: true,
-                render: () => {
-                    return {
-                        onStart: (props): void => {
-                            this.triggerMentionEvent(props.text);
-                        },
-
-                        onUpdate: (props): void => {
-                            this.triggerMentionEvent(props.text);
-                        }
-                    };
-                }
-            }
-        });
-    }
-
-    private triggerMentionEvent(filter: string): void {
-        const validMentionElement = this.mentionElements.find(
-            mention => mention.mentionInternals.validConfiguration
-                && mention.mentionInternals.character === filter.slice(0, 1)
-        );
-        validMentionElement?.onMention(filter.slice(1));
     }
 
     /**
@@ -803,10 +512,6 @@ export class RichTextEditor extends RichText implements ErrorPattern {
                 }
             }
         });
-    }
-
-    private getAllMentionExtensionNames(): string[] {
-        return this.mentionExtensionConfig?.map(config => config.name) ?? [];
     }
 }
 

--- a/packages/nimble-components/src/rich-text/editor/index.ts
+++ b/packages/nimble-components/src/rich-text/editor/index.ts
@@ -45,6 +45,11 @@ export class RichTextEditor extends RichText implements ErrorPattern {
     public tiptapEditor = createTiptapEditor(this.editor, []);
 
     /**
+     * @internal
+     */
+    public richTextMarkdownSerializer = new RichTextMarkdownSerializer([]);
+
+    /**
      * Whether to disable user from editing and interacting with toolbar buttons
      *
      * @public
@@ -149,8 +154,6 @@ export class RichTextEditor extends RichText implements ErrorPattern {
     @observable
     private mentionExtensionConfig?: MentionExtensionConfiguration[];
 
-    private richTextMarkdownSerializer = new RichTextMarkdownSerializer();
-
     private resizeObserver?: ResizeObserver;
     private updateScrollbarWidthQueued = false;
 
@@ -218,6 +221,23 @@ export class RichTextEditor extends RichText implements ErrorPattern {
             this.editor.removeAttribute('aria-label');
         }
     }
+
+    /**
+     * @internal
+     */
+    public parserMentionConfigChanged(): void {
+        const cuurr = this.getMarkdown();
+        this.setMarkdown(cuurr);
+    }
+
+    // public parserMentionConfigChanged(): void {
+    //     const currentStateMarkdown = this.getMarkdown();
+    //     this.richTextMarkdownSerializer = new RichTextMarkdownSerializer(
+    //         (this.mentionExtensionConfig ?? []).map(config => config.name)
+    //     );
+    //     this.initializeEditor();
+    //     this.setMarkdown(currentStateMarkdown);
+    // }
 
     /**
      * @internal
@@ -317,6 +337,9 @@ export class RichTextEditor extends RichText implements ErrorPattern {
      */
     public setMarkdown(markdown: string): void {
         const html = this.getHtmlContent(markdown);
+        // TODO calling setMarkdown when initial markdown <user:2> and then update mention nodes to match changes
+        // html representation from nimble-anchor to a mention view
+        // calling getmarkdown with the mention view causes the content to render as user:2
         this.tiptapEditor.commands.setContent(html);
     }
 
@@ -350,8 +373,11 @@ export class RichTextEditor extends RichText implements ErrorPattern {
         return Array.from(mentionedHrefs);
     }
 
-    protected override mentionElementsChanged(): void {
-        super.mentionElementsChanged();
+    protected override mentionElementsChanged(old: unknown): void {
+        super.mentionElementsChanged(old);
+        if (old === undefined) {
+            return;
+        }
         this.updateMentionExtensionsConfig();
     }
 

--- a/packages/nimble-components/src/rich-text/editor/index.ts
+++ b/packages/nimble-components/src/rich-text/editor/index.ts
@@ -47,6 +47,11 @@ export class RichTextEditor extends RichText implements ErrorPattern {
     /**
      * @internal
      */
+    public readonly xmlSerializer = new XMLSerializer();
+
+    /**
+     * @internal
+     */
     public richTextMarkdownSerializer = new RichTextMarkdownSerializer([]);
 
     /**
@@ -157,8 +162,6 @@ export class RichTextEditor extends RichText implements ErrorPattern {
     private resizeObserver?: ResizeObserver;
     private updateScrollbarWidthQueued = false;
 
-    private readonly xmlSerializer = new XMLSerializer();
-
     /**
      * @internal
      */
@@ -188,7 +191,7 @@ export class RichTextEditor extends RichText implements ErrorPattern {
     /**
      * @internal
      */
-    public disabledChanged(): void {
+    public disabledChanged(_prev: unknown, _next: unknown): void {
         this.tiptapEditor.setEditable(!this.disabled);
         this.setEditorTabIndex();
         this.editor.setAttribute(
@@ -201,7 +204,7 @@ export class RichTextEditor extends RichText implements ErrorPattern {
      * Update the placeholder text and view of the editor.
      * @internal
      */
-    public placeholderChanged(): void {
+    public placeholderChanged(_prev: unknown, _next: unknown): void {
         const placeholderExtension = this.getTipTapExtension(
             'placeholder'
         ) as Extension<PlaceholderOptions>;
@@ -214,7 +217,7 @@ export class RichTextEditor extends RichText implements ErrorPattern {
     /**
      * @internal
      */
-    public ariaLabelChanged(): void {
+    public ariaLabelChanged(_prev: unknown, _next: unknown): void {
         if (this.ariaLabel !== null && this.ariaLabel !== undefined) {
             this.editor.setAttribute('aria-label', this.ariaLabel);
         } else {
@@ -225,24 +228,15 @@ export class RichTextEditor extends RichText implements ErrorPattern {
     /**
      * @internal
      */
-    public parserMentionConfigChanged(): void {
+    public parserMentionConfigChanged(_prev: unknown, _next: unknown): void {
         const cuurr = this.getMarkdown();
         this.setMarkdown(cuurr);
     }
 
-    // public parserMentionConfigChanged(): void {
-    //     const currentStateMarkdown = this.getMarkdown();
-    //     this.richTextMarkdownSerializer = new RichTextMarkdownSerializer(
-    //         (this.mentionExtensionConfig ?? []).map(config => config.name)
-    //     );
-    //     this.initializeEditor();
-    //     this.setMarkdown(currentStateMarkdown);
-    // }
-
     /**
      * @internal
      */
-    public mentionExtensionConfigChanged(): void {
+    public mentionExtensionConfigChanged(_prev: unknown, _next: unknown): void {
         const currentStateMarkdown = this.getMarkdown();
         this.richTextMarkdownSerializer = new RichTextMarkdownSerializer(
             (this.mentionExtensionConfig ?? []).map(config => config.name)
@@ -373,11 +367,8 @@ export class RichTextEditor extends RichText implements ErrorPattern {
         return Array.from(mentionedHrefs);
     }
 
-    protected override mentionElementsChanged(old: unknown): void {
-        super.mentionElementsChanged(old);
-        if (old === undefined) {
-            return;
-        }
+    protected override mentionElementsChanged(prev: unknown, next: unknown): void {
+        super.mentionElementsChanged(prev, next);
         this.updateMentionExtensionsConfig();
     }
 

--- a/packages/nimble-components/src/rich-text/editor/models/create-tiptap-editor.ts
+++ b/packages/nimble-components/src/rich-text/editor/models/create-tiptap-editor.ts
@@ -1,0 +1,277 @@
+import {
+    Editor,
+    Mark,
+    Node,
+    mergeAttributes
+} from '@tiptap/core';
+import Bold from '@tiptap/extension-bold';
+import BulletList from '@tiptap/extension-bullet-list';
+import Document from '@tiptap/extension-document';
+import History from '@tiptap/extension-history';
+import Italic from '@tiptap/extension-italic';
+import Link, { LinkOptions } from '@tiptap/extension-link';
+import ListItem from '@tiptap/extension-list-item';
+import OrderedList from '@tiptap/extension-ordered-list';
+import Paragraph from '@tiptap/extension-paragraph';
+import Placeholder from '@tiptap/extension-placeholder';
+import Text from '@tiptap/extension-text';
+import Mention, { MentionOptions } from '@tiptap/extension-mention';
+import HardBreak from '@tiptap/extension-hard-break';
+import { Slice, Fragment, Node as FragmentNode } from 'prosemirror-model';
+import { PluginKey } from 'prosemirror-state';
+
+import { mentionPluginPrefix } from '../types';
+
+import { anchorTag } from '../../../anchor';
+import type { MentionExtensionConfiguration } from '../../models/mention-extension-configuration';
+
+const validAbsoluteLinkRegex = /^https?:\/\//i;
+
+export function createTiptapEditor(editor: HTMLDivElement, mentionExtensionConfig: MentionExtensionConfiguration[]): Editor {
+    const customLink = createCustomLinkExtension();
+    const mentionExtensions = mentionExtensionConfig.map(config => createCustomMentionExtension(config));
+
+    /**
+     * For more information on the extensions for the supported formatting options, refer to the links below.
+     * Tiptap marks: https://tiptap.dev/api/marks
+     * Tiptap nodes: https://tiptap.dev/api/nodes
+     */
+    const tipTapEditor = new Editor({
+        element: editor,
+        // The editor will detect markdown syntax for an input only for these items
+        // https://tiptap.dev/api/editor#enable-input-rules
+        enableInputRules: [BulletList, OrderedList],
+        // The editor will not detect markdown syntax when pasting content in any supported items
+        // Lists do not have any default paste rules, they have only input rules, so disabled paste rules
+        // https://tiptap.dev/api/editor#enable-paste-rules
+        enablePasteRules: false,
+        editorProps: {
+            // Validating whether the links in the pasted content belongs to the supported scheme (HTTPS/HTTP),
+            // and rendering it as a link in the editor. If not, rendering it as a plain text.
+            // Also, updating the link text content with its href as we support only the absolute link.
+
+            // `transformPasted` can be updated/removed when hyperlink support added
+            // See: https://github.com/ni/nimble/issues/1527
+            transformPasted
+        },
+        extensions: [
+            Document,
+            Paragraph,
+            Text,
+            BulletList,
+            OrderedList,
+            ListItem,
+            Bold,
+            Italic,
+            History,
+            Placeholder.configure({
+                placeholder: '',
+                showOnlyWhenEditable: false
+            }),
+            HardBreak,
+            customLink,
+            ...mentionExtensions
+        ]
+    });
+
+    /**
+     * @param slice contains the Fragment of the copied content. If the content is a link, the slice contains Text node with Link mark.
+     * ProseMirror reference for `transformPasted`: https://prosemirror.net/docs/ref/#view.EditorProps.transformPasted
+     */
+    function transformPasted(slice: Slice): Slice {
+        const modifiedFragment = updateLinkAndMentionNodes(
+            tipTapEditor,
+            slice.content
+        );
+        return new Slice(modifiedFragment, slice.openStart, slice.openEnd);
+    }
+
+    return tipTapEditor;
+}
+
+/**
+ * Extending the default link mark schema defined in the TipTap.
+ *
+ * "excludes": https://prosemirror.net/docs/ref/#model.MarkSpec.excludes
+ * "inclusive": https://prosemirror.net/docs/ref/#model.MarkSpec.inclusive
+ * "parseHTML": https://tiptap.dev/guide/custom-extensions#parse-html
+ * "renderHTML": https://tiptap.dev/guide/custom-extensions/#render-html
+ */
+function createCustomLinkExtension(): Mark<LinkOptions> {
+    return Link.extend({
+        // Excludes can be removed/enabled when hyperlink support added
+        // See: https://github.com/ni/nimble/issues/1527
+        excludes: '_',
+        // Inclusive can be updated when hyperlink support added
+        // See: https://github.com/ni/nimble/issues/1527
+        inclusive: false,
+        parseHTML() {
+            return [
+                // To load the `nimble-anchor` from the HTML parsed content by markdown-parser as links in the Tiptap editor, the `parseHTML`
+                // of Link extension should return nimble `anchorTag`.
+                // This is because the link mark schema in `markdown-parser.ts` file uses `<nimble-anchor>` as anchor tag and not `<a>`.
+                {
+                    tag: anchorTag
+                },
+                // `<a>` tag is added here to support when pasting a link from external source.
+                {
+                    tag: 'a'
+                }
+            ];
+        },
+        // HTMLAttribute cannot be in camelCase as we want to match it with the name in Tiptap
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        renderHTML({ HTMLAttributes }) {
+            // The below 'a' tag should be replaced with 'nimble-anchor' once the below issue is fixed.
+            // https://github.com/ni/nimble/issues/1516
+            return ['a', HTMLAttributes];
+        }
+    }).configure({
+        // HTMLAttribute cannot be in camelCase as we want to match it with the name in Tiptap
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        HTMLAttributes: {
+            rel: 'noopener noreferrer',
+            target: null
+        },
+        autolink: true,
+        openOnClick: false,
+        // linkOnPaste can be enabled when hyperlink support added
+        // See: https://github.com/ni/nimble/issues/1527
+        linkOnPaste: false,
+        validate: href => validAbsoluteLinkRegex.test(href)
+    });
+}
+
+function createCustomMentionExtension(
+    config: MentionExtensionConfiguration
+): Node<MentionOptions> {
+    return Mention.extend({
+        name: config.name,
+        parseHTML() {
+            return [
+                {
+                    tag: config.viewElement
+                }
+            ];
+        },
+        addAttributes() {
+            return {
+                href: {
+                    default: null,
+                    parseHTML: element => element.getAttribute('mention-href'),
+                    renderHTML: attributes => {
+                        return {
+                            'mention-href': attributes.href as string
+                        };
+                    }
+                },
+
+                label: {
+                    default: null,
+                    parseHTML: element => element.getAttribute('mention-label'),
+                    renderHTML: attributes => {
+                        return {
+                            'mention-label': attributes.label as string
+                        };
+                    }
+                }
+            };
+        },
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        renderHTML({ HTMLAttributes }) {
+            return [
+                config.viewElement,
+                mergeAttributes(
+                    this.options.HTMLAttributes,
+                    HTMLAttributes,
+                    { 'disable-editing': true }
+                )
+            ];
+        }
+    }).configure({
+        suggestion: {
+            char: config.character,
+            decorationTag: config.viewElement,
+            pluginKey: new PluginKey(config.key),
+            allowSpaces: true,
+            render: () => {
+                return {
+                    onStart: (props): void => {
+                        config.mentionUpdateEmitter(props.text);
+                    },
+
+                    onUpdate: (props): void => {
+                        config.mentionUpdateEmitter(props.text);
+                    }
+                };
+            }
+        }
+    });
+}
+
+/**
+ * This method finds the Link mark in the pasted content and update its Text node.
+ * If there is no text node, pass the node's fragment recursively and updates only node containing Link mark.
+ * If the Text node does not contains Link mark, push the same node to `updatedNodes`.
+ *
+ * @param fragment Fragment containing the pasted content. [Fragment](https://prosemirror.net/docs/ref/#model.Fragment)
+ * @returns modified fragment from the `updatedNode` after updating the valid link text with its href value.
+ */
+function updateLinkAndMentionNodes(
+    tiptapEditor: Editor,
+    fragment: Fragment
+): Fragment {
+    const updatedNodes: FragmentNode[] = [];
+
+    fragment.forEach(node => {
+        if (node.isText && node.marks.length > 0) {
+            const linkMark = node.marks.find(
+                mark => mark.type.name === 'link' && mark.attrs
+            );
+            if (linkMark) {
+                // Checks if the link is valid link or not
+                // Needing to separately validate the link on paste is a workaround for a tiptap issue
+                // See: https://github.com/ni/nimble/issues/1527
+                if (
+                    validAbsoluteLinkRegex.test(
+                        linkMark.attrs.href as string
+                    )
+                ) {
+                    // The below lines of code is responsible for updating the text content with its href value and creates a new updated text node.
+                    // This code needs an update when the hyperlink support is added.
+                    // See: https://github.com/ni/nimble/issues/1527
+                    updatedNodes.push(
+                        tiptapEditor.schema.text(
+                            linkMark.attrs.href as string,
+                            node.marks
+                        )
+                    );
+                } else {
+                    // If it is a invalid link, creates a new Text node with the same text content and without a Link mark.
+                    updatedNodes.push(
+                        tiptapEditor.schema.text(
+                            node.textContent,
+                            linkMark.removeFromSet(node.marks)
+                        )
+                    );
+                }
+            } else {
+                updatedNodes.push(node);
+            }
+        } else if (
+            node.type.name.startsWith(mentionPluginPrefix)
+        ) {
+            updatedNodes.push(
+                tiptapEditor.schema.text(node.attrs.label as string)
+            );
+        } else {
+            const updatedContent = updateLinkAndMentionNodes(
+                tiptapEditor,
+                node.content
+            );
+            updatedNodes.push(node.copy(updatedContent));
+        }
+    });
+
+    return Fragment.fromArray(updatedNodes);
+}

--- a/packages/nimble-components/src/rich-text/editor/models/create-tiptap-editor.ts
+++ b/packages/nimble-components/src/rich-text/editor/models/create-tiptap-editor.ts
@@ -1,9 +1,4 @@
-import {
-    Editor,
-    Mark,
-    Node,
-    mergeAttributes
-} from '@tiptap/core';
+import { Editor, Mark, Node, mergeAttributes } from '@tiptap/core';
 import Bold from '@tiptap/extension-bold';
 import BulletList from '@tiptap/extension-bullet-list';
 import Document from '@tiptap/extension-document';
@@ -27,7 +22,10 @@ import type { MentionExtensionConfiguration } from '../../models/mention-extensi
 
 const validAbsoluteLinkRegex = /^https?:\/\//i;
 
-export function createTiptapEditor(editor: HTMLDivElement, mentionExtensionConfig: MentionExtensionConfiguration[]): Editor {
+export function createTiptapEditor(
+    editor: HTMLDivElement,
+    mentionExtensionConfig: MentionExtensionConfiguration[]
+): Editor {
     const customLink = createCustomLinkExtension();
     const mentionExtensions = mentionExtensionConfig.map(config => createCustomMentionExtension(config));
 
@@ -234,9 +232,7 @@ function updateLinkAndMentionNodes(
                 // Needing to separately validate the link on paste is a workaround for a tiptap issue
                 // See: https://github.com/ni/nimble/issues/1527
                 if (
-                    validAbsoluteLinkRegex.test(
-                        linkMark.attrs.href as string
-                    )
+                    validAbsoluteLinkRegex.test(linkMark.attrs.href as string)
                 ) {
                     // The below lines of code is responsible for updating the text content with its href value and creates a new updated text node.
                     // This code needs an update when the hyperlink support is added.
@@ -259,9 +255,7 @@ function updateLinkAndMentionNodes(
             } else {
                 updatedNodes.push(node);
             }
-        } else if (
-            node.type.name.startsWith(mentionPluginPrefix)
-        ) {
+        } else if (node.type.name.startsWith(mentionPluginPrefix)) {
             updatedNodes.push(
                 tiptapEditor.schema.text(node.attrs.label as string)
             );

--- a/packages/nimble-components/src/rich-text/editor/models/create-tiptap-editor.ts
+++ b/packages/nimble-components/src/rich-text/editor/models/create-tiptap-editor.ts
@@ -184,7 +184,8 @@ function createCustomMentionExtension(
                 mergeAttributes(
                     this.options.HTMLAttributes,
                     HTMLAttributes,
-                    { 'disable-editing': true }
+                    // disable-editing is a boolean attribute
+                    { 'disable-editing': '' }
                 )
             ];
         }

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
@@ -65,7 +65,7 @@ async function appendTestMentionConfiguration(
 ): Promise<void> {
     const testMention = document.createElement(
         richTextMentionTestTag
-    ) as RichTextMentionTest;
+    );
     testMention.pattern = '^test:(.*)';
 
     if (userKeys || displayNames) {

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
@@ -63,9 +63,7 @@ async function appendTestMentionConfiguration(
     userKeys?: string[],
     displayNames?: string[]
 ): Promise<void> {
-    const testMention = document.createElement(
-        richTextMentionTestTag
-    );
+    const testMention = document.createElement(richTextMentionTestTag);
     testMention.pattern = '^test:(.*)';
 
     if (userKeys || displayNames) {

--- a/packages/nimble-components/src/rich-text/editor/types.ts
+++ b/packages/nimble-components/src/rich-text/editor/types.ts
@@ -10,9 +10,4 @@ export const TipTapNodeName = {
 export type TipTapNodeName =
     (typeof TipTapNodeName)[keyof typeof TipTapNodeName];
 
-export interface MentionExtensionConfig {
-    name: string;
-    key: string;
-    character: string;
-    viewElement: string;
-}
+export const mentionPluginPrefix = 'mention-plugin-';

--- a/packages/nimble-components/src/rich-text/models/configuration.ts
+++ b/packages/nimble-components/src/rich-text/models/configuration.ts
@@ -1,0 +1,25 @@
+import type { RichTextMention } from '../../rich-text-mention/base';
+import { MarkdownParserMentionConfiguration } from './markdown-parser-mention-configuration';
+
+/**
+ * Base class for Configuration, contains mention configuration required for RichTextMarkdownParser
+ */
+export class Configuration {
+    public parserMentionConfig: MarkdownParserMentionConfiguration[] = [];
+
+    protected isValid = true;
+
+    public constructor(mentionElements: RichTextMention[]) {
+        this.isValid = mentionElements.every(
+            mention => mention.mentionInternals.validConfiguration
+        );
+
+        this.parserMentionConfig = this.isValid
+            ? mentionElements.map(
+                mention => new MarkdownParserMentionConfiguration(
+                    mention.mentionInternals
+                )
+            )
+            : [];
+    }
+}

--- a/packages/nimble-components/src/rich-text/models/editor-configuration.ts
+++ b/packages/nimble-components/src/rich-text/models/editor-configuration.ts
@@ -1,0 +1,21 @@
+import type { RichTextMention } from '../../rich-text-mention/base';
+import { Configuration } from './configuration';
+import { MentionExtensionConfiguration } from './mention-extension-configuration';
+
+/**
+ * EditorConfiguration which will hold mentionExtensionConfig for configuring editor's mention extension and RichTextMarkdownSerializer
+ */
+export class EditorConfiguration extends Configuration {
+    public mentionExtensionConfig: MentionExtensionConfiguration[];
+
+    public constructor(mentionElements: RichTextMention[]) {
+        super(mentionElements);
+        this.mentionExtensionConfig = this.isValid
+            ? mentionElements.map(
+                mentionElement => new MentionExtensionConfiguration(
+                    mentionElement.mentionInternals
+                )
+            )
+            : [];
+    }
+}

--- a/packages/nimble-components/src/rich-text/models/markdown-parser-mention-configuration.ts
+++ b/packages/nimble-components/src/rich-text/models/markdown-parser-mention-configuration.ts
@@ -1,6 +1,4 @@
-import type {
-    MappingConfigs,
-} from '../../rich-text-mention/base/types';
+import type { MappingConfigs } from '../../rich-text-mention/base/types';
 import type { MentionInternals } from '../../rich-text-mention/base/models/mention-internals';
 
 /**
@@ -13,16 +11,17 @@ export class MarkdownParserMentionConfiguration {
     private readonly regexPattern: RegExp;
     private readonly mappingConfigs?: MappingConfigs;
 
-    public constructor(
-        mentionInternals: MentionInternals
-    ) {
+    public constructor(mentionInternals: MentionInternals) {
         this.regexPattern = new RegExp(mentionInternals.pattern ?? '');
         this.mappingConfigs = mentionInternals.mappingConfigs;
         this.viewElement = mentionInternals.viewElement;
     }
 
     public static isObservedMentionInternalsProperty(arg: unknown): boolean {
-        return typeof arg === 'string' && ['regexPattern', 'mappingConfigs'].includes(arg);
+        return (
+            typeof arg === 'string'
+            && ['regexPattern', 'mappingConfigs'].includes(arg)
+        );
     }
 
     public isValidMentionHref(mentionHref: string): boolean {

--- a/packages/nimble-components/src/rich-text/models/markdown-parser-mention-configuration.ts
+++ b/packages/nimble-components/src/rich-text/models/markdown-parser-mention-configuration.ts
@@ -20,7 +20,7 @@ export class MarkdownParserMentionConfiguration {
     public static isObservedMentionInternalsProperty(arg: unknown): boolean {
         return (
             typeof arg === 'string'
-            && ['regexPattern', 'mappingConfigs'].includes(arg)
+            && ['pattern', 'mappingConfigs'].includes(arg)
         );
     }
 

--- a/packages/nimble-components/src/rich-text/models/markdown-parser-mention-configuration.ts
+++ b/packages/nimble-components/src/rich-text/models/markdown-parser-mention-configuration.ts
@@ -1,6 +1,5 @@
 import type {
     MappingConfigs,
-    RichTextMentionConfig
 } from '../../rich-text-mention/base/types';
 import type { MentionInternals } from '../../rich-text-mention/base/models/mention-internals';
 
@@ -15,11 +14,15 @@ export class MarkdownParserMentionConfiguration {
     private readonly mappingConfigs?: MappingConfigs;
 
     public constructor(
-        mentionInternals: MentionInternals<RichTextMentionConfig>
+        mentionInternals: MentionInternals
     ) {
         this.regexPattern = new RegExp(mentionInternals.pattern ?? '');
-        this.mappingConfigs = mentionInternals.mentionConfig?.mappingConfigs;
+        this.mappingConfigs = mentionInternals.mappingConfigs;
         this.viewElement = mentionInternals.viewElement;
+    }
+
+    public static isObservedMentionInternalsProperty(arg: unknown): boolean {
+        return typeof arg === 'string' && ['regexPattern', 'mappingConfigs'].includes(arg);
     }
 
     public isValidMentionHref(mentionHref: string): boolean {

--- a/packages/nimble-components/src/rich-text/models/markdown-serializer.ts
+++ b/packages/nimble-components/src/rich-text/models/markdown-serializer.ts
@@ -20,7 +20,7 @@ interface Nodes {
 export class RichTextMarkdownSerializer {
     private readonly markdownSerializer: MarkdownSerializer;
 
-    public constructor(mentionList: string[] = []) {
+    public constructor(mentionList: string[]) {
         this.markdownSerializer = this.initializeMarkdownSerializerForTipTap(mentionList);
     }
 

--- a/packages/nimble-components/src/rich-text/models/mention-extension-configuration.ts
+++ b/packages/nimble-components/src/rich-text/models/mention-extension-configuration.ts
@@ -1,24 +1,30 @@
-import type { RichTextMentionConfig } from '../../rich-text-mention/base/types';
 import type { MentionInternals } from '../../rich-text-mention/base/models/mention-internals';
+import type { MentionUpdateEmitter } from '../../rich-text-mention/base/types';
+import { mentionPluginPrefix } from '../editor/types';
 
 /**
  * A configuration object for a Mention extension, to be used by the editor for loading mention plugins in tiptap.
  * This object maintains the necessary internal values for loading mention extension.
  */
 export class MentionExtensionConfiguration {
+    private static instance = 0;
+
     public readonly viewElement: string;
     public readonly character: string;
     public readonly name: string;
     public readonly key: string;
+    public readonly mentionUpdateEmitter: MentionUpdateEmitter;
 
     public constructor(
-        mentionInternals: MentionInternals<RichTextMentionConfig>,
-        key: string
+        mentionInternals: MentionInternals
     ) {
-        // Name, Key and character should be unique for each mention plugin to be configured.
-        this.viewElement = mentionInternals.viewElement;
-        this.character = mentionInternals.character;
+        MentionExtensionConfiguration.instance += 1;
+        const key = `${mentionPluginPrefix}${MentionExtensionConfiguration.instance}`;
         this.name = key;
         this.key = key;
+
+        this.viewElement = mentionInternals.viewElement;
+        this.character = mentionInternals.character;
+        this.mentionUpdateEmitter = mentionInternals.mentionUpdateEmitter;
     }
 }

--- a/packages/nimble-components/src/rich-text/models/mention-extension-configuration.ts
+++ b/packages/nimble-components/src/rich-text/models/mention-extension-configuration.ts
@@ -15,9 +15,7 @@ export class MentionExtensionConfiguration {
     public readonly key: string;
     public readonly mentionUpdateEmitter: MentionUpdateEmitter;
 
-    public constructor(
-        mentionInternals: MentionInternals
-    ) {
+    public constructor(mentionInternals: MentionInternals) {
         MentionExtensionConfiguration.instance += 1;
         const key = `${mentionPluginPrefix}${MentionExtensionConfiguration.instance}`;
         this.name = key;

--- a/packages/nimble-components/src/rich-text/viewer/index.ts
+++ b/packages/nimble-components/src/rich-text/viewer/index.ts
@@ -48,7 +48,7 @@ export class RichTextViewer extends RichText {
     /**
      * @internal
      */
-    public parserMentionConfigChanged(): void {
+    public configurationChanged(): void {
         this.updateView();
     }
 
@@ -63,7 +63,7 @@ export class RichTextViewer extends RichText {
         if (this.markdown) {
             const parseResult = RichTextMarkdownParser.parseMarkdownToDOM(
                 this.markdown,
-                this.parserMentionConfig
+                this.configuration.parserMentionConfig
             );
             this.viewer.replaceChildren(parseResult.fragment);
             this.mentionedHrefs = parseResult.mentionedHrefs;

--- a/packages/nimble-components/src/rich-text/viewer/tests/rich-text-viewer.spec.ts
+++ b/packages/nimble-components/src/rich-text/viewer/tests/rich-text-viewer.spec.ts
@@ -64,7 +64,7 @@ async function appendTestMentionConfiguration(
 ): Promise<void> {
     const testMention = document.createElement(
         richTextMentionTestTag
-    ) as RichTextMentionTest;
+    );
     testMention.pattern = '^test:(.*)';
 
     if (userKeys || displayNames) {

--- a/packages/nimble-components/src/rich-text/viewer/tests/rich-text-viewer.spec.ts
+++ b/packages/nimble-components/src/rich-text/viewer/tests/rich-text-viewer.spec.ts
@@ -62,9 +62,7 @@ async function appendTestMentionConfiguration(
     userKeys?: string[],
     displayNames?: string[]
 ): Promise<void> {
-    const testMention = document.createElement(
-        richTextMentionTestTag
-    );
+    const testMention = document.createElement(richTextMentionTestTag);
     testMention.pattern = '^test:(.*)';
 
     if (userKeys || displayNames) {

--- a/packages/nimble-components/src/utilities/tests/rich-text-markdown-string.ts
+++ b/packages/nimble-components/src/utilities/tests/rich-text-markdown-string.ts
@@ -1,1 +1,3 @@
-export const richTextMarkdownString = 'Supported rich text formatting options:\n1. **Bold**\n2. *Italics*\n3. Numbered lists\n   1. Option 1\n   2. Option 2\n4. Bulleted lists\n   * Option 1\n   * Option 2\n5. Absolute link: <https://nimble.ni.dev/>\n 6. @mention:\n    1. User pattern: <user:1>\n    2. HTTPS pattern: <https://user/2>';
+export const richTextMarkdownString = '<user:1>';
+// export const richTextMarkdownString = 'Supported rich text formatting options:\n1. **Bold**\n2. *Italics*\n3. Numbered lists\n   1. Option 1\n   2. Option 2\n4. Bulleted lists\n   * Option 1\n   * Option 2\n5. Absolute link: <https://nimble.ni.dev/>\n 6. @mention:\n    1. User pattern: <user:1>\n    2. HTTPS pattern: <https://user/2>';
+

--- a/packages/nimble-components/src/utilities/tests/rich-text-markdown-string.ts
+++ b/packages/nimble-components/src/utilities/tests/rich-text-markdown-string.ts
@@ -1,3 +1,2 @@
 export const richTextMarkdownString = '<user:1>';
 // export const richTextMarkdownString = 'Supported rich text formatting options:\n1. **Bold**\n2. *Italics*\n3. Numbered lists\n   1. Option 1\n   2. Option 2\n4. Bulleted lists\n   * Option 1\n   * Option 2\n5. Absolute link: <https://nimble.ni.dev/>\n 6. @mention:\n    1. User pattern: <user:1>\n    2. HTTPS pattern: <https://user/2>';
-


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

High-level changes:
- Split out entension and parser config to be separate observation paths
- Created a separate parserMentionConfigChanged and mentionExtensionConfigChanged so they can be handled separately with different amounts of work needed
- Created mentionPluginPrefix and try to use that in locations where it didn't seem necessary to have the exact list of current mentions

Refactors:
- Moved tiptap editor creation to a separate file
- Made the tiptap editor only rely on only the passed in extension configuration and editor element reference
- Moved the mappingConfigs onto MentionInternals instead of MentionInternals.mentionConfig.mappingConfig
