### PR TITLE
Add button alignment visual test

### DIFF
--- a/change/@ni-nimble-components-f4776f02-4ee0-4534-8a00-bbc51b09d9c3.json
+++ b/change/@ni-nimble-components-f4776f02-4ee0-4534-8a00-bbc51b09d9c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add button alignment visual test",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/button/tests/button-matrix.stories.ts
+++ b/packages/nimble-components/src/button/tests/button-matrix.stories.ts
@@ -82,10 +82,22 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
     textCustomizationWrapper(html`<${buttonTag}>Button</${buttonTag}>`)
 );
 
+// The baseline of the elements should be aligned when positioned inline.
 export const inlineAlignment: StoryFn = createStory(
-    html`Text
-        <${buttonTag}>Button</${buttonTag}>
-        Text
-        <${buttonTag}><${iconKeyTag} slot="start"></${iconKeyTag}>Button</${buttonTag}>
-        <div style="display:inline-block; width:50px; height:50px; border: 1px black solid;"></div>`
+    html`<span style="text-decoration: underline;">Text</span>
+        <nimble-button
+            ><span style="text-decoration: underline;"
+                >Button</span
+            ></nimble-button
+        >
+        <span style="text-decoration: underline;">Text</span>
+        <nimble-button
+            ><nimble-icon-key slot="start"></nimble-icon-key
+            ><span style="text-decoration: underline;"
+                >Button</span
+            ></nimble-button
+        >
+        <div
+            style="display:inline-block; width:50px; height:50px; border: 1px black solid;"
+        ></div>`
 );

--- a/packages/nimble-components/src/button/tests/button-matrix.stories.ts
+++ b/packages/nimble-components/src/button/tests/button-matrix.stories.ts
@@ -16,6 +16,7 @@ import { textCustomizationWrapper } from '../../utilities/tests/text-customizati
 import { buttonTag } from '..';
 import { iconKeyTag } from '../../icons/key';
 import { iconArrowExpanderDownTag } from '../../icons/arrow-expander-down';
+import { bodyFont } from '../../theme-provider/design-tokens';
 
 const metadata: Meta = {
     title: 'Tests/Button',
@@ -84,20 +85,18 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
 
 // The baseline of the elements should be aligned when positioned inline.
 export const inlineAlignment: StoryFn = createStory(
-    html`<span style="text-decoration: underline;">Text</span>
-        <nimble-button
-            ><span style="text-decoration: underline;"
-                >Button</span
-            ></nimble-button
-        >
+    html`<span style="font: var(${bodyFont.cssCustomProperty});">
         <span style="text-decoration: underline;">Text</span>
-        <nimble-button
-            ><nimble-icon-key slot="start"></nimble-icon-key
-            ><span style="text-decoration: underline;"
-                >Button</span
-            ></nimble-button
-        >
+        <${buttonTag}>
+            <span style="text-decoration: underline;">Button</span>
+        </${buttonTag}>
+        <span style="text-decoration: underline;">Text</span>
+        <${buttonTag}>
+            <${iconKeyTag} slot="start"></${iconKeyTag}>
+            <span style="text-decoration: underline;">Button</span>
+        </${buttonTag}>
         <div
             style="display:inline-block; width:50px; height:50px; border: 1px black solid;"
-        ></div>`
+        ></div>
+    </span>`
 );

--- a/packages/nimble-components/src/button/tests/button-matrix.stories.ts
+++ b/packages/nimble-components/src/button/tests/button-matrix.stories.ts
@@ -81,3 +81,11 @@ export const hiddenButton: StoryFn = createStory(
 export const textCustomized: StoryFn = createMatrixThemeStory(
     textCustomizationWrapper(html`<${buttonTag}>Button</${buttonTag}>`)
 );
+
+export const inlineAlignment: StoryFn = createStory(
+    html`Text
+        <${buttonTag}>Button</${buttonTag}>
+        Text
+        <${buttonTag}><${iconKeyTag} slot="start"></${iconKeyTag}>Button</${buttonTag}>
+        <img src="https://github.com/ni/nimble/raw/main/docs/nimble-logo-icon.svg" width="50px" style="border: 1px black solid">`
+);

--- a/packages/nimble-components/src/button/tests/button-matrix.stories.ts
+++ b/packages/nimble-components/src/button/tests/button-matrix.stories.ts
@@ -87,5 +87,5 @@ export const inlineAlignment: StoryFn = createStory(
         <${buttonTag}>Button</${buttonTag}>
         Text
         <${buttonTag}><${iconKeyTag} slot="start"></${iconKeyTag}>Button</${buttonTag}>
-        <img src="https://github.com/ni/nimble/raw/main/docs/nimble-logo-icon.svg" width="50px" style="border: 1px black solid">`
+        <div style="display:inline-block; width:50px; height:50px; border: 1px black solid;"></div>`
 );

--- a/packages/nimble-components/src/patterns/button/styles.ts
+++ b/packages/nimble-components/src/patterns/button/styles.ts
@@ -47,6 +47,7 @@ export const styles = css`
                     Not sure why but this is needed to get buttons with icons and buttons
                     without icons to align on the same line when the button is inline-flex
                     See: https://github.com/microsoft/fast/issues/5414
+                    For additional discussion, see: https://github.com/ni/nimble/issues/503
                 */ ''
             }
             vertical-align: middle;

--- a/packages/nimble-components/src/patterns/button/styles.ts
+++ b/packages/nimble-components/src/patterns/button/styles.ts
@@ -46,8 +46,7 @@ export const styles = css`
                 /*
                     Not sure why but this is needed to get buttons with icons and buttons
                     without icons to align on the same line when the button is inline-flex
-                    See: https://github.com/microsoft/fast/issues/5414
-                    For additional discussion, see: https://github.com/ni/nimble/issues/503
+                    See: https://github.com/ni/nimble/issues/503
                 */ ''
             }
             vertical-align: middle;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes: #503 

## 👩‍💻 Implementation

Added a button Chromatic test for how buttons align with inline text and images.

## 🧪 Testing

New test added.

I noticed that the Safari snapshot of the new Chromatic test has unexpected alignment (top of text is aligned with top of buttons). From what I can tell, Chromatic is using version 16 of Safari. I checked the new story in versions 15.x and 17.1, and both rendered with the alignment I would expect (same as other browsers). I also tried it in Playwright's WebKit browser version 16.0, and I still got the expected alignment. I do not know how Chromatic ended up with weird alignment, but I'm satisfied enough that it looks right in all versions of Safari/WebKit I checked.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
