### PR TITLE
Rich text editor | Fix mention listbox opening at the wrong position when mention dynamically loads

### DIFF
--- a/change/@ni-nimble-components-77825b10-d033-43ac-9a4c-aa28738727ea.json
+++ b/change/@ni-nimble-components-77825b10-d033-43ac-9a4c-aa28738727ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix mention listbox when configuration dynamically changes and when cursor position change",
+  "packageName": "@ni/nimble-components",
+  "email": "123377523+vivinkrishna-ni@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/rich-text-mention/users/view/styles.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/view/styles.ts
@@ -1,4 +1,5 @@
 import { css } from '@microsoft/fast-element';
+import { display } from '@microsoft/fast-foundation';
 import {
     mentionFont,
     mentionDisabledFontColor,
@@ -8,6 +9,8 @@ import {
 } from '../../../theme-provider/design-tokens';
 
 export const styles = css`
+    ${display('inline')}
+
     :host {
         box-sizing: border-box;
         font: ${bodyFont};

--- a/packages/nimble-components/src/rich-text-mention/users/view/styles.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/view/styles.ts
@@ -1,5 +1,4 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
 import {
     mentionFont,
     mentionDisabledFontColor,
@@ -9,8 +8,6 @@ import {
 } from '../../../theme-provider/design-tokens';
 
 export const styles = css`
-    ${display('inline-block')}
-
     :host {
         box-sizing: border-box;
         font: ${bodyFont};

--- a/packages/nimble-components/src/rich-text-mention/users/view/styles.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/view/styles.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../theme-provider/design-tokens';
 
 export const styles = css`
-    ${display('inline')}
+    ${display('inline-block')}
 
     :host {
         box-sizing: border-box;

--- a/packages/nimble-components/src/rich-text-mention/users/view/styles.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/view/styles.ts
@@ -15,7 +15,7 @@ export const styles = css`
         box-sizing: border-box;
         font: ${bodyFont};
         color: ${bodyFontColor};
-        white-space: normal;
+        white-space: pre-wrap;
     }
 
     .control {

--- a/packages/nimble-components/src/rich-text-mention/users/view/tests/rich-text-mention-users-view-matrix.stories.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/view/tests/rich-text-mention-users-view-matrix.stories.ts
@@ -55,9 +55,7 @@ const component = ([
             mention-label="John Doe"
             ?disabled="${() => disabled}"
             ?disable-editing= "${() => disableEditing}"
-        >
-            @John Doe
-        </${richTextMentionUsersViewTag}>
+        >@John Doe</${richTextMentionUsersViewTag}>
         <span class="sample-text">(Mention View ${() => name})</span>
     </div>
 `;
@@ -81,9 +79,7 @@ const componentEditingMode = (): ViewTemplate => html`
         <${richTextMentionUsersViewTag}
             mention-href="user:1"
             mention-label="John Doe"
-        >
-            @John Doe
-        </${richTextMentionUsersViewTag}>
+        >@John Doe</${richTextMentionUsersViewTag}>
         <span class="sample-text">(Mention View Enabled Editing)</span>
     </div>
 `;

--- a/packages/nimble-components/src/rich-text/editor/models/create-tiptap-editor.ts
+++ b/packages/nimble-components/src/rich-text/editor/models/create-tiptap-editor.ts
@@ -223,6 +223,14 @@ function createCustomMentionExtension(
                 let inSuggestionMode = false;
                 return {
                     onStart: (props): void => {
+                        /**
+                         * If the cursor position moves to the start of the mention and configuration element changes,
+                         * the setMarkdown() will trigger this `onStart` without a decoration node because the cursor
+                         * position is moved out of the suggestion decoration
+                         */
+                        if (props.decorationNode === null) {
+                            return;
+                        }
                         inSuggestionMode = true;
                         config.mentionUpdateEmitter(props.query);
                         activeMentionCharacterEmitter(props.text.slice(0, 1));

--- a/packages/nimble-components/src/rich-text/editor/models/create-tiptap-editor.ts
+++ b/packages/nimble-components/src/rich-text/editor/models/create-tiptap-editor.ts
@@ -224,9 +224,10 @@ function createCustomMentionExtension(
                 return {
                     onStart: (props): void => {
                         /**
-                         * If the cursor position moves to the start of the mention and configuration element changes,
+                         * If the cursor position moves to outside of the mention and configuration element changes,
                          * the setMarkdown() will trigger this `onStart` without a decoration node because the cursor
-                         * position is moved out of the suggestion decoration
+                         * position is temporarily moved out of the suggestion decoration. Ignore `onStart` in that case
+                         * and don't show the mention list box since it doesn't have anything to anchor to.
                          */
                         if (props.decorationNode === null) {
                             return;

--- a/packages/nimble-components/src/rich-text/editor/testing/rich-text-editor.pageobject.ts
+++ b/packages/nimble-components/src/rich-text/editor/testing/rich-text-editor.pageobject.ts
@@ -248,6 +248,13 @@ export class RichTextEditorPageObject {
         await waitForUpdatesAsync();
     }
 
+    public async setCursorPosition(position: number): Promise<void> {
+        this.richTextEditorElement.tiptapEditor.commands.setTextSelection(
+            position
+        );
+        await waitForUpdatesAsync();
+    }
+
     public async replaceEditorContent(value: string): Promise<void> {
         const lastElement = this.getEditorLastChildElement();
         lastElement.parentElement!.textContent = value;

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
@@ -1408,7 +1408,7 @@ describe('RichTextEditorMentionListbox', () => {
             ]);
         });
 
-        it('should close mention listbox when cursor position is moved to start and configuration dynamically changes', async () => {
+        it('mention listbox should be closed when cursor position is moved to start and configuration dynamically changes', async () => {
             const { mappingElements } = await appendUserMentionConfiguration(
                 element,
                 [{ key: 'user:1', displayName: 'user name1' }]

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
@@ -1407,5 +1407,19 @@ describe('RichTextEditorMentionListbox', () => {
                 'testname2'
             ]);
         });
+
+        it('should close mention listbox when cursor position is moved to start and configuration dynamically changes', async () => {
+            const { mappingElements } = await appendUserMentionConfiguration(
+                element,
+                [{ key: 'user:1', displayName: 'user name1' }]
+            );
+            await pageObject.setEditorTextContent('@user');
+            expect(pageObject.isMentionListboxOpened()).toBeTrue();
+            await pageObject.setCursorPosition(1);
+            expect(pageObject.isMentionListboxOpened()).toBeFalse();
+            mappingElements[0]!.displayName = 'user name2';
+            await waitForUpdatesAsync();
+            expect(pageObject.isMentionListboxOpened()).toBeFalse();
+        });
     });
 });


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

<!---
Provide some background and a description of your work.
What problem does this change solve?

Include links to issues, work items, or other discussions.
-->

Whenever the `@mention` is triggered, moving the cursor away from the decoration element and updating the configuration element dynamically opens the popup at the top right of the page. 

In the GIF below, we are updating the configuration element by updating the `Load Config` button to demonstrate the issue
![popup-at-the-top-issue-nimble](https://github.com/ni/nimble/assets/123377523/4a81a93e-8dec-41a7-906c-7da494572227)

## 👩‍💻 Implementation

<!---
Describe how the change addresses the problem. Consider factors such as complexity, alternative solutions, performance impact, etc. 

Consider listing files with important changes or comment on them directly in the pull request.
-->

The issue is because the `onStart()` event of the suggestion plugin of Tiptap is triggered whenever we perform `setMarkdown()` when the configuration element updates dynamically. However, if we move the cursor to start as mentioned in the above GIF which triggers the `onExit()` event and then `onStart()` the props in `onStart()` called without a decoration node to load the popup right below `@` character.

So in `onstart()`, if the decoration node is null, we restrict opening the popup.

## 🧪 Testing

<!---
Detail the testing done to ensure this submission meets requirements. 

Include automated/manual test additions or modifications, testing done on a local build, private CI run results, and additional testing not covered by automatic pull request validation. If any functionality is not covered by automated testing, provide justification.
-->
- Written a test for the popup issue with the same workflow.
- Manually verified in SLE for the same popup issue

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
