### PR TITLE
Remove workaround for tabindex bug on Edge

### DIFF
--- a/change/@ni-nimble-components-139a7cb5-055b-4ee8-8ac8-7ba105bf516a.json
+++ b/change/@ni-nimble-components-139a7cb5-055b-4ee8-8ac8-7ba105bf516a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove workaround for tabindex bug on Edge",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/anchor-menu-item/index.ts
+++ b/packages/nimble-components/src/anchor-menu-item/index.ts
@@ -67,21 +67,6 @@ export class AnchorMenuItem extends AnchorBase {
         return true;
     }
 
-    // The FAST Menu manages the `tabindex` of its menu items. Because of a bug in Chromium
-    // (https://bugs.chromium.org/p/chromium/issues/detail?id=1346606), setting the tabindex on an element
-    // with `delegatesFocus=true` causes the element to lose focus. This causes the menu to close, preventing
-    // arrowing through the items or navigating to the url. As a workaround, we intercept attempts to
-    // set the tabindex on the host and instead set it on the inner anchor.
-    // The referenced Chromium bug is actually fixed, but it hasn't been pulled into Edge yet (it is in
-    // Chrome). Issue https://github.com/ni/nimble/issues/1118 tracks removal of this workaround.
-    public override setAttribute(qualifiedName: string, value: string): void {
-        if (qualifiedName === 'tabindex') {
-            this.anchor.setAttribute(qualifiedName, value);
-        } else {
-            super.setAttribute(qualifiedName, value);
-        }
-    }
-
     // This is part of the bug workaround described above (in setAttribute)
     public override get tabIndex(): number {
         return this.anchor.tabIndex;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #1118
The bug was fixed in Chromium 112, which corresponds to Edge v112 (released April 2023).

## 👩‍💻 Implementation

Removed workaround (`setAttribute` override).

## 🧪 Testing

Verified in Edge that arrowing through menu with anchor menu item (in Storybook) does not close menu.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
