### PR TITLE
Visual design sizing improvements for rich text editor

### DIFF
--- a/change/@ni-nimble-components-e9c3f67e-9da6-4b87-ac5d-ff81f3df19ec.json
+++ b/change/@ni-nimble-components-e9c3f67e-9da6-4b87-ac5d-ff81f3df19ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Visual design improvements for rich text editor",
+  "packageName": "@ni/nimble-components",
+  "email": "123377523+vivinkrishna-ni@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/rich-text/editor/styles.ts
+++ b/packages/nimble-components/src/rich-text/editor/styles.ts
@@ -256,11 +256,8 @@ export const styles = css`
         gap: 8px;
     }
 
+    ${buttonTag},
     ${toggleButtonTag} {
-        height: ${controlSlimHeight};
-    }
-
-    ${buttonTag} {
         height: ${controlSlimHeight};
     }
 
@@ -270,6 +267,10 @@ export const styles = css`
         margin-inline-end: ${standardPadding};
         gap: ${standardPadding};
         place-items: center;
+    }
+
+    slot[name='footer-actions']::slotted(*) {
+        height: ${controlSlimHeight};
     }
 
     :host([error-visible]) .error-icon {

--- a/packages/nimble-components/src/rich-text/editor/styles.ts
+++ b/packages/nimble-components/src/rich-text/editor/styles.ts
@@ -18,6 +18,9 @@ import {
     controlSlimHeight
 } from '../../theme-provider/design-tokens';
 import { styles as errorStyles } from '../../patterns/error/styles';
+import { toolbarTag } from '../../toolbar';
+import { toggleButtonTag } from '../../toggle-button';
+import { buttonTag } from '../../button';
 
 export const styles = css`
     ${display('inline-flex')}
@@ -241,7 +244,7 @@ export const styles = css`
         display: none;
     }
 
-    nimble-toolbar::part(positioning-region) {
+    ${toolbarTag}::part(positioning-region) {
         background: transparent;
         padding-right: 8px;
         box-sizing: border-box;
@@ -249,15 +252,15 @@ export const styles = css`
         height: var(--ni-private-rich-text-editor-footer-section-height);
     }
 
-    nimble-toolbar::part(start) {
+    ${toolbarTag}::part(start) {
         gap: 8px;
     }
 
-    nimble-toggle-button {
+    ${toggleButtonTag} {
         height: ${controlSlimHeight};
     }
 
-    nimble-button {
+    ${buttonTag} {
         height: ${controlSlimHeight};
     }
 

--- a/packages/nimble-components/src/rich-text/editor/styles.ts
+++ b/packages/nimble-components/src/rich-text/editor/styles.ts
@@ -14,7 +14,8 @@ import {
     smallDelay,
     mediumPadding,
     standardPadding,
-    linkFontColor
+    linkFontColor,
+    controlSlimHeight
 } from '../../theme-provider/design-tokens';
 import { styles as errorStyles } from '../../patterns/error/styles';
 
@@ -36,6 +37,7 @@ export const styles = css`
         }
         height: 82px;
         --ni-private-rich-text-editor-footer-section-height: 40px;
+        --ni-private-rich-text-editor-footer-section-border-top-width: 2px;
         ${
             /** Minimum width is added to accommodate all the possible buttons in the toolbar and to support the mobile width. */ ''
         }
@@ -226,8 +228,11 @@ export const styles = css`
         display: flex;
         justify-content: space-between;
         flex-shrink: 0;
-        border: ${borderWidth} solid transparent;
-        border-top-color: rgba(${borderRgbPartialColor}, 0.1);
+        border: 0px;
+        border-top: var(
+                --ni-private-rich-text-editor-footer-section-border-top-width
+            )
+            solid rgba(${borderRgbPartialColor}, 0.1);
         height: var(--ni-private-rich-text-editor-footer-section-height);
         overflow: hidden;
     }
@@ -239,10 +244,21 @@ export const styles = css`
     nimble-toolbar::part(positioning-region) {
         background: transparent;
         padding-right: 8px;
+        box-sizing: border-box;
+        gap: 0px;
+        height: var(--ni-private-rich-text-editor-footer-section-height);
     }
 
     nimble-toolbar::part(start) {
         gap: 8px;
+    }
+
+    nimble-toggle-button {
+        height: ${controlSlimHeight};
+    }
+
+    nimble-button {
+        height: ${controlSlimHeight};
     }
 
     .footer-actions {

--- a/packages/nimble-components/src/rich-text/editor/styles.ts
+++ b/packages/nimble-components/src/rich-text/editor/styles.ts
@@ -21,6 +21,8 @@ import { styles as errorStyles } from '../../patterns/error/styles';
 import { toolbarTag } from '../../toolbar';
 import { toggleButtonTag } from '../../toggle-button';
 import { buttonTag } from '../../button';
+import { anchorButtonTag } from '../../anchor-button';
+import { menuButtonTag } from '../../menu-button';
 
 export const styles = css`
     ${display('inline-flex')}
@@ -278,7 +280,10 @@ export const styles = css`
         place-items: center;
     }
 
-    slot[name='footer-actions']::slotted(*) {
+    ::slotted(${buttonTag}),
+    ::slotted(${toggleButtonTag}),
+    ::slotted(${anchorButtonTag}),
+    ::slotted(${menuButtonTag}) {
         height: ${controlSlimHeight};
     }
 

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-matrix.stories.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-matrix.stories.ts
@@ -10,10 +10,6 @@ import {
 } from '../../../utilities/tests/matrix';
 import { hiddenWrapper } from '../../../utilities/tests/hidden';
 import { richTextEditorTag } from '..';
-import {
-    cssPropertyFromTokenName,
-    tokenNames
-} from '../../../theme-provider/design-token-names';
 import { buttonTag } from '../../../button';
 import { loremIpsum } from '../../../utilities/tests/lorem-ipsum';
 import {
@@ -24,6 +20,7 @@ import {
 } from '../../../utilities/tests/states';
 import { richTextMentionUsersTag } from '../../../rich-text-mention/users';
 import { mappingUserTag } from '../../../mapping/user';
+import { bodyFont, bodyFontColor } from '../../../theme-provider/design-tokens';
 
 const metadata: Meta = {
     title: 'Tests/Rich Text Editor',
@@ -57,8 +54,8 @@ const component = (
 ): ViewTemplate => html`
     <p 
         style="
-        font: var(${cssPropertyFromTokenName(tokenNames.bodyFont)});
-        color: var(${cssPropertyFromTokenName(tokenNames.bodyFontColor)});
+        font: var(${bodyFont.cssCustomProperty});
+        color: var(${bodyFontColor.cssCustomProperty});
         margin-bottom: 0px;
         "
     >
@@ -95,21 +92,19 @@ const editorSizingTestCase = (
     [widthLabel, widthStyle]: [string, string],
     [heightLabel, heightStyle]: [string, string]
 ): ViewTemplate => html`
-    <p style="font: var(${cssPropertyFromTokenName(
-        tokenNames.bodyFont
-    )}); margin-bottom: 0px;">${() => widthLabel}; ${() => heightLabel}</p>
+    <p style="font: var(${bodyFont.cssCustomProperty}); margin-bottom: 0px;">${() => widthLabel}; ${() => heightLabel}</p>
     <div style="width: 500px; height: 180px; outline: 1px dotted black;">
         <${richTextEditorTag} style="${() => widthStyle}; ${() => heightStyle};">
             <${richTextMentionUsersTag} pattern="^user:(.*)">
                 <${mappingUserTag} key="user:1" display-name="John Doe"></${mappingUserTag}>
             </${richTextMentionUsersTag}>
             <${buttonTag}
-                style="height: var(${cssPropertyFromTokenName(tokenNames.controlSlimHeight)}); width: 72px;"
+                style="width: 72px;"
                 slot="footer-actions"
                 appearance="ghost"
             >Cancel</${buttonTag}>
             <${buttonTag}
-                style="height: var(${cssPropertyFromTokenName(tokenNames.controlSlimHeight)}); width: 72px;"
+                style="width: 72px;"
                 slot="footer-actions"
             >Ok</${buttonTag}>
         </${richTextEditorTag}>
@@ -167,12 +162,12 @@ const mobileWidthComponent = html`
             <${mappingUserTag} key="user:1" display-name="John Doe"></${mappingUserTag}>
         </${richTextMentionUsersTag}>
         <${buttonTag}
-            style="height: var(${cssPropertyFromTokenName(tokenNames.controlSlimHeight)}); width: 72px;"
+            style="width: 72px;"
             slot="footer-actions"
             appearance="ghost"
         >Cancel</${buttonTag}>
         <${buttonTag}
-            style="height: var(${cssPropertyFromTokenName(tokenNames.controlSlimHeight)}); width: 72px;"
+            style="width: 72px;"
             slot="footer-actions"
         >Ok</${buttonTag}>
     </${richTextEditorTag}>

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-matrix.stories.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-matrix.stories.ts
@@ -90,6 +90,7 @@ const longTextPlayFunction = (): void => {
     ));
 };
 
+// prettier-ignore
 const editorSizingTestCase = (
     [widthLabel, widthStyle]: [string, string],
     [heightLabel, heightStyle]: [string, string]
@@ -99,8 +100,18 @@ const editorSizingTestCase = (
     )}); margin-bottom: 0px;">${() => widthLabel}; ${() => heightLabel}</p>
     <div style="width: 500px; height: 180px; outline: 1px dotted black;">
         <${richTextEditorTag} style="${() => widthStyle}; ${() => heightStyle};">
-            <${buttonTag} slot="footer-actions" appearance="ghost">Cancel</${buttonTag}>
-            <${buttonTag} slot="footer-actions" appearance="outline">Ok</${buttonTag}>
+            <${richTextMentionUsersTag} pattern="^user:(.*)">
+                <${mappingUserTag} key="user:1" display-name="John Doe"></${mappingUserTag}>
+            </${richTextMentionUsersTag}>
+            <${buttonTag}
+                style="height: var(${cssPropertyFromTokenName(tokenNames.controlSlimHeight)}); width: 72px;"
+                slot="footer-actions"
+                appearance="ghost"
+            >Cancel</${buttonTag}>
+            <${buttonTag}
+                style="height: var(${cssPropertyFromTokenName(tokenNames.controlSlimHeight)}); width: 72px;"
+                slot="footer-actions"
+            >Ok</${buttonTag}>
         </${richTextEditorTag}>
     </div>
 `;
@@ -149,10 +160,21 @@ export const richTextEditorSizing: StoryFn = createStory(html`
     ])}
 `);
 
+// prettier-ignore
 const mobileWidthComponent = html`
-    <${richTextEditorTag} style="padding: 20px; width: 300px; height: 250px;">
-        <${buttonTag} slot="footer-actions" appearance="ghost">Cancel</${buttonTag}>
-        <${buttonTag} slot="footer-actions" appearance="outline">Ok</${buttonTag}>
+    <${richTextEditorTag} style="width: 360px; height: 250px;">
+        <${richTextMentionUsersTag} pattern="^user:(.*)">
+            <${mappingUserTag} key="user:1" display-name="John Doe"></${mappingUserTag}>
+        </${richTextMentionUsersTag}>
+        <${buttonTag}
+            style="height: var(${cssPropertyFromTokenName(tokenNames.controlSlimHeight)}); width: 72px;"
+            slot="footer-actions"
+            appearance="ghost"
+        >Cancel</${buttonTag}>
+        <${buttonTag}
+            style="height: var(${cssPropertyFromTokenName(tokenNames.controlSlimHeight)}); width: 72px;"
+            slot="footer-actions"
+        >Ok</${buttonTag}>
     </${richTextEditorTag}>
 `;
 

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-matrix.stories.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-matrix.stories.ts
@@ -21,6 +21,9 @@ import {
 import { richTextMentionUsersTag } from '../../../rich-text-mention/users';
 import { mappingUserTag } from '../../../mapping/user';
 import { bodyFont, bodyFontColor } from '../../../theme-provider/design-tokens';
+import { toggleButtonTag } from '../../../toggle-button';
+import { menuButtonTag } from '../../../menu-button';
+import { anchorButtonTag } from '../../../anchor-button';
 
 const metadata: Meta = {
     title: 'Tests/Rich Text Editor',
@@ -44,6 +47,14 @@ const placeholderValueStates = [
     ['Placeholder', 'Placeholder text']
 ] as const;
 type PlaceholderValueStates = (typeof placeholderValueStates)[number];
+
+const slotButtons = [
+    buttonTag,
+    toggleButtonTag,
+    menuButtonTag,
+    anchorButtonTag
+] as const;
+type SlotButtons = (typeof slotButtons)[number];
 
 // prettier-ignore
 const component = (
@@ -111,6 +122,19 @@ const editorSizingTestCase = (
     </div>
 `;
 
+// prettier-ignore
+const slotButtonsTextCase = (
+    slotButton: SlotButtons
+): ViewTemplate => html`
+    <p style="font: var(${bodyFont.cssCustomProperty}); margin-bottom: 0px;">${() => slotButton}</p>
+    <${richTextEditorTag}>
+        <${slotButton}
+            style="width: 72px;"
+            slot="footer-actions"
+        >Ok</${slotButton}>
+    </${richTextEditorTag}>
+`;
+
 export const richTextEditorThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         disabledStates,
@@ -153,6 +177,10 @@ export const richTextEditorSizing: StoryFn = createStory(html`
             ['Height 100%', 'height: 100%']
         ]
     ])}
+`);
+
+export const richTextEditorSlotButtons: StoryFn = createStory(html`
+    ${createMatrix(slotButtonsTextCase, [slotButtons])}
 `);
 
 // prettier-ignore

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-matrix.stories.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-matrix.stories.ts
@@ -162,7 +162,7 @@ export const richTextEditorSizing: StoryFn = createStory(html`
 
 // prettier-ignore
 const mobileWidthComponent = html`
-    <${richTextEditorTag} style="width: 360px; height: 250px;">
+    <${richTextEditorTag} style="padding: 20px; width: 360px; height: 250px;">
         <${richTextMentionUsersTag} pattern="^user:(.*)">
             <${mappingUserTag} key="user:1" display-name="John Doe"></${mappingUserTag}>
         </${richTextMentionUsersTag}>

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.stories.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.stories.ts
@@ -16,6 +16,10 @@ import { labelProviderRichTextTag } from '../../../label-provider/rich-text';
 import { richTextMarkdownString } from '../../../utilities/tests/rich-text-markdown-string';
 import { mappingUserTag } from '../../../mapping/user';
 import { richTextMentionUsersTag } from '../../../rich-text-mention/users';
+import {
+    cssPropertyFromTokenName,
+    tokenNames
+} from '../../../theme-provider/design-token-names';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface RichTextEditorArgs extends LabelUserArgs {
@@ -69,6 +73,8 @@ const setMarkdownDescription = 'A function that sets content in the editor with 
 const getMarkdownDescription = 'A function that serializes the current data in the editor and returns the markdown string.';
 const footerActionButtonDescription = `To place content such as a button at the far-right of the footer section, set \`slot="footer-actions"\`.
 
+It is recommended to set the height of the buttons to \`24px\` or use \`$ni-nimble-control-slim-height\` token.
+
 Note: The content in the \`footer-actions\` slot will not adjust based on the state of the rich-text-editor (e.g. disabled). It is the responsibility of the
 client application to make any necessary adjustments. For example, if the buttons should be disabled when the rich-text-editor is disabled, the
 client application must implement that functionality.
@@ -115,8 +121,15 @@ const metadata: Meta<RichTextEditorArgs> = {
             <${mappingUserTag} key="${x => mentionDataSets[x.mentionData].href}8" display-name="Mitert"></${mappingUserTag}>
         </${richTextMentionUsersTag}>
         ${when(x => x.footerActionButtons, html`
-            <${buttonTag} appearance="ghost" slot="footer-actions">Cancel</${buttonTag}>
-            <${buttonTag} slot="footer-actions">OK</${buttonTag}>`)}
+            <${buttonTag}
+                style="height: var(${cssPropertyFromTokenName(tokenNames.controlSlimHeight)}); min-width: 72px;"
+                appearance="ghost"
+                slot="footer-actions"
+            >Cancel</${buttonTag}>
+            <${buttonTag}
+                style="height: var(${cssPropertyFromTokenName(tokenNames.controlSlimHeight)}); min-width: 72px;"
+                slot="footer-actions"
+            >OK</${buttonTag}>`)}
     </${richTextEditorTag}>
     `),
     argTypes: {

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.stories.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.stories.ts
@@ -16,10 +16,6 @@ import { labelProviderRichTextTag } from '../../../label-provider/rich-text';
 import { richTextMarkdownString } from '../../../utilities/tests/rich-text-markdown-string';
 import { mappingUserTag } from '../../../mapping/user';
 import { richTextMentionUsersTag } from '../../../rich-text-mention/users';
-import {
-    cssPropertyFromTokenName,
-    tokenNames
-} from '../../../theme-provider/design-token-names';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface RichTextEditorArgs extends LabelUserArgs {
@@ -73,7 +69,7 @@ const setMarkdownDescription = 'A function that sets content in the editor with 
 const getMarkdownDescription = 'A function that serializes the current data in the editor and returns the markdown string.';
 const footerActionButtonDescription = `To place content such as a button at the far-right of the footer section, set \`slot="footer-actions"\`.
 
-It is recommended to set the height of the buttons to \`24px\` or use \`$ni-nimble-control-slim-height\` token.
+It is recommended to set the height of the buttons to use \`$ni-nimble-control-slim-height\` token.
 
 Note: The content in the \`footer-actions\` slot will not adjust based on the state of the rich-text-editor (e.g. disabled). It is the responsibility of the
 client application to make any necessary adjustments. For example, if the buttons should be disabled when the rich-text-editor is disabled, the
@@ -122,12 +118,12 @@ const metadata: Meta<RichTextEditorArgs> = {
         </${richTextMentionUsersTag}>
         ${when(x => x.footerActionButtons, html`
             <${buttonTag}
-                style="height: var(${cssPropertyFromTokenName(tokenNames.controlSlimHeight)}); min-width: 72px;"
+                style="min-width: 72px;"
                 appearance="ghost"
                 slot="footer-actions"
             >Cancel</${buttonTag}>
             <${buttonTag}
-                style="height: var(${cssPropertyFromTokenName(tokenNames.controlSlimHeight)}); min-width: 72px;"
+                style="min-width: 72px;"
                 slot="footer-actions"
             >OK</${buttonTag}>`)}
     </${richTextEditorTag}>

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.stories.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.stories.ts
@@ -67,9 +67,9 @@ const mentionDataSets = {
 const richTextEditorDescription = 'The rich text editor component allows users to add/edit text formatted with various styling options including bold, italics, numbered lists, and bulleted lists. The editor generates markdown output and takes markdown as input. The markdown flavor used is [CommonMark](https://spec.commonmark.org/0.30/).\n\n See the [rich text viewer](?path=/docs/incubating-rich-text-viewer--docs) component to render markdown without allowing editing.';
 const setMarkdownDescription = 'A function that sets content in the editor with the provided markdown string.';
 const getMarkdownDescription = 'A function that serializes the current data in the editor and returns the markdown string.';
-const footerActionButtonDescription = `To place content such as a button at the far-right of the footer section, set \`slot="footer-actions"\`.
+const footerActionButtonDescription = `You can place a button or anchor button at the far-right of the footer section, set \`slot="footer-actions"\`.
 
-It is recommended to set the height of the buttons to use \`$ni-nimble-control-slim-height\` token.
+Nimble will set the height of the buttons to \`$ni-nimble-control-slim-height\`.
 
 Note: The content in the \`footer-actions\` slot will not adjust based on the state of the rich-text-editor (e.g. disabled). It is the responsibility of the
 client application to make any necessary adjustments. For example, if the buttons should be disabled when the rich-text-editor is disabled, the


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

<!---
Provide some background and a description of your work.
What problem does this change solve?

Include links to issues, work items, or other discussions.
-->
- Resolves https://github.com/ni/nimble/issues/1589
- Fixing the sizing problems for screens with mobile width.

## 👩‍💻 Implementation

<!---
Describe how the change addresses the problem. Consider factors such as complexity, alternative solutions, performance impact, etc. 

Consider listing files with important changes or comment on them directly in the pull request.
-->
1. Reduce the height of all footer buttons to `$ni-nimble-control-slim-height` (24px) and update the docs to recommend the same height for footer buttons
2. Set the footer height to 40px and the border-top of footer-section to 2px (a line between the toolbar and editor)
3. Adjust the width by removing the gap in the toolbar to be compatible with the mobile screens.
4. Set the default height of the provided `footer-actions` slot buttons to `$ni-nimble-control-slim-height` using `::slotted()` and update the doc to provide only buttons.

## 🧪 Testing

<!---
Detail the testing done to ensure this submission meets requirements. 

Include automated/manual test additions or modifications, testing done on a local build, private CI run results, and additional testing not covered by automatic pull request validation. If any functionality is not covered by automated testing, provide justification.
-->
- Updated the storybook matrix tests
- Added a matrix test for different slot buttons to test the default height in the `footer-actions` slot.
- Manually verified in the mobile screen widths

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
