### PR TITLE
Add tests for list-option, menu-item, tab, and tree-view Angular directives

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/src/directives/list-option/nimble-combobox-list-option.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/list-option/nimble-combobox-list-option.directive.ts
@@ -1,6 +1,5 @@
-import { Directive, ElementRef, Host, Inject, Input, Optional, Renderer2, AfterViewInit, OnDestroy } from '@angular/core';
+import { Directive, ElementRef, Host, Inject, Input, Optional, AfterViewInit, OnDestroy } from '@angular/core';
 import type { ListOption } from '@ni/nimble-components/dist/esm/list-option';
-import { BooleanValueOrAttribute, toBooleanProperty } from '@ni/nimble-angular/internal-utilities';
 import { NimbleComboboxControlValueAccessorDirective } from '../combobox/nimble-combobox-control-value-accessor.directive';
 
 /**
@@ -10,14 +9,6 @@ import { NimbleComboboxControlValueAccessorDirective } from '../combobox/nimble-
     selector: 'nimble-list-option'
 })
 export class NimbleComboboxListOptionDirective implements AfterViewInit, OnDestroy {
-    public get disabled(): boolean {
-        return this.elementRef.nativeElement.disabled;
-    }
-
-    @Input() public set disabled(value: BooleanValueOrAttribute) {
-        this.renderer.setProperty(this.elementRef.nativeElement, 'disabled', toBooleanProperty(value));
-    }
-
     /**
      * @description
      * Tracks the value bound to the option element.
@@ -34,7 +25,6 @@ export class NimbleComboboxListOptionDirective implements AfterViewInit, OnDestr
 
     public constructor(
         private readonly elementRef: ElementRef<ListOption>,
-        private readonly renderer: Renderer2,
         @Inject(NimbleComboboxControlValueAccessorDirective) @Optional() @Host() private readonly combobox?: NimbleComboboxControlValueAccessorDirective
     ) { }
 

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/list-option/nimble-list-option.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/list-option/nimble-list-option.directive.ts
@@ -1,0 +1,32 @@
+import { Directive, Input, ElementRef, Renderer2 } from '@angular/core';
+import { type BooleanValueOrAttribute, toBooleanProperty } from '@ni/nimble-angular/internal-utilities';
+import type { ListOption, listOptionTag } from '@ni/nimble-components/dist/esm/list-option';
+
+export type { ListOption };
+export { listOptionTag };
+
+/**
+ * Directive to provide Angular integration for the list option.
+ *
+ * This directive contains the properties that are on the `nimble-list-option` nimble component, but it
+ * does not contain any Angular-specific form integration logic. The form integration logic is contained
+ * in separate directives for each component that can contain a `nimble-list-option`
+ * (e.g. `nimble-combobox-list-option.directive.ts` and `nimble-select-list-option.directive.ts`).
+ */
+@Directive({
+    selector: 'nimble-list-option'
+})
+export class NimbleListOptionDirective {
+    public get disabled(): boolean {
+        return this.elementRef.nativeElement.disabled;
+    }
+
+    @Input() public set disabled(value: BooleanValueOrAttribute) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'disabled', toBooleanProperty(value));
+    }
+
+    public constructor(
+        private readonly elementRef: ElementRef<ListOption>,
+        private readonly renderer: Renderer2,
+    ) { }
+}

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/list-option/nimble-list-option.module.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/list-option/nimble-list-option.module.ts
@@ -1,13 +1,22 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NimbleListOptionDirective } from './nimble-list-option.directive';
 import { NimbleSelectListOptionDirective } from './nimble-select-list-option.directive';
 import { NimbleComboboxListOptionDirective } from './nimble-combobox-list-option.directive';
 
 import '@ni/nimble-components/dist/esm/list-option';
 
 @NgModule({
-    declarations: [NimbleSelectListOptionDirective, NimbleComboboxListOptionDirective],
+    declarations: [
+        NimbleListOptionDirective,
+        NimbleSelectListOptionDirective,
+        NimbleComboboxListOptionDirective
+    ],
     imports: [CommonModule],
-    exports: [NimbleSelectListOptionDirective, NimbleComboboxListOptionDirective]
+    exports: [
+        NimbleListOptionDirective,
+        NimbleSelectListOptionDirective,
+        NimbleComboboxListOptionDirective
+    ]
 })
 export class NimbleListOptionModule { }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/list-option/nimble-select-list-option.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/list-option/nimble-select-list-option.directive.ts
@@ -1,6 +1,5 @@
-import { Directive, ElementRef, Host, Inject, Input, Optional, Renderer2 } from '@angular/core';
+import { Directive, ElementRef, Host, Inject, Optional, Renderer2 } from '@angular/core';
 import type { ListOption } from '@ni/nimble-components/dist/esm/list-option';
-import { BooleanValueOrAttribute, toBooleanProperty } from '@ni/nimble-angular/internal-utilities';
 import { NimbleSelectControlValueAccessorDirective } from '../select/nimble-select-control-value-accessor.directive';
 import { NgSelectOption } from '../../thirdparty/directives/select_control_value_accessor';
 
@@ -11,17 +10,9 @@ import { NgSelectOption } from '../../thirdparty/directives/select_control_value
     selector: 'nimble-list-option'
 })
 export class NimbleSelectListOptionDirective extends NgSelectOption {
-    public get disabled(): boolean {
-        return this.elementRef.nativeElement.disabled;
-    }
-
-    @Input() public set disabled(value: BooleanValueOrAttribute) {
-        this.renderer.setProperty(this.elementRef.nativeElement, 'disabled', toBooleanProperty(value));
-    }
-
     public constructor(
-        private readonly elementRef: ElementRef<ListOption>,
-        private readonly renderer: Renderer2,
+        elementRef: ElementRef<ListOption>,
+        renderer: Renderer2,
         @Inject(NimbleSelectControlValueAccessorDirective) @Optional() @Host() select: NimbleSelectControlValueAccessorDirective
     ) {
         super(elementRef, renderer, select);

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/list-option/tests/nimble-list-option.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/list-option/tests/nimble-list-option.directive.spec.ts
@@ -1,14 +1,170 @@
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, ElementRef, ViewChild } from '@angular/core';
+import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { NimbleListOptionModule } from '../nimble-list-option.module';
+import type { ListOption } from '../../../public-api';
+import { NimbleListOptionDirective } from '../nimble-list-option.directive';
 
 describe('Nimble listbox option', () => {
-    beforeEach(() => {
-        TestBed.configureTestingModule({
-            imports: [NimbleListOptionModule]
+    describe('module', () => {
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [NimbleListOptionModule]
+            });
+        });
+
+        it('custom element is defined', () => {
+            expect(customElements.get('nimble-list-option')).not.toBeUndefined();
         });
     });
 
-    it('custom element is defined', () => {
-        expect(customElements.get('nimble-list-option')).not.toBeUndefined();
+    describe('with no values in template', () => {
+        @Component({
+            template: `
+                <nimble-list-option #listOption></nimble-list-option>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('listOption', { read: NimbleListOptionDirective }) public directive: NimbleListOptionDirective;
+            @ViewChild('listOption', { read: ElementRef }) public elementRef: ElementRef<ListOption>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleListOptionDirective;
+        let nativeElement: ListOption;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleListOptionModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('has expected defaults for disabled', () => {
+            expect(directive.disabled).toBeUndefined();
+            expect(nativeElement.disabled).toBeUndefined();
+        });
+    });
+
+    describe('with template string values', () => {
+        @Component({
+            template: `
+                <nimble-list-option #listOption
+                    disabled
+                ></nimble-list-option>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('listOption', { read: NimbleListOptionDirective }) public directive: NimbleListOptionDirective;
+            @ViewChild('listOption', { read: ElementRef }) public elementRef: ElementRef<ListOption>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleListOptionDirective;
+        let nativeElement: ListOption;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleListOptionModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('will use template string values for disabled', () => {
+            expect(directive.disabled).toBeTrue();
+            expect(nativeElement.disabled).toBeTrue();
+        });
+    });
+
+    describe('with property bound values', () => {
+        @Component({
+            template: `
+                <nimble-list-option #listOption
+                    [disabled]="disabled"
+                ></nimble-list-option>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('listOption', { read: NimbleListOptionDirective }) public directive: NimbleListOptionDirective;
+            @ViewChild('listOption', { read: ElementRef }) public elementRef: ElementRef<ListOption>;
+
+            public disabled = false;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleListOptionDirective;
+        let nativeElement: ListOption;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleListOptionModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('can be configured with property binding for disabled', () => {
+            expect(directive.disabled).toBeFalse();
+            expect(nativeElement.disabled).toBeFalse();
+
+            fixture.componentInstance.disabled = true;
+            fixture.detectChanges();
+
+            expect(directive.disabled).toBeTrue();
+            expect(nativeElement.disabled).toBeTrue();
+        });
+    });
+
+    describe('with property attribute values', () => {
+        @Component({
+            template: `
+                <nimble-list-option #listOption
+                    [attr.disabled]="disabled">
+                </nimble-list-option>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('listOption', { read: NimbleListOptionDirective }) public directive: NimbleListOptionDirective;
+            @ViewChild('listOption', { read: ElementRef }) public elementRef: ElementRef<ListOption>;
+
+            public disabled: BooleanValueOrAttribute = null;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleListOptionDirective;
+        let nativeElement: ListOption;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleListOptionModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('can be configured with attribute binding for disabled', () => {
+            expect(directive.disabled).toBeUndefined();
+            expect(nativeElement.disabled).toBeUndefined();
+
+            fixture.componentInstance.disabled = '';
+            fixture.detectChanges();
+
+            expect(directive.disabled).toBeTrue();
+            expect(nativeElement.disabled).toBeTrue();
+        });
     });
 });

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/menu-item/tests/nimble-menu-item.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/menu-item/tests/nimble-menu-item.directive.spec.ts
@@ -1,14 +1,169 @@
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, ElementRef, ViewChild } from '@angular/core';
+import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { NimbleMenuItemModule } from '../nimble-menu-item.module';
+import { MenuItem, NimbleMenuItemDirective } from '../nimble-menu-item.directive';
 
 describe('Nimble menu item', () => {
-    beforeEach(() => {
-        TestBed.configureTestingModule({
-            imports: [NimbleMenuItemModule]
+    describe('module', () => {
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [NimbleMenuItemModule]
+            });
+        });
+
+        it('custom element is defined', () => {
+            expect(customElements.get('nimble-menu-item')).not.toBeUndefined();
         });
     });
 
-    it('custom element is defined', () => {
-        expect(customElements.get('nimble-menu-item')).not.toBeUndefined();
+    describe('with no values in template', () => {
+        @Component({
+            template: `
+                <nimble-menu-item #menuItem></nimble-menu-item>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('menuItem', { read: NimbleMenuItemDirective }) public directive: NimbleMenuItemDirective;
+            @ViewChild('menuItem', { read: ElementRef }) public elementRef: ElementRef<MenuItem>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleMenuItemDirective;
+        let nativeElement: MenuItem;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleMenuItemModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('has expected defaults for disabled', () => {
+            expect(directive.disabled).toBeUndefined();
+            expect(nativeElement.disabled).toBeUndefined();
+        });
+    });
+
+    describe('with template string values', () => {
+        @Component({
+            template: `
+                <nimble-menu-item #menuItem
+                    disabled
+                ></nimble-menu-item>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('menuItem', { read: NimbleMenuItemDirective }) public directive: NimbleMenuItemDirective;
+            @ViewChild('menuItem', { read: ElementRef }) public elementRef: ElementRef<MenuItem>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleMenuItemDirective;
+        let nativeElement: MenuItem;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleMenuItemModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('will use template string values for disabled', () => {
+            expect(directive.disabled).toBeTrue();
+            expect(nativeElement.disabled).toBeTrue();
+        });
+    });
+
+    describe('with property bound values', () => {
+        @Component({
+            template: `
+                <nimble-menu-item #menuItem
+                    [disabled]="disabled"
+                ></nimble-menu-item>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('menuItem', { read: NimbleMenuItemDirective }) public directive: NimbleMenuItemDirective;
+            @ViewChild('menuItem', { read: ElementRef }) public elementRef: ElementRef<MenuItem>;
+
+            public disabled = false;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleMenuItemDirective;
+        let nativeElement: MenuItem;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleMenuItemModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('can be configured with property binding for disabled', () => {
+            expect(directive.disabled).toBeFalse();
+            expect(nativeElement.disabled).toBeFalse();
+
+            fixture.componentInstance.disabled = true;
+            fixture.detectChanges();
+
+            expect(directive.disabled).toBeTrue();
+            expect(nativeElement.disabled).toBeTrue();
+        });
+    });
+
+    describe('with property attribute values', () => {
+        @Component({
+            template: `
+                <nimble-menu-item #menuItem
+                    [attr.disabled]="disabled">
+                </nimble-menu-item>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('menuItem', { read: NimbleMenuItemDirective }) public directive: NimbleMenuItemDirective;
+            @ViewChild('menuItem', { read: ElementRef }) public elementRef: ElementRef<MenuItem>;
+
+            public disabled: BooleanValueOrAttribute = null;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleMenuItemDirective;
+        let nativeElement: MenuItem;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleMenuItemModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('can be configured with attribute binding for disabled', () => {
+            expect(directive.disabled).toBeUndefined();
+            expect(nativeElement.disabled).toBeUndefined();
+
+            fixture.componentInstance.disabled = '';
+            fixture.detectChanges();
+
+            expect(directive.disabled).toBeTrue();
+            expect(nativeElement.disabled).toBeTrue();
+        });
     });
 });

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/tab/tests/nimble-tab.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/tab/tests/nimble-tab.directive.spec.ts
@@ -1,14 +1,169 @@
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, ElementRef, ViewChild } from '@angular/core';
+import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { NimbleTabModule } from '../nimble-tab.module';
+import { NimbleTabDirective, Tab } from '../nimble-tab.directive';
 
 describe('Nimble tab', () => {
-    beforeEach(() => {
-        TestBed.configureTestingModule({
-            imports: [NimbleTabModule]
+    describe('module', () => {
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [NimbleTabModule]
+            });
+        });
+
+        it('custom element is defined', () => {
+            expect(customElements.get('nimble-tab')).not.toBeUndefined();
         });
     });
 
-    it('custom element is defined', () => {
-        expect(customElements.get('nimble-tab')).not.toBeUndefined();
+    describe('with no values in template', () => {
+        @Component({
+            template: `
+                <nimble-tab #tab></nimble-tab>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('tab', { read: NimbleTabDirective }) public directive: NimbleTabDirective;
+            @ViewChild('tab', { read: ElementRef }) public elementRef: ElementRef<Tab>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleTabDirective;
+        let nativeElement: Tab;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleTabModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('has expected defaults for disabled', () => {
+            expect(directive.disabled).toBeUndefined();
+            expect(nativeElement.disabled).toBeUndefined();
+        });
+    });
+
+    describe('with template string values', () => {
+        @Component({
+            template: `
+                <nimble-tab #tab
+                    disabled
+                ></nimble-tab>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('tab', { read: NimbleTabDirective }) public directive: NimbleTabDirective;
+            @ViewChild('tab', { read: ElementRef }) public elementRef: ElementRef<Tab>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleTabDirective;
+        let nativeElement: Tab;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleTabModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('will use template string values for disabled', () => {
+            expect(directive.disabled).toBeTrue();
+            expect(nativeElement.disabled).toBeTrue();
+        });
+    });
+
+    describe('with property bound values', () => {
+        @Component({
+            template: `
+                <nimble-tab #tab
+                    [disabled]="disabled"
+                ></nimble-tab>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('tab', { read: NimbleTabDirective }) public directive: NimbleTabDirective;
+            @ViewChild('tab', { read: ElementRef }) public elementRef: ElementRef<Tab>;
+
+            public disabled = false;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleTabDirective;
+        let nativeElement: Tab;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleTabModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('can be configured with property binding for disabled', () => {
+            expect(directive.disabled).toBeFalse();
+            expect(nativeElement.disabled).toBeFalse();
+
+            fixture.componentInstance.disabled = true;
+            fixture.detectChanges();
+
+            expect(directive.disabled).toBeTrue();
+            expect(nativeElement.disabled).toBeTrue();
+        });
+    });
+
+    describe('with property attribute values', () => {
+        @Component({
+            template: `
+                <nimble-tab #tab
+                    [attr.disabled]="disabled">
+                </nimble-tab>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('tab', { read: NimbleTabDirective }) public directive: NimbleTabDirective;
+            @ViewChild('tab', { read: ElementRef }) public elementRef: ElementRef<Tab>;
+
+            public disabled: BooleanValueOrAttribute = null;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleTabDirective;
+        let nativeElement: Tab;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleTabModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('can be configured with attribute binding for disabled', () => {
+            expect(directive.disabled).toBeUndefined();
+            expect(nativeElement.disabled).toBeUndefined();
+
+            fixture.componentInstance.disabled = '';
+            fixture.detectChanges();
+
+            expect(directive.disabled).toBeTrue();
+            expect(nativeElement.disabled).toBeTrue();
+        });
     });
 });

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/tree-view/tests/nimble-tree-view.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/tree-view/tests/nimble-tree-view.directive.spec.ts
@@ -1,14 +1,168 @@
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { NimbleTreeViewModule } from '../nimble-tree-view.module';
+import { NimbleTreeViewDirective, TreeView, TreeViewSelectionMode } from '../nimble-tree-view.directive';
 
 describe('Nimble tree view', () => {
-    beforeEach(() => {
-        TestBed.configureTestingModule({
-            imports: [NimbleTreeViewModule]
+    describe('module', () => {
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [NimbleTreeViewModule]
+            });
+        });
+
+        it('custom element is defined', () => {
+            expect(customElements.get('nimble-tree-view')).not.toBeUndefined();
         });
     });
 
-    it('custom element is defined', () => {
-        expect(customElements.get('nimble-tree-view')).not.toBeUndefined();
+    describe('with no values in template', () => {
+        @Component({
+            template: `
+                <nimble-tree-view #treeView></nimble-tree-view>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('treeView', { read: NimbleTreeViewDirective }) public directive: NimbleTreeViewDirective;
+            @ViewChild('treeView', { read: ElementRef }) public elementRef: ElementRef<TreeView>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleTreeViewDirective;
+        let nativeElement: TreeView;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleTreeViewModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('has expected defaults for selectionMode', () => {
+            expect(directive.selectionMode).toBe(TreeViewSelectionMode.all);
+            expect(nativeElement.selectionMode).toBe(TreeViewSelectionMode.all);
+        });
+    });
+
+    describe('with template string values', () => {
+        @Component({
+            template: `
+                <nimble-tree-view #treeView
+                    selection-mode="none"
+                ></nimble-tree-view>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('treeView', { read: NimbleTreeViewDirective }) public directive: NimbleTreeViewDirective;
+            @ViewChild('treeView', { read: ElementRef }) public elementRef: ElementRef<TreeView>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleTreeViewDirective;
+        let nativeElement: TreeView;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleTreeViewModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('will use template string values for selectionMode', () => {
+            expect(directive.selectionMode).toBe(TreeViewSelectionMode.none);
+            expect(nativeElement.selectionMode).toBe(TreeViewSelectionMode.none);
+        });
+    });
+
+    describe('with property bound values', () => {
+        @Component({
+            template: `
+                <nimble-tree-view #treeView
+                    [selection-mode]="selectionMode"
+                ></nimble-tree-view>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('treeView', { read: NimbleTreeViewDirective }) public directive: NimbleTreeViewDirective;
+            @ViewChild('treeView', { read: ElementRef }) public elementRef: ElementRef<TreeView>;
+
+            public selectionMode: TreeViewSelectionMode = TreeViewSelectionMode.leavesOnly;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleTreeViewDirective;
+        let nativeElement: TreeView;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleTreeViewModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('can be configured with property binding for selectionMode', () => {
+            expect(directive.selectionMode).toBe(TreeViewSelectionMode.leavesOnly);
+            expect(nativeElement.selectionMode).toBe(TreeViewSelectionMode.leavesOnly);
+
+            fixture.componentInstance.selectionMode = TreeViewSelectionMode.all;
+            fixture.detectChanges();
+
+            expect(directive.selectionMode).toBe(TreeViewSelectionMode.all);
+            expect(nativeElement.selectionMode).toBe(TreeViewSelectionMode.all);
+        });
+    });
+
+    describe('with attribute bound values', () => {
+        @Component({
+            template: `
+                <nimble-tree-view #treeView
+                    [attr.selection-mode]="selectionMode"
+                ></nimble-tree-view>
+            `
+        })
+        class TestHostComponent {
+            @ViewChild('treeView', { read: NimbleTreeViewDirective }) public directive: NimbleTreeViewDirective;
+            @ViewChild('treeView', { read: ElementRef }) public elementRef: ElementRef<TreeView>;
+
+            public selectionMode: TreeViewSelectionMode = TreeViewSelectionMode.leavesOnly;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: NimbleTreeViewDirective;
+        let nativeElement: TreeView;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleTreeViewModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('can be configured with attribute binding for selectionMode', () => {
+            expect(directive.selectionMode).toBe(TreeViewSelectionMode.leavesOnly);
+            expect(nativeElement.selectionMode).toBe(TreeViewSelectionMode.leavesOnly);
+
+            fixture.componentInstance.selectionMode = TreeViewSelectionMode.all;
+            fixture.detectChanges();
+
+            expect(directive.selectionMode).toBe(TreeViewSelectionMode.all);
+            expect(nativeElement.selectionMode).toBe(TreeViewSelectionMode.all);
+        });
     });
 });

--- a/angular-workspace/projects/ni/nimble-angular/src/public-api.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/public-api.ts
@@ -48,6 +48,7 @@ export * from './directives/drawer/nimble-drawer.directive';
 export * from './directives/drawer/nimble-drawer.module';
 export * from './directives/icons';
 export * from './directives/list-option/nimble-combobox-list-option.directive';
+export * from './directives/list-option/nimble-list-option.directive';
 export * from './directives/list-option/nimble-select-list-option.directive';
 export * from './directives/list-option/nimble-list-option.module';
 export * from './directives/menu/nimble-menu.directive';
@@ -107,5 +108,4 @@ export { ButtonAppearance, ButtonAppearanceVariant } from '@ni/nimble-components
 export { SpinnerAppearance } from '@ni/nimble-components/dist/esm/spinner/types';
 export { DropdownAppearance } from '@ni/nimble-components/dist/esm/patterns/dropdown/types';
 export { IconSeverity } from '@ni/nimble-components/dist/esm/icon-base/types';
-export { type ListOption, listOptionTag } from '@ni/nimble-components/dist/esm/list-option';
 export { UserDismissed } from '@ni/nimble-components/dist/esm/dialog';

--- a/change/@ni-nimble-angular-d3ae2ab4-5a3b-4632-89aa-195d8a13a51f.json
+++ b/change/@ni-nimble-angular-d3ae2ab4-5a3b-4632-89aa-195d8a13a51f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add tests for list-option, menu-item, tab, and tree-view Angular directives",
+  "packageName": "@ni/nimble-angular",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #318 

This PR adds tests for the list-option, menu-item, tab, and tree-view Angular directives. These are the directives called out in #318 as needing tests. The theme-provider was also mentioned in the issue, but tests have already been added for that directive.

## 👩‍💻 Implementation

The bulk of the changes are adding nimble's standard Angular directive tests for each directive that was missing tests.

The more interesting change is a new list-option directive to contain the properties of the `nimble-list-option` component. It lives alongside the select-list-option and combobox-list-option directives. However, those directives previously each had their own duplicated implementation for the `nimble-list-option` properties (currently only `disabled`). This didn't seem ideal, and it also posed a problem with testing because there wasn't a great way to test each directive in isolation because they had the same selector, the same property, and were exported from the same Angular module. Now, the list-option directive contains everything that would be needed to use the list-option (exports types and contains `disabled` property), and the combobox & select specific directives for the list-option contain the form integration code that is necessary to use the combobox and select within an Angular form. All three directives are exported from the existing list-option module, so this change should be unnoticed by clients.

## 🧪 Testing

Ran auto tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
