### PR TITLE
Allow table data in storybook stories to be marked as const

### DIFF
--- a/change/@ni-nimble-components-98ef4a59-a28e-4b32-88de-c99cc5d976e5.json
+++ b/change/@ni-nimble-components-98ef4a59-a28e-4b32-88de-c99cc5d976e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Allow 'const' table data in stories",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.stories.ts
+++ b/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.stories.ts
@@ -61,7 +61,7 @@ const simpleData = [
     {
         lastName: 'Simpson'
     }
-];
+] as const;
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface AnchorColumnTableArgs extends SharedTableArgs {

--- a/packages/nimble-components/src/table-column/base/tests/table-column-stories-utils.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column-stories-utils.ts
@@ -26,7 +26,7 @@ export const sharedTableArgTypes = {
 } as const;
 
 export const sharedTableArgs = (
-    data: TableRecord[]
+    data: readonly TableRecord[]
 ): {
         selectionMode: keyof typeof TableRowSelectionMode,
         tableRef: undefined,

--- a/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
@@ -71,7 +71,7 @@ const simpleData = [
         lastName: 'Simpson',
         favoriteColor: 'Red'
     }
-];
+] as const;
 
 const overviewText = `This page contains information about configuring the columns of a \`nimble-table\`. 
 See **Table** for information about configuring the table itself and the **Table Column** specific docs for 

--- a/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.stories.ts
+++ b/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.stories.ts
@@ -51,7 +51,7 @@ const simpleData = [
         lastName: 'Simpson',
         birthday: new Date(2022, 0, 12, 20, 4, 37, 975).valueOf()
     }
-];
+] as const;
 
 const metadata: Meta<SharedTableArgs> = {
     title: 'Components/Table Column: Date Text',

--- a/packages/nimble-components/src/table-column/duration-text/tests/table-column-duration-text.stories.ts
+++ b/packages/nimble-components/src/table-column/duration-text/tests/table-column-duration-text.stories.ts
@@ -38,7 +38,7 @@ const simpleData = [
         lastName: 'Burns',
         swearWordCadence: 3.78e12
     }
-];
+] as const;
 
 const metadata: Meta<SharedTableArgs> = {
     title: 'Components/Table Column: Duration Text',

--- a/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text.stories.ts
+++ b/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text.stories.ts
@@ -34,7 +34,7 @@ const simpleData = [
         lastName: 'Simpson',
         status: 'success'
     }
-];
+] as const;
 
 const enumTextColumnDescription = `The \`nimble-table-column-enum-text\` column renders string, number, or boolean values as mapped text in the \`nimble-table\`.
 

--- a/packages/nimble-components/src/table-column/icon/tests/table-column-icon.stories.ts
+++ b/packages/nimble-components/src/table-column/icon/tests/table-column-icon.stories.ts
@@ -42,7 +42,7 @@ const simpleData = [
         status: 'success',
         isChild: true
     }
-];
+] as const;
 
 const iconColumnDescription = `The \`nimble-table-column-icon\` column renders string, number, or boolean values as a Nimble icon or \`nimble-spinner\` in the \`nimble-table\`.
 

--- a/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.stories.ts
+++ b/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.stories.ts
@@ -45,7 +45,7 @@ const simpleData = [
         age: 14.1,
         favoriteNumber: -0.00000064532623
     }
-];
+] as const;
 
 const metadata: Meta<SharedTableArgs> = {
     title: 'Components/Table Column: Number Text',

--- a/packages/nimble-components/src/table-column/text/tests/table-column-text.stories.ts
+++ b/packages/nimble-components/src/table-column/text/tests/table-column-text.stories.ts
@@ -35,7 +35,7 @@ const simpleData = [
         lastName: 'Simpson',
         favoriteColor: 'Red'
     }
-];
+] as const;
 
 const metadata: Meta<SharedTableArgs> = {
     title: 'Components/Table Column: Text',

--- a/packages/nimble-components/src/theme-provider/tests/theme-provider.stories.ts
+++ b/packages/nimble-components/src/theme-provider/tests/theme-provider.stories.ts
@@ -24,7 +24,7 @@ const simpleData = [
     {
         date: new Date(2022, 0, 12, 20, 4, 37, 975).valueOf()
     }
-];
+] as const;
 
 const metadata: Meta = {
     title: 'Tokens/Theme Provider',


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

#1613
 
## 👩‍💻 Implementation

- Update `sharedTableArgs()` to accept a `readonly` data array
- Update all callers of `sharedTableArgs()` to have their data marked as const

## 🧪 Testing

Ensured build & pipeline continues to pass

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
