### PR TITLE
Update Playwright version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,6 @@ jobs:
       # See: https://github.com/actions/setup-node/issues/529
       - run: npm i -g npm@9
       - run: npm ci
-      - run: npx playwright install --with-deps
 
       # print a log of outdated npm dependencies
       # only informational so swallow error codes

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
       # See: https://github.com/actions/setup-node/issues/529
       - run: npm i -g npm@9
       - run: npm ci
+      - run: npx playwright install
 
       # print a log of outdated npm dependencies
       # only informational so swallow error codes

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       # See: https://github.com/actions/setup-node/issues/529
       - run: npm i -g npm@9
       - run: npm ci
-      - run: npx playwright install
+      - run: npx playwright install --with-deps
 
       # print a log of outdated npm dependencies
       # only informational so swallow error codes

--- a/angular-workspace/package.json
+++ b/angular-workspace/package.json
@@ -55,7 +55,7 @@
     "karma-jasmine": "^5.1.0",
     "karma-jasmine-html-reporter": "^2.0.0",
     "ng-packagr": "^15.2.2",
-    "playwright": "1.40.1",
+    "playwright": "1.40.0",
     "rollup": "^3.10.1",
     "typescript": "~4.8.2"
   }

--- a/angular-workspace/package.json
+++ b/angular-workspace/package.json
@@ -55,7 +55,7 @@
     "karma-jasmine": "^5.1.0",
     "karma-jasmine-html-reporter": "^2.0.0",
     "ng-packagr": "^15.2.2",
-    "playwright": "^1.40.0",
+    "playwright": "1.40.1",
     "rollup": "^3.10.1",
     "typescript": "~4.8.2"
   }

--- a/angular-workspace/package.json
+++ b/angular-workspace/package.json
@@ -55,7 +55,7 @@
     "karma-jasmine": "^5.1.0",
     "karma-jasmine-html-reporter": "^2.0.0",
     "ng-packagr": "^15.2.2",
-    "playwright": "^1.30.0",
+    "playwright": "^1.40.0",
     "rollup": "^3.10.1",
     "typescript": "~4.8.2"
   }

--- a/change/@ni-nimble-blazor-997a7b59-692f-45ae-b302-993995035699.json
+++ b/change/@ni-nimble-blazor-997a7b59-692f-45ae-b302-993995035699.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update Playwright version",
+  "packageName": "@ni/nimble-blazor",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-nimble-components-ee39f42f-cd28-42b3-837e-0df5b4842e70.json
+++ b/change/@ni-nimble-components-ee39f42f-cd28-42b3-837e-0df5b4842e70.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update Playwright version",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "karma-jasmine": "^5.1.0",
         "karma-jasmine-html-reporter": "^2.0.0",
         "ng-packagr": "^15.2.2",
-        "playwright": "^1.30.0",
+        "playwright": "^1.40.0",
         "rollup": "^3.10.1",
         "typescript": "~4.8.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36268,7 +36268,7 @@
         "@rollup/plugin-node-resolve": "^15.0.1",
         "cross-env": "^7.0.3",
         "glob": "^8.1.0",
-        "playwright": "1.36.0",
+        "playwright": "^1.40.0",
         "rollup": "^3.10.1"
       }
     },
@@ -36307,34 +36307,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "packages/nimble-blazor/node_modules/playwright": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.36.0.tgz",
-      "integrity": "sha512-ODVOTp5WoRMxDJY3liMmC+wVNicc0cQB17gASvQ+zLBggVK9a2x3gdT5mbl7av+zomvtdirWOqqfD+O6qIrFgw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "playwright-core": "1.36.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "packages/nimble-blazor/node_modules/playwright-core": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.36.0.tgz",
-      "integrity": "sha512-7RTr8P6YJPAqB+8j5ATGHqD6LvLLM39sYVNsslh78g8QeLcBs5750c6+msjrHUwwGt+kEbczBj1XB22WMwn+WA==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "packages/nimble-components": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "@lhci/cli": "^0.12.0",
         "beachball": "^2.31.0",
         "cross-env": "^7.0.3",
-        "patch-package": "^6.4.7"
+        "patch-package": "^6.4.7",
+        "playwright": "1.40.1"
       }
     },
     "angular-workspace": {
@@ -63,7 +64,7 @@
         "karma-jasmine": "^5.1.0",
         "karma-jasmine-html-reporter": "^2.0.0",
         "ng-packagr": "^15.2.2",
-        "playwright": "^1.40.0",
+        "playwright": "1.40.1",
         "rollup": "^3.10.1",
         "typescript": "~4.8.2"
       }
@@ -36268,7 +36269,7 @@
         "@rollup/plugin-node-resolve": "^15.0.1",
         "cross-env": "^7.0.3",
         "glob": "^8.1.0",
-        "playwright": "1.40.0",
+        "playwright": "1.40.1",
         "rollup": "^3.10.1"
       }
     },
@@ -36307,36 +36308,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "packages/nimble-blazor/node_modules/playwright": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.0.tgz",
-      "integrity": "sha512-gyHAgQjiDf1m34Xpwzaqb76KgfzYrhK7iih+2IzcOCoZWr/8ZqmdBw+t0RU85ZmfJMgtgAiNtBQ/KS2325INXw==",
-      "dev": true,
-      "dependencies": {
-        "playwright-core": "1.40.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "packages/nimble-blazor/node_modules/playwright-core": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.0.tgz",
-      "integrity": "sha512-fvKewVJpGeca8t0ipM56jkVSU6Eo0RmFvQ/MaCQNDYm+sdvKkMBBWTE1FdeMqIdumRaXXjZChWHvIzCGM/tA/Q==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "packages/nimble-components": {
@@ -36425,7 +36396,7 @@
         "karma-spec-reporter": "^0.0.36",
         "karma-webkit-launcher": "^2.1.0",
         "karma-webpack": "^5.0.0",
-        "playwright": "^1.40.0",
+        "playwright": "1.40.1",
         "prettier": "^2.8.8",
         "prettier-eslint": "^15.0.1",
         "prettier-eslint-cli": "^7.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36268,7 +36268,7 @@
         "@rollup/plugin-node-resolve": "^15.0.1",
         "cross-env": "^7.0.3",
         "glob": "^8.1.0",
-        "playwright": "^1.40.0",
+        "playwright": "1.40.0",
         "rollup": "^3.10.1"
       }
     },
@@ -36307,6 +36307,36 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/nimble-blazor/node_modules/playwright": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.0.tgz",
+      "integrity": "sha512-gyHAgQjiDf1m34Xpwzaqb76KgfzYrhK7iih+2IzcOCoZWr/8ZqmdBw+t0RU85ZmfJMgtgAiNtBQ/KS2325INXw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.40.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "packages/nimble-blazor/node_modules/playwright-core": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.0.tgz",
+      "integrity": "sha512-fvKewVJpGeca8t0ipM56jkVSU6Eo0RmFvQ/MaCQNDYm+sdvKkMBBWTE1FdeMqIdumRaXXjZChWHvIzCGM/tA/Q==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "packages/nimble-components": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "beachball": "^2.31.0",
         "cross-env": "^7.0.3",
         "patch-package": "^6.4.7",
-        "playwright": "1.40.1"
+        "playwright": "1.40.0"
       }
     },
     "angular-workspace": {
@@ -64,7 +64,7 @@
         "karma-jasmine": "^5.1.0",
         "karma-jasmine-html-reporter": "^2.0.0",
         "ng-packagr": "^15.2.2",
-        "playwright": "1.40.1",
+        "playwright": "1.40.0",
         "rollup": "^3.10.1",
         "typescript": "~4.8.2"
       }
@@ -29157,12 +29157,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
-      "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.0.tgz",
+      "integrity": "sha512-gyHAgQjiDf1m34Xpwzaqb76KgfzYrhK7iih+2IzcOCoZWr/8ZqmdBw+t0RU85ZmfJMgtgAiNtBQ/KS2325INXw==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.40.1"
+        "playwright-core": "1.40.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -29175,9 +29175,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
-      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.0.tgz",
+      "integrity": "sha512-fvKewVJpGeca8t0ipM56jkVSU6Eo0RmFvQ/MaCQNDYm+sdvKkMBBWTE1FdeMqIdumRaXXjZChWHvIzCGM/tA/Q==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -36269,7 +36269,7 @@
         "@rollup/plugin-node-resolve": "^15.0.1",
         "cross-env": "^7.0.3",
         "glob": "^8.1.0",
-        "playwright": "1.40.1",
+        "playwright": "1.40.0",
         "rollup": "^3.10.1"
       }
     },
@@ -36396,7 +36396,7 @@
         "karma-spec-reporter": "^0.0.36",
         "karma-webkit-launcher": "^2.1.0",
         "karma-webpack": "^5.0.0",
-        "playwright": "1.40.1",
+        "playwright": "1.40.0",
         "prettier": "^2.8.8",
         "prettier-eslint": "^15.0.1",
         "prettier-eslint-cli": "^7.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29156,25 +29156,27 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.36.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.36.1.tgz",
-      "integrity": "sha512-2ZqHpD0U0COKR8bqR3W5IkyIAAM0mT9FgGJB9xWCI1qAUkqLxJskA1ueeQOTH2Qfz3+oxdwwf2EzdOX+RkZmmQ==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
+      "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
       "dev": true,
-      "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "1.36.1"
+        "playwright-core": "1.40.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
         "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.36.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.36.1.tgz",
-      "integrity": "sha512-7+tmPuMcEW4xeCL9cp9KxmYpQYHKkyjwoXRnoeTowaeNat8PoBMk/HwCYhqkH2fRkshfKEOiVus/IhID2Pg8kg==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
+      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -36421,7 +36423,7 @@
         "karma-spec-reporter": "^0.0.36",
         "karma-webkit-launcher": "^2.1.0",
         "karma-webpack": "^5.0.0",
-        "playwright": "^1.30.0",
+        "playwright": "^1.40.0",
         "prettier": "^2.8.8",
         "prettier-eslint": "^15.0.1",
         "prettier-eslint-cli": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "beachball": "^2.31.0",
     "cross-env": "^7.0.3",
     "patch-package": "^6.4.7",
-    "playwright": "1.40.1"
+    "playwright": "1.40.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "description": "The NI Nimble Design System Monorepo",
   "scripts": {
-    "postinstall": "patch-package",
+    "postinstall": "patch-package && npm run playwright:setup",
+    "playwright:setup": "playwright install --with-deps",
     "build": "npm run build --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@lhci/cli": "^0.12.0",
     "beachball": "^2.31.0",
     "cross-env": "^7.0.3",
-    "patch-package": "^6.4.7"
+    "patch-package": "^6.4.7",
+    "playwright": "1.40.1"
   }
 }

--- a/packages/nimble-blazor/package.json
+++ b/packages/nimble-blazor/package.json
@@ -44,7 +44,7 @@
     "@ni/eslint-config-javascript": "^4.2.0",
     "@ni/nimble-components": "*",
     "@ni/nimble-tokens": "*",
-    "playwright": "^1.40.0",
+    "playwright": "1.40.0",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "cross-env": "^7.0.3",
     "glob": "^8.1.0",

--- a/packages/nimble-blazor/package.json
+++ b/packages/nimble-blazor/package.json
@@ -44,7 +44,7 @@
     "@ni/eslint-config-javascript": "^4.2.0",
     "@ni/nimble-components": "*",
     "@ni/nimble-tokens": "*",
-    "playwright": "1.40.1",
+    "playwright": "1.40.0",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "cross-env": "^7.0.3",
     "glob": "^8.1.0",

--- a/packages/nimble-blazor/package.json
+++ b/packages/nimble-blazor/package.json
@@ -44,7 +44,7 @@
     "@ni/eslint-config-javascript": "^4.2.0",
     "@ni/nimble-components": "*",
     "@ni/nimble-tokens": "*",
-    "playwright": "1.40.0",
+    "playwright": "1.40.1",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "cross-env": "^7.0.3",
     "glob": "^8.1.0",

--- a/packages/nimble-blazor/package.json
+++ b/packages/nimble-blazor/package.json
@@ -3,7 +3,7 @@
   "version": "12.7.3",
   "description": "Blazor components for the NI Nimble Design System",
   "scripts": {
-    "postinstall": "node build/generate-playwright-version-properties/source/index.js",
+    "postinstall": "node build/generate-playwright-version-properties/source/index.js && npx playwright install",
     "build": "npm run generate-icons && npm run generate-hybrid && npm run build:release && npm run build:client",
     "build:release": "dotnet build -c Release /p:TreatWarningsAsErrors=true /warnaserror",
     "build:client": "dotnet publish -p:BlazorEnableCompression=false -c Release Examples/Demo.Client --output dist/blazor-client-app",
@@ -44,7 +44,7 @@
     "@ni/eslint-config-javascript": "^4.2.0",
     "@ni/nimble-components": "*",
     "@ni/nimble-tokens": "*",
-    "playwright": "1.36.0",
+    "playwright": "^1.40.0",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "cross-env": "^7.0.3",
     "glob": "^8.1.0",

--- a/packages/nimble-blazor/package.json
+++ b/packages/nimble-blazor/package.json
@@ -3,7 +3,7 @@
   "version": "12.7.3",
   "description": "Blazor components for the NI Nimble Design System",
   "scripts": {
-    "postinstall": "node build/generate-playwright-version-properties/source/index.js && npx playwright install --with-deps",
+    "postinstall": "node build/generate-playwright-version-properties/source/index.js",
     "build": "npm run generate-icons && npm run generate-hybrid && npm run build:release && npm run build:client",
     "build:release": "dotnet build -c Release /p:TreatWarningsAsErrors=true /warnaserror",
     "build:client": "dotnet publish -p:BlazorEnableCompression=false -c Release Examples/Demo.Client --output dist/blazor-client-app",

--- a/packages/nimble-blazor/package.json
+++ b/packages/nimble-blazor/package.json
@@ -3,7 +3,7 @@
   "version": "12.7.3",
   "description": "Blazor components for the NI Nimble Design System",
   "scripts": {
-    "postinstall": "node build/generate-playwright-version-properties/source/index.js && npx playwright install",
+    "postinstall": "node build/generate-playwright-version-properties/source/index.js && npx playwright install --with-deps",
     "build": "npm run generate-icons && npm run generate-hybrid && npm run build:release && npm run build:client",
     "build:release": "dotnet build -c Release /p:TreatWarningsAsErrors=true /warnaserror",
     "build:client": "dotnet publish -p:BlazorEnableCompression=false -c Release Examples/Demo.Client --output dist/blazor-client-app",

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -138,7 +138,7 @@
     "karma-spec-reporter": "^0.0.36",
     "karma-webkit-launcher": "^2.1.0",
     "karma-webpack": "^5.0.0",
-    "playwright": "1.40.1",
+    "playwright": "1.40.0",
     "prettier": "^2.8.8",
     "prettier-eslint": "^15.0.1",
     "prettier-eslint-cli": "^7.1.0",

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -138,7 +138,7 @@
     "karma-spec-reporter": "^0.0.36",
     "karma-webkit-launcher": "^2.1.0",
     "karma-webpack": "^5.0.0",
-    "playwright": "^1.30.0",
+    "playwright": "^1.40.0",
     "prettier": "^2.8.8",
     "prettier-eslint": "^15.0.1",
     "prettier-eslint-cli": "^7.1.0",

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -138,7 +138,7 @@
     "karma-spec-reporter": "^0.0.36",
     "karma-webkit-launcher": "^2.1.0",
     "karma-webpack": "^5.0.0",
-    "playwright": "^1.40.0",
+    "playwright": "1.40.1",
     "prettier": "^2.8.8",
     "prettier-eslint": "^15.0.1",
     "prettier-eslint-cli": "^7.1.0",

--- a/packages/nimble-components/src/table/testing/table.pageobject.ts
+++ b/packages/nimble-components/src/table/testing/table.pageobject.ts
@@ -338,7 +338,7 @@ export class TablePageObject<T extends TableRecord> {
         const actualWidth = cell.getBoundingClientRect().width;
         // Round to one decimal place. This is to work around a bug in Chrome related to
         // fractional widths (e.g. '1fr') in grid layouts that results in some numerical
-        // precision issues.
+        // precision issues. See: https://bugs.chromium.org/p/chromium/issues/detail?id=1515685
         return Math.round(actualWidth * 10) / 10;
     }
 

--- a/packages/nimble-components/src/table/testing/table.pageobject.ts
+++ b/packages/nimble-components/src/table/testing/table.pageobject.ts
@@ -335,7 +335,11 @@ export class TablePageObject<T extends TableRecord> {
 
     public getCellRenderedWidth(rowIndex: number, columnIndex: number): number {
         const cell = this.getCell(rowIndex, columnIndex);
-        return cell.getBoundingClientRect().width;
+        const actualWidth = cell.getBoundingClientRect().width;
+        // Round to one decimal place. This is to work around a bug in Chrome related to
+        // fractional widths (e.g. '1fr') in grid layouts that results in some numerical
+        // precision issues.
+        return Math.round(actualWidth * 10) / 10;
     }
 
     public getTotalCellRenderedWidth(): number {
@@ -613,17 +617,17 @@ export class TablePageObject<T extends TableRecord> {
         return headerContainers[index]!.querySelector('.column-divider.left');
     }
 
-    public isHorizontalScrollbarVisible(): boolean {
+    public isVerticalScrollbarVisible(): boolean {
         return (
             this.tableElement.viewport.clientHeight
-            !== this.tableElement.viewport.getBoundingClientRect().height
+            < this.tableElement.viewport.scrollHeight
         );
     }
 
-    public isVerticalScrollbarVisible(): boolean {
+    public isHorizontalScrollbarVisible(): boolean {
         return (
             this.tableElement.viewport.clientWidth
-            !== this.tableElement.viewport.getBoundingClientRect().width
+            < this.tableElement.viewport.scrollWidth
         );
     }
 

--- a/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
@@ -564,10 +564,10 @@ describe('Table Interactive Column Sizing', () => {
                 0,
                 1
             );
-            pageObject.dragSizeColumnByRightDivider(0, [50]);
+            pageObject.dragSizeColumnByRightDivider(0, [5]);
             await waitForUpdatesAsync();
             expect(pageObject.getCellRenderedWidth(0, 1)).toBe(
-                secondVisibleCellWidth - 50
+                secondVisibleCellWidth - 5
             );
         });
 
@@ -578,10 +578,10 @@ describe('Table Interactive Column Sizing', () => {
                 0,
                 1
             );
-            pageObject.dragSizeColumnByRightDivider(1, [-50]);
+            pageObject.dragSizeColumnByRightDivider(1, [-5]);
             await waitForUpdatesAsync();
             expect(pageObject.getCellRenderedWidth(0, 1)).toBe(
-                secondVisibleCellWidth - 50
+                secondVisibleCellWidth - 5
             );
         });
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #1544 

## 👩‍💻 Implementation

- Added `postinstall` script to root package file that runs `playwright install --with-deps` to ensure browsers get installed.
- Bumped dependency versions of Playwright to 1.40.0 in nimble-components, nimble-blazor, and Angular workspace. They are now pinned to one version, because the root workspace package file now installs the browsers.
- Fixed two table page object functions that were incorrect.
- Added workaround (rounding cell width) for tests failing due to pulling in new version of Chrome browser (from 115.0.5790.75 to 120.0.6099.28). Six table interactive column resize tests began failing with errors like `Expected 100.984375 to be 101.` and `Expected 74.984375 to be 75.` I confirmed that this numerical imprecision is related to using fractional width units (e.g. `1fr`).

We still cannot have Renovate update the Playwright dependency because of the inconsistency of versions between the npm package and the nuget. E.g. currently the latest npm package is 1.40.1, but the latest nuget is only 1.40.0, so our build will fail as it tries to find a nuget with the same version as the npm package.

## 🧪 Testing

Pipeline build succeeds

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
