### PR TITLE
In anchor story, only emit contenteditable when set

### DIFF
--- a/change/@ni-nimble-components-eb411161-e7dc-4ad6-94f2-b4eca4a15927.json
+++ b/change/@ni-nimble-components-eb411161-e7dc-4ad6-94f2-b4eca4a15927.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "In anchor story, only emit contenteditable when set",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/anchor/tests/anchor.stories.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor.stories.ts
@@ -15,7 +15,7 @@ interface AnchorArgs {
     label: string;
     href: string;
     underlineHidden: boolean;
-    contenteditable: string;
+    contenteditable: boolean;
     appearance: keyof typeof AnchorAppearance;
 }
 
@@ -38,10 +38,10 @@ const metadata: Meta<AnchorArgs> = {
                 outline: none;
             }
         </style>
-        <span class="anchor-container" contenteditable=${x => x.contenteditable}>Click on the <${anchorTag}
+        <span class="anchor-container" ?contenteditable=${x => x.contenteditable}>Click on the <${anchorTag}
             href=${x => (x.href !== '' ? x.href : null)}
             ?underline-hidden=${x => x.underlineHidden}
-            contenteditable=${x => x.contenteditable}
+            ?contenteditable=${x => x.contenteditable}
             appearance=${x => x.appearance}
         >${x => x.label}</${anchorTag}> to navigate.</span>
     `),
@@ -61,8 +61,6 @@ const metadata: Meta<AnchorArgs> = {
                 'Set to `prominent` to make the anchor appear in a different color than normal text.'
         },
         contenteditable: {
-            options: ['false', 'true'],
-            control: { type: 'radio' },
             description:
                 'Set this to the string "true" (or set the attribute without any value)  when the anchor is within an editable region (i.e. element/hierarchy with [contenteditable](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable)). Whereas native elements inherit their `contenteditable` value by default, the `nimble-anchor` requires this attribute be explicitly set.'
         }
@@ -71,7 +69,7 @@ const metadata: Meta<AnchorArgs> = {
         label: 'link',
         href: 'https://nimble.ni.dev',
         underlineHidden: false,
-        contenteditable: 'false',
+        contenteditable: false,
         appearance: 'default'
     }
 };

--- a/packages/nimble-components/src/anchor/tests/anchor.stories.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor.stories.ts
@@ -62,7 +62,7 @@ const metadata: Meta<AnchorArgs> = {
         },
         contenteditable: {
             description:
-                'Set this to the string "true" (or set the attribute without any value)  when the anchor is within an editable region (i.e. element/hierarchy with [contenteditable](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable)). Whereas native elements inherit their `contenteditable` value by default, the `nimble-anchor` requires this attribute be explicitly set.'
+                'Set this to the string "true" (or an empty string)  when the anchor is within an editable region (i.e. element/hierarchy with [contenteditable](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable)). Whereas native elements inherit their `contenteditable` value by default, the `nimble-anchor` requires this attribute be explicitly set.'
         }
     },
     args: {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #1723

## 👩‍💻 Implementation

Treat `contenteditable` setting as a boolean rather than a string, and omit the attribute when the setting is false.

## 🧪 Testing

Storybook

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
