### PR TITLE
Update parameterized tests

### DIFF
--- a/change/@ni-nimble-components-7a7cdc65-b568-478f-ab5d-5aa5c56949c9.json
+++ b/change/@ni-nimble-components-7a7cdc65-b568-478f-ab5d-5aa5c56949c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update all tests to use `parameterizeNamedList` and delete deprecated `getSpecTypeByNamedList` function",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-nimble-components-7a7cdc65-b568-478f-ab5d-5aa5c56949c9.json
+++ b/change/@ni-nimble-components-7a7cdc65-b568-478f-ab5d-5aa5c56949c9.json
@@ -1,6 +1,6 @@
 {
-  "type": "none",
-  "comment": "Update all tests to use `parameterizeNamedList` and delete deprecated `getSpecTypeByNamedList` function",
+  "type": "minor",
+  "comment": "- Update all tests to use `parameterizeNamedList` and delete deprecated `getSpecTypeByNamedList` function.\n- Update functions in the table page object and table validator to have `readonly` arrays as the parameters.",
   "packageName": "@ni/nimble-components",
   "email": "20542556+mollykreis@users.noreply.github.com",
   "dependentChangeType": "none"

--- a/packages/nimble-components/src/anchor-menu-item/tests/anchor-menu-item.spec.ts
+++ b/packages/nimble-components/src/anchor-menu-item/tests/anchor-menu-item.spec.ts
@@ -82,19 +82,14 @@ describe('Anchor Menu Item', () => {
         ];
         describe('should reflect value to the internal control', () => {
             parameterizeNamedList(attributeNames, (spec, name) => {
-                spec(
-                    `for attribute ${name}`,
-                    async () => {
-                        await connect();
+                spec(`for attribute ${name}`, async () => {
+                    await connect();
 
-                        element.setAttribute(name, 'foo');
-                        await waitForUpdatesAsync();
+                    element.setAttribute(name, 'foo');
+                    await waitForUpdatesAsync();
 
-                        expect(element.anchor.getAttribute(name)).toBe(
-                            'foo'
-                        );
-                    }
-                );
+                    expect(element.anchor.getAttribute(name)).toBe('foo');
+                });
             });
         });
 

--- a/packages/nimble-components/src/anchor-menu-item/tests/anchor-menu-item.spec.ts
+++ b/packages/nimble-components/src/anchor-menu-item/tests/anchor-menu-item.spec.ts
@@ -10,7 +10,7 @@ import { Menu, menuTag } from '../../menu';
 import { menuItemTag } from '../../menu-item';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
-import { getSpecTypeByNamedList } from '../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../utilities/tests/parameterized';
 
 @customElement('foundation-menu-item')
 export class TestMenuItem extends FoundationMenuItem {}
@@ -81,26 +81,21 @@ describe('Anchor Menu Item', () => {
             { name: 'type' }
         ];
         describe('should reflect value to the internal control', () => {
-            const focused: string[] = [];
-            const disabled: string[] = [];
-            for (const attribute of attributeNames) {
-                const specType = getSpecTypeByNamedList(
-                    attribute,
-                    focused,
-                    disabled
+            parameterizeNamedList(attributeNames, (spec, name, _value) => {
+                spec(
+                    `for attribute ${name}`,
+                    async () => {
+                        await connect();
+
+                        element.setAttribute(name, 'foo');
+                        await waitForUpdatesAsync();
+
+                        expect(element.anchor.getAttribute(name)).toBe(
+                            'foo'
+                        );
+                    }
                 );
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                specType(`for attribute ${attribute.name}`, async () => {
-                    await connect();
-
-                    element.setAttribute(attribute.name, 'foo');
-                    await waitForUpdatesAsync();
-
-                    expect(element.anchor.getAttribute(attribute.name)).toBe(
-                        'foo'
-                    );
-                });
-            }
+            });
         });
 
         it('should expose slotted content through properties', async () => {

--- a/packages/nimble-components/src/anchor-menu-item/tests/anchor-menu-item.spec.ts
+++ b/packages/nimble-components/src/anchor-menu-item/tests/anchor-menu-item.spec.ts
@@ -81,7 +81,7 @@ describe('Anchor Menu Item', () => {
             { name: 'type' }
         ];
         describe('should reflect value to the internal control', () => {
-            parameterizeNamedList(attributeNames, (spec, name, _value) => {
+            parameterizeNamedList(attributeNames, (spec, name) => {
                 spec(
                     `for attribute ${name}`,
                     async () => {

--- a/packages/nimble-components/src/anchor-menu-item/tests/anchor-menu-item.spec.ts
+++ b/packages/nimble-components/src/anchor-menu-item/tests/anchor-menu-item.spec.ts
@@ -70,7 +70,7 @@ describe('Anchor Menu Item', () => {
             expect(element.ariaDisabled).toBe('true');
         });
 
-        const attributeNames: { name: string }[] = [
+        const attributeNames = [
             { name: 'download' },
             { name: 'href' },
             { name: 'hreflang' },
@@ -79,7 +79,7 @@ describe('Anchor Menu Item', () => {
             { name: 'rel' },
             { name: 'target' },
             { name: 'type' }
-        ];
+        ] as const;
         describe('should reflect value to the internal control', () => {
             parameterizeNamedList(attributeNames, (spec, name) => {
                 spec(`for attribute ${name}`, async () => {

--- a/packages/nimble-components/src/anchor-tab/tests/anchor-tab.spec.ts
+++ b/packages/nimble-components/src/anchor-tab/tests/anchor-tab.spec.ts
@@ -2,7 +2,7 @@ import { html } from '@microsoft/fast-element';
 import { AnchorTab } from '..';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { Fixture, fixture } from '../../utilities/tests/fixture';
-import { getSpecTypeByNamedList } from '../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../utilities/tests/parameterized';
 
 async function setup(): Promise<Fixture<AnchorTab>> {
     return fixture<AnchorTab>(html`<nimble-anchor-tab></nimble-anchor-tab>`);
@@ -38,27 +38,22 @@ describe('AnchorTab', () => {
         { name: 'type' }
     ];
     describe('should reflect value to the internal anchor element', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const attribute of attributeNames) {
-            const specType = getSpecTypeByNamedList(
-                attribute,
-                focused,
-                disabled
+        parameterizeNamedList(attributeNames, (spec, name, _value) => {
+            spec(
+                `for attribute ${name}`,
+                async () => {
+                    await connect();
+
+                    element.setAttribute(name, 'foo');
+                    await waitForUpdatesAsync();
+
+                    expect(
+                        element
+                            .shadowRoot!.querySelector('a')!
+                            .getAttribute(name)
+                    ).toBe('foo');
+                }
             );
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(`for attribute ${attribute.name}`, async () => {
-                await connect();
-
-                element.setAttribute(attribute.name, 'foo');
-                await waitForUpdatesAsync();
-
-                expect(
-                    element
-                        .shadowRoot!.querySelector('a')!
-                        .getAttribute(attribute.name)
-                ).toBe('foo');
-            });
-        }
+        });
     });
 });

--- a/packages/nimble-components/src/anchor-tab/tests/anchor-tab.spec.ts
+++ b/packages/nimble-components/src/anchor-tab/tests/anchor-tab.spec.ts
@@ -39,21 +39,16 @@ describe('AnchorTab', () => {
     ];
     describe('should reflect value to the internal anchor element', () => {
         parameterizeNamedList(attributeNames, (spec, name) => {
-            spec(
-                `for attribute ${name}`,
-                async () => {
-                    await connect();
+            spec(`for attribute ${name}`, async () => {
+                await connect();
 
-                    element.setAttribute(name, 'foo');
-                    await waitForUpdatesAsync();
+                element.setAttribute(name, 'foo');
+                await waitForUpdatesAsync();
 
-                    expect(
-                        element
-                            .shadowRoot!.querySelector('a')!
-                            .getAttribute(name)
-                    ).toBe('foo');
-                }
-            );
+                expect(
+                    element.shadowRoot!.querySelector('a')!.getAttribute(name)
+                ).toBe('foo');
+            });
         });
     });
 });

--- a/packages/nimble-components/src/anchor-tab/tests/anchor-tab.spec.ts
+++ b/packages/nimble-components/src/anchor-tab/tests/anchor-tab.spec.ts
@@ -27,7 +27,7 @@ describe('AnchorTab', () => {
         );
     });
 
-    const attributeNames: { name: string }[] = [
+    const attributeNames = [
         { name: 'download' },
         { name: 'href' },
         { name: 'hreflang' },
@@ -36,7 +36,7 @@ describe('AnchorTab', () => {
         { name: 'rel' },
         { name: 'target' },
         { name: 'type' }
-    ];
+    ] as const;
     describe('should reflect value to the internal anchor element', () => {
         parameterizeNamedList(attributeNames, (spec, name) => {
             spec(`for attribute ${name}`, async () => {

--- a/packages/nimble-components/src/anchor-tab/tests/anchor-tab.spec.ts
+++ b/packages/nimble-components/src/anchor-tab/tests/anchor-tab.spec.ts
@@ -38,7 +38,7 @@ describe('AnchorTab', () => {
         { name: 'type' }
     ];
     describe('should reflect value to the internal anchor element', () => {
-        parameterizeNamedList(attributeNames, (spec, name, _value) => {
+        parameterizeNamedList(attributeNames, (spec, name) => {
             spec(
                 `for attribute ${name}`,
                 async () => {

--- a/packages/nimble-components/src/anchor-tree-item/tests/anchor-tree-item.spec.ts
+++ b/packages/nimble-components/src/anchor-tree-item/tests/anchor-tree-item.spec.ts
@@ -8,7 +8,7 @@ import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import type { TreeItem } from '../../tree-item';
 import type { TreeView } from '../../tree-view';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
-import { getSpecTypeByNamedList } from '../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../utilities/tests/parameterized';
 
 @customElement('foundation-tree-item')
 export class TestTreeItem extends FoundationTreeItem {}
@@ -86,26 +86,21 @@ describe('Anchor Tree Item', () => {
             { name: 'type' }
         ];
         describe('should reflect value to the internal control', () => {
-            const focused: string[] = [];
-            const disabled: string[] = [];
-            for (const attribute of attributeNames) {
-                const specType = getSpecTypeByNamedList(
-                    attribute,
-                    focused,
-                    disabled
+            parameterizeNamedList(attributeNames, (spec, name, _value) => {
+                spec(
+                    `for attribute ${name}`,
+                    async () => {
+                        await connect();
+
+                        element.setAttribute(name, 'foo');
+                        await waitForUpdatesAsync();
+
+                        expect(element.control!.getAttribute(name)).toBe(
+                            'foo'
+                        );
+                    }
                 );
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                specType(`for attribute ${attribute.name}`, async () => {
-                    await connect();
-
-                    element.setAttribute(attribute.name, 'foo');
-                    await waitForUpdatesAsync();
-
-                    expect(element.control!.getAttribute(attribute.name)).toBe(
-                        'foo'
-                    );
-                });
-            }
+            });
         });
 
         it('should expose slotted content through properties', async () => {

--- a/packages/nimble-components/src/anchor-tree-item/tests/anchor-tree-item.spec.ts
+++ b/packages/nimble-components/src/anchor-tree-item/tests/anchor-tree-item.spec.ts
@@ -75,7 +75,7 @@ describe('Anchor Tree Item', () => {
             expect(element.control!.href).toBe('');
         });
 
-        const attributeNames: { name: string }[] = [
+        const attributeNames = [
             { name: 'download' },
             { name: 'href' },
             { name: 'hreflang' },
@@ -84,7 +84,7 @@ describe('Anchor Tree Item', () => {
             { name: 'rel' },
             { name: 'target' },
             { name: 'type' }
-        ];
+        ] as const;
         describe('should reflect value to the internal control', () => {
             parameterizeNamedList(attributeNames, (spec, name) => {
                 spec(`for attribute ${name}`, async () => {

--- a/packages/nimble-components/src/anchor-tree-item/tests/anchor-tree-item.spec.ts
+++ b/packages/nimble-components/src/anchor-tree-item/tests/anchor-tree-item.spec.ts
@@ -86,7 +86,7 @@ describe('Anchor Tree Item', () => {
             { name: 'type' }
         ];
         describe('should reflect value to the internal control', () => {
-            parameterizeNamedList(attributeNames, (spec, name, _value) => {
+            parameterizeNamedList(attributeNames, (spec, name) => {
                 spec(
                     `for attribute ${name}`,
                     async () => {

--- a/packages/nimble-components/src/anchor-tree-item/tests/anchor-tree-item.spec.ts
+++ b/packages/nimble-components/src/anchor-tree-item/tests/anchor-tree-item.spec.ts
@@ -87,19 +87,14 @@ describe('Anchor Tree Item', () => {
         ];
         describe('should reflect value to the internal control', () => {
             parameterizeNamedList(attributeNames, (spec, name) => {
-                spec(
-                    `for attribute ${name}`,
-                    async () => {
-                        await connect();
+                spec(`for attribute ${name}`, async () => {
+                    await connect();
 
-                        element.setAttribute(name, 'foo');
-                        await waitForUpdatesAsync();
+                    element.setAttribute(name, 'foo');
+                    await waitForUpdatesAsync();
 
-                        expect(element.control!.getAttribute(name)).toBe(
-                            'foo'
-                        );
-                    }
-                );
+                    expect(element.control!.getAttribute(name)).toBe('foo');
+                });
             });
         });
 

--- a/packages/nimble-components/src/anchor/tests/anchor.spec.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor.spec.ts
@@ -2,9 +2,7 @@ import { html } from '@microsoft/fast-element';
 import { Anchor, anchorTag } from '..';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
-import {
-    parameterizeNamedList
-} from '../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../utilities/tests/parameterized';
 
 async function setup(): Promise<Fixture<Anchor>> {
     return fixture<Anchor>(html`<nimble-anchor></nimble-anchor>`);
@@ -73,19 +71,14 @@ describe('Anchor', () => {
     ];
     describe('should reflect value to the internal control', () => {
         parameterizeNamedList(attributeNames, (spec, name) => {
-            spec(
-                `for attribute ${name}`,
-                async () => {
-                    await connect();
+            spec(`for attribute ${name}`, async () => {
+                await connect();
 
-                    element.setAttribute(name, 'foo');
-                    await waitForUpdatesAsync();
+                element.setAttribute(name, 'foo');
+                await waitForUpdatesAsync();
 
-                    expect(element.control!.getAttribute(name)).toBe(
-                        'foo'
-                    );
-                }
-            );
+                expect(element.control!.getAttribute(name)).toBe('foo');
+            });
         });
     });
 

--- a/packages/nimble-components/src/anchor/tests/anchor.spec.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor.spec.ts
@@ -39,7 +39,7 @@ describe('Anchor', () => {
         expect(element.control!.part.contains('control')).toBe(true);
     });
 
-    const attributeNames: { name: string }[] = [
+    const attributeNames = [
         { name: 'download' },
         { name: 'href' },
         { name: 'hreflang' },
@@ -68,7 +68,7 @@ describe('Anchor', () => {
         { name: 'aria-owns' },
         { name: 'aria-relevant' },
         { name: 'aria-roledescription' }
-    ];
+    ] as const;
     describe('should reflect value to the internal control', () => {
         parameterizeNamedList(attributeNames, (spec, name) => {
             spec(`for attribute ${name}`, async () => {

--- a/packages/nimble-components/src/anchor/tests/anchor.spec.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor.spec.ts
@@ -72,7 +72,7 @@ describe('Anchor', () => {
         { name: 'aria-roledescription' }
     ];
     describe('should reflect value to the internal control', () => {
-        parameterizeNamedList(attributeNames, (spec, name, _value) => {
+        parameterizeNamedList(attributeNames, (spec, name) => {
             spec(
                 `for attribute ${name}`,
                 async () => {

--- a/packages/nimble-components/src/anchor/tests/anchor.spec.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor.spec.ts
@@ -3,7 +3,6 @@ import { Anchor, anchorTag } from '..';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import {
-    getSpecTypeByNamedList,
     parameterizeNamedList
 } from '../../utilities/tests/parameterized';
 
@@ -73,26 +72,21 @@ describe('Anchor', () => {
         { name: 'aria-roledescription' }
     ];
     describe('should reflect value to the internal control', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const attribute of attributeNames) {
-            const specType = getSpecTypeByNamedList(
-                attribute,
-                focused,
-                disabled
+        parameterizeNamedList(attributeNames, (spec, name, _value) => {
+            spec(
+                `for attribute ${name}`,
+                async () => {
+                    await connect();
+
+                    element.setAttribute(name, 'foo');
+                    await waitForUpdatesAsync();
+
+                    expect(element.control!.getAttribute(name)).toBe(
+                        'foo'
+                    );
+                }
             );
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(`for attribute ${attribute.name}`, async () => {
-                await connect();
-
-                element.setAttribute(attribute.name, 'foo');
-                await waitForUpdatesAsync();
-
-                expect(element.control!.getAttribute(attribute.name)).toBe(
-                    'foo'
-                );
-            });
-        }
+        });
     });
 
     describe('contenteditable behavior', () => {

--- a/packages/nimble-components/src/icon-base/tests/icons.spec.ts
+++ b/packages/nimble-components/src/icon-base/tests/icons.spec.ts
@@ -1,5 +1,4 @@
 import * as nimbleIconsMap from '@ni/nimble-tokens/dist/icons/js';
-import type { NimbleIconName } from '@ni/nimble-tokens/dist/icons/js';
 import { DesignSystem } from '@microsoft/fast-foundation';
 import { html } from '@microsoft/fast-element';
 import { parameterizeNamedList } from '../../utilities/tests/parameterized';
@@ -10,7 +9,6 @@ import { IconAdd, iconAddTag } from '../../icons/add';
 
 describe('Icons', () => {
     describe('should have correct SVG structure', () => {
-        // const nimbleIcons = Object.values(nimbleIconsMap) as { name: NimbleIconName, data: string }[];
         const nimbleIcons = Object.values(nimbleIconsMap);
         const getSVGElement = (htmlString: string): SVGElement => {
             const template = document.createElement('template');

--- a/packages/nimble-components/src/icon-base/tests/icons.spec.ts
+++ b/packages/nimble-components/src/icon-base/tests/icons.spec.ts
@@ -2,7 +2,7 @@ import * as nimbleIconsMap from '@ni/nimble-tokens/dist/icons/js';
 import type { NimbleIconName } from '@ni/nimble-tokens/dist/icons/js';
 import { DesignSystem } from '@microsoft/fast-foundation';
 import { html } from '@microsoft/fast-element';
-import { getSpecTypeByNamedList } from '../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../utilities/tests/parameterized';
 import * as allIconsNamespace from '../../icons/all-icons';
 import { iconMetadata } from './icon-metadata';
 import { Fixture, fixture } from '../../utilities/tests/fixture';
@@ -10,6 +10,7 @@ import { IconAdd, iconAddTag } from '../../icons/add';
 
 describe('Icons', () => {
     describe('should have correct SVG structure', () => {
+        // const nimbleIcons = Object.values(nimbleIconsMap) as { name: NimbleIconName, data: string }[];
         const nimbleIcons = Object.values(nimbleIconsMap);
         const getSVGElement = (htmlString: string): SVGElement => {
             const template = document.createElement('template');
@@ -19,12 +20,9 @@ describe('Icons', () => {
         };
         const getPaths = (svg: SVGElement): SVGPathElement[] => Array.from(svg.querySelectorAll('path'));
 
-        const focused: NimbleIconName[] = [];
-        const disabled: NimbleIconName[] = [];
-        for (const icon of nimbleIcons) {
-            const specType = getSpecTypeByNamedList(icon, focused, disabled);
-            specType(`for icon ${icon.name}`, () => {
-                const svg = getSVGElement(icon.data);
+        parameterizeNamedList(nimbleIcons, (spec, name, value) => {
+            spec(`for icon ${name}`, () => {
+                const svg = getSVGElement(value.data);
                 const paths = getPaths(svg);
                 expect(svg).toBeTruthy();
                 expect(svg.getAttribute('viewBox')).toBeTruthy();
@@ -35,7 +33,7 @@ describe('Icons', () => {
                     expect(path.getAttribute('style')).toBeNull();
                 }
             });
-        }
+        });
     });
 
     describe('can be constructed', () => {
@@ -44,20 +42,16 @@ describe('Icons', () => {
             (x: IconName) => ({ name: x, iconClass: allIconsNamespace[x] })
         );
 
-        const focused: IconName[] = [];
-        const disabled: IconName[] = [];
-        for (const icon of allIconNames) {
-            const specType = getSpecTypeByNamedList(icon, focused, disabled);
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(`for icon ${icon.name}`, () => {
-                const tagName = DesignSystem.tagFor(icon.iconClass);
+        parameterizeNamedList(allIconNames, (spec, name, value) => {
+            spec(`for icon ${name}`, () => {
+                const tagName = DesignSystem.tagFor(value.iconClass);
                 expect(typeof tagName).toBe('string');
                 expect(tagName.length).toBeGreaterThan(0);
                 expect(document.createElement(tagName)).toBeInstanceOf(
-                    icon.iconClass
+                    value.iconClass
                 );
             });
-        }
+        });
     });
 
     describe('should have valid metadata', () => {
@@ -67,14 +61,11 @@ describe('Icons', () => {
             metadata: iconMetadata[name]
         }));
 
-        const focused: IconName[] = [];
-        const disabled: IconName[] = [];
-        for (const icon of icons) {
-            const specType = getSpecTypeByNamedList(icon, focused, disabled);
-            specType(`for icon ${icon.name}`, () => {
-                expect(icon.metadata.tags).not.toContain('');
+        parameterizeNamedList(icons, (spec, name, value) => {
+            spec(`for icon ${name}`, () => {
+                expect(value.metadata.tags).not.toContain('');
             });
-        }
+        });
     });
 
     describe('Representative icon', () => {

--- a/packages/nimble-components/src/label-provider/core/tests/label-provider-core.spec.ts
+++ b/packages/nimble-components/src/label-provider/core/tests/label-provider-core.spec.ts
@@ -2,7 +2,7 @@ import { spinalCase } from '@microsoft/fast-web-utilities';
 import { html } from '@microsoft/fast-element';
 import * as labelTokensNamespace from '../label-tokens';
 import { LabelProviderCore, labelProviderCoreTag } from '..';
-import { getSpecTypeByNamedList } from '../../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../../utilities/tests/parameterized';
 import {
     getAttributeName,
     getPropertyName
@@ -53,19 +53,12 @@ describe('Label Provider Core', () => {
             })
         );
 
-        for (const tokenEntry of tokenEntries) {
-            const focused: DesignTokenPropertyName[] = [];
-            const disabled: DesignTokenPropertyName[] = [];
-            const specType = getSpecTypeByNamedList(
-                tokenEntry,
-                focused,
-                disabled
-            );
-            specType(`for token name ${tokenEntry.name}`, () => {
-                const convertedTokenValue = spinalCase(tokenEntry.name);
-                expect(tokenEntry.labelToken.name).toBe(convertedTokenValue);
+        parameterizeNamedList(tokenEntries, (spec, name, value) => {
+            spec(`for token name ${name}`, () => {
+                const convertedTokenValue = spinalCase(value.name);
+                expect(value.labelToken.name).toBe(convertedTokenValue);
             });
-        }
+        });
     });
 
     describe('token JS key should match a LabelProvider property/attribute', () => {
@@ -76,18 +69,10 @@ describe('Label Provider Core', () => {
             })
         );
 
-        for (const tokenEntry of tokenEntries) {
-            const focused: DesignTokenPropertyName[] = [];
-            const disabled: DesignTokenPropertyName[] = [];
-            const specType = getSpecTypeByNamedList(
-                tokenEntry,
-                focused,
-                disabled
-            );
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(`for token name ${tokenEntry.name}`, () => {
-                const expectedPropertyName = getPropertyName(tokenEntry.name);
-                const expectedAttributeName = getAttributeName(tokenEntry.name);
+        parameterizeNamedList(tokenEntries, (spec, name, value) => {
+            spec(`for token name ${name}`, () => {
+                const expectedPropertyName = getPropertyName(value.name);
+                const expectedAttributeName = getAttributeName(value.name);
                 const attributeDefinition = element.$fastController.definition.attributes.find(
                     a => a.name === expectedPropertyName
                 );
@@ -96,7 +81,7 @@ describe('Label Provider Core', () => {
                     attributeDefinition!.attribute
                 );
             });
-        }
+        });
     });
 
     describe('token value is updated after setting corresponding LabelProvider attribute', () => {
@@ -107,24 +92,16 @@ describe('Label Provider Core', () => {
             })
         );
 
-        for (const tokenEntry of tokenEntries) {
-            const focused: DesignTokenPropertyName[] = [];
-            const disabled: DesignTokenPropertyName[] = [];
-            const specType = getSpecTypeByNamedList(
-                tokenEntry,
-                focused,
-                disabled
-            );
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(`for token name ${tokenEntry.name}`, () => {
-                const attributeName = getAttributeName(tokenEntry.name);
-                const updatedValue = `NewString-${tokenEntry.name}`;
+        parameterizeNamedList(tokenEntries, (spec, name, value) => {
+            spec(`for token name ${name}`, () => {
+                const attributeName = getAttributeName(value.name);
+                const updatedValue = `NewString-${value.name}`;
                 element.setAttribute(attributeName, updatedValue);
 
-                expect(tokenEntry.labelToken.getValueFor(themeProvider)).toBe(
+                expect(value.labelToken.getValueFor(themeProvider)).toBe(
                     updatedValue
                 );
             });
-        }
+        });
     });
 });

--- a/packages/nimble-components/src/label-provider/rich-text/tests/label-provider-rich-text.spec.ts
+++ b/packages/nimble-components/src/label-provider/rich-text/tests/label-provider-rich-text.spec.ts
@@ -2,7 +2,7 @@ import { spinalCase } from '@microsoft/fast-web-utilities';
 import { html } from '@microsoft/fast-element';
 import * as labelTokensNamespace from '../label-tokens';
 import { LabelProviderRichText, labelProviderRichTextTag } from '..';
-import { getSpecTypeByNamedList } from '../../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../../utilities/tests/parameterized';
 import {
     getAttributeName,
     getPropertyName,
@@ -54,19 +54,12 @@ describe('Label Provider Rich Text', () => {
             })
         );
 
-        for (const tokenEntry of tokenEntries) {
-            const focused: DesignTokenPropertyName[] = [];
-            const disabled: DesignTokenPropertyName[] = [];
-            const specType = getSpecTypeByNamedList(
-                tokenEntry,
-                focused,
-                disabled
-            );
-            specType(`for token name ${tokenEntry.name}`, () => {
-                const convertedTokenValue = spinalCase(tokenEntry.name);
-                expect(tokenEntry.labelToken.name).toBe(convertedTokenValue);
+        parameterizeNamedList(tokenEntries, (spec, name, value) => {
+            spec(`for token name ${name}`, () => {
+                const convertedTokenValue = spinalCase(value.name);
+                expect(value.labelToken.name).toBe(convertedTokenValue);
             });
-        }
+        });
     });
 
     describe('token JS key should match a LabelProvider property/attribute', () => {
@@ -77,18 +70,10 @@ describe('Label Provider Rich Text', () => {
             })
         );
 
-        for (const tokenEntry of tokenEntries) {
-            const focused: DesignTokenPropertyName[] = [];
-            const disabled: DesignTokenPropertyName[] = [];
-            const specType = getSpecTypeByNamedList(
-                tokenEntry,
-                focused,
-                disabled
-            );
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(`for token name ${tokenEntry.name}`, () => {
+        parameterizeNamedList(tokenEntries, (spec, name, value) => {
+            spec(`for token name ${name}`, () => {
                 const tokenName = removePrefixAndCamelCase(
-                    tokenEntry.name,
+                    value.name,
                     'richText'
                 );
                 const expectedPropertyName = getPropertyName(tokenName);
@@ -101,7 +86,7 @@ describe('Label Provider Rich Text', () => {
                     attributeDefinition!.attribute
                 );
             });
-        }
+        });
     });
 
     describe('token value is updated after setting corresponding LabelProvider attribute', () => {
@@ -112,28 +97,20 @@ describe('Label Provider Rich Text', () => {
             })
         );
 
-        for (const tokenEntry of tokenEntries) {
-            const focused: DesignTokenPropertyName[] = [];
-            const disabled: DesignTokenPropertyName[] = [];
-            const specType = getSpecTypeByNamedList(
-                tokenEntry,
-                focused,
-                disabled
-            );
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(`for token name ${tokenEntry.name}`, () => {
+        parameterizeNamedList(tokenEntries, (spec, name, value) => {
+            spec(`for token name ${name}`, () => {
                 const tokenName = removePrefixAndCamelCase(
-                    tokenEntry.name,
+                    value.name,
                     'richText'
                 );
                 const attributeName = getAttributeName(tokenName);
                 const updatedValue = `NewString-${tokenName}`;
                 element.setAttribute(attributeName, updatedValue);
 
-                expect(tokenEntry.labelToken.getValueFor(themeProvider)).toBe(
+                expect(value.labelToken.getValueFor(themeProvider)).toBe(
                     updatedValue
                 );
             });
-        }
+        });
     });
 });

--- a/packages/nimble-components/src/label-provider/table/tests/label-provider-table.spec.ts
+++ b/packages/nimble-components/src/label-provider/table/tests/label-provider-table.spec.ts
@@ -2,7 +2,7 @@ import { spinalCase } from '@microsoft/fast-web-utilities';
 import { html } from '@microsoft/fast-element';
 import * as labelTokensNamespace from '../label-tokens';
 import { LabelProviderTable, labelProviderTableTag } from '..';
-import { getSpecTypeByNamedList } from '../../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../../utilities/tests/parameterized';
 import {
     getAttributeName,
     getPropertyName,
@@ -54,19 +54,12 @@ describe('Label Provider Table', () => {
             })
         );
 
-        for (const tokenEntry of tokenEntries) {
-            const focused: DesignTokenPropertyName[] = [];
-            const disabled: DesignTokenPropertyName[] = [];
-            const specType = getSpecTypeByNamedList(
-                tokenEntry,
-                focused,
-                disabled
-            );
-            specType(`for token name ${tokenEntry.name}`, () => {
-                const convertedTokenValue = spinalCase(tokenEntry.name);
-                expect(tokenEntry.labelToken.name).toBe(convertedTokenValue);
+        parameterizeNamedList(tokenEntries, (spec, name, value) => {
+            spec(`for token name ${name}`, () => {
+                const convertedTokenValue = spinalCase(value.name);
+                expect(value.labelToken.name).toBe(convertedTokenValue);
             });
-        }
+        });
     });
 
     describe('token JS key should match a LabelProvider property/attribute', () => {
@@ -77,18 +70,10 @@ describe('Label Provider Table', () => {
             })
         );
 
-        for (const tokenEntry of tokenEntries) {
-            const focused: DesignTokenPropertyName[] = [];
-            const disabled: DesignTokenPropertyName[] = [];
-            const specType = getSpecTypeByNamedList(
-                tokenEntry,
-                focused,
-                disabled
-            );
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(`for token name ${tokenEntry.name}`, () => {
+        parameterizeNamedList(tokenEntries, (spec, name, value) => {
+            spec(`for token name ${name}`, () => {
                 const tokenName = removePrefixAndCamelCase(
-                    tokenEntry.name,
+                    value.name,
                     'table'
                 );
                 const expectedPropertyName = getPropertyName(tokenName);
@@ -101,7 +86,7 @@ describe('Label Provider Table', () => {
                     attributeDefinition!.attribute
                 );
             });
-        }
+        });
     });
 
     describe('token value is updated after setting corresponding LabelProvider attribute', () => {
@@ -112,28 +97,20 @@ describe('Label Provider Table', () => {
             })
         );
 
-        for (const tokenEntry of tokenEntries) {
-            const focused: DesignTokenPropertyName[] = [];
-            const disabled: DesignTokenPropertyName[] = [];
-            const specType = getSpecTypeByNamedList(
-                tokenEntry,
-                focused,
-                disabled
-            );
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(`for token name ${tokenEntry.name}`, () => {
+        parameterizeNamedList(tokenEntries, (spec, name, value) => {
+            spec(`for token name ${name}`, () => {
                 const tokenName = removePrefixAndCamelCase(
-                    tokenEntry.name,
+                    value.name,
                     'table'
                 );
                 const attributeName = getAttributeName(tokenName);
                 const updatedValue = `NewString-${tokenName}`;
                 element.setAttribute(attributeName, updatedValue);
 
-                expect(tokenEntry.labelToken.getValueFor(themeProvider)).toBe(
+                expect(value.labelToken.getValueFor(themeProvider)).toBe(
                     updatedValue
                 );
             });
-        }
+        });
     });
 });

--- a/packages/nimble-components/src/label-provider/table/tests/label-provider-table.spec.ts
+++ b/packages/nimble-components/src/label-provider/table/tests/label-provider-table.spec.ts
@@ -72,10 +72,7 @@ describe('Label Provider Table', () => {
 
         parameterizeNamedList(tokenEntries, (spec, name, value) => {
             spec(`for token name ${name}`, () => {
-                const tokenName = removePrefixAndCamelCase(
-                    value.name,
-                    'table'
-                );
+                const tokenName = removePrefixAndCamelCase(value.name, 'table');
                 const expectedPropertyName = getPropertyName(tokenName);
                 const expectedAttributeName = getAttributeName(tokenName);
                 const attributeDefinition = element.$fastController.definition.attributes.find(
@@ -99,10 +96,7 @@ describe('Label Provider Table', () => {
 
         parameterizeNamedList(tokenEntries, (spec, name, value) => {
             spec(`for token name ${name}`, () => {
-                const tokenName = removePrefixAndCamelCase(
-                    value.name,
-                    'table'
-                );
+                const tokenName = removePrefixAndCamelCase(value.name, 'table');
                 const attributeName = getAttributeName(tokenName);
                 const updatedValue = `NewString-${tokenName}`;
                 element.setAttribute(attributeName, updatedValue);

--- a/packages/nimble-components/src/rich-text-mention/users/view/tests/rich-text-mention-users-view.spec.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/view/tests/rich-text-mention-users-view.spec.ts
@@ -54,13 +54,13 @@ describe('RichTextMentionUsersView', () => {
     });
 
     describe('various wacky strings should reflect the `mention-label` attribute value to its text content', () => {
-        parameterizeNamedList(wackyStrings, (spec, name, value) => {
+        parameterizeNamedList(wackyStrings, (spec, name) => {
             spec(`for ${name}`, async () => {
                 await connect();
-                element.setAttribute('mention-label', value.name);
+                element.setAttribute('mention-label', name);
 
                 await waitForUpdatesAsync();
-                expect(pageObject.getTextContent()).toBe(`@${value.name}`);
+                expect(pageObject.getTextContent()).toBe(`@${name}`);
             });
         });
     });

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-labels.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-labels.spec.ts
@@ -7,7 +7,7 @@ import {
     labelProviderRichTextTag
 } from '../../../label-provider/rich-text';
 import { RichTextEditorPageObject } from '../testing/rich-text-editor.pageobject';
-import { LabelProvider, ToolbarButton } from '../testing/types';
+import { ToolbarButton } from '../testing/types';
 import { parameterizeNamedList } from '../../../utilities/tests/parameterized';
 import { waitForUpdatesAsync } from '../../../testing/async-helpers';
 

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-labels.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-labels.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../label-provider/rich-text';
 import { RichTextEditorPageObject } from '../testing/rich-text-editor.pageobject';
 import { LabelProvider, ToolbarButton } from '../testing/types';
-import { getSpecTypeByNamedList } from '../../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../../utilities/tests/parameterized';
 import { waitForUpdatesAsync } from '../../../testing/async-helpers';
 
 async function setup(): Promise<Fixture<ThemeProvider>> {
@@ -59,8 +59,6 @@ describe('Rich Text Editor with LabelProviderRichText', () => {
     let connect: () => Promise<void>;
     let disconnect: () => Promise<void>;
     let pageObject: RichTextEditorPageObject;
-    const focused: string[] = [];
-    const disabled: string[] = [];
 
     beforeEach(async () => {
         let themeProvider: ThemeProvider;
@@ -75,11 +73,8 @@ describe('Rich Text Editor with LabelProviderRichText', () => {
         await disconnect();
     });
 
-    for (const value of formattingButtons) {
-        const specType = getSpecTypeByNamedList(value, focused, disabled);
-        specType(
-            `uses correct label '${value.label}' for ${value.name} button`,
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
+    parameterizeNamedList(formattingButtons, (spec, name, value) => {
+        spec(`uses correct label for '${value.label}' for ${name} button`,
             async () => {
                 labelProvider[value.property] = value.label;
                 await waitForUpdatesAsync();
@@ -93,5 +88,5 @@ describe('Rich Text Editor with LabelProviderRichText', () => {
                 ).toBe(value.label);
             }
         );
-    }
+    });
 });

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-labels.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-labels.spec.ts
@@ -74,7 +74,8 @@ describe('Rich Text Editor with LabelProviderRichText', () => {
     });
 
     parameterizeNamedList(formattingButtons, (spec, name, value) => {
-        spec(`uses correct label for '${value.label}' for ${name} button`,
+        spec(
+            `uses correct label for '${value.label}' for ${name} button`,
             async () => {
                 labelProvider[value.property] = value.label;
                 await waitForUpdatesAsync();

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-labels.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-labels.spec.ts
@@ -21,12 +21,7 @@ async function setup(): Promise<Fixture<ThemeProvider>> {
     );
 }
 
-const formattingButtons: {
-    name: string,
-    property: LabelProvider,
-    label: string,
-    toolbarButton: ToolbarButton
-}[] = [
+const formattingButtons = [
     {
         name: 'Bold',
         property: 'toggleBold',
@@ -51,7 +46,7 @@ const formattingButtons: {
         label: 'Customized Numbered List Label',
         toolbarButton: ToolbarButton.numberedList
     }
-];
+] as const;
 
 describe('Rich Text Editor with LabelProviderRichText', () => {
     let element: RichTextEditor;

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
@@ -961,15 +961,15 @@ describe('RichTextEditorMentionListbox', () => {
         });
 
         describe('various wacky strings should display as it is in the mention popup option', () => {
-            parameterizeNamedList(wackyStrings, (spec, name, value) => {
+            parameterizeNamedList(wackyStrings, (spec, name) => {
                 spec(`for ${name}`, async () => {
                     await appendUserMentionConfiguration(element, [
-                        { key: 'user:1', displayName: value.name }
+                        { key: 'user:1', displayName: name }
                     ]);
                     await pageObject.setEditorTextContent('@');
 
                     expect(pageObject.getMentionListboxItemsName()).toEqual([
-                        value.name
+                        name
                     ]);
                 });
             });

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
@@ -129,13 +129,7 @@ describe('RichTextEditor', () => {
         expect(pageObject.isRichTextEditorActiveElement()).toBeTrue();
     });
 
-    const formattingButtons: {
-        name: string,
-        toolbarButtonIndex: ToolbarButton,
-        iconName: string,
-        shortcutKey: string,
-        shiftKey: boolean
-    }[] = [
+    const formattingButtons = [
         {
             name: 'bold',
             toolbarButtonIndex: ToolbarButton.bold,
@@ -164,7 +158,7 @@ describe('RichTextEditor', () => {
             shortcutKey: '7',
             shiftKey: true
         }
-    ];
+    ] as const;
 
     describe('clicking buttons should update the checked state of the toggle button with focus', () => {
         parameterizeNamedList(formattingButtons, (spec, name, value) => {
@@ -803,7 +797,7 @@ describe('RichTextEditor', () => {
 
         describe('Absolute link interactions in the editor', () => {
             describe('various absolute links without other nodes and marks', () => {
-                const supportedAbsoluteLink: { name: string }[] = [
+                const supportedAbsoluteLink = [
                     { name: 'https://nimble.ni.dev/ ' },
                     { name: 'HTTPS://NIMBLE.NI.DEV ' },
                     { name: 'HttPS://NIMBLE.ni.DEV ' },
@@ -817,7 +811,7 @@ describe('RichTextEditor', () => {
                     { name: 'https://example.com/smiley😀.html ' },
                     { name: 'https://www.😀.com ' },
                     { name: 'https://example.com/пример.html ' }
-                ];
+                ] as const;
 
                 parameterizeNamedList(supportedAbsoluteLink, (spec, name) => {
                     spec(
@@ -926,7 +920,7 @@ describe('RichTextEditor', () => {
             });
 
             describe('various absolute links with different protocols other than https/http should be render as unchanged strings', () => {
-                const differentProtocolLinks: { name: string }[] = [
+                const differentProtocolLinks = [
                     { name: 'ftp://example.com/files/document.pdf ' },
                     { name: 'mailto:info@example.com ' },
                     { name: 'info@example.com ' },
@@ -947,7 +941,7 @@ describe('RichTextEditor', () => {
                     // eslint-disable-next-line no-script-url
                     { name: 'javascript:vbscript:alert("not alert") ' },
                     { name: 'test://test.com ' }
-                ];
+                ] as const;
 
                 parameterizeNamedList(differentProtocolLinks, (spec, name) => {
                     spec(
@@ -1496,7 +1490,7 @@ describe('RichTextEditor', () => {
     });
 
     describe('Should return markdown without any changes when various not supported markdown string values are assigned', () => {
-        const notSupportedMarkdownStrings: { name: string }[] = [
+        const notSupportedMarkdownStrings = [
             { name: '&nbsp;' },
             { name: '(c) (C) (r) (R) (tm) (TM) (p) (P) +-' },
             { name: '<div><p>text</p></div>' },
@@ -1508,7 +1502,7 @@ describe('RichTextEditor', () => {
                 name: '<a href="https://nimble.ni.dev/">https://nimble.ni.dev/</a>'
             },
             { name: '<script>alert("not alert")</script>' }
-        ];
+        ] as const;
 
         parameterizeNamedList(notSupportedMarkdownStrings, (spec, name) => {
             spec(
@@ -1528,7 +1522,7 @@ describe('RichTextEditor', () => {
 
     describe('Should return markdown with escape character (back slash) when various special markdown syntax are assigned', () => {
         const r = String.raw;
-        const specialMarkdownStrings: { name: string, value: string }[] = [
+        const specialMarkdownStrings = [
             { name: '> blockquote', value: r`\> blockquote` },
             { name: '`code`', value: '\\`code\\`' },
             { name: '```fence```', value: '\\`\\`\\`fence\\`\\`\\`' },
@@ -1547,7 +1541,7 @@ describe('RichTextEditor', () => {
             { name: '___', value: r`\__\_` },
             { name: '-Infinity', value: r`\-Infinity` },
             { name: '-2147483648/-1', value: r`\-2147483648/-1` }
-        ];
+        ] as const;
 
         parameterizeNamedList(specialMarkdownStrings, (spec, name, value) => {
             spec(
@@ -1567,7 +1561,7 @@ describe('RichTextEditor', () => {
 
     describe('`getMarkdown` with hard break backslashes should be same immediately after `setMarkdown`', () => {
         const r = String.raw;
-        const hardBreakMarkdownStrings: { name: string, value: string }[] = [
+        const hardBreakMarkdownStrings = [
             {
                 name: 'bold and italics',
                 value: r`**bold**\
@@ -1607,7 +1601,7 @@ describe('RichTextEditor', () => {
    1. nested list\
       nested hard break content`
             }
-        ];
+        ] as const;
 
         parameterizeNamedList(hardBreakMarkdownStrings, (spec, name, value) => {
             spec(
@@ -1650,13 +1644,10 @@ describe('RichTextEditor', () => {
 
     describe('Should return markdown with escape character (back slash) when wacky string with special markdown syntax are assigned', () => {
         const r = String.raw;
-        const wackyStringWithSpecialMarkdownCharacter: {
-            name: string,
-            value: string
-        }[] = [
+        const wackyStringWithSpecialMarkdownCharacter = [
             { name: '-Infinity', value: r`\-Infinity` },
             { name: '-2147483648/-1', value: r`\-2147483648/-1` }
-        ];
+        ] as const;
 
         parameterizeNamedList(
             wackyStringWithSpecialMarkdownCharacter,
@@ -1678,16 +1669,12 @@ describe('RichTextEditor', () => {
     });
 
     describe('Should return modified markdown when various wacky string values are assigned', () => {
-        const modifiedWackyStrings: {
-            name: string,
-            value: string,
-            content: string
-        }[] = [
+        const modifiedWackyStrings = [
             { name: '\\0', value: '\0', content: '�' },
             { name: '\\uFFFD', value: '\uFFFD', content: '�' },
             { name: '\\x00', value: '\x00', content: '�' },
             { name: '\\r\\r', value: '\r\r', content: '' }
-        ];
+        ] as const;
 
         parameterizeNamedList(modifiedWackyStrings, (spec, name, value) => {
             spec(

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
@@ -2,7 +2,6 @@ import { html } from '@microsoft/fast-element';
 import { richTextEditorTag, RichTextEditor } from '..';
 import { type Fixture, fixture } from '../../../utilities/tests/fixture';
 import {
-    getSpecTypeByNamedList,
     parameterizeNamedList
 } from '../../../utilities/tests/parameterized';
 import { RichTextEditorPageObject } from '../testing/rich-text-editor.pageobject';
@@ -170,14 +169,9 @@ describe('RichTextEditor', () => {
     ];
 
     describe('clicking buttons should update the checked state of the toggle button with focus', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
-
-        for (const value of formattingButtons) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            specType(
-                `"${value.name}" button click check`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
+        parameterizeNamedList(formattingButtons, (spec, name, value) => {
+            spec(
+                `"${name}" button click check`,
                 async () => {
                     expect(
                         pageObject.getButtonCheckedState(
@@ -199,18 +193,13 @@ describe('RichTextEditor', () => {
                     ).toBe(0);
                 }
             );
-        }
+        });
     });
 
     describe('space key press should update the checked state of the buttons', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
-
-        for (const value of formattingButtons) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            specType(
-                `"${value.name}" button key press check`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
+        parameterizeNamedList(formattingButtons, (spec, name, value) => {
+            spec(
+                `"${name}" button key press check`,
                 () => {
                     expect(
                         pageObject.getButtonCheckedState(
@@ -229,18 +218,13 @@ describe('RichTextEditor', () => {
                     ).toBeTrue();
                 }
             );
-        }
+        });
     });
 
     describe('enter key press should update the checked state of the buttons', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
-
-        for (const value of formattingButtons) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            specType(
-                `"${value.name}" button key press check`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
+        parameterizeNamedList(formattingButtons, (spec, name, value) => {
+            spec(
+                `"${name}" button key press check`,
                 () => {
                     expect(
                         pageObject.getButtonCheckedState(
@@ -259,18 +243,13 @@ describe('RichTextEditor', () => {
                     ).toBeTrue();
                 }
             );
-        }
+        });
     });
 
     describe('keyboard shortcuts should update the checked state of the buttons', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
-
-        for (const value of formattingButtons) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            specType(
-                `"${value.name}" button keyboard shortcut check`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
+        parameterizeNamedList(formattingButtons, (spec, name, value) => {
+            spec(
+                `"${name}" button keyboard shortcut check`,
                 async () => {
                     expect(
                         pageObject.getButtonCheckedState(
@@ -290,18 +269,13 @@ describe('RichTextEditor', () => {
                     ).toBeTrue();
                 }
             );
-        }
+        });
     });
 
     describe('should not leak change event through shadow DOM for buttons', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
-
-        for (const value of formattingButtons) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            specType(
-                `"${value.name}" button not propagate change event to parent element`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
+        parameterizeNamedList(formattingButtons, (spec, name, value) => {
+            spec(
+                `"${name}" button not propagate change event to parent element`,
                 () => {
                     const buttons: NodeListOf<ToggleButton> = element.shadowRoot!.querySelectorAll(
                         'nimble-toggle-button'
@@ -317,7 +291,7 @@ describe('RichTextEditor', () => {
                     expect(spy).toHaveBeenCalledTimes(0);
                 }
             );
-        }
+        });
     });
 
     describe('rich text formatting options to its respective HTML elements', () => {
@@ -881,17 +855,9 @@ describe('RichTextEditor', () => {
                     { name: 'https://example.com/пример.html ' }
                 ];
 
-                const focused: string[] = [];
-                const disabled: string[] = [];
-                for (const value of supportedAbsoluteLink) {
-                    const specType = getSpecTypeByNamedList(
-                        value,
-                        focused,
-                        disabled
-                    );
-                    specType(
-                        `should change the ${value.name} to "a" tag when it is a valid absolute link`,
-                        // eslint-disable-next-line @typescript-eslint/no-loop-func
+                parameterizeNamedList(supportedAbsoluteLink, (spec, name, value) => {
+                    spec(
+                        `should change the ${name} to "a" tag when it is a valid absolute link`,
                         async () => {
                             await pageObject.setEditorTextContent(value.name);
 
@@ -905,7 +871,7 @@ describe('RichTextEditor', () => {
                             ]);
                         }
                     );
-                }
+                });
             });
 
             it('the "a" tag should have href and rel attributes', async () => {
@@ -1019,17 +985,9 @@ describe('RichTextEditor', () => {
                     { name: 'test://test.com ' }
                 ];
 
-                const focused: string[] = [];
-                const disabled: string[] = [];
-                for (const value of differentProtocolLinks) {
-                    const specType = getSpecTypeByNamedList(
-                        value,
-                        focused,
-                        disabled
-                    );
-                    specType(
-                        `string "${value.name}" renders as plain text "${value.name}" within paragraph tag`,
-                        // eslint-disable-next-line @typescript-eslint/no-loop-func
+                parameterizeNamedList(differentProtocolLinks, (spec, name, value) => {
+                    spec(
+                        `string "${name}" renders as plain text "${name}" within paragraph tag`,
                         async () => {
                             await pageObject.setEditorTextContent(value.name);
 
@@ -1041,7 +999,7 @@ describe('RichTextEditor', () => {
                             ]);
                         }
                     );
-                }
+                });
             });
 
             describe('pasting various valid(https/http) links should render as absolute links', () => {
@@ -1234,14 +1192,9 @@ describe('RichTextEditor', () => {
     });
 
     describe('various wacky string values input into the editor', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
-
-        wackyStrings.forEach(value => {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            specType(
-                `wacky string "${value.name}" that are unmodified when rendered the same value within paragraph tag`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
+        parameterizeNamedList(wackyStrings, (spec, name, value) => {
+            spec(
+                `wacky string "${name}" that are unmodified when rendered the same value within paragraph tag`,
                 async () => {
                     await pageObject.setEditorTextContent(value.name);
 
@@ -1593,12 +1546,9 @@ describe('RichTextEditor', () => {
             { name: '<script>alert("not alert")</script>' }
         ];
 
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const value of notSupportedMarkdownStrings) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            specType(
-                `markdown string "${value.name}" returns as plain text "${value.name}" without any change`,
+        parameterizeNamedList(notSupportedMarkdownStrings, (spec, name, value) => {
+            spec(
+                `markdown string "${name}" returns as plain text "${name}" without any change`,
                 // eslint-disable-next-line @typescript-eslint/no-loop-func
                 async () => {
                     element.setMarkdown(value.name);
@@ -1610,7 +1560,7 @@ describe('RichTextEditor', () => {
                     await disconnect();
                 }
             );
-        }
+        });
     });
 
     describe('Should return markdown with escape character (back slash) when various special markdown syntax are assigned', () => {
@@ -1636,12 +1586,9 @@ describe('RichTextEditor', () => {
             { name: '-2147483648/-1', value: r`\-2147483648/-1` }
         ];
 
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const value of specialMarkdownStrings) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            specType(
-                `special markdown string "${value.name}" returns as plain text "${value.value}" with added esacpe character`,
+        parameterizeNamedList(specialMarkdownStrings, (spec, name, value) => {
+            spec(
+                `special markdown string "${name}" returns as plain text "${value.value}" with added esacpe character`,
                 // eslint-disable-next-line @typescript-eslint/no-loop-func
                 async () => {
                     element.setMarkdown(value.name);
@@ -1653,7 +1600,7 @@ describe('RichTextEditor', () => {
                     await disconnect();
                 }
             );
-        }
+        });
     });
 
     describe('`getMarkdown` with hard break backslashes should be same immediately after `setMarkdown`', () => {
@@ -1700,13 +1647,9 @@ describe('RichTextEditor', () => {
             }
         ];
 
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const value of hardBreakMarkdownStrings) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            specType(
-                `markdown string with hard break in "${value.name}" returns as same without any change`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
+        parameterizeNamedList(hardBreakMarkdownStrings, (spec, name, value) => {
+            spec(
+                `markdown string with hard break in "${name}" returns as same without any change`,
                 async () => {
                     element.setMarkdown(value.value);
 
@@ -1717,39 +1660,31 @@ describe('RichTextEditor', () => {
                     await disconnect();
                 }
             );
-        }
+        });
     });
 
     describe('Should return markdown without any changes when various wacky string values are assigned', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
-
-        wackyStrings
+        const wackyStringsToTest = wackyStrings
             .filter(
                 value => value.name !== '\x00'
                     && value.name !== '-Infinity'
                     && value.name !== '-2147483648/-1'
-            )
-            .forEach(value => {
-                const specType = getSpecTypeByNamedList(
-                    value,
-                    focused,
-                    disabled
-                );
-                specType(
-                    `wacky string "${value.name}" returns unmodified when set the same markdown string"${value.name}"`,
-                    // eslint-disable-next-line @typescript-eslint/no-loop-func
-                    async () => {
-                        element.setMarkdown(value.name);
+            );
 
-                        await connect();
+        parameterizeNamedList(wackyStringsToTest, (spec, name, value) => {
+            spec(
+                `wacky string "${name}" returns unmodified when set the same markdown string "${name}"`,
+                async () => {
+                    element.setMarkdown(value.name);
 
-                        expect(element.getMarkdown()).toBe(value.name);
+                    await connect();
 
-                        await disconnect();
-                    }
-                );
-            });
+                    expect(element.getMarkdown()).toBe(value.name);
+
+                    await disconnect();
+                }
+            );
+        });
     });
 
     describe('Should return markdown with escape character (back slash) when wacky string with special markdown syntax are assigned', () => {
@@ -1762,13 +1697,9 @@ describe('RichTextEditor', () => {
             { name: '-2147483648/-1', value: r`\-2147483648/-1` }
         ];
 
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const value of wackyStringWithSpecialMarkdownCharacter) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            specType(
-                ` wacky string contains special markdown syntax "${value.name}" returns as plain text "${value.value}" with added escape character`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
+        parameterizeNamedList(wackyStringWithSpecialMarkdownCharacter, (spec, name, value) => {
+            spec(
+                ` wacky string contains special markdown syntax "${name}" returns as plain text "${value}" with added escape character`,
                 async () => {
                     element.setMarkdown(value.name);
 
@@ -1779,29 +1710,26 @@ describe('RichTextEditor', () => {
                     await disconnect();
                 }
             );
-        }
+        });
     });
 
     describe('Should return modified markdown when various wacky string values are assigned', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
         const modifiedWackyStrings: {
             name: string,
+            value: string,
             content: string
         }[] = [
-            { name: '\0', content: '�' },
-            { name: '\uFFFD', content: '�' },
-            { name: '\x00', content: '�' },
-            { name: '\r\r', content: '' }
+            { name: '\\0', value: '\0', content: '�' },
+            { name: '\\uFFFD', value: '\uFFFD', content: '�' },
+            { name: '\\x00', value: '\x00', content: '�' },
+            { name: '\\r\\r', value: '\r\r', content: '' }
         ];
 
-        for (const value of modifiedWackyStrings) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            specType(
-                `wacky string "${value.name}" returns modified when assigned`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
+        parameterizeNamedList(modifiedWackyStrings, (spec, name, value) => {
+            spec(
+                `wacky string "${name}" returns modified when assigned`,
                 async () => {
-                    element.setMarkdown(value.name);
+                    element.setMarkdown(value.value);
 
                     await connect();
 
@@ -1810,7 +1738,7 @@ describe('RichTextEditor', () => {
                     await disconnect();
                 }
             );
-        }
+        });
     });
 
     describe('disabled state', () => {
@@ -1851,17 +1779,8 @@ describe('RichTextEditor', () => {
         });
 
         describe('should reflect disabled value to the disabled and aria-disabled state of toggle buttons', () => {
-            const focused: string[] = [];
-            const disabled: string[] = [];
-            for (const value of formattingButtons) {
-                const specType = getSpecTypeByNamedList(
-                    value,
-                    focused,
-                    disabled
-                );
-                specType(
-                    `for "${value.name}" button`,
-                    // eslint-disable-next-line @typescript-eslint/no-loop-func
+            parameterizeNamedList(formattingButtons, (spec, name, value) => {
+                spec(`for "${name}" button`,
                     async () => {
                         expect(
                             pageObject.isButtonDisabled(
@@ -1878,7 +1797,7 @@ describe('RichTextEditor', () => {
                         ).toBeTrue();
                     }
                 );
-            }
+            });
         });
     });
 

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
@@ -1,9 +1,7 @@
 import { html } from '@microsoft/fast-element';
 import { richTextEditorTag, RichTextEditor } from '..';
 import { type Fixture, fixture } from '../../../utilities/tests/fixture';
-import {
-    parameterizeNamedList
-} from '../../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../../utilities/tests/parameterized';
 import { RichTextEditorPageObject } from '../testing/rich-text-editor.pageobject';
 import { wackyStrings } from '../../../utilities/tests/wacky-strings';
 import type { Button } from '../../../button';
@@ -170,105 +168,71 @@ describe('RichTextEditor', () => {
 
     describe('clicking buttons should update the checked state of the toggle button with focus', () => {
         parameterizeNamedList(formattingButtons, (spec, name, value) => {
-            spec(
-                `"${name}" button click check`,
-                async () => {
-                    expect(
-                        pageObject.getButtonCheckedState(
-                            value.toolbarButtonIndex
-                        )
-                    ).toBeFalse();
+            spec(`"${name}" button click check`, async () => {
+                expect(
+                    pageObject.getButtonCheckedState(value.toolbarButtonIndex)
+                ).toBeFalse();
 
-                    await pageObject.toggleFooterButton(
-                        value.toolbarButtonIndex
-                    );
+                await pageObject.toggleFooterButton(value.toolbarButtonIndex);
 
-                    expect(
-                        pageObject.getButtonCheckedState(
-                            value.toolbarButtonIndex
-                        )
-                    ).toBeTrue();
-                    expect(
-                        pageObject.getButtonTabIndex(value.toolbarButtonIndex)
-                    ).toBe(0);
-                }
-            );
+                expect(
+                    pageObject.getButtonCheckedState(value.toolbarButtonIndex)
+                ).toBeTrue();
+                expect(
+                    pageObject.getButtonTabIndex(value.toolbarButtonIndex)
+                ).toBe(0);
+            });
         });
     });
 
     describe('space key press should update the checked state of the buttons', () => {
         parameterizeNamedList(formattingButtons, (spec, name, value) => {
-            spec(
-                `"${name}" button key press check`,
-                () => {
-                    expect(
-                        pageObject.getButtonCheckedState(
-                            value.toolbarButtonIndex
-                        )
-                    ).toBeFalse();
+            spec(`"${name}" button key press check`, () => {
+                expect(
+                    pageObject.getButtonCheckedState(value.toolbarButtonIndex)
+                ).toBeFalse();
 
-                    pageObject.spaceKeyActivatesButton(
-                        value.toolbarButtonIndex
-                    );
+                pageObject.spaceKeyActivatesButton(value.toolbarButtonIndex);
 
-                    expect(
-                        pageObject.getButtonCheckedState(
-                            value.toolbarButtonIndex
-                        )
-                    ).toBeTrue();
-                }
-            );
+                expect(
+                    pageObject.getButtonCheckedState(value.toolbarButtonIndex)
+                ).toBeTrue();
+            });
         });
     });
 
     describe('enter key press should update the checked state of the buttons', () => {
         parameterizeNamedList(formattingButtons, (spec, name, value) => {
-            spec(
-                `"${name}" button key press check`,
-                () => {
-                    expect(
-                        pageObject.getButtonCheckedState(
-                            value.toolbarButtonIndex
-                        )
-                    ).toBeFalse();
+            spec(`"${name}" button key press check`, () => {
+                expect(
+                    pageObject.getButtonCheckedState(value.toolbarButtonIndex)
+                ).toBeFalse();
 
-                    pageObject.enterKeyActivatesButton(
-                        value.toolbarButtonIndex
-                    );
+                pageObject.enterKeyActivatesButton(value.toolbarButtonIndex);
 
-                    expect(
-                        pageObject.getButtonCheckedState(
-                            value.toolbarButtonIndex
-                        )
-                    ).toBeTrue();
-                }
-            );
+                expect(
+                    pageObject.getButtonCheckedState(value.toolbarButtonIndex)
+                ).toBeTrue();
+            });
         });
     });
 
     describe('keyboard shortcuts should update the checked state of the buttons', () => {
         parameterizeNamedList(formattingButtons, (spec, name, value) => {
-            spec(
-                `"${name}" button keyboard shortcut check`,
-                async () => {
-                    expect(
-                        pageObject.getButtonCheckedState(
-                            value.toolbarButtonIndex
-                        )
-                    ).toBeFalse();
+            spec(`"${name}" button keyboard shortcut check`, async () => {
+                expect(
+                    pageObject.getButtonCheckedState(value.toolbarButtonIndex)
+                ).toBeFalse();
 
-                    await pageObject.clickEditorShortcutKeys(
-                        value.shortcutKey,
-                        value.shiftKey
-                    );
+                await pageObject.clickEditorShortcutKeys(
+                    value.shortcutKey,
+                    value.shiftKey
+                );
 
-                    expect(
-                        pageObject.getButtonCheckedState(
-                            value.toolbarButtonIndex
-                        )
-                    ).toBeTrue();
-                }
-            );
+                expect(
+                    pageObject.getButtonCheckedState(value.toolbarButtonIndex)
+                ).toBeTrue();
+            });
         });
     });
 
@@ -1662,12 +1626,11 @@ describe('RichTextEditor', () => {
     });
 
     describe('Should return markdown without any changes when various wacky string values are assigned', () => {
-        const wackyStringsToTest = wackyStrings
-            .filter(
-                value => value.name !== '\x00'
-                    && value.name !== '-Infinity'
-                    && value.name !== '-2147483648/-1'
-            );
+        const wackyStringsToTest = wackyStrings.filter(
+            value => value.name !== '\x00'
+                && value.name !== '-Infinity'
+                && value.name !== '-2147483648/-1'
+        );
 
         parameterizeNamedList(wackyStringsToTest, (spec, name) => {
             spec(
@@ -1695,20 +1658,23 @@ describe('RichTextEditor', () => {
             { name: '-2147483648/-1', value: r`\-2147483648/-1` }
         ];
 
-        parameterizeNamedList(wackyStringWithSpecialMarkdownCharacter, (spec, name, value) => {
-            spec(
-                ` wacky string contains special markdown syntax "${name}" returns as plain text "${value.value}" with added escape character`,
-                async () => {
-                    element.setMarkdown(value.name);
+        parameterizeNamedList(
+            wackyStringWithSpecialMarkdownCharacter,
+            (spec, name, value) => {
+                spec(
+                    ` wacky string contains special markdown syntax "${name}" returns as plain text "${value.value}" with added escape character`,
+                    async () => {
+                        element.setMarkdown(value.name);
 
-                    await connect();
+                        await connect();
 
-                    expect(element.getMarkdown()).toBe(value.value);
+                        expect(element.getMarkdown()).toBe(value.value);
 
-                    await disconnect();
-                }
-            );
-        });
+                        await disconnect();
+                    }
+                );
+            }
+        );
     });
 
     describe('Should return modified markdown when various wacky string values are assigned', () => {
@@ -1778,24 +1744,17 @@ describe('RichTextEditor', () => {
 
         describe('should reflect disabled value to the disabled and aria-disabled state of toggle buttons', () => {
             parameterizeNamedList(formattingButtons, (spec, name, value) => {
-                spec(
-                    `for "${name}" button`,
-                    async () => {
-                        expect(
-                            pageObject.isButtonDisabled(
-                                value.toolbarButtonIndex
-                            )
-                        ).toBeFalse();
+                spec(`for "${name}" button`, async () => {
+                    expect(
+                        pageObject.isButtonDisabled(value.toolbarButtonIndex)
+                    ).toBeFalse();
 
-                        await pageObject.setDisabled(true);
+                    await pageObject.setDisabled(true);
 
-                        expect(
-                            pageObject.isButtonDisabled(
-                                value.toolbarButtonIndex
-                            )
-                        ).toBeTrue();
-                    }
-                );
+                    expect(
+                        pageObject.isButtonDisabled(value.toolbarButtonIndex)
+                    ).toBeTrue();
+                });
             });
         });
     });

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
@@ -855,11 +855,11 @@ describe('RichTextEditor', () => {
                     { name: 'https://example.com/пример.html ' }
                 ];
 
-                parameterizeNamedList(supportedAbsoluteLink, (spec, name, value) => {
+                parameterizeNamedList(supportedAbsoluteLink, (spec, name) => {
                     spec(
                         `should change the ${name} to "a" tag when it is a valid absolute link`,
                         async () => {
-                            await pageObject.setEditorTextContent(value.name);
+                            await pageObject.setEditorTextContent(name);
 
                             expect(pageObject.getEditorTagNames()).toEqual([
                                 'P',
@@ -867,7 +867,7 @@ describe('RichTextEditor', () => {
                             ]);
                             expect(pageObject.getEditorLeafContents()).toEqual([
                                 // Name without the trailing space used by the editor to trigger conversion to a link
-                                value.name.slice(0, -1)
+                                name.slice(0, -1)
                             ]);
                         }
                     );
@@ -985,17 +985,17 @@ describe('RichTextEditor', () => {
                     { name: 'test://test.com ' }
                 ];
 
-                parameterizeNamedList(differentProtocolLinks, (spec, name, value) => {
+                parameterizeNamedList(differentProtocolLinks, (spec, name) => {
                     spec(
                         `string "${name}" renders as plain text "${name}" within paragraph tag`,
                         async () => {
-                            await pageObject.setEditorTextContent(value.name);
+                            await pageObject.setEditorTextContent(name);
 
                             expect(pageObject.getEditorTagNames()).toEqual([
                                 'P'
                             ]);
                             expect(pageObject.getEditorLeafContents()).toEqual([
-                                value.name
+                                name
                             ]);
                         }
                     );
@@ -1192,11 +1192,11 @@ describe('RichTextEditor', () => {
     });
 
     describe('various wacky string values input into the editor', () => {
-        parameterizeNamedList(wackyStrings, (spec, name, value) => {
+        parameterizeNamedList(wackyStrings, (spec, name) => {
             spec(
                 `wacky string "${name}" that are unmodified when rendered the same value within paragraph tag`,
                 async () => {
-                    await pageObject.setEditorTextContent(value.name);
+                    await pageObject.setEditorTextContent(name);
 
                     await connect();
 
@@ -1204,7 +1204,7 @@ describe('RichTextEditor', () => {
                         'P'
                     );
                     expect(pageObject.getEditorFirstChildTextContent()).toBe(
-                        value.name
+                        name
                     );
 
                     await disconnect();
@@ -1546,16 +1546,15 @@ describe('RichTextEditor', () => {
             { name: '<script>alert("not alert")</script>' }
         ];
 
-        parameterizeNamedList(notSupportedMarkdownStrings, (spec, name, value) => {
+        parameterizeNamedList(notSupportedMarkdownStrings, (spec, name) => {
             spec(
                 `markdown string "${name}" returns as plain text "${name}" without any change`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
                 async () => {
-                    element.setMarkdown(value.name);
+                    element.setMarkdown(name);
 
                     await connect();
 
-                    expect(element.getMarkdown()).toBe(value.name);
+                    expect(element.getMarkdown()).toBe(name);
 
                     await disconnect();
                 }
@@ -1589,7 +1588,6 @@ describe('RichTextEditor', () => {
         parameterizeNamedList(specialMarkdownStrings, (spec, name, value) => {
             spec(
                 `special markdown string "${name}" returns as plain text "${value.value}" with added esacpe character`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
                 async () => {
                     element.setMarkdown(value.name);
 
@@ -1671,15 +1669,15 @@ describe('RichTextEditor', () => {
                     && value.name !== '-2147483648/-1'
             );
 
-        parameterizeNamedList(wackyStringsToTest, (spec, name, value) => {
+        parameterizeNamedList(wackyStringsToTest, (spec, name) => {
             spec(
                 `wacky string "${name}" returns unmodified when set the same markdown string "${name}"`,
                 async () => {
-                    element.setMarkdown(value.name);
+                    element.setMarkdown(name);
 
                     await connect();
 
-                    expect(element.getMarkdown()).toBe(value.name);
+                    expect(element.getMarkdown()).toBe(name);
 
                     await disconnect();
                 }
@@ -1699,7 +1697,7 @@ describe('RichTextEditor', () => {
 
         parameterizeNamedList(wackyStringWithSpecialMarkdownCharacter, (spec, name, value) => {
             spec(
-                ` wacky string contains special markdown syntax "${name}" returns as plain text "${value}" with added escape character`,
+                ` wacky string contains special markdown syntax "${name}" returns as plain text "${value.value}" with added escape character`,
                 async () => {
                     element.setMarkdown(value.name);
 
@@ -1780,7 +1778,8 @@ describe('RichTextEditor', () => {
 
         describe('should reflect disabled value to the disabled and aria-disabled state of toggle buttons', () => {
             parameterizeNamedList(formattingButtons, (spec, name, value) => {
-                spec(`for "${name}" button`,
+                spec(
+                    `for "${name}" button`,
                     async () => {
                         expect(
                             pageObject.isButtonDisabled(

--- a/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
+++ b/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
@@ -242,10 +242,7 @@ describe('Markdown parser', () => {
 
         describe('Absolute link', () => {
             describe('various valid absolute links should render same as in the markdown', () => {
-                const supportedAbsoluteLink: {
-                    name: string,
-                    validLink: string
-                }[] = [
+                const supportedAbsoluteLink = [
                     {
                         name: 'Lowercase HTTPS URL',
                         validLink: '<https://nimble.ni.dev/>'
@@ -311,7 +308,7 @@ describe('Markdown parser', () => {
                         name: 'URL with Port Number',
                         validLink: '<http://www.example.com:8080/path/page>'
                     }
-                ];
+                ] as const;
 
                 describe('should reflect value to the internal control', () => {
                     parameterizeNamedList(
@@ -349,11 +346,7 @@ describe('Markdown parser', () => {
             });
 
             describe('various absolute links with non-ASCII (IRI) characters within it', () => {
-                const supportedAbsoluteLink: {
-                    name: string,
-                    validLink: string,
-                    encodeURL: string
-                }[] = [
+                const supportedAbsoluteLink = [
                     {
                         name: 'Emoji',
                         validLink: '<https://example.com/smiley😀.html>',
@@ -425,7 +418,7 @@ describe('Markdown parser', () => {
                         validLink: '<https://example.com/東京.html>',
                         encodeURL: 'https://example.com/%E6%9D%B1%E4%BA%AC.html'
                     }
-                ];
+                ] as const;
 
                 describe('should reflect value to the internal control', () => {
                     parameterizeNamedList(
@@ -642,7 +635,7 @@ describe('Markdown parser', () => {
                     { name: '<javascript:void(0)>' },
                     { name: '<file:///path/to/local/file.txt>' },
                     { name: '<javascript:vbscript:alert("not alert")>' }
-                ];
+                ] as const;
                 parameterizeNamedList(
                     notSupportedAbsoluteLink,
                     (spec, name) => {
@@ -729,7 +722,7 @@ describe('Markdown parser', () => {
                 tags: ['P'],
                 textContent: ['-2147483648/-1']
             }
-        ];
+        ] as const;
 
         parameterizeNamedList(
             testsWithEscapeCharacters,
@@ -801,7 +794,7 @@ describe('Markdown parser', () => {
     });
 
     describe('various not supported markdown string values render as unchanged strings', () => {
-        const notSupportedMarkdownStrings: { name: string }[] = [
+        const notSupportedMarkdownStrings = [
             { name: '> blockquote' },
             { name: '`code`' },
             { name: '```fence```' },
@@ -826,7 +819,7 @@ describe('Markdown parser', () => {
                 name: '<a href="https://nimble.ni.dev/">https://nimble.ni.dev/</a>'
             },
             { name: '<script>alert("not alert")</script>' }
-        ];
+        ] as const;
 
         parameterizeNamedList(notSupportedMarkdownStrings, (spec, name) => {
             spec(
@@ -864,12 +857,7 @@ describe('Markdown parser', () => {
     });
 
     describe('various wacky string values modified when rendered', () => {
-        const modifiedWackyStrings: {
-            name: string,
-            value: string,
-            tags: string[],
-            textContent: string[]
-        }[] = [
+        const modifiedWackyStrings = [
             { name: '\\0', value: '\0', tags: ['P'], textContent: ['�'] },
             { name: '\\r\\r', value: '\r\r', tags: ['P'], textContent: [''] },
             {
@@ -879,7 +867,7 @@ describe('Markdown parser', () => {
                 textContent: ['�']
             },
             { name: '\\x00', value: '\x00', tags: ['P'], textContent: ['�'] }
-        ];
+        ] as const;
 
         parameterizeNamedList(modifiedWackyStrings, (spec, name, value) => {
             spec(`wacky string "${name}" modified when rendered`, () => {
@@ -897,11 +885,7 @@ describe('Markdown parser', () => {
 
     describe('Markdown string with hard break should have respective br tag when rendered', () => {
         const r = String.raw;
-        const markdownStringWithHardBreak: {
-            name: string,
-            value: string,
-            tags: string[]
-        }[] = [
+        const markdownStringWithHardBreak = [
             {
                 name: 'bold and italics',
                 value: r`**bold**\
@@ -952,7 +936,7 @@ describe('Markdown parser', () => {
       nested hard break content`,
                 tags: ['OL', 'LI', 'P', 'BR', 'LI', 'P', 'OL', 'LI', 'P', 'BR']
             }
-        ];
+        ] as const;
 
         parameterizeNamedList(
             markdownStringWithHardBreak,

--- a/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
+++ b/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
@@ -712,7 +712,6 @@ describe('Markdown parser', () => {
             }
         ];
 
-        
         parameterizeNamedList(testsWithEscapeCharacters, (spec, name, value) => {
             spec(
                 `"${name}"`,
@@ -810,18 +809,17 @@ describe('Markdown parser', () => {
             { name: '<script>alert("not alert")</script>' }
         ];
 
-        
-        parameterizeNamedList(notSupportedMarkdownStrings, (spec, name, value) => {
+        parameterizeNamedList(notSupportedMarkdownStrings, (spec, name) => {
             spec(
                 `string "${name}" renders as plain text "${name}" within paragraph tag`,
                 () => {
                     const doc = RichTextMarkdownParser.parseMarkdownToDOM(
-                        value.name
+                        name
                     ).fragment;
 
                     expect(getTagsFromElement(doc)).toEqual(['P']);
                     expect(getLeafContentsFromElement(doc)).toEqual([
-                        value.name
+                        name
                     ]);
                 }
             );
@@ -831,17 +829,17 @@ describe('Markdown parser', () => {
     describe('various wacky string values render as unchanged strings', () => {
         const wackyStringsToTest = wackyStrings.filter(value => value.name !== '\x00');
 
-        parameterizeNamedList(wackyStringsToTest, (spec, name, value) => {
+        parameterizeNamedList(wackyStringsToTest, (spec, name) => {
             spec(
                 `wacky string "${name}" that are unmodified when set the same "${name}" within paragraph tag`,
                 () => {
                     const doc = RichTextMarkdownParser.parseMarkdownToDOM(
-                        value.name
+                        name
                     ).fragment;
 
                     expect(getTagsFromElement(doc)).toEqual(['P']);
                     expect(getLeafContentsFromElement(doc)).toEqual([
-                        value.name
+                        name
                     ]);
                 }
             );
@@ -861,7 +859,6 @@ describe('Markdown parser', () => {
             { name: '\\r\\r', value: '\r\r', tags: ['P'], textContent: ['�'] }
         ];
 
-        
         parameterizeNamedList(modifiedWackyStrings, (spec, name, value) => {
             spec(
                 `wacky string "${name}" modified when rendered`,
@@ -938,7 +935,6 @@ describe('Markdown parser', () => {
             }
         ];
 
-        
         parameterizeNamedList(markdownStringWithHardBreak, (spec, name, value) => {
             spec(`should render br tag with "${name}"`, () => {
                 const doc = RichTextMarkdownParser.parseMarkdownToDOM(

--- a/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
+++ b/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
@@ -6,7 +6,6 @@ import {
 } from '../../../rich-text-mention/users';
 import { type Fixture, fixture } from '../../../utilities/tests/fixture';
 import {
-    getSpecTypeByNamedList,
     parameterizeNamedList
 } from '../../../utilities/tests/parameterized';
 import { wackyStrings } from '../../../utilities/tests/wacky-strings';
@@ -316,18 +315,9 @@ describe('Markdown parser', () => {
                     }
                 ];
 
-                const focused: string[] = [];
-                const disabled: string[] = [];
-                for (const value of supportedAbsoluteLink) {
-                    const specType = getSpecTypeByNamedList(
-                        value,
-                        focused,
-                        disabled
-                    );
-                    specType(
-                        `${value.name} to "nimble-anchor" tags with the link as the text content`,
-                        // eslint-disable-next-line @typescript-eslint/no-loop-func
-                        () => {
+                describe('should reflect value to the internal control', () => {
+                    parameterizeNamedList(supportedAbsoluteLink, (spec, name, value) => {
+                        spec(`${name} to "nimble-anchor" tags with the link as the text content`, () => {
                             const doc = RichTextMarkdownParser.parseMarkdownToDOM(
                                 value.validLink
                             ).fragment;
@@ -343,9 +333,9 @@ describe('Markdown parser', () => {
                             expect(
                                 getLastChildElementAttribute('href', doc)
                             ).toBe(renderedLink);
-                        }
-                    );
-                }
+                        });
+                    });
+                });
             });
 
             describe('various absolute links with non-ASCII (IRI) characters within it', () => {
@@ -427,36 +417,30 @@ describe('Markdown parser', () => {
                     }
                 ];
 
-                const focused: string[] = [];
-                const disabled: string[] = [];
-                for (const value of supportedAbsoluteLink) {
-                    const specType = getSpecTypeByNamedList(
-                        value,
-                        focused,
-                        disabled
-                    );
-                    specType(
-                        `${value.name} to "nimble-anchor" tags with the non-ASCII characters as the text content and encoded as their href`,
-                        // eslint-disable-next-line @typescript-eslint/no-loop-func
-                        () => {
-                            const doc = RichTextMarkdownParser.parseMarkdownToDOM(
-                                value.validLink
-                            ).fragment;
-                            const renderedLink = value.validLink.slice(1, -1);
+                describe('should reflect value to the internal control', () => {
+                    parameterizeNamedList(supportedAbsoluteLink, (spec, name, value) => {
+                        spec(
+                            `${name} to "nimble-anchor" tags with the non-ASCII characters as the text content and encoded as their href`,
+                            () => {
+                                const doc = RichTextMarkdownParser.parseMarkdownToDOM(
+                                    value.validLink
+                                ).fragment;
+                                const renderedLink = value.validLink.slice(1, -1);
 
-                            expect(getTagsFromElement(doc)).toEqual([
-                                'P',
-                                'NIMBLE-ANCHOR'
-                            ]);
-                            expect(getLeafContentsFromElement(doc)).toEqual([
-                                renderedLink
-                            ]);
-                            expect(
-                                getLastChildElementAttribute('href', doc)
-                            ).toBe(value.encodeURL);
-                        }
-                    );
-                }
+                                expect(getTagsFromElement(doc)).toEqual([
+                                    'P',
+                                    'NIMBLE-ANCHOR'
+                                ]);
+                                expect(getLeafContentsFromElement(doc)).toEqual([
+                                    renderedLink
+                                ]);
+                                expect(
+                                    getLastChildElementAttribute('href', doc)
+                                ).toBe(value.encodeURL);
+                            }
+                        );
+                    });
+                });
             });
 
             it('absolute link should add "rel" attribute', () => {
@@ -690,8 +674,6 @@ describe('Markdown parser', () => {
     });
 
     describe('escape backslashes should be ignored while parsing', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
         const r = String.raw;
         const testsWithEscapeCharacters = [
             { name: r`\*`, tags: ['P'], textContent: ['*'] },
@@ -730,11 +712,10 @@ describe('Markdown parser', () => {
             }
         ];
 
-        for (const value of testsWithEscapeCharacters) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            specType(
-                `"${value.name}"`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
+        
+        parameterizeNamedList(testsWithEscapeCharacters, (spec, name, value) => {
+            spec(
+                `"${name}"`,
                 () => {
                     const doc = RichTextMarkdownParser.parseMarkdownToDOM(
                         value.name
@@ -746,7 +727,7 @@ describe('Markdown parser', () => {
                     );
                 }
             );
-        }
+        });
 
         it('special character `.` should be parsed properly (number list test)', () => {
             const doc = RichTextMarkdownParser.parseMarkdownToDOM(
@@ -829,13 +810,10 @@ describe('Markdown parser', () => {
             { name: '<script>alert("not alert")</script>' }
         ];
 
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const value of notSupportedMarkdownStrings) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            specType(
-                `string "${value.name}" renders as plain text "${value.name}" within paragraph tag`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
+        
+        parameterizeNamedList(notSupportedMarkdownStrings, (spec, name, value) => {
+            spec(
+                `string "${name}" renders as plain text "${name}" within paragraph tag`,
                 () => {
                     const doc = RichTextMarkdownParser.parseMarkdownToDOM(
                         value.name
@@ -847,60 +825,49 @@ describe('Markdown parser', () => {
                     ]);
                 }
             );
-        }
+        });
     });
 
     describe('various wacky string values render as unchanged strings', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
+        const wackyStringsToTest = wackyStrings.filter(value => value.name !== '\x00');
 
-        wackyStrings
-            .filter(value => value.name !== '\x00')
-            .forEach(value => {
-                const specType = getSpecTypeByNamedList(
-                    value,
-                    focused,
-                    disabled
-                );
-                specType(
-                    `wacky string "${value.name}" that are unmodified when set the same "${value.name}" within paragraph tag`,
-                    // eslint-disable-next-line @typescript-eslint/no-loop-func
-                    () => {
-                        const doc = RichTextMarkdownParser.parseMarkdownToDOM(
-                            value.name
-                        ).fragment;
-
-                        expect(getTagsFromElement(doc)).toEqual(['P']);
-                        expect(getLeafContentsFromElement(doc)).toEqual([
-                            value.name
-                        ]);
-                    }
-                );
-            });
-    });
-
-    describe('various wacky string values modified when rendered', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        const modifiedWackyStrings: {
-            name: string,
-            tags: string[],
-            textContent: string[]
-        }[] = [
-            { name: '\0', tags: ['P'], textContent: ['�'] },
-            { name: '\r\r', tags: ['P'], textContent: [''] },
-            { name: '\uFFFD', tags: ['P'], textContent: ['�'] },
-            { name: '\x00', tags: ['P'], textContent: ['�'] }
-        ];
-
-        for (const value of modifiedWackyStrings) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            specType(
-                `wacky string "${value.name}" modified when rendered`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
+        parameterizeNamedList(wackyStringsToTest, (spec, name, value) => {
+            spec(
+                `wacky string "${name}" that are unmodified when set the same "${name}" within paragraph tag`,
                 () => {
                     const doc = RichTextMarkdownParser.parseMarkdownToDOM(
                         value.name
+                    ).fragment;
+
+                    expect(getTagsFromElement(doc)).toEqual(['P']);
+                    expect(getLeafContentsFromElement(doc)).toEqual([
+                        value.name
+                    ]);
+                }
+            );
+        });
+    });
+
+    describe('various wacky string values modified when rendered', () => {
+        const modifiedWackyStrings: {
+            name: string,
+            value: string,
+            tags: string[],
+            textContent: string[]
+        }[] = [
+            { name: '\\0', value: '\0', tags: ['P'], textContent: ['�'] },
+            { name: '\\uFFFD', value: '\uFFFD', tags: ['P'], textContent: [''] },
+            { name: '\\x00', value: '\x00', tags: ['P'], textContent: ['�'] },
+            { name: '\\r\\r', value: '\r\r', tags: ['P'], textContent: ['�'] }
+        ];
+
+        
+        parameterizeNamedList(modifiedWackyStrings, (spec, name, value) => {
+            spec(
+                `wacky string "${name}" modified when rendered`,
+                () => {
+                    const doc = RichTextMarkdownParser.parseMarkdownToDOM(
+                        value.value
                     ).fragment;
 
                     expect(getTagsFromElement(doc)).toEqual(value.tags);
@@ -909,12 +876,10 @@ describe('Markdown parser', () => {
                     );
                 }
             );
-        }
+        });
     });
 
     describe('Markdown string with hard break should have respective br tag when rendered', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
         const r = String.raw;
         const markdownStringWithHardBreak: {
             name: string,
@@ -973,19 +938,15 @@ describe('Markdown parser', () => {
             }
         ];
 
-        for (const value of markdownStringWithHardBreak) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            specType(
-                `should render br tag with "${value.name}"`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                () => {
-                    const doc = RichTextMarkdownParser.parseMarkdownToDOM(
-                        value.value
-                    ).fragment;
-                    expect(getTagsFromElement(doc)).toEqual(value.tags);
-                }
-            );
-        }
+        
+        parameterizeNamedList(markdownStringWithHardBreak, (spec, name, value) => {
+            spec(`should render br tag with "${name}"`, () => {
+                const doc = RichTextMarkdownParser.parseMarkdownToDOM(
+                    value.value
+                ).fragment;
+                expect(getTagsFromElement(doc)).toEqual(value.tags);
+            });
+        });
     });
 
     describe('user mention', () => {

--- a/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
+++ b/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
@@ -5,9 +5,7 @@ import {
     richTextMentionUsersTag
 } from '../../../rich-text-mention/users';
 import { type Fixture, fixture } from '../../../utilities/tests/fixture';
-import {
-    parameterizeNamedList
-} from '../../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../../utilities/tests/parameterized';
 import { wackyStrings } from '../../../utilities/tests/wacky-strings';
 import { RichTextMarkdownParser } from '../markdown-parser';
 import {
@@ -316,25 +314,37 @@ describe('Markdown parser', () => {
                 ];
 
                 describe('should reflect value to the internal control', () => {
-                    parameterizeNamedList(supportedAbsoluteLink, (spec, name, value) => {
-                        spec(`${name} to "nimble-anchor" tags with the link as the text content`, () => {
-                            const doc = RichTextMarkdownParser.parseMarkdownToDOM(
-                                value.validLink
-                            ).fragment;
-                            const renderedLink = value.validLink.slice(1, -1);
+                    parameterizeNamedList(
+                        supportedAbsoluteLink,
+                        (spec, name, value) => {
+                            spec(
+                                `${name} to "nimble-anchor" tags with the link as the text content`,
+                                () => {
+                                    const doc = RichTextMarkdownParser.parseMarkdownToDOM(
+                                        value.validLink
+                                    ).fragment;
+                                    const renderedLink = value.validLink.slice(
+                                        1,
+                                        -1
+                                    );
 
-                            expect(getTagsFromElement(doc)).toEqual([
-                                'P',
-                                'NIMBLE-ANCHOR'
-                            ]);
-                            expect(getLeafContentsFromElement(doc)).toEqual([
-                                renderedLink
-                            ]);
-                            expect(
-                                getLastChildElementAttribute('href', doc)
-                            ).toBe(renderedLink);
-                        });
-                    });
+                                    expect(getTagsFromElement(doc)).toEqual([
+                                        'P',
+                                        'NIMBLE-ANCHOR'
+                                    ]);
+                                    expect(
+                                        getLeafContentsFromElement(doc)
+                                    ).toEqual([renderedLink]);
+                                    expect(
+                                        getLastChildElementAttribute(
+                                            'href',
+                                            doc
+                                        )
+                                    ).toBe(renderedLink);
+                                }
+                            );
+                        }
+                    );
                 });
             });
 
@@ -418,28 +428,37 @@ describe('Markdown parser', () => {
                 ];
 
                 describe('should reflect value to the internal control', () => {
-                    parameterizeNamedList(supportedAbsoluteLink, (spec, name, value) => {
-                        spec(
-                            `${name} to "nimble-anchor" tags with the non-ASCII characters as the text content and encoded as their href`,
-                            () => {
-                                const doc = RichTextMarkdownParser.parseMarkdownToDOM(
-                                    value.validLink
-                                ).fragment;
-                                const renderedLink = value.validLink.slice(1, -1);
+                    parameterizeNamedList(
+                        supportedAbsoluteLink,
+                        (spec, name, value) => {
+                            spec(
+                                `${name} to "nimble-anchor" tags with the non-ASCII characters as the text content and encoded as their href`,
+                                () => {
+                                    const doc = RichTextMarkdownParser.parseMarkdownToDOM(
+                                        value.validLink
+                                    ).fragment;
+                                    const renderedLink = value.validLink.slice(
+                                        1,
+                                        -1
+                                    );
 
-                                expect(getTagsFromElement(doc)).toEqual([
-                                    'P',
-                                    'NIMBLE-ANCHOR'
-                                ]);
-                                expect(getLeafContentsFromElement(doc)).toEqual([
-                                    renderedLink
-                                ]);
-                                expect(
-                                    getLastChildElementAttribute('href', doc)
-                                ).toBe(value.encodeURL);
-                            }
-                        );
-                    });
+                                    expect(getTagsFromElement(doc)).toEqual([
+                                        'P',
+                                        'NIMBLE-ANCHOR'
+                                    ]);
+                                    expect(
+                                        getLeafContentsFromElement(doc)
+                                    ).toEqual([renderedLink]);
+                                    expect(
+                                        getLastChildElementAttribute(
+                                            'href',
+                                            doc
+                                        )
+                                    ).toBe(value.encodeURL);
+                                }
+                            );
+                        }
+                    );
                 });
             });
 
@@ -712,10 +731,10 @@ describe('Markdown parser', () => {
             }
         ];
 
-        parameterizeNamedList(testsWithEscapeCharacters, (spec, name, value) => {
-            spec(
-                `"${name}"`,
-                () => {
+        parameterizeNamedList(
+            testsWithEscapeCharacters,
+            (spec, name, value) => {
+                spec(`"${name}"`, () => {
                     const doc = RichTextMarkdownParser.parseMarkdownToDOM(
                         value.name
                     ).fragment;
@@ -724,9 +743,9 @@ describe('Markdown parser', () => {
                     expect(getLeafContentsFromElement(doc)).toEqual(
                         value.textContent
                     );
-                }
-            );
-        });
+                });
+            }
+        );
 
         it('special character `.` should be parsed properly (number list test)', () => {
             const doc = RichTextMarkdownParser.parseMarkdownToDOM(
@@ -818,16 +837,16 @@ describe('Markdown parser', () => {
                     ).fragment;
 
                     expect(getTagsFromElement(doc)).toEqual(['P']);
-                    expect(getLeafContentsFromElement(doc)).toEqual([
-                        name
-                    ]);
+                    expect(getLeafContentsFromElement(doc)).toEqual([name]);
                 }
             );
         });
     });
 
     describe('various wacky string values render as unchanged strings', () => {
-        const wackyStringsToTest = wackyStrings.filter(value => value.name !== '\x00');
+        const wackyStringsToTest = wackyStrings.filter(
+            value => value.name !== '\x00'
+        );
 
         parameterizeNamedList(wackyStringsToTest, (spec, name) => {
             spec(
@@ -838,9 +857,7 @@ describe('Markdown parser', () => {
                     ).fragment;
 
                     expect(getTagsFromElement(doc)).toEqual(['P']);
-                    expect(getLeafContentsFromElement(doc)).toEqual([
-                        name
-                    ]);
+                    expect(getLeafContentsFromElement(doc)).toEqual([name]);
                 }
             );
         });
@@ -854,25 +871,27 @@ describe('Markdown parser', () => {
             textContent: string[]
         }[] = [
             { name: '\\0', value: '\0', tags: ['P'], textContent: ['�'] },
-            { name: '\\uFFFD', value: '\uFFFD', tags: ['P'], textContent: [''] },
-            { name: '\\x00', value: '\x00', tags: ['P'], textContent: ['�'] },
-            { name: '\\r\\r', value: '\r\r', tags: ['P'], textContent: ['�'] }
+            { name: '\\r\\r', value: '\r\r', tags: ['P'], textContent: [''] },
+            {
+                name: '\\uFFFD',
+                value: '\uFFFD',
+                tags: ['P'],
+                textContent: ['�']
+            },
+            { name: '\\x00', value: '\x00', tags: ['P'], textContent: ['�'] }
         ];
 
         parameterizeNamedList(modifiedWackyStrings, (spec, name, value) => {
-            spec(
-                `wacky string "${name}" modified when rendered`,
-                () => {
-                    const doc = RichTextMarkdownParser.parseMarkdownToDOM(
-                        value.value
-                    ).fragment;
+            spec(`wacky string "${name}" modified when rendered`, () => {
+                const doc = RichTextMarkdownParser.parseMarkdownToDOM(
+                    value.value
+                ).fragment;
 
-                    expect(getTagsFromElement(doc)).toEqual(value.tags);
-                    expect(getLeafContentsFromElement(doc)).toEqual(
-                        value.textContent
-                    );
-                }
-            );
+                expect(getTagsFromElement(doc)).toEqual(value.tags);
+                expect(getLeafContentsFromElement(doc)).toEqual(
+                    value.textContent
+                );
+            });
         });
     });
 
@@ -935,14 +954,17 @@ describe('Markdown parser', () => {
             }
         ];
 
-        parameterizeNamedList(markdownStringWithHardBreak, (spec, name, value) => {
-            spec(`should render br tag with "${name}"`, () => {
-                const doc = RichTextMarkdownParser.parseMarkdownToDOM(
-                    value.value
-                ).fragment;
-                expect(getTagsFromElement(doc)).toEqual(value.tags);
-            });
-        });
+        parameterizeNamedList(
+            markdownStringWithHardBreak,
+            (spec, name, value) => {
+                spec(`should render br tag with "${name}"`, () => {
+                    const doc = RichTextMarkdownParser.parseMarkdownToDOM(
+                        value.value
+                    ).fragment;
+                    expect(getTagsFromElement(doc)).toEqual(value.tags);
+                });
+            }
+        );
     });
 
     describe('user mention', () => {

--- a/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.spec.ts
+++ b/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.spec.ts
@@ -87,7 +87,7 @@ describe('TableColumnAnchor', () => {
             }
         ];
         parameterizeNamedList(noValueData, (spec, name, value) => {
-            spec(`displays empty string when label ${name}`, async() => {
+            spec(`displays empty string when label ${name}`, async () => {
                 await element.setData(value.data);
                 await connect();
                 await waitForUpdatesAsync();
@@ -184,9 +184,9 @@ describe('TableColumnAnchor', () => {
                     await element.setData([{ label: name }]);
                     await waitForUpdatesAsync();
 
-                    expect(
-                        pageObject.getRenderedCellTextContent(0, 0)
-                    ).toBe(name);
+                    expect(pageObject.getRenderedCellTextContent(0, 0)).toBe(
+                        name
+                    );
                 });
             });
         });
@@ -260,7 +260,7 @@ describe('TableColumnAnchor', () => {
                 expect(
                     value.accessor(pageObject.getRenderedCellAnchor(0, 0))
                 ).toBe(`${value.name} value`);
-            })
+            });
         });
 
         describe('with no label', () => {
@@ -417,14 +417,12 @@ describe('TableColumnAnchor', () => {
                 spec(`data "${name}" renders correctly`, async () => {
                     await connect();
 
-                    await element.setData([
-                        { label: name, link: 'url' }
-                    ]);
+                    await element.setData([{ label: name, link: 'url' }]);
                     await waitForUpdatesAsync();
 
-                    expect(
-                        pageObject.getRenderedCellTextContent(0, 0)
-                    ).toBe(name);
+                    expect(pageObject.getRenderedCellTextContent(0, 0)).toBe(
+                        name
+                    );
                 });
             });
         });
@@ -434,9 +432,7 @@ describe('TableColumnAnchor', () => {
                 spec(`data "${name}" renders correctly`, async () => {
                     await connect();
 
-                    await element.setData([
-                        { label: name, link: 'url' }
-                    ]);
+                    await element.setData([{ label: name, link: 'url' }]);
                     await waitForUpdatesAsync();
 
                     expect(

--- a/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.spec.ts
+++ b/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.spec.ts
@@ -6,7 +6,7 @@ import { type Fixture, fixture } from '../../../utilities/tests/fixture';
 import { TableColumnSortDirection, TableRecord } from '../../../table/types';
 import { TablePageObject } from '../../../table/testing/table.pageobject';
 import { wackyStrings } from '../../../utilities/tests/wacky-strings';
-import { getSpecTypeByNamedList } from '../../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../../utilities/tests/parameterized';
 import type { Anchor } from '../../../anchor';
 
 interface SimpleTableRecord extends TableRecord {
@@ -178,30 +178,18 @@ describe('TableColumnAnchor', () => {
         });
 
         describe('various string values render as expected', () => {
-            const focused: string[] = [];
-            const disabled: string[] = [];
-            for (const value of wackyStrings) {
-                const specType = getSpecTypeByNamedList(
-                    value,
-                    focused,
-                    disabled
-                );
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                specType(
-                    `data "${value.name}" renders as "${value.name}"`,
-                    // eslint-disable-next-line @typescript-eslint/no-loop-func
-                    async () => {
-                        await connect();
+            parameterizeNamedList(wackyStrings, (spec, name, value) => {
+                spec(`data "${value.name}" renders as "${value.name}"`, async () => {
+                    await connect();
 
-                        await element.setData([{ label: value.name }]);
-                        await waitForUpdatesAsync();
+                    await element.setData([{ label: value.name }]);
+                    await waitForUpdatesAsync();
 
-                        expect(
-                            pageObject.getRenderedCellTextContent(0, 0)
-                        ).toBe(value.name);
-                    }
-                );
-            }
+                    expect(
+                        pageObject.getRenderedCellTextContent(0, 0)
+                    ).toBe(value.name);
+                });
+            });
         });
     });
 
@@ -427,61 +415,37 @@ describe('TableColumnAnchor', () => {
         }
 
         describe('various string values render as expected', () => {
-            const focused: string[] = [];
-            const disabled: string[] = [];
-            for (const value of wackyStrings) {
-                const specType = getSpecTypeByNamedList(
-                    value,
-                    focused,
-                    disabled
-                );
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                specType(
-                    `data "${value.name}" renders as "${value.name}"`,
-                    // eslint-disable-next-line @typescript-eslint/no-loop-func
-                    async () => {
-                        await connect();
+            parameterizeNamedList(wackyStrings, (spec, name, value) => {
+                spec(`data "${name}" renders as "${name}"`, async () => {
+                    await connect();
 
-                        await element.setData([
-                            { label: value.name, link: 'url' }
-                        ]);
-                        await waitForUpdatesAsync();
+                    await element.setData([
+                        { label: value.name, link: 'url' }
+                    ]);
+                    await waitForUpdatesAsync();
 
-                        expect(
-                            pageObject.getRenderedCellTextContent(0, 0)
-                        ).toBe(value.name);
-                    }
-                );
-            }
+                    expect(
+                        pageObject.getRenderedCellTextContent(0, 0)
+                    ).toBe(value.name);
+                });
+            });
         });
 
         describe('various string values render in group header as expected', () => {
-            const focused: string[] = [];
-            const disabled: string[] = [];
-            for (const value of wackyStrings) {
-                const specType = getSpecTypeByNamedList(
-                    value,
-                    focused,
-                    disabled
-                );
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                specType(
-                    `data "${value.name}" renders as "${value.name}"`,
-                    // eslint-disable-next-line @typescript-eslint/no-loop-func
-                    async () => {
-                        await connect();
+            parameterizeNamedList(wackyStrings, (spec, name, value) => {
+                spec(`data "${name}" renders as "${name}"`, async () => {
+                    await connect();
 
-                        await element.setData([
-                            { label: value.name, link: 'url' }
-                        ]);
-                        await waitForUpdatesAsync();
+                    await element.setData([
+                        { label: value.name, link: 'url' }
+                    ]);
+                    await waitForUpdatesAsync();
 
-                        expect(
-                            pageObject.getRenderedGroupHeaderTextContent(0)
-                        ).toContain(value.name);
-                    }
-                );
-            }
+                    expect(
+                        pageObject.getRenderedGroupHeaderTextContent(0)
+                    ).toContain(value.name);
+                });
+            });
         });
     });
 });

--- a/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.spec.ts
+++ b/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.spec.ts
@@ -85,7 +85,7 @@ describe('TableColumnAnchor', () => {
                 name: 'value is not a string',
                 data: [{ label: 10 as unknown as string }]
             }
-        ];
+        ] as const;
         parameterizeNamedList(noValueData, (spec, name, value) => {
             spec(`displays empty string when label ${name}`, async () => {
                 await element.setData(value.data);
@@ -250,7 +250,7 @@ describe('TableColumnAnchor', () => {
             { name: 'target', accessor: (x: Anchor) => x.target },
             { name: 'type', accessor: (x: Anchor) => x.type },
             { name: 'download', accessor: (x: Anchor) => x.download }
-        ];
+        ] as const;
         parameterizeNamedList(linkOptionData, (spec, name, value) => {
             spec(`sets ${name} on anchor`, async () => {
                 await element.setData([{ link: 'foo' }]);

--- a/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.spec.ts
+++ b/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.spec.ts
@@ -78,24 +78,23 @@ describe('TableColumnAnchor', () => {
 
     describe('with no href', () => {
         const noValueData = [
-            { description: 'field not present', data: [{ unused: 'foo' }] },
-            { description: 'value is null', data: [{ label: null }] },
-            { description: 'value is undefined', data: [{ label: undefined }] },
+            { name: 'field not present', data: [{ unused: 'foo' }] },
+            { name: 'value is null', data: [{ label: null }] },
+            { name: 'value is undefined', data: [{ label: undefined }] },
             {
-                description: 'value is not a string',
+                name: 'value is not a string',
                 data: [{ label: 10 as unknown as string }]
             }
         ];
-        for (const testData of noValueData) {
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            it(`displays empty string when label ${testData.description}`, async () => {
-                await element.setData(testData.data);
+        parameterizeNamedList(noValueData, (spec, name, value) => {
+            spec(`displays empty string when label ${name}`, async() => {
+                await element.setData(value.data);
                 await connect();
                 await waitForUpdatesAsync();
 
                 expect(pageObject.getRenderedCellTextContent(0, 0)).toBe('');
             });
-        }
+        });
 
         it('changing labelFieldName updates display', async () => {
             await element.setData([{ label: 'foo', otherLabel: 'bar' }]);
@@ -178,16 +177,16 @@ describe('TableColumnAnchor', () => {
         });
 
         describe('various string values render as expected', () => {
-            parameterizeNamedList(wackyStrings, (spec, name, value) => {
-                spec(`data "${value.name}" renders as "${value.name}"`, async () => {
+            parameterizeNamedList(wackyStrings, (spec, name) => {
+                spec(`data "${name}" renders correctly`, async () => {
                     await connect();
 
-                    await element.setData([{ label: value.name }]);
+                    await element.setData([{ label: name }]);
                     await waitForUpdatesAsync();
 
                     expect(
                         pageObject.getRenderedCellTextContent(0, 0)
-                    ).toBe(value.name);
+                    ).toBe(name);
                 });
             });
         });
@@ -252,18 +251,17 @@ describe('TableColumnAnchor', () => {
             { name: 'type', accessor: (x: Anchor) => x.type },
             { name: 'download', accessor: (x: Anchor) => x.download }
         ];
-        for (const option of linkOptionData) {
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            it(`sets ${option.name} on anchor`, async () => {
+        parameterizeNamedList(linkOptionData, (spec, name, value) => {
+            spec(`sets ${name} on anchor`, async () => {
                 await element.setData([{ link: 'foo' }]);
                 await connect();
                 await waitForUpdatesAsync();
 
                 expect(
-                    option.accessor(pageObject.getRenderedCellAnchor(0, 0))
-                ).toBe(`${option.name} value`);
-            });
-        }
+                    value.accessor(pageObject.getRenderedCellAnchor(0, 0))
+                ).toBe(`${value.name} value`);
+            })
+        });
 
         describe('with no label', () => {
             it('displays empty string when href is not string', async () => {
@@ -415,35 +413,35 @@ describe('TableColumnAnchor', () => {
         }
 
         describe('various string values render as expected', () => {
-            parameterizeNamedList(wackyStrings, (spec, name, value) => {
-                spec(`data "${name}" renders as "${name}"`, async () => {
+            parameterizeNamedList(wackyStrings, (spec, name) => {
+                spec(`data "${name}" renders correctly`, async () => {
                     await connect();
 
                     await element.setData([
-                        { label: value.name, link: 'url' }
+                        { label: name, link: 'url' }
                     ]);
                     await waitForUpdatesAsync();
 
                     expect(
                         pageObject.getRenderedCellTextContent(0, 0)
-                    ).toBe(value.name);
+                    ).toBe(name);
                 });
             });
         });
 
         describe('various string values render in group header as expected', () => {
-            parameterizeNamedList(wackyStrings, (spec, name, value) => {
-                spec(`data "${name}" renders as "${name}"`, async () => {
+            parameterizeNamedList(wackyStrings, (spec, name) => {
+                spec(`data "${name}" renders correctly`, async () => {
                     await connect();
 
                     await element.setData([
-                        { label: value.name, link: 'url' }
+                        { label: name, link: 'url' }
                     ]);
                     await waitForUpdatesAsync();
 
                     expect(
                         pageObject.getRenderedGroupHeaderTextContent(0)
-                    ).toContain(value.name);
+                    ).toContain(name);
                 });
             });
         });

--- a/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.spec.ts
+++ b/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.spec.ts
@@ -6,7 +6,7 @@ import { type Fixture, fixture } from '../../../utilities/tests/fixture';
 import type { TableRecord } from '../../../table/types';
 import { TablePageObject } from '../../../table/testing/table.pageobject';
 import { TableColumnDateTextPageObject } from '../testing/table-column-date-text.pageobject';
-import { getSpecTypeByNamedList } from '../../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../../utilities/tests/parameterized';
 import { lang, themeProviderTag } from '../../../theme-provider';
 
 interface SimpleTableRecord extends TableRecord {
@@ -109,22 +109,14 @@ describe('TableColumnDateText', () => {
                 }
             ];
 
-            for (const entry of badValueData) {
-                const focused: string[] = [];
-                const disabled: string[] = [];
-                const specType = getSpecTypeByNamedList(
-                    entry,
-                    focused,
-                    disabled
-                );
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                specType(entry.name, async () => {
-                    await table.setData(entry.data);
+            parameterizeNamedList(badValueData, (spec, name, value) => {
+                spec(name, async () => {
+                    await table.setData(value.data);
                     await waitForUpdatesAsync();
 
                     expect(pageObject.getRenderedCellContent(0, 0)).toEqual('');
                 });
-            }
+            });
         });
 
         it('changing fieldName updates display', async () => {

--- a/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.spec.ts
+++ b/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.spec.ts
@@ -107,7 +107,7 @@ describe('TableColumnDateText', () => {
                     name: 'value is not a number',
                     data: [{ field: 'foo' as unknown as number }]
                 }
-            ];
+            ] as const;
 
             parameterizeNamedList(badValueData, (spec, name, value) => {
                 spec(name, async () => {

--- a/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text.spec.ts
+++ b/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text.spec.ts
@@ -7,7 +7,7 @@ import { type Fixture, fixture } from '../../../utilities/tests/fixture';
 import type { TableRecord } from '../../../table/types';
 import { TablePageObject } from '../../../table/testing/table.pageobject';
 import { wackyStrings } from '../../../utilities/tests/wacky-strings';
-import { getSpecTypeByNamedList } from '../../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../../utilities/tests/parameterized';
 import { MappingText, mappingTextTag } from '../../../mapping/text';
 import { mappingSpinnerTag } from '../../../mapping/spinner';
 import { mappingIconTag } from '../../../mapping/icon';
@@ -84,18 +84,14 @@ describe('TableColumnEnumText', () => {
             { name: 'number', key: 10 },
             { name: 'boolean', key: true }
         ];
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const test of dataTypeTests) {
-            const specType = getSpecTypeByNamedList(test, focused, disabled);
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(`displays text mapped from ${test.name}`, async () => {
+        parameterizeNamedList(dataTypeTests, (spec, name, value) => {
+            spec(`displays text mapped from ${name}`, async () => {
                 ({ element, connect, disconnect, model } = await setup(
-                    [{ key: test.key, text: 'alpha' }],
-                    test.name
+                    [{ key: value.key, text: 'alpha' }],
+                    value.name
                 ));
                 pageObject = new TablePageObject<SimpleTableRecord>(element);
-                await element.setData([{ field1: test.key }]);
+                await element.setData([{ field1: value.key }]);
                 await connect();
                 await waitForUpdatesAsync();
 
@@ -103,7 +99,7 @@ describe('TableColumnEnumText', () => {
                     'alpha'
                 );
             });
-        }
+        });
     });
 
     it('displays blank when no matches', async () => {
@@ -168,41 +164,28 @@ describe('TableColumnEnumText', () => {
     });
 
     describe('various string values render as expected', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const value of wackyStrings) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            specType(
-                `data "${value.name}" renders as "${value.name}"`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                async () => {
-                    ({ element, connect, disconnect, model } = await setup([
-                        { key: 'a', text: value.name }
-                    ]));
-                    pageObject = new TablePageObject<SimpleTableRecord>(
-                        element
-                    );
-                    await element.setData([{ field1: 'a' }]);
-                    await connect();
-                    await waitForUpdatesAsync();
+        parameterizeNamedList(wackyStrings, (spec, name, value) => {
+            spec(`data "${name}" renders as "${name}"`, async () => {
+                ({ element, connect, disconnect, model } = await setup([
+                    { key: 'a', text: value.name }
+                ]));
+                pageObject = new TablePageObject<SimpleTableRecord>(
+                    element
+                );
+                await element.setData([{ field1: 'a' }]);
+                await connect();
+                await waitForUpdatesAsync();
 
-                    expect(pageObject.getRenderedCellTextContent(0, 0)).toBe(
-                        value.name
-                    );
-                }
-            );
-        }
+                expect(pageObject.getRenderedCellTextContent(0, 0)).toBe(
+                    value.name
+                );
+            });
+        });
     });
 
     describe('various string values render in group header as expected', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const value of wackyStrings) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            specType(
-                `data "${value.name}" renders as "${value.name}"`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                async () => {
+        parameterizeNamedList(wackyStrings, (spec, name, value) => {
+            spec(`data "${name}" renders as "${name}"`, async () => {
                     ({ element, connect, disconnect, model } = await setup([
                         { key: 'a', text: value.name }
                     ]));
@@ -220,7 +203,7 @@ describe('TableColumnEnumText', () => {
                     ).toContain(value.name);
                 }
             );
-        }
+        });
     });
 
     it('sets group header text to blank when unmatched', async () => {
@@ -355,18 +338,10 @@ describe('TableColumnEnumText', () => {
                 { name: 'FALSE', key: 'FALSE' },
                 { name: '0', key: 0 }
             ];
-            const focused: string[] = [];
-            const disabled: string[] = [];
-            for (const test of dataTypeTests) {
-                const specType = getSpecTypeByNamedList(
-                    test,
-                    focused,
-                    disabled
-                );
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                specType(` ${test.name}`, async () => {
+            parameterizeNamedList(dataTypeTests, (spec, name, value) => {
+                spec(name, async () => {
                     ({ element, connect, disconnect, model } = await setup(
-                        [{ key: test.key, text: 'alpha' }],
+                        [{ key: value.key, text: 'alpha' }],
                         'boolean'
                     ));
                     await connect();
@@ -377,7 +352,7 @@ describe('TableColumnEnumText', () => {
                         column.validity.invalidMappingKeyValueForType
                     ).toBeTrue();
                 });
-            }
+            });
         });
 
         class ModelInvalidMappings {

--- a/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text.spec.ts
+++ b/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text.spec.ts
@@ -83,7 +83,7 @@ describe('TableColumnEnumText', () => {
             { name: 'string', key: 'a' },
             { name: 'number', key: 10 },
             { name: 'boolean', key: true }
-        ];
+        ] as const;
         parameterizeNamedList(dataTypeTests, (spec, name, value) => {
             spec(`displays text mapped from ${name}`, async () => {
                 ({ element, connect, disconnect, model } = await setup(
@@ -330,7 +330,7 @@ describe('TableColumnEnumText', () => {
                 { name: '(blank)', key: '' },
                 { name: 'FALSE', key: 'FALSE' },
                 { name: '0', key: 0 }
-            ];
+            ] as const;
             parameterizeNamedList(dataTypeTests, (spec, name, value) => {
                 spec(name, async () => {
                     ({ element, connect, disconnect, model } = await setup(

--- a/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text.spec.ts
+++ b/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text.spec.ts
@@ -169,16 +169,12 @@ describe('TableColumnEnumText', () => {
                 ({ element, connect, disconnect, model } = await setup([
                     { key: 'a', text: name }
                 ]));
-                pageObject = new TablePageObject<SimpleTableRecord>(
-                    element
-                );
+                pageObject = new TablePageObject<SimpleTableRecord>(element);
                 await element.setData([{ field1: 'a' }]);
                 await connect();
                 await waitForUpdatesAsync();
 
-                expect(pageObject.getRenderedCellTextContent(0, 0)).toBe(
-                    name
-                );
+                expect(pageObject.getRenderedCellTextContent(0, 0)).toBe(name);
             });
         });
     });
@@ -189,9 +185,7 @@ describe('TableColumnEnumText', () => {
                 ({ element, connect, disconnect, model } = await setup([
                     { key: 'a', text: name }
                 ]));
-                pageObject = new TablePageObject<SimpleTableRecord>(
-                    element
-                );
+                pageObject = new TablePageObject<SimpleTableRecord>(element);
                 await element.setData([{ field1: 'a' }]);
                 await connect();
                 await waitForUpdatesAsync();

--- a/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text.spec.ts
+++ b/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text.spec.ts
@@ -164,10 +164,10 @@ describe('TableColumnEnumText', () => {
     });
 
     describe('various string values render as expected', () => {
-        parameterizeNamedList(wackyStrings, (spec, name, value) => {
+        parameterizeNamedList(wackyStrings, (spec, name) => {
             spec(`data "${name}" renders as "${name}"`, async () => {
                 ({ element, connect, disconnect, model } = await setup([
-                    { key: 'a', text: value.name }
+                    { key: 'a', text: name }
                 ]));
                 pageObject = new TablePageObject<SimpleTableRecord>(
                     element
@@ -177,32 +177,31 @@ describe('TableColumnEnumText', () => {
                 await waitForUpdatesAsync();
 
                 expect(pageObject.getRenderedCellTextContent(0, 0)).toBe(
-                    value.name
+                    name
                 );
             });
         });
     });
 
     describe('various string values render in group header as expected', () => {
-        parameterizeNamedList(wackyStrings, (spec, name, value) => {
+        parameterizeNamedList(wackyStrings, (spec, name) => {
             spec(`data "${name}" renders as "${name}"`, async () => {
-                    ({ element, connect, disconnect, model } = await setup([
-                        { key: 'a', text: value.name }
-                    ]));
-                    pageObject = new TablePageObject<SimpleTableRecord>(
-                        element
-                    );
-                    await element.setData([{ field1: 'a' }]);
-                    await connect();
-                    await waitForUpdatesAsync();
-                    model.col1.groupIndex = 0;
-                    await waitForUpdatesAsync();
+                ({ element, connect, disconnect, model } = await setup([
+                    { key: 'a', text: name }
+                ]));
+                pageObject = new TablePageObject<SimpleTableRecord>(
+                    element
+                );
+                await element.setData([{ field1: 'a' }]);
+                await connect();
+                await waitForUpdatesAsync();
+                model.col1.groupIndex = 0;
+                await waitForUpdatesAsync();
 
-                    expect(
-                        pageObject.getRenderedGroupHeaderTextContent(0)
-                    ).toContain(value.name);
-                }
-            );
+                expect(
+                    pageObject.getRenderedGroupHeaderTextContent(0)
+                ).toContain(name);
+            });
         });
     });
 

--- a/packages/nimble-components/src/table-column/icon/tests/table-column-icon.spec.ts
+++ b/packages/nimble-components/src/table-column/icon/tests/table-column-icon.spec.ts
@@ -6,7 +6,7 @@ import { type Fixture, fixture } from '../../../utilities/tests/fixture';
 import type { TableRecord } from '../../../table/types';
 import { TablePageObject } from '../../../table/testing/table.pageobject';
 import { wackyStrings } from '../../../utilities/tests/wacky-strings';
-import { getSpecTypeByNamedList } from '../../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../../utilities/tests/parameterized';
 import { mappingTextTag } from '../../../mapping/text';
 import { MappingIcon, mappingIconTag } from '../../../mapping/icon';
 import { iconXmarkTag } from '../../../icons/xmark';
@@ -101,21 +101,17 @@ describe('TableColumnIcon', () => {
             { name: MappingKeyType.number, key: 10 },
             { name: MappingKeyType.boolean, key: true }
         ];
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const test of dataTypeTests) {
-            const specType = getSpecTypeByNamedList(test, focused, disabled);
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(`displays icon mapped from ${test.name}`, async () => {
+        parameterizeNamedList(dataTypeTests, (spec, name, value) => {
+            spec(`displays icon mapped from ${name}`, async () => {
                 ({ element, connect, disconnect, model } = await setup({
-                    keyType: test.name,
+                    keyType: value.name,
                     iconMappings: [
-                        { key: test.key, text: 'alpha', icon: iconXmarkTag }
+                        { key: value.key, text: 'alpha', icon: iconXmarkTag }
                     ],
                     spinnerMappings: []
                 }));
                 pageObject = new TablePageObject<SimpleTableRecord>(element);
-                await element.setData([{ field1: test.key }]);
+                await element.setData([{ field1: value.key }]);
                 await connect();
                 await waitForUpdatesAsync();
 
@@ -123,19 +119,17 @@ describe('TableColumnIcon', () => {
                     pageObject.getRenderedIconColumnCellIconTagName(0, 0)
                 ).toBe(iconXmarkTag);
             });
-        }
+        });
 
-        for (const test of dataTypeTests) {
-            const specType = getSpecTypeByNamedList(test, focused, disabled);
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(`displays spinner mapped from ${test.name}`, async () => {
+        parameterizeNamedList(dataTypeTests, (spec, name, value) => {
+            spec(`displays spinner mapped from ${name}`, async () => {
                 ({ element, connect, disconnect, model } = await setup({
-                    keyType: test.name,
+                    keyType: value.name,
                     iconMappings: [],
-                    spinnerMappings: [{ key: test.key, text: 'alpha' }]
+                    spinnerMappings: [{ key: value.key, text: 'alpha' }]
                 }));
                 pageObject = new TablePageObject<SimpleTableRecord>(element);
-                await element.setData([{ field1: test.key }]);
+                await element.setData([{ field1: value.key }]);
                 await connect();
                 await waitForUpdatesAsync();
 
@@ -143,7 +137,7 @@ describe('TableColumnIcon', () => {
                     pageObject.getRenderedIconColumnCellIconTagName(0, 0)
                 ).toBe(spinnerTag);
             });
-        }
+        });
     });
 
     it('displays blank when no matches', async () => {
@@ -271,41 +265,33 @@ describe('TableColumnIcon', () => {
     });
 
     describe('various string values render in group header as expected', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const value of wackyStrings) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(
-                `data "${value.name}" renders as "${value.name}"`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                async () => {
-                    ({ element, connect, disconnect, model } = await setup({
-                        keyType: MappingKeyType.string,
-                        iconMappings: [
-                            {
-                                key: 'a',
-                                text: value.name,
-                                icon: iconXmarkTag
-                            }
-                        ],
-                        spinnerMappings: []
-                    }));
-                    pageObject = new TablePageObject<SimpleTableRecord>(
-                        element
-                    );
-                    await element.setData([{ field1: 'a' }]);
-                    await connect();
-                    await waitForUpdatesAsync();
-                    model.col1.groupIndex = 0;
-                    await waitForUpdatesAsync();
+        parameterizeNamedList(wackyStrings, (spec, name, value) => {
+            spec(`data "${name}" renders as "${name}"`, async () => {
+                ({ element, connect, disconnect, model } = await setup({
+                    keyType: MappingKeyType.string,
+                    iconMappings: [
+                        {
+                            key: 'a',
+                            text: value.name,
+                            icon: iconXmarkTag
+                        }
+                    ],
+                    spinnerMappings: []
+                }));
+                pageObject = new TablePageObject<SimpleTableRecord>(
+                    element
+                );
+                await element.setData([{ field1: 'a' }]);
+                await connect();
+                await waitForUpdatesAsync();
+                model.col1.groupIndex = 0;
+                await waitForUpdatesAsync();
 
-                    expect(
-                        pageObject.getRenderedGroupHeaderTextContent(0)
-                    ).toContain(value.name);
-                }
-            );
-        }
+                expect(
+                    pageObject.getRenderedGroupHeaderTextContent(0)
+                ).toContain(value.name);
+            });
+        });
     });
 
     it('sets group header text to blank when unmatched', async () => {
@@ -407,21 +393,13 @@ describe('TableColumnIcon', () => {
                 { name: 'FALSE', key: 'FALSE' },
                 { name: '0', key: 0 }
             ];
-            const focused: string[] = [];
-            const disabled: string[] = [];
-            for (const test of dataTypeTests) {
-                const specType = getSpecTypeByNamedList(
-                    test,
-                    focused,
-                    disabled
-                );
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                specType(` ${test.name}`, async () => {
+            parameterizeNamedList(dataTypeTests, (spec, name, value) => {
+                spec(name, async () => {
                     ({ element, connect, disconnect, model } = await setup({
                         keyType: MappingKeyType.boolean,
                         iconMappings: [
                             {
-                                key: test.key,
+                                key: value.key,
                                 text: 'alpha',
                                 icon: iconXmarkTag
                             }
@@ -435,7 +413,7 @@ describe('TableColumnIcon', () => {
                         model.col1.validity.invalidMappingKeyValueForType
                     ).toBeTrue();
                 });
-            }
+            });
         });
 
         it('is invalid with invalid numeric key values', async () => {

--- a/packages/nimble-components/src/table-column/icon/tests/table-column-icon.spec.ts
+++ b/packages/nimble-components/src/table-column/icon/tests/table-column-icon.spec.ts
@@ -278,9 +278,7 @@ describe('TableColumnIcon', () => {
                     ],
                     spinnerMappings: []
                 }));
-                pageObject = new TablePageObject<SimpleTableRecord>(
-                    element
-                );
+                pageObject = new TablePageObject<SimpleTableRecord>(element);
                 await element.setData([{ field1: 'a' }]);
                 await connect();
                 await waitForUpdatesAsync();

--- a/packages/nimble-components/src/table-column/icon/tests/table-column-icon.spec.ts
+++ b/packages/nimble-components/src/table-column/icon/tests/table-column-icon.spec.ts
@@ -265,14 +265,14 @@ describe('TableColumnIcon', () => {
     });
 
     describe('various string values render in group header as expected', () => {
-        parameterizeNamedList(wackyStrings, (spec, name, value) => {
+        parameterizeNamedList(wackyStrings, (spec, name) => {
             spec(`data "${name}" renders as "${name}"`, async () => {
                 ({ element, connect, disconnect, model } = await setup({
                     keyType: MappingKeyType.string,
                     iconMappings: [
                         {
                             key: 'a',
-                            text: value.name,
+                            text: name,
                             icon: iconXmarkTag
                         }
                     ],
@@ -289,7 +289,7 @@ describe('TableColumnIcon', () => {
 
                 expect(
                     pageObject.getRenderedGroupHeaderTextContent(0)
-                ).toContain(value.name);
+                ).toContain(name);
             });
         });
     });

--- a/packages/nimble-components/src/table-column/icon/tests/table-column-icon.spec.ts
+++ b/packages/nimble-components/src/table-column/icon/tests/table-column-icon.spec.ts
@@ -100,7 +100,7 @@ describe('TableColumnIcon', () => {
             { name: MappingKeyType.string, key: 'a' },
             { name: MappingKeyType.number, key: 10 },
             { name: MappingKeyType.boolean, key: true }
-        ];
+        ] as const;
         parameterizeNamedList(dataTypeTests, (spec, name, value) => {
             spec(`displays icon mapped from ${name}`, async () => {
                 ({ element, connect, disconnect, model } = await setup({
@@ -390,7 +390,7 @@ describe('TableColumnIcon', () => {
                 { name: '(blank)', key: '' },
                 { name: 'FALSE', key: 'FALSE' },
                 { name: '0', key: 0 }
-            ];
+            ] as const;
             parameterizeNamedList(dataTypeTests, (spec, name, value) => {
                 spec(name, async () => {
                     ({ element, connect, disconnect, model } = await setup({

--- a/packages/nimble-components/src/table-column/number-text/models/tests/decimal-formatter.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/models/tests/decimal-formatter.spec.ts
@@ -3,16 +3,7 @@ import { DecimalFormatter } from '../decimal-formatter';
 
 describe('DecimalFormatter', () => {
     const locales = ['en', 'de'] as const;
-    const testCases: readonly {
-        name: string,
-        minDigits: number,
-        maxDigits: number,
-        value: number,
-        expectedFormattedValue: {
-            en: string,
-            de: string
-        }
-    }[] = [
+    const testCases = [
         {
             name: 'NEGATIVE_INFINITY renders as -∞',
             minDigits: 1,

--- a/packages/nimble-components/src/table-column/number-text/models/tests/decimal-formatter.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/models/tests/decimal-formatter.spec.ts
@@ -133,9 +133,7 @@ describe('DecimalFormatter', () => {
                     value.minDigits,
                     value.maxDigits
                 );
-                const formattedValue = formatter.formatValue(
-                    value.value
-                );
+                const formattedValue = formatter.formatValue(value.value);
                 expect(formattedValue).toEqual(
                     value.expectedFormattedValue[locale]
                 );

--- a/packages/nimble-components/src/table-column/number-text/models/tests/decimal-formatter.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/models/tests/decimal-formatter.spec.ts
@@ -1,4 +1,4 @@
-import { getSpecTypeByNamedList } from '../../../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../../../utilities/tests/parameterized';
 import { DecimalFormatter } from '../decimal-formatter';
 
 describe('DecimalFormatter', () => {
@@ -125,33 +125,21 @@ describe('DecimalFormatter', () => {
         }
     ] as const;
 
-    const focused: string[] = [];
-    const disabled: string[] = [];
     for (const locale of locales) {
-        for (const testCase of testCases) {
-            const specType = getSpecTypeByNamedList(
-                testCase,
-                focused,
-                disabled
-            );
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(
-                `${testCase.name} with '${locale}' locale`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                () => {
-                    const formatter = new DecimalFormatter(
-                        locale,
-                        testCase.minDigits,
-                        testCase.maxDigits
-                    );
-                    const formattedValue = formatter.formatValue(
-                        testCase.value
-                    );
-                    expect(formattedValue).toEqual(
-                        testCase.expectedFormattedValue[locale]
-                    );
-                }
-            );
-        }
+        parameterizeNamedList(testCases, (spec, name, value) => {
+            spec(`${name} with '${locale}' locale`, () => {
+                const formatter = new DecimalFormatter(
+                    locale,
+                    value.minDigits,
+                    value.maxDigits
+                );
+                const formattedValue = formatter.formatValue(
+                    value.value
+                );
+                expect(formattedValue).toEqual(
+                    value.expectedFormattedValue[locale]
+                );
+            });
+        });
     }
 });

--- a/packages/nimble-components/src/table-column/number-text/models/tests/default-formatter.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/models/tests/default-formatter.spec.ts
@@ -217,9 +217,7 @@ describe('DefaultFormatter', () => {
         parameterizeNamedList(testCases, (spec, name, value) => {
             spec(`${name} with '${locale}' locale`, () => {
                 const formatter = new DefaultFormatter(locale);
-                const formattedValue = formatter.formatValue(
-                    value.value
-                );
+                const formattedValue = formatter.formatValue(value.value);
                 expect(formattedValue).toEqual(
                     value.expectedFormattedValue[locale]
                 );

--- a/packages/nimble-components/src/table-column/number-text/models/tests/default-formatter.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/models/tests/default-formatter.spec.ts
@@ -3,14 +3,7 @@ import { DefaultFormatter } from '../default-formatter';
 
 describe('DefaultFormatter', () => {
     const locales = ['en', 'de'] as const;
-    const testCases: readonly {
-        name: string,
-        value: number,
-        expectedFormattedValue: {
-            en: string,
-            de: string
-        }
-    }[] = [
+    const testCases = [
         {
             name: 'NEGATIVE_INFINITY renders as -∞',
             value: Number.NEGATIVE_INFINITY,

--- a/packages/nimble-components/src/table-column/number-text/models/tests/default-formatter.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/models/tests/default-formatter.spec.ts
@@ -1,4 +1,4 @@
-import { getSpecTypeByNamedList } from '../../../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../../../utilities/tests/parameterized';
 import { DefaultFormatter } from '../default-formatter';
 
 describe('DefaultFormatter', () => {
@@ -213,29 +213,17 @@ describe('DefaultFormatter', () => {
         }
     ] as const;
 
-    const focused: string[] = [];
-    const disabled: string[] = [];
     for (const locale of locales) {
-        for (const testCase of testCases) {
-            const specType = getSpecTypeByNamedList(
-                testCase,
-                focused,
-                disabled
-            );
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(
-                `${testCase.name} with '${locale}' locale`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                () => {
-                    const formatter = new DefaultFormatter(locale);
-                    const formattedValue = formatter.formatValue(
-                        testCase.value
-                    );
-                    expect(formattedValue).toEqual(
-                        testCase.expectedFormattedValue[locale]
-                    );
-                }
-            );
-        }
+        parameterizeNamedList(testCases, (spec, name, value) => {
+            spec(`${name} with '${locale}' locale`, () => {
+                const formatter = new DefaultFormatter(locale);
+                const formattedValue = formatter.formatValue(
+                    value.value
+                );
+                expect(formattedValue).toEqual(
+                    value.expectedFormattedValue[locale]
+                );
+            });
+        });
     }
 });

--- a/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.spec.ts
@@ -7,7 +7,7 @@ import type { TableRecord } from '../../../table/types';
 import { TablePageObject } from '../../../table/testing/table.pageobject';
 import { NumberTextAlignment, NumberTextFormat } from '../types';
 import type { TableColumnNumberTextCellView } from '../cell-view';
-import { getSpecTypeByNamedList } from '../../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../../utilities/tests/parameterized';
 import { TextCellViewBaseAlignment } from '../../text-base/cell-view/types';
 import { lang, themeProviderTag } from '../../../theme-provider';
 
@@ -579,20 +579,12 @@ describe('TableColumnNumberText', () => {
         }
     ] as const;
     describe('sets the correct initial alignment on the cell', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const testCase of alignmentTestCases) {
-            const specType = getSpecTypeByNamedList(
-                testCase,
-                focused,
-                disabled
-            );
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(`${testCase.name}`, async () => {
+        parameterizeNamedList(alignmentTestCases, (spec, name, value) => {
+            spec(name, async () => {
                 await table.setData([{ number1: 10 }]);
-                elementReferences.column1.format = testCase.format;
-                elementReferences.column1.decimalMaximumDigits = testCase.decimalMaximumDigits;
-                elementReferences.column1.alignment = testCase.configuredColumnAlignment;
+                elementReferences.column1.format = value.format;
+                elementReferences.column1.decimalMaximumDigits = value.decimalMaximumDigits;
+                elementReferences.column1.alignment = value.configuredColumnAlignment;
                 await connect();
                 await waitForUpdatesAsync();
 
@@ -601,10 +593,10 @@ describe('TableColumnNumberText', () => {
                     0
                 ) as TableColumnNumberTextCellView;
                 expect(cellView.alignment).toEqual(
-                    testCase.expectedCellViewAlignment
+                    value.expectedCellViewAlignment
                 );
             });
-        }
+        });
     });
 
     describe('updates alignment', () => {

--- a/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.spec.ts
@@ -78,24 +78,23 @@ describe('TableColumnNumberText', () => {
     });
 
     const noValueData = [
-        { description: 'field not present', data: [{ unused: 'foo' }] },
-        { description: 'value is null', data: [{ number1: null }] },
-        { description: 'value is undefined', data: [{ number1: undefined }] },
+        { name: 'field not present', data: [{ unused: 'foo' }] },
+        { name: 'value is null', data: [{ number1: null }] },
+        { name: 'value is undefined', data: [{ number1: undefined }] },
         {
-            description: 'value is not a number',
+            name: 'value is not a number',
             data: [{ number1: 'hello world' as unknown as number }]
         }
     ];
-    for (const testData of noValueData) {
-        // eslint-disable-next-line @typescript-eslint/no-loop-func
-        it(`displays empty string when ${testData.description}`, async () => {
-            await table.setData(testData.data);
+    parameterizeNamedList(noValueData, (spec, name, value) => {
+        spec(`displays empty string when ${name}`, async () => {
+            await table.setData(value.data);
             await connect();
             await waitForUpdatesAsync();
 
             expect(pageObject.getRenderedCellTextContent(0, 0)).toBe('');
         });
-    }
+    });
 
     it('defaults to "default" format', () => {
         expect(elementReferences.column1.format).toBe(NumberTextFormat.default);

--- a/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.spec.ts
@@ -85,7 +85,7 @@ describe('TableColumnNumberText', () => {
             name: 'value is not a number',
             data: [{ number1: 'hello world' as unknown as number }]
         }
-    ];
+    ] as const;
     parameterizeNamedList(noValueData, (spec, name, value) => {
         spec(`displays empty string when ${name}`, async () => {
             await table.setData(value.data);

--- a/packages/nimble-components/src/table-column/text/tests/table-column-text.spec.ts
+++ b/packages/nimble-components/src/table-column/text/tests/table-column-text.spec.ts
@@ -62,24 +62,23 @@ describe('TableColumnText', () => {
     });
 
     const noValueData = [
-        { description: 'field not present', data: [{ unused: 'foo' }] },
-        { description: 'value is null', data: [{ field: null }] },
-        { description: 'value is undefined', data: [{ field: undefined }] },
+        { name: 'field not present', data: [{ unused: 'foo' }] },
+        { name: 'value is null', data: [{ field: null }] },
+        { name: 'value is undefined', data: [{ field: undefined }] },
         {
-            description: 'value is not a string',
+            name: 'value is not a string',
             data: [{ field: 10 as unknown as string }]
         }
     ];
-    for (const testData of noValueData) {
-        // eslint-disable-next-line @typescript-eslint/no-loop-func
-        it(`displays empty string when ${testData.description}`, async () => {
-            await element.setData(testData.data);
+    parameterizeNamedList(noValueData, (spec, name, value) => {
+        spec(`displays empty string when ${name}`, async () => {
+            await element.setData(value.data);
             await connect();
             await waitForUpdatesAsync();
 
             expect(pageObject.getRenderedCellTextContent(0, 0)).toBe('');
         });
-    }
+    });
 
     it('changing fieldName updates display', async () => {
         await element.setData([{ field: 'foo', anotherField: 'bar' }]);
@@ -197,31 +196,31 @@ describe('TableColumnText', () => {
     });
 
     describe('various string values render as expected', () => {
-        parameterizeNamedList(wackyStrings, (spec, name, value) => {
+        parameterizeNamedList(wackyStrings, (spec, name) => {
             spec(`data "${name}" renders as "${name}"`, async () => {
                 await connect();
 
-                await element.setData([{ field: value.name }]);
+                await element.setData([{ field: name }]);
                 await waitForUpdatesAsync();
 
                 expect(pageObject.getRenderedCellTextContent(0, 0)).toBe(
-                    value.name
+                    name
                 );
             });
         });
     });
 
     describe('various string values render in group header as expected', () => {
-        parameterizeNamedList(wackyStrings, (spec, name, value) => {
+        parameterizeNamedList(wackyStrings, (spec, name) => {
             spec(`data "${name}" renders as "${name}"`, async () => {
                 await connect();
 
-                await element.setData([{ field: value.name }]);
+                await element.setData([{ field: name }]);
                 await waitForUpdatesAsync();
 
                 expect(
                     pageObject.getRenderedGroupHeaderTextContent(0)
-                ).toContain(value.name);
+                ).toContain(name);
             });
         });
     });

--- a/packages/nimble-components/src/table-column/text/tests/table-column-text.spec.ts
+++ b/packages/nimble-components/src/table-column/text/tests/table-column-text.spec.ts
@@ -69,7 +69,7 @@ describe('TableColumnText', () => {
             name: 'value is not a string',
             data: [{ field: 10 as unknown as string }]
         }
-    ];
+    ] as const;
     parameterizeNamedList(noValueData, (spec, name, value) => {
         spec(`displays empty string when ${name}`, async () => {
             await element.setData(value.data);

--- a/packages/nimble-components/src/table-column/text/tests/table-column-text.spec.ts
+++ b/packages/nimble-components/src/table-column/text/tests/table-column-text.spec.ts
@@ -203,9 +203,7 @@ describe('TableColumnText', () => {
                 await element.setData([{ field: name }]);
                 await waitForUpdatesAsync();
 
-                expect(pageObject.getRenderedCellTextContent(0, 0)).toBe(
-                    name
-                );
+                expect(pageObject.getRenderedCellTextContent(0, 0)).toBe(name);
             });
         });
     });

--- a/packages/nimble-components/src/table-column/text/tests/table-column-text.spec.ts
+++ b/packages/nimble-components/src/table-column/text/tests/table-column-text.spec.ts
@@ -6,7 +6,7 @@ import { type Fixture, fixture } from '../../../utilities/tests/fixture';
 import type { TableRecord } from '../../../table/types';
 import { TablePageObject } from '../../../table/testing/table.pageobject';
 import { wackyStrings } from '../../../utilities/tests/wacky-strings';
-import { getSpecTypeByNamedList } from '../../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../../utilities/tests/parameterized';
 
 interface SimpleTableRecord extends TableRecord {
     field?: string | null;
@@ -197,48 +197,32 @@ describe('TableColumnText', () => {
     });
 
     describe('various string values render as expected', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const value of wackyStrings) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(
-                `data "${value.name}" renders as "${value.name}"`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                async () => {
-                    await connect();
+        parameterizeNamedList(wackyStrings, (spec, name, value) => {
+            spec(`data "${name}" renders as "${name}"`, async () => {
+                await connect();
 
-                    await element.setData([{ field: value.name }]);
-                    await waitForUpdatesAsync();
+                await element.setData([{ field: value.name }]);
+                await waitForUpdatesAsync();
 
-                    expect(pageObject.getRenderedCellTextContent(0, 0)).toBe(
-                        value.name
-                    );
-                }
-            );
-        }
+                expect(pageObject.getRenderedCellTextContent(0, 0)).toBe(
+                    value.name
+                );
+            });
+        });
     });
 
     describe('various string values render in group header as expected', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const value of wackyStrings) {
-            const specType = getSpecTypeByNamedList(value, focused, disabled);
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(
-                `data "${value.name}" renders as "${value.name}"`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                async () => {
-                    await connect();
+        parameterizeNamedList(wackyStrings, (spec, name, value) => {
+            spec(`data "${name}" renders as "${name}"`, async () => {
+                await connect();
 
-                    await element.setData([{ field: value.name }]);
-                    await waitForUpdatesAsync();
+                await element.setData([{ field: value.name }]);
+                await waitForUpdatesAsync();
 
-                    expect(
-                        pageObject.getRenderedGroupHeaderTextContent(0)
-                    ).toContain(value.name);
-                }
-            );
-        }
+                expect(
+                    pageObject.getRenderedGroupHeaderTextContent(0)
+                ).toContain(value.name);
+            });
+        });
     });
 });

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -307,7 +307,9 @@ export class Table<
         return selectedRecordIds;
     }
 
-    public async setSelectedRecordIds(recordIds: readonly string[]): Promise<void> {
+    public async setSelectedRecordIds(
+        recordIds: readonly string[]
+    ): Promise<void> {
         await this.processPendingUpdates();
 
         if (this.selectionMode === TableRowSelectionMode.none) {

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -307,7 +307,7 @@ export class Table<
         return selectedRecordIds;
     }
 
-    public async setSelectedRecordIds(recordIds: string[]): Promise<void> {
+    public async setSelectedRecordIds(recordIds: readonly string[]): Promise<void> {
         await this.processPendingUpdates();
 
         if (this.selectionMode === TableRowSelectionMode.none) {
@@ -1075,7 +1075,7 @@ export class Table<
     }
 
     private calculateTanStackSelectionState(
-        recordIdsToSelect: string[]
+        recordIdsToSelect: readonly string[]
     ): TanStackRowSelectionState {
         if (this.selectionMode === TableRowSelectionMode.none) {
             return {};

--- a/packages/nimble-components/src/table/models/table-validator.ts
+++ b/packages/nimble-components/src/table/models/table-validator.ts
@@ -102,7 +102,9 @@ export class TableValidator<TData extends TableNode> {
         );
     }
 
-    public validateColumnIds(columnIds: readonly (string | undefined)[]): boolean {
+    public validateColumnIds(
+        columnIds: readonly (string | undefined)[]
+    ): boolean {
         this.missingColumnId = false;
         this.duplicateColumnId = false;
 
@@ -133,19 +135,25 @@ export class TableValidator<TData extends TableNode> {
         return !this.duplicateSortIndex;
     }
 
-    public validateColumnGroupIndices(groupIndices: readonly number[]): boolean {
+    public validateColumnGroupIndices(
+        groupIndices: readonly number[]
+    ): boolean {
         this.duplicateGroupIndex = !this.validateIndicesAreUnique(groupIndices);
         return !this.duplicateGroupIndex;
     }
 
-    public validateColumnConfigurations(columns: readonly TableColumn[]): boolean {
+    public validateColumnConfigurations(
+        columns: readonly TableColumn[]
+    ): boolean {
         this.invalidColumnConfiguration = columns.some(
             x => !x.columnInternals.validConfiguration
         );
         return !this.invalidColumnConfiguration;
     }
 
-    public getPresentRecordIds(requestedRecordIds: readonly string[]): string[] {
+    public getPresentRecordIds(
+        requestedRecordIds: readonly string[]
+    ): string[] {
         return requestedRecordIds.filter(id => this.recordIds.has(id));
     }
 

--- a/packages/nimble-components/src/table/models/table-validator.ts
+++ b/packages/nimble-components/src/table/models/table-validator.ts
@@ -59,7 +59,7 @@ export class TableValidator<TData extends TableNode> {
     }
 
     public validateRecordIds(
-        data: TData[],
+        data: readonly TData[],
         idFieldName: string | undefined
     ): boolean {
         // Start off by assuming all IDs are valid.
@@ -102,7 +102,7 @@ export class TableValidator<TData extends TableNode> {
         );
     }
 
-    public validateColumnIds(columnIds: (string | undefined)[]): boolean {
+    public validateColumnIds(columnIds: readonly (string | undefined)[]): boolean {
         this.missingColumnId = false;
         this.duplicateColumnId = false;
 
@@ -128,28 +128,28 @@ export class TableValidator<TData extends TableNode> {
         return !this.missingColumnId && !this.duplicateColumnId;
     }
 
-    public validateColumnSortIndices(sortIndices: number[]): boolean {
+    public validateColumnSortIndices(sortIndices: readonly number[]): boolean {
         this.duplicateSortIndex = !this.validateIndicesAreUnique(sortIndices);
         return !this.duplicateSortIndex;
     }
 
-    public validateColumnGroupIndices(groupIndices: number[]): boolean {
+    public validateColumnGroupIndices(groupIndices: readonly number[]): boolean {
         this.duplicateGroupIndex = !this.validateIndicesAreUnique(groupIndices);
         return !this.duplicateGroupIndex;
     }
 
-    public validateColumnConfigurations(columns: TableColumn[]): boolean {
+    public validateColumnConfigurations(columns: readonly TableColumn[]): boolean {
         this.invalidColumnConfiguration = columns.some(
             x => !x.columnInternals.validConfiguration
         );
         return !this.invalidColumnConfiguration;
     }
 
-    public getPresentRecordIds(requestedRecordIds: string[]): string[] {
+    public getPresentRecordIds(requestedRecordIds: readonly string[]): string[] {
         return requestedRecordIds.filter(id => this.recordIds.has(id));
     }
 
-    private validateIndicesAreUnique(indices: number[]): boolean {
+    private validateIndicesAreUnique(indices: readonly number[]): boolean {
         const numberSet = new Set<number>(indices);
         return numberSet.size === indices.length;
     }

--- a/packages/nimble-components/src/table/models/tests/table-validator.spec.ts
+++ b/packages/nimble-components/src/table/models/tests/table-validator.spec.ts
@@ -1,6 +1,6 @@
 import { TableNode, TableRowSelectionMode, TableValidity } from '../../types';
 import { TableValidator } from '../table-validator';
-import { getSpecTypeByNamedList } from '../../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../../utilities/tests/parameterized';
 import {
     TableColumnValidationTest,
     tableColumnValidationTestTag
@@ -282,26 +282,19 @@ describe('TableValidator', () => {
             }
         ];
 
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const columnConfiguration of columnConfigurations) {
-            const specType = getSpecTypeByNamedList(
-                columnConfiguration,
-                focused,
-                disabled
-            );
-            specType(columnConfiguration.name, () => {
+        parameterizeNamedList(columnConfigurations, (spec, name, value) => {
+            spec(name, () => {
                 const tableValidator = new TableValidator();
                 const isValid = tableValidator.validateColumnConfigurations(
-                    columnConfiguration.columns
+                    value.columns
                 );
 
-                expect(isValid).toBe(columnConfiguration.isValid);
+                expect(isValid).toBe(value.isValid);
                 expect(tableValidator.isValid()).toBe(
-                    columnConfiguration.isValid
+                    value.isValid
                 );
             });
-        }
+        });
 
         it('updates when column validity changes to invalid', () => {
             const tableValidator = new TableValidator();
@@ -379,31 +372,24 @@ describe('TableValidator', () => {
             }
         ];
 
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const columnConfiguration of columnConfigurations) {
-            const specType = getSpecTypeByNamedList(
-                columnConfiguration,
-                focused,
-                disabled
-            );
-            specType(columnConfiguration.name, () => {
+        parameterizeNamedList(columnConfigurations, (spec, name, value) => {
+            spec(name, () => {
                 const tableValidator = new TableValidator();
                 const isValid = tableValidator.validateColumnIds(
-                    columnConfiguration.columnIds
+                    value.columnIds
                 );
 
-                expect(isValid).toBe(columnConfiguration.isValid);
+                expect(isValid).toBe(value.isValid);
                 expect(tableValidator.isValid()).toBe(
-                    columnConfiguration.invalidKeys.length === 0
+                    value.invalidKeys.length === 0
                 );
                 expect(getInvalidKeys(tableValidator)).toEqual(
                     jasmine.arrayWithExactContents(
-                        columnConfiguration.invalidKeys
+                        value.invalidKeys
                     )
                 );
             });
-        }
+        });
     });
 
     describe('column sort index validation', () => {
@@ -475,31 +461,24 @@ describe('TableValidator', () => {
             }
         ];
 
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const columnConfiguration of columnConfigurations) {
-            const specType = getSpecTypeByNamedList(
-                columnConfiguration,
-                focused,
-                disabled
-            );
-            specType(columnConfiguration.name, () => {
+        parameterizeNamedList(columnConfigurations, (spec, name, value) => {
+            spec(name, () => {
                 const tableValidator = new TableValidator();
                 const isValid = tableValidator.validateColumnSortIndices(
-                    columnConfiguration.sortIndices
+                    value.sortIndices
                 );
 
-                expect(isValid).toBe(columnConfiguration.isValid);
+                expect(isValid).toBe(value.isValid);
                 expect(tableValidator.isValid()).toBe(
-                    columnConfiguration.invalidKeys.length === 0
+                    value.invalidKeys.length === 0
                 );
                 expect(getInvalidKeys(tableValidator)).toEqual(
                     jasmine.arrayWithExactContents(
-                        columnConfiguration.invalidKeys
+                        value.invalidKeys
                     )
                 );
             });
-        }
+        });
     });
 
     describe('column group index validation', () => {
@@ -579,31 +558,24 @@ describe('TableValidator', () => {
             }
         ];
 
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const columnConfiguration of columnConfigurations) {
-            const specType = getSpecTypeByNamedList(
-                columnConfiguration,
-                focused,
-                disabled
-            );
-            specType(columnConfiguration.name, () => {
+        parameterizeNamedList(columnConfigurations, (spec, name, value) => {
+            spec(name, () => {
                 const tableValidator = new TableValidator();
                 const isValid = tableValidator.validateColumnGroupIndices(
-                    columnConfiguration.groupIndices
+                    value.groupIndices
                 );
 
-                expect(isValid).toBe(columnConfiguration.isValid);
+                expect(isValid).toBe(value.isValid);
                 expect(tableValidator.isValid()).toBe(
-                    columnConfiguration.invalidKeys.length === 0
+                    value.invalidKeys.length === 0
                 );
                 expect(getInvalidKeys(tableValidator)).toEqual(
                     jasmine.arrayWithExactContents(
-                        columnConfiguration.invalidKeys
+                        value.invalidKeys
                     )
                 );
             });
-        }
+        });
     });
 
     describe('row selection mode validation', () => {
@@ -658,32 +630,25 @@ describe('TableValidator', () => {
             }
         ];
 
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const selectionConfiguration of selectionConfigurations) {
-            const specType = getSpecTypeByNamedList(
-                selectionConfiguration,
-                focused,
-                disabled
-            );
-            specType(selectionConfiguration.name, () => {
+        parameterizeNamedList(selectionConfigurations, (spec, name, value) => {
+            spec(name, () => {
                 const tableValidator = new TableValidator();
                 const isValid = tableValidator.validateSelectionMode(
-                    selectionConfiguration.selectionMode,
-                    selectionConfiguration.idFieldName
+                    value.selectionMode,
+                    value.idFieldName
                 );
 
-                expect(isValid).toBe(selectionConfiguration.isValid);
+                expect(isValid).toBe(value.isValid);
                 expect(tableValidator.isValid()).toBe(
-                    selectionConfiguration.isValid
+                    value.isValid
                 );
                 expect(getInvalidKeys(tableValidator)).toEqual(
                     jasmine.arrayWithExactContents(
-                        selectionConfiguration.invalidKeys
+                        value.invalidKeys
                     )
                 );
             });
-        }
+        });
     });
 
     describe('getPresentRecordIds', () => {

--- a/packages/nimble-components/src/table/models/tests/table-validator.spec.ts
+++ b/packages/nimble-components/src/table/models/tests/table-validator.spec.ts
@@ -1,4 +1,4 @@
-import { TableNode, TableRowSelectionMode, TableValidity } from '../../types';
+import { TableNode, TableRowSelectionMode } from '../../types';
 import { TableValidator } from '../table-validator';
 import { parameterizeNamedList } from '../../../utilities/tests/parameterized';
 import {

--- a/packages/nimble-components/src/table/models/tests/table-validator.spec.ts
+++ b/packages/nimble-components/src/table/models/tests/table-validator.spec.ts
@@ -247,11 +247,7 @@ describe('TableValidator', () => {
     });
 
     describe('column config validation', () => {
-        const columnConfigurations: {
-            columns: TableColumnValidationTest[],
-            isValid: boolean,
-            name: string
-        }[] = [
+        const columnConfigurations = [
             {
                 columns: [
                     Object.assign(
@@ -280,7 +276,7 @@ describe('TableValidator', () => {
                 isValid: true,
                 name: 'is valid when all columns return true from checkValidity'
             }
-        ];
+        ] as const;
 
         parameterizeNamedList(columnConfigurations, (spec, name, value) => {
             spec(name, () => {
@@ -326,12 +322,7 @@ describe('TableValidator', () => {
     });
 
     describe('column ID validation', () => {
-        const columnConfigurations: {
-            columnIds: (string | undefined)[],
-            isValid: boolean,
-            invalidKeys: (keyof TableValidity)[],
-            name: string
-        }[] = [
+        const columnConfigurations = [
             {
                 columnIds: [undefined, ''],
                 isValid: true,
@@ -368,7 +359,7 @@ describe('TableValidator', () => {
                 invalidKeys: ['missingColumnId'],
                 name: 'does not allow empty string as a defined column ID'
             }
-        ];
+        ] as const;
 
         parameterizeNamedList(columnConfigurations, (spec, name, value) => {
             spec(name, () => {
@@ -389,12 +380,7 @@ describe('TableValidator', () => {
     });
 
     describe('column sort index validation', () => {
-        const columnConfigurations: {
-            sortIndices: number[],
-            isValid: boolean,
-            invalidKeys: (keyof TableValidity)[],
-            name: string
-        }[] = [
+        const columnConfigurations = [
             {
                 sortIndices: [1, 2, 3],
                 isValid: true,
@@ -455,7 +441,7 @@ describe('TableValidator', () => {
                 invalidKeys: [],
                 name: 'special numeric values are valid'
             }
-        ];
+        ] as const;
 
         parameterizeNamedList(columnConfigurations, (spec, name, value) => {
             spec(name, () => {
@@ -476,12 +462,7 @@ describe('TableValidator', () => {
     });
 
     describe('column group index validation', () => {
-        const columnConfigurations: {
-            groupIndices: number[],
-            isValid: boolean,
-            invalidKeys: (keyof TableValidity)[],
-            name: string
-        }[] = [
+        const columnConfigurations = [
             {
                 groupIndices: [1, 2, 3],
                 isValid: true,
@@ -550,7 +531,7 @@ describe('TableValidator', () => {
                 invalidKeys: [],
                 name: 'special numeric values are valid'
             }
-        ];
+        ] as const;
 
         parameterizeNamedList(columnConfigurations, (spec, name, value) => {
             spec(name, () => {
@@ -571,13 +552,7 @@ describe('TableValidator', () => {
     });
 
     describe('row selection mode validation', () => {
-        const selectionConfigurations: {
-            selectionMode: TableRowSelectionMode,
-            idFieldName: string | undefined,
-            isValid: boolean,
-            invalidKeys: (keyof TableValidity)[],
-            name: string
-        }[] = [
+        const selectionConfigurations = [
             {
                 selectionMode: TableRowSelectionMode.none,
                 idFieldName: 'my-id',
@@ -620,7 +595,7 @@ describe('TableValidator', () => {
                 invalidKeys: ['idFieldNameNotConfigured'],
                 name: 'selection mode of "multiple" without an id field name specified is invalid'
             }
-        ];
+        ] as const;
 
         parameterizeNamedList(selectionConfigurations, (spec, name, value) => {
             spec(name, () => {

--- a/packages/nimble-components/src/table/models/tests/table-validator.spec.ts
+++ b/packages/nimble-components/src/table/models/tests/table-validator.spec.ts
@@ -290,9 +290,7 @@ describe('TableValidator', () => {
                 );
 
                 expect(isValid).toBe(value.isValid);
-                expect(tableValidator.isValid()).toBe(
-                    value.isValid
-                );
+                expect(tableValidator.isValid()).toBe(value.isValid);
             });
         });
 
@@ -384,9 +382,7 @@ describe('TableValidator', () => {
                     value.invalidKeys.length === 0
                 );
                 expect(getInvalidKeys(tableValidator)).toEqual(
-                    jasmine.arrayWithExactContents(
-                        value.invalidKeys
-                    )
+                    jasmine.arrayWithExactContents(value.invalidKeys)
                 );
             });
         });
@@ -473,9 +469,7 @@ describe('TableValidator', () => {
                     value.invalidKeys.length === 0
                 );
                 expect(getInvalidKeys(tableValidator)).toEqual(
-                    jasmine.arrayWithExactContents(
-                        value.invalidKeys
-                    )
+                    jasmine.arrayWithExactContents(value.invalidKeys)
                 );
             });
         });
@@ -570,9 +564,7 @@ describe('TableValidator', () => {
                     value.invalidKeys.length === 0
                 );
                 expect(getInvalidKeys(tableValidator)).toEqual(
-                    jasmine.arrayWithExactContents(
-                        value.invalidKeys
-                    )
+                    jasmine.arrayWithExactContents(value.invalidKeys)
                 );
             });
         });
@@ -639,13 +631,9 @@ describe('TableValidator', () => {
                 );
 
                 expect(isValid).toBe(value.isValid);
-                expect(tableValidator.isValid()).toBe(
-                    value.isValid
-                );
+                expect(tableValidator.isValid()).toBe(value.isValid);
                 expect(getInvalidKeys(tableValidator)).toEqual(
-                    jasmine.arrayWithExactContents(
-                        value.invalidKeys
-                    )
+                    jasmine.arrayWithExactContents(value.invalidKeys)
                 );
             });
         });

--- a/packages/nimble-components/src/table/testing/table.pageobject.ts
+++ b/packages/nimble-components/src/table/testing/table.pageobject.ts
@@ -528,7 +528,7 @@ export class TablePageObject<T extends TableRecord> {
      */
     public dragSizeColumnByRightDivider(
         columnIndex: number,
-        deltas: number[]
+        deltas: readonly number[]
     ): void {
         const divider = this.getColumnRightDivider(columnIndex);
         if (!divider) {
@@ -563,7 +563,7 @@ export class TablePageObject<T extends TableRecord> {
      */
     public dragSizeColumnByLeftDivider(
         columnIndex: number,
-        deltas: number[]
+        deltas: readonly number[]
     ): void {
         const divider = this.getColumnLeftDivider(columnIndex);
         if (!divider) {

--- a/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
@@ -195,7 +195,8 @@ describe('Table Column Sizing', () => {
             }
         ];
         parameterizeNamedList(columnSizeTests, (spec, name, value) => {
-            spec(name,
+            spec(
+                name,
                 async () => {
                     await connect();
                     await pageObject.sizeTableToGivenRowWidth(
@@ -297,38 +298,37 @@ describe('Table Column Sizing', () => {
         ];
         parameterizeNamedList(tests, (spec, name, value) => {
             spec(name, async () => {
-                    await connect();
-                    await pageObject.sizeTableToGivenRowWidth(300, element);
-                    await element.setData(largeTableData);
-                    await connect();
-                    await waitForUpdatesAsync();
+                await connect();
+                await pageObject.sizeTableToGivenRowWidth(300, element);
+                await element.setData(largeTableData);
+                await connect();
+                await waitForUpdatesAsync();
 
-                    column1.columnInternals.fractionalWidth = value.column1FractionalWidth;
-                    if (value.column1MinPixelWidth !== null) {
-                        column1.columnInternals.minPixelWidth = value.column1MinPixelWidth;
-                    }
-
-                    column2.columnInternals.fractionalWidth = value.column2FractionalWidth;
-                    if (value.column2MinPixelWidth !== null) {
-                        column2.columnInternals.minPixelWidth = value.column2MinPixelWidth;
-                    }
-
-                    await waitForUpdatesAsync();
-                    const firstRowColumn1RenderedWidth = pageObject.getCellRenderedWidth(0, 0);
-                    const firstRowColumn2RenderedWidth = pageObject.getCellRenderedWidth(0, 1);
-                    await pageObject.scrollToLastRowAsync();
-                    const lastRowIndex = pageObject.getRenderedRowCount() - 1;
-                    const lastRowColumn1RenderedWidth = pageObject.getCellRenderedWidth(lastRowIndex, 0);
-                    const lastRowColumn2RenderedWidth = pageObject.getCellRenderedWidth(lastRowIndex, 1);
-
-                    expect(firstRowColumn1RenderedWidth).toBe(
-                        lastRowColumn1RenderedWidth
-                    );
-                    expect(firstRowColumn2RenderedWidth).toBe(
-                        lastRowColumn2RenderedWidth
-                    );
+                column1.columnInternals.fractionalWidth = value.column1FractionalWidth;
+                if (value.column1MinPixelWidth !== null) {
+                    column1.columnInternals.minPixelWidth = value.column1MinPixelWidth;
                 }
-            );
+
+                column2.columnInternals.fractionalWidth = value.column2FractionalWidth;
+                if (value.column2MinPixelWidth !== null) {
+                    column2.columnInternals.minPixelWidth = value.column2MinPixelWidth;
+                }
+
+                await waitForUpdatesAsync();
+                const firstRowColumn1RenderedWidth = pageObject.getCellRenderedWidth(0, 0);
+                const firstRowColumn2RenderedWidth = pageObject.getCellRenderedWidth(0, 1);
+                await pageObject.scrollToLastRowAsync();
+                const lastRowIndex = pageObject.getRenderedRowCount() - 1;
+                const lastRowColumn1RenderedWidth = pageObject.getCellRenderedWidth(lastRowIndex, 0);
+                const lastRowColumn2RenderedWidth = pageObject.getCellRenderedWidth(lastRowIndex, 1);
+
+                expect(firstRowColumn1RenderedWidth).toBe(
+                    lastRowColumn1RenderedWidth
+                );
+                expect(firstRowColumn2RenderedWidth).toBe(
+                    lastRowColumn2RenderedWidth
+                );
+            });
         });
     });
 });
@@ -466,22 +466,21 @@ describe('Table Interactive Column Sizing', () => {
         ];
         parameterizeNamedList(columnSizeTests, (spec, name, value) => {
             spec(name, async () => {
-                    element.columns.forEach((column, i) => {
-                        column.columnInternals.fractionalWidth = value.fractionalWidths[i]!;
-                        column.columnInternals.pixelWidth = value.pixelWidths[i]!;
-                        column.columnInternals.minPixelWidth = value.minPixelWidths[i]!;
-                    });
-                    await waitForUpdatesAsync();
-                    pageObject.dragSizeColumnByRightDivider(
-                        value.columnDragIndex,
-                        value.dragDeltas
-                    );
-                    await waitForUpdatesAsync();
-                    value.expectedColumnWidths.forEach((width, i) => expect(pageObject.getCellRenderedWidth(0, i)).toBe(
-                        width
-                    ));
-                }
-            );
+                element.columns.forEach((column, i) => {
+                    column.columnInternals.fractionalWidth = value.fractionalWidths[i]!;
+                    column.columnInternals.pixelWidth = value.pixelWidths[i]!;
+                    column.columnInternals.minPixelWidth = value.minPixelWidths[i]!;
+                });
+                await waitForUpdatesAsync();
+                pageObject.dragSizeColumnByRightDivider(
+                    value.columnDragIndex,
+                    value.dragDeltas
+                );
+                await waitForUpdatesAsync();
+                value.expectedColumnWidths.forEach((width, i) => expect(pageObject.getCellRenderedWidth(0, i)).toBe(
+                    width
+                ));
+            });
         });
 
         it('when table width is smaller than total column min width, dragging column still expands column', async () => {
@@ -725,24 +724,23 @@ describe('Table Interactive Column Sizing', () => {
         ];
         parameterizeNamedList(hiddenColumDragRightDividerTests, (spec, name, value) => {
             spec(name, async () => {
-                    await pageObject.sizeTableToGivenRowWidth(
-                        value.tableWidth,
-                        element
-                    );
-                    value.hiddenColumns.forEach(columnIndex => {
-                        element.columns[columnIndex]!.columnHidden = true;
-                    });
-                    await waitForUpdatesAsync();
-                    pageObject.dragSizeColumnByLeftDivider(
-                        value.dragColumnIndex,
-                        value.dragDeltas
-                    );
-                    await waitForUpdatesAsync();
-                    value.expectedColumnWidths.forEach((width, i) => expect(pageObject.getCellRenderedWidth(0, i)).toBe(
-                        width
-                    ));
-                }
-            );
+                await pageObject.sizeTableToGivenRowWidth(
+                    value.tableWidth,
+                    element
+                );
+                value.hiddenColumns.forEach(columnIndex => {
+                    element.columns[columnIndex]!.columnHidden = true;
+                });
+                await waitForUpdatesAsync();
+                pageObject.dragSizeColumnByLeftDivider(
+                    value.dragColumnIndex,
+                    value.dragDeltas
+                );
+                await waitForUpdatesAsync();
+                value.expectedColumnWidths.forEach((width, i) => expect(pageObject.getCellRenderedWidth(0, i)).toBe(
+                    width
+                ));
+            });
         });
     });
 

--- a/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
@@ -193,7 +193,7 @@ describe('Table Column Sizing', () => {
                 column1ExpectedRenderedWidth: 350,
                 column2ExpectedRenderedWidth: 100
             }
-        ];
+        ] as const;
         parameterizeNamedList(columnSizeTests, (spec, name, value) => {
             spec(name, async () => {
                 await connect();
@@ -294,7 +294,7 @@ describe('Table Column Sizing', () => {
                 column2PixelWidth: null,
                 column2MinPixelWidth: null
             }
-        ];
+        ] as const;
         parameterizeNamedList(tests, (spec, name, value) => {
             spec(name, async () => {
                 await connect();
@@ -462,7 +462,7 @@ describe('Table Interactive Column Sizing', () => {
                 minPixelWidths: [50, 50, 50, 175],
                 expectedColumnWidths: [75, 75, 50, 200]
             }
-        ];
+        ] as const;
         parameterizeNamedList(columnSizeTests, (spec, name, value) => {
             spec(name, async () => {
                 element.columns.forEach((column, i) => {
@@ -629,7 +629,7 @@ describe('Table Interactive Column Sizing', () => {
                 dragDeltas: [-50],
                 expectedColumnWidths: [100, 50, 150]
             }
-        ];
+        ] as const;
         parameterizeNamedList(
             hiddenColumDragRightDividerTests,
             (spec, name, value) => {
@@ -721,7 +721,7 @@ describe('Table Interactive Column Sizing', () => {
                 dragDeltas: [-50],
                 expectedColumnWidths: [100, 50, 150]
             }
-        ];
+        ] as const;
         parameterizeNamedList(
             hiddenColumDragRightDividerTests,
             (spec, name, value) => {
@@ -780,7 +780,7 @@ describe('Table Interactive Column Sizing', () => {
                 dividerClickIndex: 5,
                 expectedActiveIndexes: [5]
             }
-        ];
+        ] as const;
         parameterizeNamedList(dividerActiveTests, (spec, name, value) => {
             spec(name, async () => {
                 const dividers = Array.from(

--- a/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
@@ -8,7 +8,7 @@ import type {
     TableRecord
 } from '../types';
 import { TablePageObject } from '../testing/table.pageobject';
-import { getSpecTypeByNamedList } from '../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../utilities/tests/parameterized';
 import { createEventListener } from '../../utilities/tests/component';
 
 interface SimpleTableRecord extends TableRecord {
@@ -194,41 +194,32 @@ describe('Table Column Sizing', () => {
                 column2ExpectedRenderedWidth: 100
             }
         ];
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const columnSizeTest of columnSizeTests) {
-            const specType = getSpecTypeByNamedList(
-                columnSizeTest,
-                focused,
-                disabled
-            );
-            specType(
-                `${columnSizeTest.name}`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
+        parameterizeNamedList(columnSizeTests, (spec, name, value) => {
+            spec(name,
                 async () => {
                     await connect();
                     await pageObject.sizeTableToGivenRowWidth(
-                        columnSizeTest.rowWidth,
+                        value.rowWidth,
                         element
                     );
                     await element.setData(simpleTableData);
                     await connect();
                     await waitForUpdatesAsync();
 
-                    column1.columnInternals.fractionalWidth = columnSizeTest.column1FractionalWidth;
-                    column1.columnInternals.pixelWidth = columnSizeTest.column1PixelWidth;
+                    column1.columnInternals.fractionalWidth = value.column1FractionalWidth;
+                    column1.columnInternals.pixelWidth = value.column1PixelWidth;
                     if (
-                        typeof columnSizeTest.column1MinPixelWidth === 'number'
+                        typeof value.column1MinPixelWidth === 'number'
                     ) {
-                        column1.columnInternals.minPixelWidth = columnSizeTest.column1MinPixelWidth;
+                        column1.columnInternals.minPixelWidth = value.column1MinPixelWidth;
                     }
 
-                    column2.columnInternals.fractionalWidth = columnSizeTest.column2FractionalWidth;
-                    column2.columnInternals.pixelWidth = columnSizeTest.column2PixelWidth;
+                    column2.columnInternals.fractionalWidth = value.column2FractionalWidth;
+                    column2.columnInternals.pixelWidth = value.column2PixelWidth;
                     if (
-                        typeof columnSizeTest.column2MinPixelWidth === 'number'
+                        typeof value.column2MinPixelWidth === 'number'
                     ) {
-                        column2.columnInternals.minPixelWidth = columnSizeTest.column2MinPixelWidth;
+                        column2.columnInternals.minPixelWidth = value.column2MinPixelWidth;
                     }
 
                     await waitForUpdatesAsync();
@@ -237,20 +228,20 @@ describe('Table Column Sizing', () => {
                     const header1RenderedWidth = pageObject.getHeaderRenderedWidth(0);
                     const header2RenderedWidth = pageObject.getHeaderRenderedWidth(1);
                     expect(column1RenderedWidth).toBe(
-                        columnSizeTest.column1ExpectedRenderedWidth
+                        value.column1ExpectedRenderedWidth
                     );
                     expect(column2RenderedWidth).toBe(
-                        columnSizeTest.column2ExpectedRenderedWidth
+                        value.column2ExpectedRenderedWidth
                     );
                     expect(header1RenderedWidth).toBe(
-                        columnSizeTest.column1ExpectedRenderedWidth
+                        value.column1ExpectedRenderedWidth
                     );
                     expect(header2RenderedWidth).toBe(
-                        columnSizeTest.column2ExpectedRenderedWidth
+                        value.column2ExpectedRenderedWidth
                     );
                 }
             );
-        }
+        });
 
         it('resizing table with fractionalWidth columns changes column rendered widths', async () => {
             await connect();
@@ -304,32 +295,22 @@ describe('Table Column Sizing', () => {
                 column2MinPixelWidth: null
             }
         ];
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const rowScrollTest of tests) {
-            const specType = getSpecTypeByNamedList(
-                rowScrollTest,
-                focused,
-                disabled
-            );
-            specType(
-                `${rowScrollTest.name}`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                async () => {
+        parameterizeNamedList(tests, (spec, name, value) => {
+            spec(name, async () => {
                     await connect();
                     await pageObject.sizeTableToGivenRowWidth(300, element);
                     await element.setData(largeTableData);
                     await connect();
                     await waitForUpdatesAsync();
 
-                    column1.columnInternals.fractionalWidth = rowScrollTest.column1FractionalWidth;
-                    if (rowScrollTest.column1MinPixelWidth !== null) {
-                        column1.columnInternals.minPixelWidth = rowScrollTest.column1MinPixelWidth;
+                    column1.columnInternals.fractionalWidth = value.column1FractionalWidth;
+                    if (value.column1MinPixelWidth !== null) {
+                        column1.columnInternals.minPixelWidth = value.column1MinPixelWidth;
                     }
 
-                    column2.columnInternals.fractionalWidth = rowScrollTest.column2FractionalWidth;
-                    if (rowScrollTest.column2MinPixelWidth !== null) {
-                        column2.columnInternals.minPixelWidth = rowScrollTest.column2MinPixelWidth;
+                    column2.columnInternals.fractionalWidth = value.column2FractionalWidth;
+                    if (value.column2MinPixelWidth !== null) {
+                        column2.columnInternals.minPixelWidth = value.column2MinPixelWidth;
                     }
 
                     await waitForUpdatesAsync();
@@ -348,7 +329,7 @@ describe('Table Column Sizing', () => {
                     );
                 }
             );
-        }
+        });
     });
 });
 
@@ -483,35 +464,25 @@ describe('Table Interactive Column Sizing', () => {
                 expectedColumnWidths: [75, 75, 50, 200]
             }
         ];
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const columnSizeTest of columnSizeTests) {
-            const specType = getSpecTypeByNamedList(
-                columnSizeTest,
-                focused,
-                disabled
-            );
-            specType(
-                `${columnSizeTest.name}`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                async () => {
+        parameterizeNamedList(columnSizeTests, (spec, name, value) => {
+            spec(name, async () => {
                     element.columns.forEach((column, i) => {
-                        column.columnInternals.fractionalWidth = columnSizeTest.fractionalWidths[i]!;
-                        column.columnInternals.pixelWidth = columnSizeTest.pixelWidths[i]!;
-                        column.columnInternals.minPixelWidth = columnSizeTest.minPixelWidths[i]!;
+                        column.columnInternals.fractionalWidth = value.fractionalWidths[i]!;
+                        column.columnInternals.pixelWidth = value.pixelWidths[i]!;
+                        column.columnInternals.minPixelWidth = value.minPixelWidths[i]!;
                     });
                     await waitForUpdatesAsync();
                     pageObject.dragSizeColumnByRightDivider(
-                        columnSizeTest.columnDragIndex,
-                        columnSizeTest.dragDeltas
+                        value.columnDragIndex,
+                        value.dragDeltas
                     );
                     await waitForUpdatesAsync();
-                    columnSizeTest.expectedColumnWidths.forEach((width, i) => expect(pageObject.getCellRenderedWidth(0, i)).toBe(
+                    value.expectedColumnWidths.forEach((width, i) => expect(pageObject.getCellRenderedWidth(0, i)).toBe(
                         width
                     ));
                 }
             );
-        }
+        });
 
         it('when table width is smaller than total column min width, dragging column still expands column', async () => {
             await pageObject.sizeTableToGivenRowWidth(100, element);
@@ -663,37 +634,26 @@ describe('Table Interactive Column Sizing', () => {
                 expectedColumnWidths: [100, 50, 150]
             }
         ];
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const columnSizeTest of hiddenColumDragRightDividerTests) {
-            const specType = getSpecTypeByNamedList(
-                columnSizeTest,
-                focused,
-                disabled
-            );
-            specType(
-                `${columnSizeTest.name}`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                async () => {
-                    await pageObject.sizeTableToGivenRowWidth(
-                        columnSizeTest.tableWidth,
-                        element
-                    );
-                    columnSizeTest.hiddenColumns.forEach(columnIndex => {
-                        element.columns[columnIndex]!.columnHidden = true;
-                    });
-                    await waitForUpdatesAsync();
-                    pageObject.dragSizeColumnByRightDivider(
-                        columnSizeTest.dragColumnIndex,
-                        columnSizeTest.dragDeltas
-                    );
-                    await waitForUpdatesAsync();
-                    columnSizeTest.expectedColumnWidths.forEach((width, i) => expect(pageObject.getCellRenderedWidth(0, i)).toBe(
-                        width
-                    ));
-                }
-            );
-        }
+        parameterizeNamedList(hiddenColumDragRightDividerTests, (spec, name, value) => {
+            spec(name, async () => {
+                await pageObject.sizeTableToGivenRowWidth(
+                    value.tableWidth,
+                    element
+                );
+                value.hiddenColumns.forEach(columnIndex => {
+                    element.columns[columnIndex]!.columnHidden = true;
+                });
+                await waitForUpdatesAsync();
+                pageObject.dragSizeColumnByRightDivider(
+                    value.dragColumnIndex,
+                    value.dragDeltas
+                );
+                await waitForUpdatesAsync();
+                value.expectedColumnWidths.forEach((width, i) => expect(pageObject.getCellRenderedWidth(0, i)).toBe(
+                    width
+                ));
+            });
+        });
     });
 
     describe('hidden column drag left divider tests ', () => {
@@ -763,37 +723,27 @@ describe('Table Interactive Column Sizing', () => {
                 expectedColumnWidths: [100, 50, 150]
             }
         ];
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const columnSizeTest of hiddenColumDragRightDividerTests) {
-            const specType = getSpecTypeByNamedList(
-                columnSizeTest,
-                focused,
-                disabled
-            );
-            specType(
-                `${columnSizeTest.name}`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                async () => {
+        parameterizeNamedList(hiddenColumDragRightDividerTests, (spec, name, value) => {
+            spec(name, async () => {
                     await pageObject.sizeTableToGivenRowWidth(
-                        columnSizeTest.tableWidth,
+                        value.tableWidth,
                         element
                     );
-                    columnSizeTest.hiddenColumns.forEach(columnIndex => {
+                    value.hiddenColumns.forEach(columnIndex => {
                         element.columns[columnIndex]!.columnHidden = true;
                     });
                     await waitForUpdatesAsync();
                     pageObject.dragSizeColumnByLeftDivider(
-                        columnSizeTest.dragColumnIndex,
-                        columnSizeTest.dragDeltas
+                        value.dragColumnIndex,
+                        value.dragDeltas
                     );
                     await waitForUpdatesAsync();
-                    columnSizeTest.expectedColumnWidths.forEach((width, i) => expect(pageObject.getCellRenderedWidth(0, i)).toBe(
+                    value.expectedColumnWidths.forEach((width, i) => expect(pageObject.getCellRenderedWidth(0, i)).toBe(
                         width
                     ));
                 }
             );
-        }
+        });
     });
 
     describe('active divider tests', () => {
@@ -830,43 +780,32 @@ describe('Table Interactive Column Sizing', () => {
                 expectedActiveIndexes: [5]
             }
         ];
-        const focusedActiveDividerTests: string[] = [];
-        const disabledActiveDividerTests: string[] = [];
-        for (const dividerActiveTest of dividerActiveTests) {
-            const specType = getSpecTypeByNamedList(
-                dividerActiveTest,
-                focusedActiveDividerTests,
-                disabledActiveDividerTests
-            );
-            specType(
-                `${dividerActiveTest.name}`,
-                // eslint-disable-next-line @typescript-eslint/no-loop-func
-                async () => {
-                    const dividers = Array.from(
-                        element.shadowRoot!.querySelectorAll('.column-divider')
-                    );
-                    const divider = dividers[dividerActiveTest.dividerClickIndex]!;
-                    const dividerRect = divider.getBoundingClientRect();
-                    const mouseDownEvent = new MouseEvent('mousedown', {
-                        clientX: (dividerRect.x + dividerRect.width) / 2,
-                        clientY: (dividerRect.y + dividerRect.height) / 2
-                    });
-                    const mouseUpEvent = new MouseEvent('mouseup');
-                    divider.dispatchEvent(mouseDownEvent);
-                    await waitForUpdatesAsync();
-                    const activeDividers = [];
-                    for (let i = 0; i < dividers.length; i++) {
-                        if (dividers[i]!.classList.contains('active')) {
-                            activeDividers.push(i);
-                        }
+        parameterizeNamedList(dividerActiveTests, (spec, name, value) => {
+            spec(name, async () => {
+                const dividers = Array.from(
+                    element.shadowRoot!.querySelectorAll('.column-divider')
+                );
+                const divider = dividers[value.dividerClickIndex]!;
+                const dividerRect = divider.getBoundingClientRect();
+                const mouseDownEvent = new MouseEvent('mousedown', {
+                    clientX: (dividerRect.x + dividerRect.width) / 2,
+                    clientY: (dividerRect.y + dividerRect.height) / 2
+                });
+                const mouseUpEvent = new MouseEvent('mouseup');
+                divider.dispatchEvent(mouseDownEvent);
+                await waitForUpdatesAsync();
+                const activeDividers = [];
+                for (let i = 0; i < dividers.length; i++) {
+                    if (dividers[i]!.classList.contains('active')) {
+                        activeDividers.push(i);
                     }
-                    document.dispatchEvent(mouseUpEvent); // clean up registered event handlers
-                    expect(activeDividers).toEqual(
-                        dividerActiveTest.expectedActiveIndexes
-                    );
                 }
-            );
-        }
+                document.dispatchEvent(mouseUpEvent); // clean up registered event handlers
+                expect(activeDividers).toEqual(
+                    value.expectedActiveIndexes
+                );
+            });
+        });
 
         it('first column only has right divider', () => {
             const rightDivider = pageObject.getColumnRightDivider(0);

--- a/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
@@ -195,53 +195,52 @@ describe('Table Column Sizing', () => {
             }
         ];
         parameterizeNamedList(columnSizeTests, (spec, name, value) => {
-            spec(
-                name,
-                async () => {
-                    await connect();
-                    await pageObject.sizeTableToGivenRowWidth(
-                        value.rowWidth,
-                        element
-                    );
-                    await element.setData(simpleTableData);
-                    await connect();
-                    await waitForUpdatesAsync();
+            spec(name, async () => {
+                await connect();
+                await pageObject.sizeTableToGivenRowWidth(
+                    value.rowWidth,
+                    element
+                );
+                await element.setData(simpleTableData);
+                await connect();
+                await waitForUpdatesAsync();
 
-                    column1.columnInternals.fractionalWidth = value.column1FractionalWidth;
-                    column1.columnInternals.pixelWidth = value.column1PixelWidth;
-                    if (
-                        typeof value.column1MinPixelWidth === 'number'
-                    ) {
-                        column1.columnInternals.minPixelWidth = value.column1MinPixelWidth;
-                    }
-
-                    column2.columnInternals.fractionalWidth = value.column2FractionalWidth;
-                    column2.columnInternals.pixelWidth = value.column2PixelWidth;
-                    if (
-                        typeof value.column2MinPixelWidth === 'number'
-                    ) {
-                        column2.columnInternals.minPixelWidth = value.column2MinPixelWidth;
-                    }
-
-                    await waitForUpdatesAsync();
-                    const column1RenderedWidth = pageObject.getCellRenderedWidth(0, 0);
-                    const column2RenderedWidth = pageObject.getCellRenderedWidth(0, 1);
-                    const header1RenderedWidth = pageObject.getHeaderRenderedWidth(0);
-                    const header2RenderedWidth = pageObject.getHeaderRenderedWidth(1);
-                    expect(column1RenderedWidth).toBe(
-                        value.column1ExpectedRenderedWidth
-                    );
-                    expect(column2RenderedWidth).toBe(
-                        value.column2ExpectedRenderedWidth
-                    );
-                    expect(header1RenderedWidth).toBe(
-                        value.column1ExpectedRenderedWidth
-                    );
-                    expect(header2RenderedWidth).toBe(
-                        value.column2ExpectedRenderedWidth
-                    );
+                column1.columnInternals.fractionalWidth = value.column1FractionalWidth;
+                column1.columnInternals.pixelWidth = value.column1PixelWidth;
+                if (typeof value.column1MinPixelWidth === 'number') {
+                    column1.columnInternals.minPixelWidth = value.column1MinPixelWidth;
                 }
-            );
+
+                column2.columnInternals.fractionalWidth = value.column2FractionalWidth;
+                column2.columnInternals.pixelWidth = value.column2PixelWidth;
+                if (typeof value.column2MinPixelWidth === 'number') {
+                    column2.columnInternals.minPixelWidth = value.column2MinPixelWidth;
+                }
+
+                await waitForUpdatesAsync();
+                const column1RenderedWidth = pageObject.getCellRenderedWidth(
+                    0,
+                    0
+                );
+                const column2RenderedWidth = pageObject.getCellRenderedWidth(
+                    0,
+                    1
+                );
+                const header1RenderedWidth = pageObject.getHeaderRenderedWidth(0);
+                const header2RenderedWidth = pageObject.getHeaderRenderedWidth(1);
+                expect(column1RenderedWidth).toBe(
+                    value.column1ExpectedRenderedWidth
+                );
+                expect(column2RenderedWidth).toBe(
+                    value.column2ExpectedRenderedWidth
+                );
+                expect(header1RenderedWidth).toBe(
+                    value.column1ExpectedRenderedWidth
+                );
+                expect(header2RenderedWidth).toBe(
+                    value.column2ExpectedRenderedWidth
+                );
+            });
         });
 
         it('resizing table with fractionalWidth columns changes column rendered widths', async () => {
@@ -477,9 +476,7 @@ describe('Table Interactive Column Sizing', () => {
                     value.dragDeltas
                 );
                 await waitForUpdatesAsync();
-                value.expectedColumnWidths.forEach((width, i) => expect(pageObject.getCellRenderedWidth(0, i)).toBe(
-                    width
-                ));
+                value.expectedColumnWidths.forEach((width, i) => expect(pageObject.getCellRenderedWidth(0, i)).toBe(width));
             });
         });
 
@@ -633,26 +630,29 @@ describe('Table Interactive Column Sizing', () => {
                 expectedColumnWidths: [100, 50, 150]
             }
         ];
-        parameterizeNamedList(hiddenColumDragRightDividerTests, (spec, name, value) => {
-            spec(name, async () => {
-                await pageObject.sizeTableToGivenRowWidth(
-                    value.tableWidth,
-                    element
-                );
-                value.hiddenColumns.forEach(columnIndex => {
-                    element.columns[columnIndex]!.columnHidden = true;
+        parameterizeNamedList(
+            hiddenColumDragRightDividerTests,
+            (spec, name, value) => {
+                spec(name, async () => {
+                    await pageObject.sizeTableToGivenRowWidth(
+                        value.tableWidth,
+                        element
+                    );
+                    value.hiddenColumns.forEach(columnIndex => {
+                        element.columns[columnIndex]!.columnHidden = true;
+                    });
+                    await waitForUpdatesAsync();
+                    pageObject.dragSizeColumnByRightDivider(
+                        value.dragColumnIndex,
+                        value.dragDeltas
+                    );
+                    await waitForUpdatesAsync();
+                    value.expectedColumnWidths.forEach((width, i) => expect(pageObject.getCellRenderedWidth(0, i)).toBe(
+                        width
+                    ));
                 });
-                await waitForUpdatesAsync();
-                pageObject.dragSizeColumnByRightDivider(
-                    value.dragColumnIndex,
-                    value.dragDeltas
-                );
-                await waitForUpdatesAsync();
-                value.expectedColumnWidths.forEach((width, i) => expect(pageObject.getCellRenderedWidth(0, i)).toBe(
-                    width
-                ));
-            });
-        });
+            }
+        );
     });
 
     describe('hidden column drag left divider tests ', () => {
@@ -722,26 +722,29 @@ describe('Table Interactive Column Sizing', () => {
                 expectedColumnWidths: [100, 50, 150]
             }
         ];
-        parameterizeNamedList(hiddenColumDragRightDividerTests, (spec, name, value) => {
-            spec(name, async () => {
-                await pageObject.sizeTableToGivenRowWidth(
-                    value.tableWidth,
-                    element
-                );
-                value.hiddenColumns.forEach(columnIndex => {
-                    element.columns[columnIndex]!.columnHidden = true;
+        parameterizeNamedList(
+            hiddenColumDragRightDividerTests,
+            (spec, name, value) => {
+                spec(name, async () => {
+                    await pageObject.sizeTableToGivenRowWidth(
+                        value.tableWidth,
+                        element
+                    );
+                    value.hiddenColumns.forEach(columnIndex => {
+                        element.columns[columnIndex]!.columnHidden = true;
+                    });
+                    await waitForUpdatesAsync();
+                    pageObject.dragSizeColumnByLeftDivider(
+                        value.dragColumnIndex,
+                        value.dragDeltas
+                    );
+                    await waitForUpdatesAsync();
+                    value.expectedColumnWidths.forEach((width, i) => expect(pageObject.getCellRenderedWidth(0, i)).toBe(
+                        width
+                    ));
                 });
-                await waitForUpdatesAsync();
-                pageObject.dragSizeColumnByLeftDivider(
-                    value.dragColumnIndex,
-                    value.dragDeltas
-                );
-                await waitForUpdatesAsync();
-                value.expectedColumnWidths.forEach((width, i) => expect(pageObject.getCellRenderedWidth(0, i)).toBe(
-                    width
-                ));
-            });
-        });
+            }
+        );
     });
 
     describe('active divider tests', () => {
@@ -799,9 +802,7 @@ describe('Table Interactive Column Sizing', () => {
                     }
                 }
                 document.dispatchEvent(mouseUpEvent); // clean up registered event handlers
-                expect(activeDividers).toEqual(
-                    value.expectedActiveIndexes
-                );
+                expect(activeDividers).toEqual(value.expectedActiveIndexes);
             });
         });
 

--- a/packages/nimble-components/src/table/tests/table-selection.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-selection.spec.ts
@@ -644,16 +644,7 @@ describe('Table row selection', () => {
                 });
 
                 describe('interactions that modify the selection', () => {
-                    const configurations: {
-                        name: string,
-                        initialSelection: string[],
-                        rowToClick: number,
-                        clickModifiers: {
-                            shiftKey?: boolean,
-                            ctrlKey?: boolean
-                        },
-                        expectedSelection: string[]
-                    }[] = [
+                    const configurations = [
                         {
                             name: 'clicking a row with no previous selection selects the clicked row',
                             initialSelection: [],
@@ -696,7 +687,7 @@ describe('Table row selection', () => {
                             clickModifiers: { shiftKey: true },
                             expectedSelection: ['0']
                         }
-                    ];
+                    ] as const;
                     parameterizeNamedList(
                         configurations,
                         (spec, name, value) => {
@@ -732,15 +723,7 @@ describe('Table row selection', () => {
                 });
 
                 describe('interactions that do not modify the selection', () => {
-                    const configurations: {
-                        name: string,
-                        initialSelection: string[],
-                        rowToClick: number,
-                        clickModifiers: {
-                            shiftKey?: boolean,
-                            ctrlKey?: boolean
-                        }
-                    }[] = [
+                    const configurations = [
                         {
                             name: 'clicking the already selected row maintains its selection',
                             initialSelection: ['0'],
@@ -759,7 +742,7 @@ describe('Table row selection', () => {
                             rowToClick: 0,
                             clickModifiers: { shiftKey: true }
                         }
-                    ];
+                    ] as const;
                     parameterizeNamedList(
                         configurations,
                         (spec, name, value) => {
@@ -794,13 +777,7 @@ describe('Table row selection', () => {
                     await waitForUpdatesAsync();
                 });
 
-                const configurations: {
-                    name: string,
-                    initialSelection: string[],
-                    rowToClick: number,
-                    clickModifiers: { shiftKey?: boolean, ctrlKey?: boolean },
-                    expectedSelection: string[]
-                }[] = [
+                const configurations = [
                     {
                         name: 'clicking a row with no previous selection selects the clicked row',
                         initialSelection: [],
@@ -864,7 +841,7 @@ describe('Table row selection', () => {
                         clickModifiers: { ctrlKey: true },
                         expectedSelection: ['2']
                     }
-                ];
+                ] as const;
                 parameterizeNamedList(configurations, (spec, name, value) => {
                     spec(name, async () => {
                         await element.setSelectedRecordIds(

--- a/packages/nimble-components/src/table/tests/table-selection.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-selection.spec.ts
@@ -697,35 +697,38 @@ describe('Table row selection', () => {
                             expectedSelection: ['0']
                         }
                     ];
-                    parameterizeNamedList(configurations, (spec, name, value) => {
-                        spec(name, async () => {
-                            await element.setSelectedRecordIds(
-                                value.initialSelection
-                            );
-                            await pageObject.clickRow(
-                                value.rowToClick,
-                                value.clickModifiers
-                            );
+                    parameterizeNamedList(
+                        configurations,
+                        (spec, name, value) => {
+                            spec(name, async () => {
+                                await element.setSelectedRecordIds(
+                                    value.initialSelection
+                                );
+                                await pageObject.clickRow(
+                                    value.rowToClick,
+                                    value.clickModifiers
+                                );
 
-                            const currentSelection = await element.getSelectedRecordIds();
-                            expect(currentSelection).toEqual(
-                                jasmine.arrayWithExactContents(
-                                    value.expectedSelection
-                                )
-                            );
-                            expect(
-                                selectionChangeListener.spy
-                            ).toHaveBeenCalledTimes(1);
-                            const emittedIds = getEmittedRecordIdsFromSpy(
-                                selectionChangeListener.spy
-                            );
-                            expect(emittedIds).toEqual(
-                                jasmine.arrayWithExactContents(
-                                    value.expectedSelection
-                                )
-                            );
-                        });
-                    });
+                                const currentSelection = await element.getSelectedRecordIds();
+                                expect(currentSelection).toEqual(
+                                    jasmine.arrayWithExactContents(
+                                        value.expectedSelection
+                                    )
+                                );
+                                expect(
+                                    selectionChangeListener.spy
+                                ).toHaveBeenCalledTimes(1);
+                                const emittedIds = getEmittedRecordIdsFromSpy(
+                                    selectionChangeListener.spy
+                                );
+                                expect(emittedIds).toEqual(
+                                    jasmine.arrayWithExactContents(
+                                        value.expectedSelection
+                                    )
+                                );
+                            });
+                        }
+                    );
                 });
 
                 describe('interactions that do not modify the selection', () => {
@@ -757,27 +760,30 @@ describe('Table row selection', () => {
                             clickModifiers: { shiftKey: true }
                         }
                     ];
-                    parameterizeNamedList(configurations, (spec, name, value) => {
-                        spec(name, async () => {
-                            await element.setSelectedRecordIds(
-                                value.initialSelection
-                            );
-                            await pageObject.clickRow(
-                                value.rowToClick,
-                                value.clickModifiers
-                            );
-
-                            const currentSelection = await element.getSelectedRecordIds();
-                            expect(currentSelection).toEqual(
-                                jasmine.arrayWithExactContents(
+                    parameterizeNamedList(
+                        configurations,
+                        (spec, name, value) => {
+                            spec(name, async () => {
+                                await element.setSelectedRecordIds(
                                     value.initialSelection
-                                )
-                            );
-                            expect(
-                                selectionChangeListener.spy
-                            ).not.toHaveBeenCalled();
-                        });
-                    });
+                                );
+                                await pageObject.clickRow(
+                                    value.rowToClick,
+                                    value.clickModifiers
+                                );
+
+                                const currentSelection = await element.getSelectedRecordIds();
+                                expect(currentSelection).toEqual(
+                                    jasmine.arrayWithExactContents(
+                                        value.initialSelection
+                                    )
+                                );
+                                expect(
+                                    selectionChangeListener.spy
+                                ).not.toHaveBeenCalled();
+                            });
+                        }
+                    );
                 });
             });
 

--- a/packages/nimble-components/src/table/tests/table-selection.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-selection.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '../types';
 import { TablePageObject } from '../testing/table.pageobject';
 import type { TableColumnText } from '../../table-column/text';
-import { getSpecTypeByNamedList } from '../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../utilities/tests/parameterized';
 
 interface SimpleTableRecord extends TableRecord {
     id: string;
@@ -697,28 +697,20 @@ describe('Table row selection', () => {
                             expectedSelection: ['0']
                         }
                     ];
-                    const focused: string[] = [];
-                    const disabled: string[] = [];
-                    for (const configuration of configurations) {
-                        const specType = getSpecTypeByNamedList(
-                            configuration,
-                            focused,
-                            disabled
-                        );
-                        // eslint-disable-next-line @typescript-eslint/no-loop-func
-                        specType(configuration.name, async () => {
+                    parameterizeNamedList(configurations, (spec, name, value) => {
+                        spec(name, async () => {
                             await element.setSelectedRecordIds(
-                                configuration.initialSelection
+                                value.initialSelection
                             );
                             await pageObject.clickRow(
-                                configuration.rowToClick,
-                                configuration.clickModifiers
+                                value.rowToClick,
+                                value.clickModifiers
                             );
 
                             const currentSelection = await element.getSelectedRecordIds();
                             expect(currentSelection).toEqual(
                                 jasmine.arrayWithExactContents(
-                                    configuration.expectedSelection
+                                    value.expectedSelection
                                 )
                             );
                             expect(
@@ -729,11 +721,11 @@ describe('Table row selection', () => {
                             );
                             expect(emittedIds).toEqual(
                                 jasmine.arrayWithExactContents(
-                                    configuration.expectedSelection
+                                    value.expectedSelection
                                 )
                             );
                         });
-                    }
+                    });
                 });
 
                 describe('interactions that do not modify the selection', () => {
@@ -765,35 +757,27 @@ describe('Table row selection', () => {
                             clickModifiers: { shiftKey: true }
                         }
                     ];
-                    const focused: string[] = [];
-                    const disabled: string[] = [];
-                    for (const configuration of configurations) {
-                        const specType = getSpecTypeByNamedList(
-                            configuration,
-                            focused,
-                            disabled
-                        );
-                        // eslint-disable-next-line @typescript-eslint/no-loop-func
-                        specType(configuration.name, async () => {
+                    parameterizeNamedList(configurations, (spec, name, value) => {
+                        spec(name, async () => {
                             await element.setSelectedRecordIds(
-                                configuration.initialSelection
+                                value.initialSelection
                             );
                             await pageObject.clickRow(
-                                configuration.rowToClick,
-                                configuration.clickModifiers
+                                value.rowToClick,
+                                value.clickModifiers
                             );
 
                             const currentSelection = await element.getSelectedRecordIds();
                             expect(currentSelection).toEqual(
                                 jasmine.arrayWithExactContents(
-                                    configuration.initialSelection
+                                    value.initialSelection
                                 )
                             );
                             expect(
                                 selectionChangeListener.spy
                             ).not.toHaveBeenCalled();
                         });
-                    }
+                    });
                 });
             });
 
@@ -875,28 +859,20 @@ describe('Table row selection', () => {
                         expectedSelection: ['2']
                     }
                 ];
-                const focused: string[] = [];
-                const disabled: string[] = [];
-                for (const configuration of configurations) {
-                    const specType = getSpecTypeByNamedList(
-                        configuration,
-                        focused,
-                        disabled
-                    );
-                    // eslint-disable-next-line @typescript-eslint/no-loop-func
-                    specType(configuration.name, async () => {
+                parameterizeNamedList(configurations, (spec, name, value) => {
+                    spec(name, async () => {
                         await element.setSelectedRecordIds(
-                            configuration.initialSelection
+                            value.initialSelection
                         );
                         await pageObject.clickRow(
-                            configuration.rowToClick,
-                            configuration.clickModifiers
+                            value.rowToClick,
+                            value.clickModifiers
                         );
 
                         const currentSelection = await element.getSelectedRecordIds();
                         expect(currentSelection).toEqual(
                             jasmine.arrayWithExactContents(
-                                configuration.expectedSelection
+                                value.expectedSelection
                             )
                         );
                         expect(
@@ -907,11 +883,11 @@ describe('Table row selection', () => {
                         );
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(
-                                configuration.expectedSelection
+                                value.expectedSelection
                             )
                         );
                     });
-                }
+                });
 
                 it('clicking the already selected row maintains its selection and does not emit an event', async () => {
                     await element.setSelectedRecordIds(['0']);

--- a/packages/nimble-components/src/text-area/tests/text-area.spec.ts
+++ b/packages/nimble-components/src/text-area/tests/text-area.spec.ts
@@ -90,9 +90,7 @@ describe('Text Area', () => {
                 await waitForUpdatesAsync();
 
                 if (value.boolean) {
-                    expect(
-                        element.control.hasAttribute(value.name)
-                    ).toBeTrue();
+                    expect(element.control.hasAttribute(value.name)).toBeTrue();
                 } else {
                     expect(element.control.getAttribute(value.name)).toBe(
                         value.value ?? 'foo'

--- a/packages/nimble-components/src/text-area/tests/text-area.spec.ts
+++ b/packages/nimble-components/src/text-area/tests/text-area.spec.ts
@@ -41,7 +41,7 @@ describe('Text Area', () => {
         expect(element.control.part.contains('control')).toBe(true);
     });
 
-    const attributeNames: {
+    const attributeNames: readonly {
         name: string,
         value?: string,
         boolean?: boolean
@@ -77,7 +77,7 @@ describe('Text Area', () => {
         { name: 'aria-owns' },
         { name: 'aria-relevant' },
         { name: 'aria-roledescription' }
-    ];
+    ] as const;
     describe('should reflect value to the internal control', () => {
         parameterizeNamedList(attributeNames, (spec, name, value) => {
             spec(`for attribute ${name}`, async () => {

--- a/packages/nimble-components/src/text-area/tests/text-area.spec.ts
+++ b/packages/nimble-components/src/text-area/tests/text-area.spec.ts
@@ -2,7 +2,7 @@ import { html } from '@microsoft/fast-element';
 import { TextArea, textAreaTag } from '..';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
-import { getSpecTypeByNamedList } from '../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../utilities/tests/parameterized';
 
 async function setup(): Promise<Fixture<TextArea>> {
     return fixture<TextArea>(html`<nimble-text-area></nimble-text-area>`);
@@ -79,35 +79,27 @@ describe('Text Area', () => {
         { name: 'aria-roledescription' }
     ];
     describe('should reflect value to the internal control', () => {
-        const focused: string[] = [];
-        const disabled: string[] = [];
-        for (const attribute of attributeNames) {
-            const specType = getSpecTypeByNamedList(
-                attribute,
-                focused,
-                disabled
-            );
-            // eslint-disable-next-line @typescript-eslint/no-loop-func
-            specType(`for attribute ${attribute.name}`, async () => {
+        parameterizeNamedList(attributeNames, (spec, name, value) => {
+            spec(`for attribute ${name}`, async () => {
                 await connect();
 
                 element.setAttribute(
-                    attribute.name,
-                    attribute.value ?? (attribute.boolean ? '' : 'foo')
+                    value.name,
+                    value.value ?? (value.boolean ? '' : 'foo')
                 );
                 await waitForUpdatesAsync();
 
-                if (attribute.boolean) {
+                if (value.boolean) {
                     expect(
-                        element.control.hasAttribute(attribute.name)
+                        element.control.hasAttribute(value.name)
                     ).toBeTrue();
                 } else {
-                    expect(element.control.getAttribute(attribute.name)).toBe(
-                        attribute.value ?? 'foo'
+                    expect(element.control.getAttribute(value.name)).toBe(
+                        value.value ?? 'foo'
                     );
                 }
             });
-        }
+        });
 
         it('for property value', async () => {
             await connect();

--- a/packages/nimble-components/src/theme-provider/tests/theme-provider.spec.ts
+++ b/packages/nimble-components/src/theme-provider/tests/theme-provider.spec.ts
@@ -2,7 +2,7 @@ import { html } from '@microsoft/fast-element';
 import { spinalCase } from '@microsoft/fast-web-utilities';
 import * as designTokensNamespace from '../design-tokens';
 import { tokenNames, suffixFromTokenName } from '../design-token-names';
-import { getSpecTypeByNamedList } from '../../utilities/tests/parameterized';
+import { parameterizeNamedList } from '../../utilities/tests/parameterized';
 import { ThemeProvider, lang, themeProviderTag } from '..';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { fixture, type Fixture } from '../../utilities/tests/fixture';
@@ -147,19 +147,12 @@ describe('Theme Provider', () => {
         );
         const tokenNameValues = Object.values(tokenNames);
 
-        for (const tokenEntry of tokenEntries) {
-            const focused: DesignTokenPropertyName[] = [];
-            const disabled: DesignTokenPropertyName[] = [];
-            const specType = getSpecTypeByNamedList(
-                tokenEntry,
-                focused,
-                disabled
-            );
-            specType(`for token name ${tokenEntry.name}`, () => {
-                const tokenValue = tokenEntry.cssDesignToken.name.split('ni-nimble-')[1]!;
+        parameterizeNamedList(tokenEntries, (spec, name, value) => {
+            spec(`for token name ${name}`, () => {
+                const tokenValue = value.cssDesignToken.name.split('ni-nimble-')[1]!;
                 expect(tokenNameValues).toContain(tokenValue);
             });
-        }
+        });
     });
 
     describe('design token should match JS key', () => {
@@ -168,38 +161,24 @@ describe('Theme Provider', () => {
         );
         const tokenNameValues = Object.values(tokenNames);
 
-        for (const propertyName of propertyNames) {
-            const focused: DesignTokenPropertyName[] = [];
-            const disabled: DesignTokenPropertyName[] = [];
-            const specType = getSpecTypeByNamedList(
-                propertyName,
-                focused,
-                disabled
-            );
-            specType(`for token name ${propertyName.name}`, () => {
-                const convertedTokenValue = spinalCase(propertyName.name);
+        parameterizeNamedList(propertyNames, (spec, name, value) => {
+            spec(`for token name ${name}`, () => {
+                const convertedTokenValue = spinalCase(value.name);
                 expect(tokenNameValues).toContain(convertedTokenValue);
             });
-        }
+        });
     });
 
     describe('design token has approved suffix', () => {
         const propertyNames = designTokenPropertyNames.map(
             (name: DesignTokenPropertyName) => ({ name })
         );
-        for (const propertyName of propertyNames) {
-            const focused: DesignTokenPropertyName[] = [];
-            const disabled: DesignTokenPropertyName[] = [];
-            const specType = getSpecTypeByNamedList(
-                propertyName,
-                focused,
-                disabled
-            );
-            specType(`for token name ${propertyName.name}`, () => {
+        parameterizeNamedList(propertyNames, (spec, name, value) => {
+            spec(`for token name ${name}`, () => {
                 expect(
-                    suffixFromTokenName(propertyName.name)
+                    suffixFromTokenName(value.name)
                 ).not.toBeUndefined();
             });
-        }
+        });
     });
 });

--- a/packages/nimble-components/src/theme-provider/tests/theme-provider.spec.ts
+++ b/packages/nimble-components/src/theme-provider/tests/theme-provider.spec.ts
@@ -175,9 +175,7 @@ describe('Theme Provider', () => {
         );
         parameterizeNamedList(propertyNames, (spec, name) => {
             spec(`for token name ${name}`, () => {
-                expect(
-                    suffixFromTokenName(name)
-                ).not.toBeUndefined();
+                expect(suffixFromTokenName(name)).not.toBeUndefined();
             });
         });
     });

--- a/packages/nimble-components/src/theme-provider/tests/theme-provider.spec.ts
+++ b/packages/nimble-components/src/theme-provider/tests/theme-provider.spec.ts
@@ -161,9 +161,9 @@ describe('Theme Provider', () => {
         );
         const tokenNameValues = Object.values(tokenNames);
 
-        parameterizeNamedList(propertyNames, (spec, name, value) => {
+        parameterizeNamedList(propertyNames, (spec, name) => {
             spec(`for token name ${name}`, () => {
-                const convertedTokenValue = spinalCase(value.name);
+                const convertedTokenValue = spinalCase(name);
                 expect(tokenNameValues).toContain(convertedTokenValue);
             });
         });
@@ -173,10 +173,10 @@ describe('Theme Provider', () => {
         const propertyNames = designTokenPropertyNames.map(
             (name: DesignTokenPropertyName) => ({ name })
         );
-        parameterizeNamedList(propertyNames, (spec, name, value) => {
+        parameterizeNamedList(propertyNames, (spec, name) => {
             spec(`for token name ${name}`, () => {
                 expect(
-                    suffixFromTokenName(value.name)
+                    suffixFromTokenName(name)
                 ).not.toBeUndefined();
             });
         });

--- a/packages/nimble-components/src/utilities/models/tests/string-normalizers.spec.ts
+++ b/packages/nimble-components/src/utilities/models/tests/string-normalizers.spec.ts
@@ -30,7 +30,7 @@ const wackyStrings = [
     { name: '中文 (Chinese characters)', output: '中文 (chinese characters)' },
     { name: 'Iñtërnâtiônàlizætiøn☃💩', output: 'internationalizætiøn☃💩' },
     { name: '１', output: '１' }
-];
+] as const;
 
 describe('The string normalizer utility', () => {
     parameterizeNamedList(wackyStrings, (spec, name, value) => {

--- a/packages/nimble-components/src/utilities/tests/parameterized.ts
+++ b/packages/nimble-components/src/utilities/tests/parameterized.ts
@@ -1,35 +1,3 @@
-// eslint-disable-next-line no-restricted-globals
-type SpecTypes = typeof fit | typeof xit | typeof it;
-/**
- * @deprecated switch to `parameterize` or `parameterizeNamedList` instead
- */
-const getSpecType = <T>(
-    value: T,
-    isFocused: (value: T) => boolean,
-    isDisabled: (value: T) => boolean
-): SpecTypes => {
-    if (isFocused(value)) {
-        // eslint-disable-next-line no-restricted-globals
-        return fit;
-    }
-    if (isDisabled(value)) {
-        return xit;
-    }
-    return it;
-};
-
-/**
- * @deprecated switch to `parameterize` or `parameterizeNamedList` instead
- */
-export const getSpecTypeByNamedList = <T extends { name: string }>(
-    value: T,
-    focusList: string[],
-    disabledList: string[]
-): SpecTypes => getSpecType(
-    value,
-    (x: T) => focusList.includes(x.name),
-    (x: T) => disabledList.includes(x.name)
-);
 // The following aliases are just to reduce the number
 // of eslint disables in this source file. In normal
 // test code use the globals directly so eslint can

--- a/packages/nimble-components/src/utilities/tests/wacky-strings.ts
+++ b/packages/nimble-components/src/utilities/tests/wacky-strings.ts
@@ -17,4 +17,4 @@ export const wackyStrings = [
     { name: '中文 (Chinese characters)' },
     { name: 'Iñtërnâtiônàlizætiøn☃💩' },
     { name: '１' }
-];
+] as const;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This PR addresses the first part of #1551. It migrates tests in `nimble-components` to the `parameterizeNamedList` utility and deletes the deprecated `getSpecTypeByNamedList`.

To complete #1551, `parameterizeNamedList` needs to be exported and used from `nimble-angular`, but this will be tackled in a separate PR.

## 👩‍💻 Implementation

- Use `parameterizeNamedList` in the places where `getSpecTypeByNamedList` had been used (plus a few more places that weren't using either)
- Delete `getSpecTypeByNamedList`

## 🧪 Testing

Ran unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
