### PR TITLE
Ensure all parameterized tests get run

### DIFF
--- a/change/@ni-nimble-components-86390fa6-4b05-4673-8eb8-47dc3470733c.json
+++ b/change/@ni-nimble-components-86390fa6-4b05-4673-8eb8-47dc3470733c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Ensure all parameterized tests get run",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
@@ -414,11 +414,11 @@ describe('RichTextEditor', () => {
 
         describe('should render as lists when its input rule is entered into the editor', () => {
             const markdownInput = [
-                { name: 'bullet list', input: '*', tagName: 'UL' },
-                { name: 'bullet list', input: '+', tagName: 'UL' },
-                { name: 'bullet list', input: '-', tagName: 'UL' },
-                { name: 'numbered list', input: '1.', tagName: 'OL' },
-                { name: 'numbered list', input: '5.', tagName: 'OL' }
+                { name: 'bullet list (*)', input: '*', tagName: 'UL' },
+                { name: 'bullet list (+)', input: '+', tagName: 'UL' },
+                { name: 'bullet list (-)', input: '-', tagName: 'UL' },
+                { name: 'numbered list (1.)', input: '1.', tagName: 'OL' },
+                { name: 'numbered list (5.)', input: '5.', tagName: 'OL' }
             ] as const;
             parameterizeNamedList(markdownInput, (spec, name, value) => {
                 spec(`for ${name} markdown input to the editor`, async () => {
@@ -1183,32 +1183,32 @@ describe('RichTextEditor', () => {
                         text: 'info@example.com'
                     },
                     {
-                        name: 'Anchor with invalid link',
+                        name: 'Anchor with invalid link (javascript)',
                         input: '<a href="javascript:vbscript:alert("not alert")">Invalid link</a>',
                         text: 'Invalid link'
                     },
                     {
-                        name: 'Anchor with invalid link',
+                        name: 'Anchor with invalid link (file)',
                         input: '<a href="file:///path/to/local/file.txt">Invalid link</a>',
                         text: 'Invalid link'
                     },
                     {
-                        name: 'Anchor with invalid link',
+                        name: 'Anchor with invalid link (data)',
                         input: '<a href="data:image/png;base64,iVBORw0KG...">Invalid link</a>',
                         text: 'Invalid link'
                     },
                     {
-                        name: 'Anchor with invalid link',
+                        name: 'Anchor with invalid link (tel)',
                         input: '<a href="tel:+1234567890">Invalid link</a>',
                         text: 'Invalid link'
                     },
                     {
-                        name: 'Anchor with invalid link',
+                        name: 'Anchor with invalid link (ssh)',
                         input: '<a href="ssh://username@example.com">Invalid link</a>',
                         text: 'Invalid link'
                     },
                     {
-                        name: 'Anchor with invalid link',
+                        name: 'Anchor with invalid link (urn)',
                         input: '<a href="urn:isbn:0451450523">Invalid link</a>',
                         text: 'Invalid link'
                     }

--- a/packages/nimble-components/src/utilities/tests/parameterized.ts
+++ b/packages/nimble-components/src/utilities/tests/parameterized.ts
@@ -144,6 +144,11 @@ export const parameterizeNamedList = <T extends readonly { name: string }[]>(
 ): void => {
     const testCases = list.reduce<{ [key: string]: { name: string } }>(
         (result, entry) => {
+            if (result[entry.name]) {
+                throw new Error(
+                    `Duplicate name found in test case list: ${entry.name}`
+                );
+            }
             result[entry.name] = entry;
             return result;
         },

--- a/packages/nimble-components/src/utilities/tests/wacky-strings.ts
+++ b/packages/nimble-components/src/utilities/tests/wacky-strings.ts
@@ -2,7 +2,6 @@ export const wackyStrings = [
     { name: '<button></button>' },
     { name: 'null' },
     { name: 'undefined' },
-    { name: 'null' },
     { name: 'NaN' },
     { name: '-Infinity' },
     { name: 'Infinity' },


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

If test cases passed to `parameterizeNamedList` have multiple cases with the same name, only the last one gets run. This was the case for some rich-text editor tests. We want to ensure that all test cases get run.

## 👩‍💻 Implementation

- Now throwing error from `parameterizeNamedList` if multiple test cases with the same name are encountered. This should prevent developers from accidentally creating tests that don't get run.
- Uniquified some rich-text editor test case names so that they all get run.

## 🧪 Testing

Tests pass.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
