### PR TITLE
Export tag name as literals

### DIFF
--- a/change/@ni-nimble-components-6ea7360c-c1c8-4ac9-b9fb-707b3c1faf24.json
+++ b/change/@ni-nimble-components-6ea7360c-c1c8-4ac9-b9fb-707b3c1faf24.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Export tag names as literals to improve type inferencing",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/CONTRIBUTING.md
+++ b/packages/nimble-components/CONTRIBUTING.md
@@ -337,7 +337,7 @@ The project uses a code generation build script to create a Nimble component for
 Every component should export its custom element tag (e.g. `nimble-button`) in a constant like this:
 
 ```ts
-export const buttonTag = DesignSystem.tagFor(Button);
+export const buttonTag = 'nimble-button';
 ```
 
 Client code can use this to refer to the component in an HTML template and having a dependency on the export will let a compiled application detect if a tag name changes.

--- a/packages/nimble-components/build/generate-icons/source/index.js
+++ b/packages/nimble-components/build/generate-icons/source/index.js
@@ -66,7 +66,7 @@ export class ${className} extends Icon {
 }
 
 registerIcon('${elementBaseName}', ${className});
-export const ${tagName} = DesignSystem.tagFor(${className});
+export const ${tagName} = '${elementName}';
 `;
 
     const filePath = path.resolve(iconsDirectory, `${fileName}.ts`);

--- a/packages/nimble-components/build/generate-icons/source/index.js
+++ b/packages/nimble-components/build/generate-icons/source/index.js
@@ -47,7 +47,6 @@ for (const key of Object.keys(icons)) {
 
     const componentFileContents = `${generatedFilePrefix}
 import { ${svgName} } from '@ni/nimble-tokens/dist/icons/js';
-import { DesignSystem } from '@microsoft/fast-foundation';
 import { Icon, registerIcon } from '../icon-base';
 
 declare global {

--- a/packages/nimble-components/src/anchor-button/index.ts
+++ b/packages/nimble-components/src/anchor-button/index.ts
@@ -65,4 +65,4 @@ const nimbleAnchorButton = AnchorButton.compose<AnchorOptions>({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleAnchorButton());
-export const anchorButtonTag = DesignSystem.tagFor(AnchorButton);
+export const anchorButtonTag = 'nimble-anchor-button';

--- a/packages/nimble-components/src/anchor-menu-item/index.ts
+++ b/packages/nimble-components/src/anchor-menu-item/index.ts
@@ -107,7 +107,7 @@ const nimbleAnchorMenuItem = AnchorMenuItem.compose<AnchorOptions>({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleAnchorMenuItem());
-export const anchorMenuItemTag = DesignSystem.tagFor(AnchorMenuItem);
+export const anchorMenuItemTag = 'nimble-anchor-menu-item';
 
 // This is a workaround for the fact that FAST's menu uses `instanceof MenuItem`
 // in their logic for indenting menu items. Since our AnchorMenuItem derives from

--- a/packages/nimble-components/src/anchor-tab/index.ts
+++ b/packages/nimble-components/src/anchor-tab/index.ts
@@ -53,4 +53,4 @@ const nimbleAnchorTab = AnchorTab.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleAnchorTab());
-export const anchorTabTag = DesignSystem.tagFor(AnchorTab);
+export const anchorTabTag = 'nimble-anchor-tab';

--- a/packages/nimble-components/src/anchor-tabs/index.ts
+++ b/packages/nimble-components/src/anchor-tabs/index.ts
@@ -295,4 +295,4 @@ const nimbleAnchorTabs = AnchorTabs.compose<TabsOptions>({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleAnchorTabs());
-export const anchorTabsTag = DesignSystem.tagFor(AnchorTabs);
+export const anchorTabsTag = 'nimble-anchor-tabs';

--- a/packages/nimble-components/src/anchor-tree-item/index.ts
+++ b/packages/nimble-components/src/anchor-tree-item/index.ts
@@ -130,4 +130,4 @@ const nimbleAnchorTreeItem = AnchorTreeItem.compose<AnchorOptions>({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleAnchorTreeItem());
-export const anchorTreeItemTag = DesignSystem.tagFor(AnchorTreeItem);
+export const anchorTreeItemTag = 'nimble-anchor-tree-item';

--- a/packages/nimble-components/src/anchor/index.ts
+++ b/packages/nimble-components/src/anchor/index.ts
@@ -62,4 +62,4 @@ const nimbleAnchor = Anchor.compose<AnchorOptions>({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleAnchor());
-export const anchorTag = DesignSystem.tagFor(Anchor);
+export const anchorTag = 'nimble-anchor';

--- a/packages/nimble-components/src/anchored-region/index.ts
+++ b/packages/nimble-components/src/anchored-region/index.ts
@@ -34,4 +34,4 @@ const nimbleAnchoredRegion = AnchoredRegion.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleAnchoredRegion());
-export const anchoredRegionTag = DesignSystem.tagFor(AnchoredRegion);
+export const anchoredRegionTag = 'nimble-anchored-region';

--- a/packages/nimble-components/src/banner/index.ts
+++ b/packages/nimble-components/src/banner/index.ts
@@ -81,4 +81,4 @@ const nimbleBanner = Banner.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleBanner());
-export const bannerTag = DesignSystem.tagFor(Banner);
+export const bannerTag = 'nimble-banner';

--- a/packages/nimble-components/src/breadcrumb-item/index.ts
+++ b/packages/nimble-components/src/breadcrumb-item/index.ts
@@ -29,4 +29,4 @@ const nimbleBreadcrumbItem = BreadcrumbItem.compose<BreadcrumbItemOptions>({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleBreadcrumbItem());
-export const breadcrumbItemTag = DesignSystem.tagFor(BreadcrumbItem);
+export const breadcrumbItemTag = 'nimble-breadcrumb-item';

--- a/packages/nimble-components/src/breadcrumb/index.ts
+++ b/packages/nimble-components/src/breadcrumb/index.ts
@@ -29,4 +29,4 @@ const nimbleBreadcrumb = Breadcrumb.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleBreadcrumb());
-export const breadcrumbTag = DesignSystem.tagFor(Breadcrumb);
+export const breadcrumbTag = 'nimble-breadcrumb';

--- a/packages/nimble-components/src/button/index.ts
+++ b/packages/nimble-components/src/button/index.ts
@@ -69,4 +69,4 @@ const nimbleButton = Button.compose<ButtonOptions>({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleButton());
-export const buttonTag = DesignSystem.tagFor(Button);
+export const buttonTag = 'nimble-button';

--- a/packages/nimble-components/src/card-button/index.ts
+++ b/packages/nimble-components/src/card-button/index.ts
@@ -44,4 +44,4 @@ const nimbleCardButton = CardButton.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleCardButton());
-export const cardButtonTag = DesignSystem.tagFor(CardButton);
+export const cardButtonTag = 'nimble-card-button';

--- a/packages/nimble-components/src/card/index.ts
+++ b/packages/nimble-components/src/card/index.ts
@@ -24,4 +24,4 @@ const nimbleCard = Card.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleCard());
-export const cardTag = DesignSystem.tagFor(Card);
+export const cardTag = 'nimble-card';

--- a/packages/nimble-components/src/checkbox/index.ts
+++ b/packages/nimble-components/src/checkbox/index.ts
@@ -28,4 +28,4 @@ const nimbleCheckbox = Checkbox.compose<CheckboxOptions>({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleCheckbox());
-export const checkboxTag = DesignSystem.tagFor(Checkbox);
+export const checkboxTag = 'nimble-checkbox';

--- a/packages/nimble-components/src/combobox/index.ts
+++ b/packages/nimble-components/src/combobox/index.ts
@@ -322,4 +322,4 @@ const nimbleCombobox = Combobox.compose<ComboboxOptions>({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleCombobox());
-export const comboboxTag = DesignSystem.tagFor(Combobox);
+export const comboboxTag = 'nimble-combobox';

--- a/packages/nimble-components/src/dialog/index.ts
+++ b/packages/nimble-components/src/dialog/index.ts
@@ -144,4 +144,4 @@ const nimbleDialog = Dialog.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleDialog());
-export const dialogTag = DesignSystem.tagFor(Dialog);
+export const dialogTag = 'nimble-dialog';

--- a/packages/nimble-components/src/drawer/index.ts
+++ b/packages/nimble-components/src/drawer/index.ts
@@ -142,4 +142,4 @@ const nimbleDrawer = Drawer.compose({
     styles
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleDrawer());
-export const drawerTag = DesignSystem.tagFor(Drawer);
+export const drawerTag = 'nimble-drawer';

--- a/packages/nimble-components/src/label-provider/core/index.ts
+++ b/packages/nimble-components/src/label-provider/core/index.ts
@@ -59,4 +59,4 @@ const nimbleLabelProviderCore = LabelProviderCore.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleLabelProviderCore());
-export const labelProviderCoreTag = DesignSystem.tagFor(LabelProviderCore);
+export const labelProviderCoreTag = 'nimble-label-provider-core';

--- a/packages/nimble-components/src/label-provider/rich-text/index.ts
+++ b/packages/nimble-components/src/label-provider/rich-text/index.ts
@@ -49,6 +49,4 @@ const nimbleLabelProviderRichText = LabelProviderRichText.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleLabelProviderRichText());
-export const labelProviderRichTextTag = DesignSystem.tagFor(
-    LabelProviderRichText
-);
+export const labelProviderRichTextTag = 'nimble-label-provider-rich-text';

--- a/packages/nimble-components/src/label-provider/table/index.ts
+++ b/packages/nimble-components/src/label-provider/table/index.ts
@@ -94,4 +94,4 @@ const nimbleLabelProviderTable = LabelProviderTable.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleLabelProviderTable());
-export const labelProviderTableTag = DesignSystem.tagFor(LabelProviderTable);
+export const labelProviderTableTag = 'nimble-label-provider-table';

--- a/packages/nimble-components/src/list-option/index.ts
+++ b/packages/nimble-components/src/list-option/index.ts
@@ -40,4 +40,4 @@ const nimbleListOption = ListOption.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleListOption());
-export const listOptionTag = DesignSystem.tagFor(ListOption);
+export const listOptionTag = 'nimble-list-option';

--- a/packages/nimble-components/src/listbox/index.ts
+++ b/packages/nimble-components/src/listbox/index.ts
@@ -23,4 +23,4 @@ const nimbleListbox = Listbox.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleListbox());
-export const listboxTag = DesignSystem.tagFor(Listbox);
+export const listboxTag = 'nimble-listbox';

--- a/packages/nimble-components/src/mapping/icon/index.ts
+++ b/packages/nimble-components/src/mapping/icon/index.ts
@@ -83,4 +83,4 @@ const iconMapping = MappingIcon.compose({
     template
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(iconMapping());
-export const mappingIconTag = DesignSystem.tagFor(MappingIcon);
+export const mappingIconTag = 'nimble-mapping-icon';

--- a/packages/nimble-components/src/mapping/spinner/index.ts
+++ b/packages/nimble-components/src/mapping/spinner/index.ts
@@ -25,4 +25,4 @@ const spinnerMapping = MappingSpinner.compose({
     template
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(spinnerMapping());
-export const mappingSpinnerTag = DesignSystem.tagFor(MappingSpinner);
+export const mappingSpinnerTag = 'nimble-mapping-spinner';

--- a/packages/nimble-components/src/mapping/text/index.ts
+++ b/packages/nimble-components/src/mapping/text/index.ts
@@ -25,4 +25,4 @@ const textMapping = MappingText.compose({
     template
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(textMapping());
-export const mappingTextTag = DesignSystem.tagFor(MappingText);
+export const mappingTextTag = 'nimble-mapping-text';

--- a/packages/nimble-components/src/mapping/user/index.ts
+++ b/packages/nimble-components/src/mapping/user/index.ts
@@ -22,4 +22,4 @@ const mappingUser = MappingUser.compose({
     template
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(mappingUser());
-export const mappingUserTag = DesignSystem.tagFor(MappingUser);
+export const mappingUserTag = 'nimble-mapping-user';

--- a/packages/nimble-components/src/menu-button/index.ts
+++ b/packages/nimble-components/src/menu-button/index.ts
@@ -258,4 +258,4 @@ const nimbleMenuButton = MenuButton.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleMenuButton());
-export const menuButtonTag = DesignSystem.tagFor(MenuButton);
+export const menuButtonTag = 'nimble-menu-button';

--- a/packages/nimble-components/src/menu-item/index.ts
+++ b/packages/nimble-components/src/menu-item/index.ts
@@ -36,4 +36,4 @@ const nimbleMenuItem = MenuItem.compose<MenuItemOptions>({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleMenuItem());
-export const menuItemTag = DesignSystem.tagFor(MenuItem);
+export const menuItemTag = 'nimble-menu-item';

--- a/packages/nimble-components/src/menu/index.ts
+++ b/packages/nimble-components/src/menu/index.ts
@@ -37,4 +37,4 @@ const nimbleMenu = Menu.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleMenu());
-export const menuTag = DesignSystem.tagFor(Menu);
+export const menuTag = 'nimble-menu';

--- a/packages/nimble-components/src/number-field/index.ts
+++ b/packages/nimble-components/src/number-field/index.ts
@@ -107,4 +107,4 @@ const nimbleNumberField = NumberField.compose<NumberFieldOptions>({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleNumberField());
-export const numberFieldTag = DesignSystem.tagFor(NumberField);
+export const numberFieldTag = 'nimble-number-field';

--- a/packages/nimble-components/src/radio-group/index.ts
+++ b/packages/nimble-components/src/radio-group/index.ts
@@ -30,4 +30,4 @@ const nimbleRadioGroup = RadioGroup.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleRadioGroup());
-export const radioGroupTag = DesignSystem.tagFor(RadioGroup);
+export const radioGroupTag = 'nimble-radio-group';

--- a/packages/nimble-components/src/radio/index.ts
+++ b/packages/nimble-components/src/radio/index.ts
@@ -27,4 +27,4 @@ const nimbleRadio = Radio.compose<RadioOptions>({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleRadio());
-export const radioTag = DesignSystem.tagFor(Radio);
+export const radioTag = 'nimble-radio';

--- a/packages/nimble-components/src/rich-text-mention/users/index.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/index.ts
@@ -56,4 +56,4 @@ const nimbleRichTextMentionUsers = RichTextMentionUsers.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleRichTextMentionUsers());
-export const richTextMentionUsersTag = DesignSystem.tagFor(RichTextMentionUsers);
+export const richTextMentionUsersTag = 'nimble-rich-text-mention-users';

--- a/packages/nimble-components/src/rich-text-mention/users/tests/rich-text-mention-users.spec.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/tests/rich-text-mention-users.spec.ts
@@ -18,9 +18,7 @@ async function setUserMappingElements(
 ): Promise<void> {
     const newUserMappingElements: MappingUser[] = [];
     mappings.forEach(mapping => {
-        const mappingUser = document.createElement(
-            mappingUserTag
-        ) as MappingUser;
+        const mappingUser = document.createElement(mappingUserTag);
         mappingUser.key = mapping.key ?? '';
         mappingUser.displayName = mapping.displayName ?? '';
         newUserMappingElements.push(mappingUser);

--- a/packages/nimble-components/src/rich-text-mention/users/view/index.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/view/index.ts
@@ -3,6 +3,12 @@ import { RichTextMentionView } from '../../base/view';
 import { template } from './template';
 import { styles } from './styles';
 
+declare global {
+    interface HTMLElementTagNameMap {
+        'nimble-rich-text-mention-users-view': RichTextMentionUsersView;
+    }
+}
+
 /**
  * A nimble styled rich text mention users view
  */
@@ -17,6 +23,4 @@ const nimbleRichTextMentionUsersView = RichTextMentionUsersView.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleRichTextMentionUsersView());
-export const richTextMentionUsersViewTag = DesignSystem.tagFor(
-    RichTextMentionUsersView
-);
+export const richTextMentionUsersViewTag = 'nimble-rich-text-mention-users-view';

--- a/packages/nimble-components/src/rich-text/editor/index.ts
+++ b/packages/nimble-components/src/rich-text/editor/index.ts
@@ -755,4 +755,4 @@ const nimbleRichTextEditor = RichTextEditor.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleRichTextEditor());
-export const richTextEditorTag = DesignSystem.tagFor(RichTextEditor);
+export const richTextEditorTag = 'nimble-rich-text-editor';

--- a/packages/nimble-components/src/rich-text/editor/testing/rich-text-editor-utils.ts
+++ b/packages/nimble-components/src/rich-text/editor/testing/rich-text-editor-utils.ts
@@ -16,15 +16,11 @@ export async function appendUserMentionConfiguration(
     element: RichTextEditor,
     mappings?: MappingConfiguration[]
 ): Promise<UserMentionElements> {
-    const userMentionElement = document.createElement(
-        richTextMentionUsersTag
-    ) as RichTextMentionUsers;
+    const userMentionElement = document.createElement(richTextMentionUsersTag);
     userMentionElement.pattern = '^user:(.*)';
     const mappingElements: MappingUser[] = [];
     mappings?.forEach(mapping => {
-        const mappingUser = document.createElement(
-            mappingUserTag
-        ) as MappingUser;
+        const mappingUser = document.createElement(mappingUserTag);
         mappingUser.key = mapping.key ?? '';
         mappingUser.displayName = mapping.displayName;
         userMentionElement.appendChild(mappingUser);
@@ -46,9 +42,7 @@ export async function appendTestMentionConfiguration(
     testMentionElement.pattern = '^test:(.*)';
     const mappingElements: MappingUser[] = [];
     mappings?.forEach(mapping => {
-        const mappingUser = document.createElement(
-            mappingUserTag
-        ) as MappingUser;
+        const mappingUser = document.createElement(mappingUserTag);
         mappingUser.key = mapping.key;
         mappingUser.displayName = mapping.displayName;
         testMentionElement.appendChild(mappingUser);
@@ -68,9 +62,7 @@ export async function replaceUserMappingElements(
 ): Promise<void> {
     const newUserMappingElements: MappingUser[] = [];
     mappings.forEach(mapping => {
-        const mappingUser = document.createElement(
-            mappingUserTag
-        ) as MappingUser;
+        const mappingUser = document.createElement(mappingUserTag);
         mappingUser.key = mapping.key ?? '';
         mappingUser.displayName = mapping.displayName ?? '';
         newUserMappingElements.push(mappingUser);

--- a/packages/nimble-components/src/rich-text/mention-listbox/index.ts
+++ b/packages/nimble-components/src/rich-text/mention-listbox/index.ts
@@ -281,6 +281,4 @@ const nimbleRichTextMentionListbox = RichTextMentionListbox.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleRichTextMentionListbox());
-export const richTextMentionListboxTag = DesignSystem.tagFor(
-    RichTextMentionListbox
-);
+export const richTextMentionListboxTag = 'nimble-rich-text-mention-listbox';

--- a/packages/nimble-components/src/rich-text/viewer/index.ts
+++ b/packages/nimble-components/src/rich-text/viewer/index.ts
@@ -83,4 +83,4 @@ const nimbleRichTextViewer = RichTextViewer.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleRichTextViewer());
-export const richTextViewerTag = DesignSystem.tagFor(RichTextViewer);
+export const richTextViewerTag = 'nimble-rich-text-viewer';

--- a/packages/nimble-components/src/rich-text/viewer/tests/rich-text-viewer.spec.ts
+++ b/packages/nimble-components/src/rich-text/viewer/tests/rich-text-viewer.spec.ts
@@ -34,16 +34,12 @@ async function appendUserMentionConfiguration(
     userKeys?: string[],
     displayNames?: string[]
 ): Promise<void> {
-    const userMention = document.createElement(
-        richTextMentionUsersTag
-    ) as RichTextMentionUsers;
+    const userMention = document.createElement(richTextMentionUsersTag);
     userMention.pattern = '^user:(.*)';
 
     if (userKeys || displayNames) {
         userKeys?.forEach((userKey, index) => {
-            const mappingUser = document.createElement(
-                mappingUserTag
-            ) as MappingUser;
+            const mappingUser = document.createElement(mappingUserTag);
             mappingUser.key = userKey ?? '';
             mappingUser.displayName = displayNames?.[index] ?? '';
             userMention.appendChild(mappingUser);

--- a/packages/nimble-components/src/select/index.ts
+++ b/packages/nimble-components/src/select/index.ts
@@ -120,4 +120,4 @@ const nimbleSelect = Select.compose<SelectOptions>({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleSelect());
-export const selectTag = DesignSystem.tagFor(Select);
+export const selectTag = 'nimble-select';

--- a/packages/nimble-components/src/spinner/index.ts
+++ b/packages/nimble-components/src/spinner/index.ts
@@ -30,4 +30,4 @@ const nimbleSpinner = Spinner.compose({
     styles
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleSpinner());
-export const spinnerTag = DesignSystem.tagFor(Spinner);
+export const spinnerTag = 'nimble-spinner';

--- a/packages/nimble-components/src/switch/index.ts
+++ b/packages/nimble-components/src/switch/index.ts
@@ -25,4 +25,4 @@ const nimbleSwitch = Switch.compose<SwitchOptions>({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleSwitch());
-export const switchTag = DesignSystem.tagFor(Switch);
+export const switchTag = 'nimble-switch';

--- a/packages/nimble-components/src/tab-panel/index.ts
+++ b/packages/nimble-components/src/tab-panel/index.ts
@@ -24,4 +24,4 @@ const nimbleTabPanel = TabPanel.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleTabPanel());
-export const tabPanelTag = DesignSystem.tagFor(TabPanel);
+export const tabPanelTag = 'nimble-tab-panel';

--- a/packages/nimble-components/src/tab/index.ts
+++ b/packages/nimble-components/src/tab/index.ts
@@ -24,4 +24,4 @@ const nimbleTab = Tab.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleTab());
-export const tabTag = DesignSystem.tagFor(Tab);
+export const tabTag = 'nimble-tab';

--- a/packages/nimble-components/src/table-column/anchor/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/anchor/cell-view/index.ts
@@ -51,6 +51,4 @@ const anchorCellView = TableColumnAnchorCellView.compose({
     styles
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(anchorCellView());
-export const tableColumnAnchorCellViewTag = DesignSystem.tagFor(
-    TableColumnAnchorCellView
-);
+export const tableColumnAnchorCellViewTag = 'nimble-table-column-anchor-cell-view';

--- a/packages/nimble-components/src/table-column/anchor/index.ts
+++ b/packages/nimble-components/src/table-column/anchor/index.ts
@@ -155,4 +155,4 @@ const nimbleTableColumnAnchor = TableColumnAnchor.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleTableColumnAnchor());
-export const tableColumnAnchorTag = DesignSystem.tagFor(TableColumnAnchor);
+export const tableColumnAnchorTag = 'nimble-table-column-anchor';

--- a/packages/nimble-components/src/table-column/base/tests/table-cell-view.spec.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-cell-view.spec.ts
@@ -9,7 +9,6 @@ import type { TableCellView } from '../cell-view';
 import type { DelegatedEventEventDetails } from '../types';
 import {
     tableColumnEmptyCellViewTag,
-    TableColumnEmpty,
     tableColumnEmptyGroupHeaderViewTag,
     tableColumnEmptyTag
 } from './table-column.fixtures';
@@ -72,9 +71,7 @@ describe('TableCellView', () => {
             }
         });
         // Configure column that delegates no events
-        const emptyColumn = document.createElement(
-            tableColumnEmptyTag
-        ) as TableColumnEmpty;
+        const emptyColumn = document.createElement(tableColumnEmptyTag);
         let gotClickOnEmptyColumn = false;
         let gotKeydownOnEmptyColumn = false;
         let gotOtherEventOnEmptyColumn = false;

--- a/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
@@ -11,6 +11,11 @@ import type {
 import { ColumnValidator } from '../models/column-validator';
 
 export const tableColumnEmptyCellViewTag = 'nimble-test-table-column-empty-cell-view';
+declare global {
+    interface HTMLElementTagNameMap {
+        [tableColumnEmptyCellViewTag]: TableCellView;
+    }
+}
 /**
  * Simple empty cell view for testing
  */
@@ -20,6 +25,11 @@ export const tableColumnEmptyCellViewTag = 'nimble-test-table-column-empty-cell-
 class EmptyTableCellView extends TableCellView {}
 
 export const tableColumnEmptyGroupHeaderViewTag = 'nimble-test-table-column-empty-group-header-view';
+declare global {
+    interface HTMLElementTagNameMap {
+        [tableColumnEmptyGroupHeaderViewTag]: EmptyTableGroupHeaderView;
+    }
+}
 /**
  * Simple empty group header view for testing
  */
@@ -29,6 +39,11 @@ export const tableColumnEmptyGroupHeaderViewTag = 'nimble-test-table-column-empt
 class EmptyTableGroupHeaderView extends TableGroupHeaderView {}
 
 export const tableColumnEmptyTag = 'nimble-test-table-column-empty';
+declare global {
+    interface HTMLElementTagNameMap {
+        [tableColumnEmptyTag]: TableColumnEmpty;
+    }
+}
 /**
  * Simple empty table column for testing
  */
@@ -67,13 +82,12 @@ export class TestColumnValidator extends ColumnValidator<
     }
 }
 
+export const tableColumnValidationTestTag = 'nimble-test-table-column-validation';
 declare global {
     interface HTMLElementTagNameMap {
-        'nimble-test-table-column-validation': TableColumnValidationTest;
+        [tableColumnValidationTestTag]: TableColumnValidationTest;
     }
 }
-
-export const tableColumnValidationTestTag = 'nimble-test-table-column-validation';
 /**
  * Test column type used to verify column config validation.
  * The foo and bar properties are only considered valid when their values are true.

--- a/packages/nimble-components/src/table-column/date-text/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/cell-view/index.ts
@@ -47,6 +47,4 @@ const dateTextCellView = TableColumnDateTextCellView.compose({
     styles
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(dateTextCellView());
-export const tableColumnDateTextCellViewTag = DesignSystem.tagFor(
-    TableColumnDateTextCellView
-);
+export const tableColumnDateTextCellViewTag = 'nimble-table-column-date-text-cell-view';

--- a/packages/nimble-components/src/table-column/date-text/group-header-view/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/group-header-view/index.ts
@@ -46,6 +46,4 @@ const tableColumnDateTextGroupHeaderView = TableColumnDateTextGroupHeaderView.co
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(tableColumnDateTextGroupHeaderView());
-export const tableColumnDateTextGroupHeaderViewTag = DesignSystem.tagFor(
-    TableColumnDateTextGroupHeaderView
-);
+export const tableColumnDateTextGroupHeaderViewTag = 'nimble-table-column-date-text-group-header-view';

--- a/packages/nimble-components/src/table-column/date-text/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/index.ts
@@ -295,4 +295,4 @@ const nimbleTableColumnDateText = TableColumnDateText.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleTableColumnDateText());
-export const tableColumnDateTextTag = DesignSystem.tagFor(TableColumnDateText);
+export const tableColumnDateTextTag = 'nimble-table-column-date-text';

--- a/packages/nimble-components/src/table-column/duration-text/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/duration-text/cell-view/index.ts
@@ -41,6 +41,4 @@ const durationTextCellView = TableColumnDurationTextCellView.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(durationTextCellView());
-export const tableColumnDurationTextCellViewTag = DesignSystem.tagFor(
-    TableColumnDurationTextCellView
-);
+export const tableColumnDurationTextCellViewTag = 'nimble-table-column-duration-text-cell-view';

--- a/packages/nimble-components/src/table-column/duration-text/group-header-view/index.ts
+++ b/packages/nimble-components/src/table-column/duration-text/group-header-view/index.ts
@@ -44,6 +44,4 @@ const tableColumnDurationTextGroupHeaderView = TableColumnDurationTextGroupHeade
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(tableColumnDurationTextGroupHeaderView());
-export const tableColumnDurationTextGroupHeaderViewTag = DesignSystem.tagFor(
-    TableColumnDurationTextGroupHeaderView
-);
+export const tableColumnDurationTextGroupHeaderViewTag = 'nimble-table-column-duration-text-group-header-view';

--- a/packages/nimble-components/src/table-column/duration-text/index.ts
+++ b/packages/nimble-components/src/table-column/duration-text/index.ts
@@ -78,6 +78,4 @@ const nimbleTableColumnDurationText = TableColumnDurationText.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleTableColumnDurationText());
-export const tableColumnDurationTextTag = DesignSystem.tagFor(
-    TableColumnDurationText
-);
+export const tableColumnDurationTextTag = 'nimble-table-column-duration-text';

--- a/packages/nimble-components/src/table-column/enum-text/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/enum-text/cell-view/index.ts
@@ -49,6 +49,4 @@ const enumTextCellView = TableColumnEnumTextCellView.compose({
     styles
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(enumTextCellView());
-export const tableColumnEnumTextCellViewTag = DesignSystem.tagFor(
-    TableColumnEnumTextCellView
-);
+export const tableColumnEnumTextCellViewTag = 'nimble-table-column-enum-text-cell-view';

--- a/packages/nimble-components/src/table-column/enum-text/group-header-view/index.ts
+++ b/packages/nimble-components/src/table-column/enum-text/group-header-view/index.ts
@@ -49,4 +49,4 @@ const enumTextGroupHeaderView = TableColumnEnumTextGroupHeaderView.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(enumTextGroupHeaderView());
-export const tableColumnEnumTextGroupHeaderViewTag = 'table-column-enum-text-group-header-view';
+export const tableColumnEnumTextGroupHeaderViewTag = 'nimble-table-column-enum-text-group-header-view';

--- a/packages/nimble-components/src/table-column/enum-text/group-header-view/index.ts
+++ b/packages/nimble-components/src/table-column/enum-text/group-header-view/index.ts
@@ -49,6 +49,4 @@ const enumTextGroupHeaderView = TableColumnEnumTextGroupHeaderView.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(enumTextGroupHeaderView());
-export const tableColumnEnumTextGroupHeaderViewTag = DesignSystem.tagFor(
-    TableColumnEnumTextGroupHeaderView
-);
+export const tableColumnEnumTextGroupHeaderViewTag = 'table-column-enum-text-group-header-view';

--- a/packages/nimble-components/src/table-column/enum-text/index.ts
+++ b/packages/nimble-components/src/table-column/enum-text/index.ts
@@ -80,4 +80,4 @@ const nimbleTableColumnEnumText = TableColumnEnumText.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleTableColumnEnumText());
-export const tableColumnEnumTextTag = DesignSystem.tagFor(TableColumnEnumText);
+export const tableColumnEnumTextTag = 'nimble-table-column-enum-text';

--- a/packages/nimble-components/src/table-column/icon/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/icon/cell-view/index.ts
@@ -75,6 +75,4 @@ const iconCellView = TableColumnIconCellView.compose({
     template
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(iconCellView());
-export const tableColumnIconCellViewTag = DesignSystem.tagFor(
-    TableColumnIconCellView
-);
+export const tableColumnIconCellViewTag = 'nimble-table-column-icon-cell-view';

--- a/packages/nimble-components/src/table-column/icon/group-header-view/index.ts
+++ b/packages/nimble-components/src/table-column/icon/group-header-view/index.ts
@@ -72,6 +72,4 @@ const iconGroupHeaderView = TableColumnIconGroupHeaderView.compose({
     styles
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(iconGroupHeaderView());
-export const tableColumnIconGroupHeaderViewTag = DesignSystem.tagFor(
-    TableColumnIconGroupHeaderView
-);
+export const tableColumnIconGroupHeaderViewTag = 'nimble-table-column-icon-group-header-view';

--- a/packages/nimble-components/src/table-column/icon/index.ts
+++ b/packages/nimble-components/src/table-column/icon/index.ts
@@ -92,4 +92,4 @@ const nimbleTableColumnIcon = TableColumnIcon.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleTableColumnIcon());
-export const tableColumnIconTag = DesignSystem.tagFor(TableColumnIcon);
+export const tableColumnIconTag = 'nimble-table-column-icon';

--- a/packages/nimble-components/src/table-column/number-text/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/cell-view/index.ts
@@ -42,6 +42,4 @@ const numberTextCellView = TableColumnNumberTextCellView.compose({
     styles
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(numberTextCellView());
-export const tableColumnNumberTextCellViewTag = DesignSystem.tagFor(
-    TableColumnNumberTextCellView
-);
+export const tableColumnNumberTextCellViewTag = 'nimble-table-column-number-text-cell-view';

--- a/packages/nimble-components/src/table-column/number-text/group-header-view/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/group-header-view/index.ts
@@ -39,6 +39,4 @@ const tableColumnNumberTextGroupHeaderView = TableColumnNumberTextGroupHeaderVie
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(tableColumnNumberTextGroupHeaderView());
-export const tableColumnNumberTextGroupHeaderTag = DesignSystem.tagFor(
-    TableColumnNumberTextGroupHeaderView
-);
+export const tableColumnNumberTextGroupHeaderTag = 'nimble-table-column-number-text-group-header-view';

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -175,6 +175,4 @@ const nimbleTableColumnNumberText = TableColumnNumberText.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleTableColumnNumberText());
-export const tableColumnNumberTextTag = DesignSystem.tagFor(
-    TableColumnNumberText
-);
+export const tableColumnNumberTextTag = 'nimble-table-column-number-text';

--- a/packages/nimble-components/src/table-column/text/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/text/cell-view/index.ts
@@ -33,6 +33,4 @@ const textCellView = TableColumnTextCellView.compose({
     styles
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(textCellView());
-export const tableColumnTextCellViewTag = DesignSystem.tagFor(
-    TableColumnTextCellView
-);
+export const tableColumnTextCellViewTag = 'nimble-table-column-text-cell-view';

--- a/packages/nimble-components/src/table-column/text/group-header-view/index.ts
+++ b/packages/nimble-components/src/table-column/text/group-header-view/index.ts
@@ -32,6 +32,4 @@ const tableColumnTextGroupHeaderView = TableColumnTextGroupHeaderView.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(tableColumnTextGroupHeaderView());
-export const tableColumnTextGroupHeaderViewTag = DesignSystem.tagFor(
-    TableColumnTextGroupHeaderView
-);
+export const tableColumnTextGroupHeaderViewTag = 'nimble-table-column-text-group-header-view';

--- a/packages/nimble-components/src/table-column/text/index.ts
+++ b/packages/nimble-components/src/table-column/text/index.ts
@@ -42,4 +42,4 @@ const nimbleTableColumnText = TableColumnText.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleTableColumnText());
-export const tableColumnTextTag = DesignSystem.tagFor(TableColumnText);
+export const tableColumnTextTag = 'nimble-table-column-text';

--- a/packages/nimble-components/src/table/components/cell/index.ts
+++ b/packages/nimble-components/src/table/components/cell/index.ts
@@ -73,4 +73,4 @@ const nimbleTableCell = TableCell.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleTableCell());
-export const tableCellTag = DesignSystem.tagFor(TableCell);
+export const tableCellTag = 'nimble-table-cell';

--- a/packages/nimble-components/src/table/components/group-row/index.ts
+++ b/packages/nimble-components/src/table/components/group-row/index.ts
@@ -134,4 +134,4 @@ const nimbleTableGroupRow = TableGroupRow.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleTableGroupRow());
-export const tableGroupRowTag = DesignSystem.tagFor(TableGroupRow);
+export const tableGroupRowTag = 'nimble-table-group-row';

--- a/packages/nimble-components/src/table/components/header/index.ts
+++ b/packages/nimble-components/src/table/components/header/index.ts
@@ -59,4 +59,4 @@ const nimbleTableHeader = TableHeader.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleTableHeader());
-export const tableHeaderTag = DesignSystem.tagFor(TableHeader);
+export const tableHeaderTag = 'nimble-table-header';

--- a/packages/nimble-components/src/table/components/row/index.ts
+++ b/packages/nimble-components/src/table/components/row/index.ts
@@ -335,4 +335,4 @@ const nimbleTableRow = TableRow.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleTableRow());
-export const tableRowTag = DesignSystem.tagFor(TableRow);
+export const tableRowTag = 'nimble-table-row';

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -1105,4 +1105,4 @@ const nimbleTable = Table.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleTable());
-export const tableTag = DesignSystem.tagFor(Table);
+export const tableTag = 'nimble-table';

--- a/packages/nimble-components/src/table/specs/table-column-specs/table-column-formatted-text.md
+++ b/packages/nimble-components/src/table/specs/table-column-specs/table-column-formatted-text.md
@@ -109,8 +109,8 @@ const myAppProgressColumn = MyAppProgressColumn.compose({
     styles
 });
 
-DesignSystem.getOrCreate().withPrefix('my-app').register(myAppProgressColumn());
-export const myAppProgressColumnTag = DesignSystem.tagFor(MyAppProgressColumn);
+DesignSystem.getOrCreate().withPrefix('nimble').register(myAppProgressColumn());
+export const myAppProgressColumnTag = 'nimble-table-column-progress';
 ```
 
 **Specify formatting of cells and group headers in their custom elements**

--- a/packages/nimble-components/src/table/testing/table.pageobject.ts
+++ b/packages/nimble-components/src/table/testing/table.pageobject.ts
@@ -185,7 +185,7 @@ export class TablePageObject<T extends TableRecord> {
                 `Anchor not found at cell ${rowIndex},${columnIndex}`
             );
         }
-        return anchor as Anchor;
+        return anchor;
     }
 
     public getRenderedIconColumnCellIconSeverity(

--- a/packages/nimble-components/src/table/tests/table-labels.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-labels.spec.ts
@@ -57,7 +57,7 @@ describe('Table with LabelProviderTable', () => {
     beforeEach(async () => {
         let themeProvider: ThemeProvider;
         ({ element: themeProvider, connect, disconnect } = await setup());
-        element = themeProvider.querySelector(tableTag)!;
+        element = themeProvider.querySelector<Table<SimpleTableRecord>>(tableTag)!;
         labelProvider = themeProvider.querySelector(labelProviderTableTag)!;
 
         pageObject = new TablePageObject<SimpleTableRecord>(element);

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -2,7 +2,7 @@
 import { attr, customElement, html } from '@microsoft/fast-element';
 import { Table, tableTag } from '..';
 import { TableColumn } from '../../table-column/base';
-import { TableColumnText, tableColumnTextTag } from '../../table-column/text';
+import { tableColumnTextTag } from '../../table-column/text';
 import { TableColumnTextCellView } from '../../table-column/text/cell-view';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { controlHeight } from '../../theme-provider/design-tokens';
@@ -365,9 +365,7 @@ describe('Table', () => {
             await element.setData(simpleTableData);
             await waitForUpdatesAsync();
 
-            const dateColumn = document.createElement(
-                tableColumnTextTag
-            ) as TableColumnText;
+            const dateColumn = document.createElement(tableColumnTextTag);
             dateColumn.fieldName = 'moreStringData';
 
             element.appendChild(dateColumn);
@@ -384,9 +382,7 @@ describe('Table', () => {
             await element.setData(simpleTableData);
             await waitForUpdatesAsync();
 
-            const dateColumn = document.createElement(
-                tableColumnTextTag
-            ) as TableColumnText;
+            const dateColumn = document.createElement(tableColumnTextTag);
             dateColumn.fieldName = 'moreStringData';
 
             element.insertBefore(dateColumn, element.columns[0]!);

--- a/packages/nimble-components/src/tabs-toolbar/index.ts
+++ b/packages/nimble-components/src/tabs-toolbar/index.ts
@@ -20,4 +20,4 @@ const nimbleTabsToolbar = TabsToolbar.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleTabsToolbar());
-export const tabsToolbarTag = DesignSystem.tagFor(TabsToolbar);
+export const tabsToolbarTag = 'nimble-tabs-toolbar';

--- a/packages/nimble-components/src/tabs/index.ts
+++ b/packages/nimble-components/src/tabs/index.ts
@@ -31,4 +31,4 @@ const nimbleTabs = Tabs.compose<TabsOptions>({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleTabs());
-export const tabsTag = DesignSystem.tagFor(Tabs);
+export const tabsTag = 'nimble-tabs';

--- a/packages/nimble-components/src/text-area/index.ts
+++ b/packages/nimble-components/src/text-area/index.ts
@@ -137,4 +137,4 @@ const nimbleTextArea = TextArea.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleTextArea());
-export const textAreaTag = DesignSystem.tagFor(TextArea);
+export const textAreaTag = 'nimble-text-area';

--- a/packages/nimble-components/src/text-field/index.ts
+++ b/packages/nimble-components/src/text-field/index.ts
@@ -69,4 +69,4 @@ const nimbleTextField = TextField.compose<TextFieldOptions>({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleTextField());
-export const textFieldTag = DesignSystem.tagFor(TextField);
+export const textFieldTag = 'nimble-text-field';

--- a/packages/nimble-components/src/theme-provider/index.ts
+++ b/packages/nimble-components/src/theme-provider/index.ts
@@ -125,4 +125,4 @@ const nimbleDesignSystemProvider = ThemeProvider.compose({
 DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleDesignSystemProvider());
-export const themeProviderTag = DesignSystem.tagFor(ThemeProvider);
+export const themeProviderTag = 'nimble-theme-provider';

--- a/packages/nimble-components/src/toggle-button/index.ts
+++ b/packages/nimble-components/src/toggle-button/index.ts
@@ -54,4 +54,4 @@ const nimbleToggleButton = ToggleButton.compose<ButtonOptions>({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleToggleButton());
-export const toggleButtonTag = DesignSystem.tagFor(ToggleButton);
+export const toggleButtonTag = 'nimble-toggle-button';

--- a/packages/nimble-components/src/toolbar/index.ts
+++ b/packages/nimble-components/src/toolbar/index.ts
@@ -28,4 +28,4 @@ const nimbleToolbar = Toolbar.compose<ToolbarOptions>({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleToolbar());
-export const toolbarTag = DesignSystem.tagFor(Toolbar);
+export const toolbarTag = 'nimble-toolbar';

--- a/packages/nimble-components/src/tooltip/index.ts
+++ b/packages/nimble-components/src/tooltip/index.ts
@@ -37,4 +37,4 @@ const nimbleTooltip = Tooltip.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleTooltip());
-export const tooltipTag = DesignSystem.tagFor(Tooltip);
+export const tooltipTag = 'nimble-tooltip';

--- a/packages/nimble-components/src/tree-item/index.ts
+++ b/packages/nimble-components/src/tree-item/index.ts
@@ -41,4 +41,4 @@ const nimbleTreeItem = TreeItem.compose<TreeItemOptions>({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleTreeItem());
-export const treeItemTag = DesignSystem.tagFor(TreeItem);
+export const treeItemTag = 'nimble-tree-item';

--- a/packages/nimble-components/src/tree-view/index.ts
+++ b/packages/nimble-components/src/tree-view/index.ts
@@ -103,4 +103,4 @@ const nimbleTreeView = TreeView.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleTreeView());
-export const treeViewTag = DesignSystem.tagFor(TreeView);
+export const treeViewTag = 'nimble-tree-view';

--- a/packages/nimble-components/src/wafer-map/index.ts
+++ b/packages/nimble-components/src/wafer-map/index.ts
@@ -309,4 +309,4 @@ const nimbleWaferMap = WaferMap.compose({
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleWaferMap());
-export const waferMapTag = DesignSystem.tagFor(WaferMap);
+export const waferMapTag = 'nimble-wafer-map';


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

We include type definitions such as the following so that TypeScript is aware of the tag names we register:
```ts
declare global {
    interface HTMLElementTagNameMap {
        'nimble-anchor': Anchor;
    }
}
```

With that kind of definition using an API like `document.createElement('nimble-anchor')` will let TypeScript infer the result will be an instance of `Anchor`. However, because we were exporting tag names as runtime calculated strings, TypeScript was not able to infer the type using `document.createElement(anchorTag);`.

## 👩‍💻 Implementation

This change modifies our tag definitions to export them as constant string literals to improve inferred typing. Notice how in some of the tests `as` casts were removed by the linter for having unnecessary casting.

## 🧪 Testing

Relied on exisiting tests.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed. Updated the element creation doc snippets.
