### PR TITLE
Rich Text Editor | Fix for losing the state of format buttons when the configuration is updated dynamically

### DIFF
--- a/change/@ni-nimble-components-456f6771-229b-4052-ada2-7f642545afdf.json
+++ b/change/@ni-nimble-components-456f6771-229b-4052-ada2-7f642545afdf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add fix to retain the format button state when user configuration gets dynamically updated",
+  "packageName": "@ni/nimble-components",
+  "email": "123377167+aagash-ni@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-456f6771-229b-4052-ada2-7f642545afdf.json
+++ b/change/@ni-nimble-components-456f6771-229b-4052-ada2-7f642545afdf.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Add fix to retain the format button state when user configuration gets dynamically updated",
+  "comment": "Add fix to retain rich text editor format button state when user configuration gets dynamically updated",
   "packageName": "@ni/nimble-components",
   "email": "123377167+aagash-ni@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/nimble-components/src/rich-text/editor/index.ts
+++ b/packages/nimble-components/src/rich-text/editor/index.ts
@@ -265,19 +265,21 @@ export class RichTextEditor extends RichText implements ErrorPattern {
         prev: EditorConfiguration | undefined,
         next: EditorConfiguration
     ): void {
+        const formatButtonsState = this.getButtonsState(this.tiptapEditor);
+        const { from, to } = this.tiptapEditor.view.state.selection;
         if (this.isMentionExtensionConfigUnchanged(prev, next)) {
-            this.refreshMarkdownContent();
+            this.setMarkdown(this.getMarkdown());
         } else {
             const mentionExtensionConfig = this.getMentionExtensionConfig();
             const currentStateMarkdown = this.getMarkdown();
             this.richTextMarkdownSerializer = new RichTextMarkdownSerializer(
                 mentionExtensionConfig.map(config => config.name)
             );
-            const formatButtonsState = this.getButtonsState(this.tiptapEditor);
             this.initializeEditor();
             this.setMarkdown(currentStateMarkdown);
-            this.resetEditorButtonsState(formatButtonsState);
         }
+        this.tiptapEditor.commands.setTextSelection({ from, to });
+        this.resetEditorButtonsState(formatButtonsState);
         this.setActiveMappingConfigs();
     }
 
@@ -688,7 +690,7 @@ export class RichTextEditor extends RichText implements ErrorPattern {
     }
 
     private resetEditorButtonsState(
-        buttonsState: FormatButtonsState | null
+        buttonsState: FormatButtonsState | undefined
     ): void {
         if (buttonsState?.bold && !this.tiptapEditor.isActive('bold')) {
             this.tiptapEditor.chain().focus().toggleBold().run();
@@ -698,23 +700,16 @@ export class RichTextEditor extends RichText implements ErrorPattern {
         }
     }
 
-    private getButtonsState(tiptapEditor: Editor): FormatButtonsState | null {
+    private getButtonsState(
+        tiptapEditor: Editor
+    ): FormatButtonsState | undefined {
         if (!this.$fastController.isConnected) {
-            return null;
+            return undefined;
         }
         return {
             bold: tiptapEditor.isActive('bold'),
             italics: tiptapEditor.isActive('italic')
         };
-    }
-
-    // This method restore the cursor selection and format button state after setting the editor content when the editor is focused
-    private refreshMarkdownContent(): void {
-        const formatButtonsState = this.getButtonsState(this.tiptapEditor);
-        const { from, to } = this.tiptapEditor.view.state.selection;
-        this.setMarkdown(this.getMarkdown());
-        this.tiptapEditor.commands.setTextSelection({ from, to });
-        this.resetEditorButtonsState(formatButtonsState);
     }
 }
 

--- a/packages/nimble-components/src/rich-text/editor/testing/rich-text-editor.pageobject.ts
+++ b/packages/nimble-components/src/rich-text/editor/testing/rich-text-editor.pageobject.ts
@@ -442,6 +442,10 @@ export class RichTextEditorPageObject {
         this.richTextEditorElement.tiptapEditor.commands.focus('start');
     }
 
+    public getCursorPosition(): number {
+        return this.richTextEditorElement.tiptapEditor.state.selection.anchor;
+    }
+
     private getEditorSection(): Element | null | undefined {
         return this.richTextEditorElement.shadowRoot?.querySelector('.editor');
     }

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
@@ -131,6 +131,27 @@ describe('RichTextEditorMention', () => {
             ).toBeTrue();
         });
 
+        it('should retain the cursor position when configuration added dynamically', async () => {
+            await pageObject.setEditorTextContent('test');
+            await pageObject.setCursorPosition(3);
+            expect(pageObject.getCursorPosition()).toBe(3);
+            await appendUserMentionConfiguration(element);
+            expect(pageObject.getCursorPosition()).toBe(3);
+        });
+
+        it('should retain the cursor position when configuration updated', async () => {
+            const { mappingElements } = await appendUserMentionConfiguration(
+                element,
+                [{ key: 'user:1', displayName: 'username1' }]
+            );
+            await pageObject.setEditorTextContent('test');
+            await pageObject.setCursorPosition(3);
+            expect(pageObject.getCursorPosition()).toBe(3);
+            mappingElements[0]!.displayName = 'updated-name';
+            await waitForUpdatesAsync();
+            expect(pageObject.getCursorPosition()).toBe(3);
+        });
+
         it('adding mention configuration converts the absolute link matching the pattern to mention node', async () => {
             element.setMarkdown('<user:1>');
 

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
@@ -14,7 +14,7 @@ import {
 } from '../testing/rich-text-editor-utils';
 import { iconAtTag } from '../../../icons/at';
 import { iconExclamationMarkTag } from '../../../icons/exclamation-mark';
-import { ArrowKeyButton } from '../testing/types';
+import { ArrowKeyButton, ToolbarButton } from '../testing/types';
 import { wackyStrings } from '../../../utilities/tests/wacky-strings';
 
 const RICH_TEXT_MENTION_USERS_VIEW_TAG = richTextMentionUsersViewTag.toUpperCase();
@@ -90,6 +90,47 @@ describe('RichTextEditorMention', () => {
     });
 
     describe('user mention dynamic loading', () => {
+        it('should retain the checked state of the format buttons when configuration added dynamically', async () => {
+            await pageObject.toggleFooterButton(ToolbarButton.bold);
+            await pageObject.toggleFooterButton(ToolbarButton.italics);
+            expect(
+                pageObject.getButtonCheckedState(ToolbarButton.bold)
+            ).toBeTrue();
+            expect(
+                pageObject.getButtonCheckedState(ToolbarButton.italics)
+            ).toBeTrue();
+            await appendUserMentionConfiguration(element);
+            expect(
+                pageObject.getButtonCheckedState(ToolbarButton.bold)
+            ).toBeTrue();
+            expect(
+                pageObject.getButtonCheckedState(ToolbarButton.italics)
+            ).toBeTrue();
+        });
+
+        it('should retain the checked state of the format buttons when configuration updated', async () => {
+            const { mappingElements } = await appendUserMentionConfiguration(
+                element,
+                [{ key: 'user:1', displayName: 'username1' }]
+            );
+            await pageObject.toggleFooterButton(ToolbarButton.bold);
+            await pageObject.toggleFooterButton(ToolbarButton.italics);
+            expect(
+                pageObject.getButtonCheckedState(ToolbarButton.bold)
+            ).toBeTrue();
+            expect(
+                pageObject.getButtonCheckedState(ToolbarButton.italics)
+            ).toBeTrue();
+            mappingElements[0]!.displayName = 'updated-name';
+            await waitForUpdatesAsync();
+            expect(
+                pageObject.getButtonCheckedState(ToolbarButton.bold)
+            ).toBeTrue();
+            expect(
+                pageObject.getButtonCheckedState(ToolbarButton.italics)
+            ).toBeTrue();
+        });
+
         it('adding mention configuration converts the absolute link matching the pattern to mention node', async () => {
             element.setMarkdown('<user:1>');
 

--- a/packages/nimble-components/src/rich-text/editor/types.ts
+++ b/packages/nimble-components/src/rich-text/editor/types.ts
@@ -19,6 +19,11 @@ export interface MentionExtensionConfig {
     viewElement: string;
 }
 
+export interface FormatButtonsState {
+    bold: boolean;
+    italics: boolean;
+}
+
 export interface MentionDetail {
     href: string;
     displayName: string;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

- Fix for  [Bug 2614292](https://dev.azure.com/ni/DevCentral/_workitems/edit/2614292): Editor format buttons active state (Bold and Italics) are not retained when user configuration gets loaded dynamically

- Currently, when there are changes in the configuration, the states of the bold and italics buttons are reverted to an inactive state. This is happening because of the tiptap API [setContent()](https://tiptap.dev/docs/editor/api/commands/set-content) which will reset the formatting button states when setting content.  This PR will address this issue by resetting its states. 

## 👩‍💻 Implementation

- Added the `resetEditorButtonsState()` method after  `setMarkdown()` method which will take previous button states as arguments and retain the formatting button states.

## 🧪 Testing

- Written test cases to check the formatting button states on configuration change.
- Manually tested and verified the functionality in Storybook.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
