### PR TITLE
Move column validator into columnInternals

### DIFF
--- a/change/@ni-nimble-components-ca8544da-d13f-4d2d-9707-1b767141f3d1.json
+++ b/change/@ni-nimble-components-ca8544da-d13f-4d2d-9707-1b767141f3d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Include validator in table column internals",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table-column/base/index.ts
+++ b/packages/nimble-components/src/table-column/base/index.ts
@@ -53,11 +53,11 @@ export abstract class TableColumn<
     public contentSlot!: HTMLSlotElement;
 
     public checkValidity(): boolean {
-        return this.columnInternals.validConfiguration;
+        return this.columnInternals.validator.isValid();
     }
 
     public get validity(): TableColumnValidity {
-        return {};
+        return this.columnInternals.validator.getValidity();
     }
 
     /** @internal */

--- a/packages/nimble-components/src/table-column/base/index.ts
+++ b/packages/nimble-components/src/table-column/base/index.ts
@@ -10,6 +10,10 @@ import {
     ColumnInternalsOptions
 } from './models/column-internals';
 import type { TableColumnValidity } from './types';
+import type { ColumnValidator } from './models/column-validator';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ColumnValidatorConstructor<T extends ColumnValidator<[]>> = abstract new (...args: any[]) => T;
 
 /**
  * The base class for table columns
@@ -97,5 +101,16 @@ export abstract class TableColumn<
             this.columnInternals.currentSortDirection = this.sortDirection;
             this.columnInternals.currentSortIndex = this.sortIndex;
         }
+    }
+
+    protected getTypedValidator<T extends ColumnValidator<[]>>(requiredType: ColumnValidatorConstructor<T>): T {
+        if (
+            this.columnInternals.validator
+            instanceof requiredType
+        ) {
+            return this.columnInternals.validator;
+        }
+
+        throw new Error('Unexpected column validator type found');
     }
 }

--- a/packages/nimble-components/src/table-column/base/index.ts
+++ b/packages/nimble-components/src/table-column/base/index.ts
@@ -13,7 +13,9 @@ import type { TableColumnValidity } from './types';
 import type { ColumnValidator } from './models/column-validator';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ColumnValidatorConstructor<T extends ColumnValidator<[]>> = abstract new (...args: any[]) => T;
+type ColumnValidatorConstructor<T extends ColumnValidator<[]>> = abstract new (
+    ...args: any[]
+) => T;
 
 /**
  * The base class for table columns
@@ -103,11 +105,10 @@ export abstract class TableColumn<
         }
     }
 
-    protected getTypedValidator<T extends ColumnValidator<[]>>(requiredType: ColumnValidatorConstructor<T>): T {
-        if (
-            this.columnInternals.validator
-            instanceof requiredType
-        ) {
+    protected getTypedValidator<T extends ColumnValidator<[]>>(
+        requiredType: ColumnValidatorConstructor<T>
+    ): T {
+        if (this.columnInternals.validator instanceof requiredType) {
             return this.columnInternals.validator;
         }
 

--- a/packages/nimble-components/src/table-column/base/index.ts
+++ b/packages/nimble-components/src/table-column/base/index.ts
@@ -12,8 +12,8 @@ import {
 import type { TableColumnValidity } from './types';
 import type { ColumnValidator } from './models/column-validator';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ColumnValidatorConstructor<T extends ColumnValidator<[]>> = abstract new (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ...args: any[]
 ) => T;
 

--- a/packages/nimble-components/src/table-column/base/models/column-validator.ts
+++ b/packages/nimble-components/src/table-column/base/models/column-validator.ts
@@ -34,10 +34,6 @@ export class ColumnValidator<
         } else {
             this.untrack(name);
         }
-        this.updateIsColumnValidFlag();
-    }
-
-    private updateIsColumnValidFlag(): void {
         this.isColumnValid = this.isValid();
     }
 }

--- a/packages/nimble-components/src/table-column/base/models/column-validator.ts
+++ b/packages/nimble-components/src/table-column/base/models/column-validator.ts
@@ -1,6 +1,6 @@
+import { observable } from '@microsoft/fast-element';
 import { Validator } from '../../../utilities/models/validator';
 import type { TableColumnValidity } from '../types';
-import type { ColumnInternals } from './column-internals';
 
 /**
  * Base column validator
@@ -8,8 +8,10 @@ import type { ColumnInternals } from './column-internals';
 export class ColumnValidator<
     ValidityFlagNames extends readonly string[]
 > extends Validator<ValidityFlagNames> {
+    @observable
+    public isColumnValid = true;
+
     public constructor(
-        private readonly columnInternals: ColumnInternals<unknown>,
         configValidityKeys: ValidityFlagNames
     ) {
         super(configValidityKeys);
@@ -34,10 +36,10 @@ export class ColumnValidator<
         } else {
             this.untrack(name);
         }
-        this.updateColumnInternalsFlag();
+        this.updateIsColumnValidFlag();
     }
 
-    private updateColumnInternalsFlag(): void {
-        this.columnInternals.validConfiguration = this.isValid();
+    private updateIsColumnValidFlag(): void {
+        this.isColumnValid = this.isValid();
     }
 }

--- a/packages/nimble-components/src/table-column/base/models/column-validator.ts
+++ b/packages/nimble-components/src/table-column/base/models/column-validator.ts
@@ -11,9 +11,7 @@ export class ColumnValidator<
     @observable
     public isColumnValid = true;
 
-    public constructor(
-        configValidityKeys: ValidityFlagNames
-    ) {
+    public constructor(configValidityKeys: ValidityFlagNames) {
         super(configValidityKeys);
     }
 

--- a/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
@@ -54,8 +54,8 @@ const configValidity = ['invalidFoo', 'invalidBar'] as const;
 export class TestColumnValidator extends ColumnValidator<
     typeof configValidity
 > {
-    public constructor(columnInternals: ColumnInternals<unknown>) {
-        super(columnInternals, configValidity);
+    public constructor() {
+        super(configValidity);
     }
 
     public validateFoo(isValid: boolean): void {
@@ -82,9 +82,6 @@ export const tableColumnValidationTestTag = 'nimble-test-table-column-validation
     name: tableColumnValidationTestTag
 })
 export class TableColumnValidationTest extends TableColumn {
-    /* @internal */
-    public readonly validator = new TestColumnValidator(this.columnInternals);
-
     @attr({ mode: 'boolean' })
     public foo = false;
 
@@ -96,8 +93,13 @@ export class TableColumnValidationTest extends TableColumn {
             cellRecordFieldNames: [],
             cellViewTag: tableColumnEmptyCellViewTag,
             groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-            delegatedEvents: []
+            delegatedEvents: [],
+            validator: new TestColumnValidator()
         };
+    }
+
+    private get validator(): TestColumnValidator {
+        return this.columnInternals.validator as TestColumnValidator;
     }
 
     private fooChanged(): void {

--- a/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
@@ -112,15 +112,13 @@ export class TableColumnValidationTest extends TableColumn {
         };
     }
 
-    private get validator(): TestColumnValidator {
-        return this.columnInternals.validator as TestColumnValidator;
-    }
-
     private fooChanged(): void {
-        this.validator.validateFoo(this.foo);
+        const validator = this.getTypedValidator(TestColumnValidator);
+        validator.validateFoo(this.foo);
     }
 
     private barChanged(): void {
-        this.validator.validateBar(this.bar);
+        const validator = this.getTypedValidator(TestColumnValidator);
+        validator.validateBar(this.bar);
     }
 }

--- a/packages/nimble-components/src/table-column/date-text/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/index.ts
@@ -219,28 +219,19 @@ export class TableColumnDateText extends TableColumnTextBase {
         this.updateColumnConfig();
     }
 
-    private get validator(): TableColumnDateTextValidator {
-        if (
-            this.columnInternals.validator
-            instanceof TableColumnDateTextValidator
-        ) {
-            return this.columnInternals.validator;
-        }
-        throw new Error('Unexpected column validator type found');
-    }
-
     private updateColumnConfig(): void {
         const formatter = this.createFormatter();
+        const validator = this.getTypedValidator(TableColumnDateTextValidator);
 
         if (formatter) {
             const columnConfig: TableColumnDateTextColumnConfig = {
                 formatter
             };
             this.columnInternals.columnConfig = columnConfig;
-            this.validator.setCustomOptionsValidity(true);
+            validator.setCustomOptionsValidity(true);
         } else {
             this.columnInternals.columnConfig = undefined;
-            this.validator.setCustomOptionsValidity(false);
+            validator.setCustomOptionsValidity(false);
         }
     }
 

--- a/packages/nimble-components/src/table-column/date-text/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/index.ts
@@ -7,7 +7,7 @@ import { styles } from '../base/styles';
 import { template } from '../base/template';
 import type { TableNumberField } from '../../table/types';
 import { TableColumnTextBase } from '../text-base';
-import { TableColumnSortOperation, TableColumnValidity } from '../base/types';
+import { TableColumnSortOperation } from '../base/types';
 import { tableColumnDateTextGroupHeaderViewTag } from './group-header-view';
 import { tableColumnDateTextCellViewTag } from './cell-view';
 import type { ColumnInternalsOptions } from '../base/models/column-internals';
@@ -48,9 +48,6 @@ declare global {
  * The table column for displaying dates/times as text.
  */
 export class TableColumnDateText extends TableColumnTextBase {
-    /** @internal */
-    public validator = new TableColumnDateTextValidator(this.columnInternals);
-
     @attr
     public format: DateTextFormat;
 
@@ -131,17 +128,14 @@ export class TableColumnDateText extends TableColumnTextBase {
         lang.unsubscribe(this.langSubscriber, this);
     }
 
-    public override get validity(): TableColumnValidity {
-        return this.validator.getValidity();
-    }
-
     protected override getColumnInternalsOptions(): ColumnInternalsOptions {
         return {
             cellRecordFieldNames: ['value'],
             cellViewTag: tableColumnDateTextCellViewTag,
             groupHeaderViewTag: tableColumnDateTextGroupHeaderViewTag,
             delegatedEvents: [],
-            sortOperation: TableColumnSortOperation.basic
+            sortOperation: TableColumnSortOperation.basic,
+            validator: new TableColumnDateTextValidator()
         };
     }
 
@@ -223,6 +217,13 @@ export class TableColumnDateText extends TableColumnTextBase {
 
     protected customHourCycleChanged(): void {
         this.updateColumnConfig();
+    }
+
+    private get validator(): TableColumnDateTextValidator {
+        if (this.columnInternals.validator instanceof TableColumnDateTextValidator) {
+            return this.columnInternals.validator;
+        }
+        throw new Error('Unexpected column validator type found');
     }
 
     private updateColumnConfig(): void {

--- a/packages/nimble-components/src/table-column/date-text/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/index.ts
@@ -220,7 +220,10 @@ export class TableColumnDateText extends TableColumnTextBase {
     }
 
     private get validator(): TableColumnDateTextValidator {
-        if (this.columnInternals.validator instanceof TableColumnDateTextValidator) {
+        if (
+            this.columnInternals.validator
+            instanceof TableColumnDateTextValidator
+        ) {
             return this.columnInternals.validator;
         }
         throw new Error('Unexpected column validator type found');

--- a/packages/nimble-components/src/table-column/date-text/models/table-column-date-text-validator.ts
+++ b/packages/nimble-components/src/table-column/date-text/models/table-column-date-text-validator.ts
@@ -1,4 +1,3 @@
-import type { ColumnInternals } from '../../base/models/column-internals';
 import { ColumnValidator } from '../../base/models/column-validator';
 
 const dateTextValidityFlagNames = ['invalidCustomOptionsCombination'] as const;
@@ -9,8 +8,8 @@ const dateTextValidityFlagNames = ['invalidCustomOptionsCombination'] as const;
 export class TableColumnDateTextValidator extends ColumnValidator<
     typeof dateTextValidityFlagNames
 > {
-    public constructor(columnInternals: ColumnInternals<unknown>) {
-        super(columnInternals, dateTextValidityFlagNames);
+    public constructor() {
+        super(dateTextValidityFlagNames);
     }
 
     public setCustomOptionsValidity(valid: boolean): void {

--- a/packages/nimble-components/src/table-column/enum-base/index.ts
+++ b/packages/nimble-components/src/table-column/enum-base/index.ts
@@ -75,7 +75,9 @@ export abstract class TableColumnEnumBase<
      * Called when any Mapping related state has changed.
      */
     private updateColumnConfig(): void {
-        const validator = this.getTypedValidator(TableColumnEnumBaseValidator<[]>);
+        const validator = this.getTypedValidator(
+            TableColumnEnumBaseValidator<[]>
+        );
         validator.validate(this.mappings, this.keyType);
         this.columnInternals.columnConfig = validator.isValid()
             ? this.createColumnConfig(this.getMappingConfigs())

--- a/packages/nimble-components/src/table-column/enum-base/index.ts
+++ b/packages/nimble-components/src/table-column/enum-base/index.ts
@@ -71,23 +71,13 @@ export abstract class TableColumnEnumBase<
         mappingConfigs: MappingConfigs
     ): TColumnConfig;
 
-    private get validator(): TableColumnEnumBaseValidator<[]> {
-        if (
-            this.columnInternals.validator
-            instanceof TableColumnEnumBaseValidator
-        ) {
-            return this.columnInternals.validator;
-        }
-
-        throw new Error('');
-    }
-
     /**
      * Called when any Mapping related state has changed.
      */
     private updateColumnConfig(): void {
-        this.validator.validate(this.mappings, this.keyType);
-        this.columnInternals.columnConfig = this.validator.isValid()
+        const validator = this.getTypedValidator(TableColumnEnumBaseValidator<[]>);
+        validator.validate(this.mappings, this.keyType);
+        this.columnInternals.columnConfig = validator.isValid()
             ? this.createColumnConfig(this.getMappingConfigs())
             : undefined;
     }

--- a/packages/nimble-components/src/table-column/enum-base/index.ts
+++ b/packages/nimble-components/src/table-column/enum-base/index.ts
@@ -72,7 +72,10 @@ export abstract class TableColumnEnumBase<
     ): TColumnConfig;
 
     private get validator(): TableColumnEnumBaseValidator<[]> {
-        if (this.columnInternals.validator instanceof TableColumnEnumBaseValidator) {
+        if (
+            this.columnInternals.validator
+            instanceof TableColumnEnumBaseValidator
+        ) {
             return this.columnInternals.validator;
         }
 

--- a/packages/nimble-components/src/table-column/enum-base/index.ts
+++ b/packages/nimble-components/src/table-column/enum-base/index.ts
@@ -16,7 +16,7 @@ import type { MappingKeyType } from './types';
 import type { MappingConfig } from './models/mapping-config';
 import type { MappingKey } from '../../mapping/base/types';
 import { resolveKeyWithType } from './models/mapping-key-resolver';
-import type { TableColumnEnumBaseValidator } from './models/table-column-enum-base-validator';
+import { TableColumnEnumBaseValidator } from './models/table-column-enum-base-validator';
 
 export type TableColumnEnumCellRecord =
     | TableStringField<'value'>
@@ -31,16 +31,10 @@ export interface TableColumnEnumColumnConfig {
  * Base class for table columns that map values to content (e.g. nimble-table-column-enum-text and nimble-table-column-icon)
  */
 export abstract class TableColumnEnumBase<
-    TColumnConfig extends TableColumnEnumColumnConfig,
-    TEnumValidator extends TableColumnEnumBaseValidator<[]>
+    TColumnConfig extends TableColumnEnumColumnConfig
 >
     extends TableColumn<TColumnConfig>
     implements Subscriber {
-    // To ensure the validator is available when other properties get initialized
-    // (which can trigger validation), declare the validator first.
-    /** @internal */
-    public validator = this.createValidator();
-
     /** @internal */
     public mappingNotifiers: Notifier[] = [];
 
@@ -66,8 +60,6 @@ export abstract class TableColumnEnumBase<
         }
     }
 
-    public abstract createValidator(): TEnumValidator;
-
     /**
      * Implementations should throw an error if an invalid Mapping is passed.
      */
@@ -78,6 +70,14 @@ export abstract class TableColumnEnumBase<
     protected abstract createColumnConfig(
         mappingConfigs: MappingConfigs
     ): TColumnConfig;
+
+    private get validator(): TableColumnEnumBaseValidator<[]> {
+        if (this.columnInternals.validator instanceof TableColumnEnumBaseValidator) {
+            return this.columnInternals.validator;
+        }
+
+        throw new Error('');
+    }
 
     /**
      * Called when any Mapping related state has changed.

--- a/packages/nimble-components/src/table-column/enum-base/models/table-column-enum-base-validator.ts
+++ b/packages/nimble-components/src/table-column/enum-base/models/table-column-enum-base-validator.ts
@@ -1,5 +1,4 @@
 import { ColumnValidator } from '../../base/models/column-validator';
-import type { ColumnInternals } from '../../base/models/column-internals';
 import type { Mapping } from '../../../mapping/base';
 import type { MappingKeyType } from '../types';
 import { resolveKeyWithType } from './mapping-key-resolver';
@@ -19,10 +18,9 @@ export abstract class TableColumnEnumBaseValidator<
     typeof enumBaseValidityFlagNames | ValidityFlagNames
     > {
     public constructor(
-        columnInternals: ColumnInternals<unknown>,
         configValidityKeys: ValidityFlagNames
     ) {
-        super(columnInternals, configValidityKeys);
+        super(configValidityKeys);
     }
 
     public validate(

--- a/packages/nimble-components/src/table-column/enum-base/models/table-column-enum-base-validator.ts
+++ b/packages/nimble-components/src/table-column/enum-base/models/table-column-enum-base-validator.ts
@@ -17,9 +17,7 @@ export abstract class TableColumnEnumBaseValidator<
 > extends ColumnValidator<
     typeof enumBaseValidityFlagNames | ValidityFlagNames
     > {
-    public constructor(
-        configValidityKeys: ValidityFlagNames
-    ) {
+    public constructor(configValidityKeys: ValidityFlagNames) {
         super(configValidityKeys);
     }
 

--- a/packages/nimble-components/src/table-column/enum-base/template.ts
+++ b/packages/nimble-components/src/table-column/enum-base/template.ts
@@ -3,7 +3,5 @@ import { template as baseTemplate } from '../base/template';
 import type { TableColumnEnumBase, TableColumnEnumColumnConfig } from '.';
 
 export const template = html<
-TableColumnEnumBase<
-TableColumnEnumColumnConfig
->
+TableColumnEnumBase<TableColumnEnumColumnConfig>
 >`${baseTemplate}<slot ${slotted('mappings')} name="mapping"></slot>`;

--- a/packages/nimble-components/src/table-column/enum-base/template.ts
+++ b/packages/nimble-components/src/table-column/enum-base/template.ts
@@ -1,11 +1,9 @@
 import { slotted, html } from '@microsoft/fast-element';
 import { template as baseTemplate } from '../base/template';
 import type { TableColumnEnumBase, TableColumnEnumColumnConfig } from '.';
-import type { TableColumnEnumBaseValidator } from './models/table-column-enum-base-validator';
 
 export const template = html<
 TableColumnEnumBase<
-TableColumnEnumColumnConfig,
-TableColumnEnumBaseValidator<[]>
+TableColumnEnumColumnConfig
 >
 >`${baseTemplate}<slot ${slotted('mappings')} name="mapping"></slot>`;

--- a/packages/nimble-components/src/table-column/enum-text/index.ts
+++ b/packages/nimble-components/src/table-column/enum-text/index.ts
@@ -6,7 +6,7 @@ import {
 } from '../enum-base';
 import { styles } from '../enum-base/styles';
 import { template } from '../enum-base/template';
-import { TableColumnSortOperation, TableColumnValidity } from '../base/types';
+import { TableColumnSortOperation } from '../base/types';
 import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
 import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
 import { MappingText } from '../../mapping/text';
@@ -30,26 +30,18 @@ declare global {
 export class TableColumnEnumText extends mixinGroupableColumnAPI(
     mixinFractionalWidthColumnAPI(
         TableColumnEnumBase<
-        TableColumnEnumColumnConfig,
-        TableColumnEnumTextValidator
+        TableColumnEnumColumnConfig
         >
     )
 ) {
-    public override createValidator(): TableColumnEnumTextValidator {
-        return new TableColumnEnumTextValidator(this.columnInternals);
-    }
-
-    public override get validity(): TableColumnValidity {
-        return this.validator.getValidity();
-    }
-
     protected override getColumnInternalsOptions(): ColumnInternalsOptions {
         return {
             cellRecordFieldNames: ['value'],
             cellViewTag: tableColumnEnumTextCellViewTag,
             groupHeaderViewTag: tableColumnEnumTextGroupHeaderViewTag,
             delegatedEvents: [],
-            sortOperation: TableColumnSortOperation.basic
+            sortOperation: TableColumnSortOperation.basic,
+            validator: new TableColumnEnumTextValidator()
         };
     }
 

--- a/packages/nimble-components/src/table-column/enum-text/index.ts
+++ b/packages/nimble-components/src/table-column/enum-text/index.ts
@@ -29,9 +29,7 @@ declare global {
  */
 export class TableColumnEnumText extends mixinGroupableColumnAPI(
     mixinFractionalWidthColumnAPI(
-        TableColumnEnumBase<
-        TableColumnEnumColumnConfig
-        >
+        TableColumnEnumBase<TableColumnEnumColumnConfig>
     )
 ) {
     protected override getColumnInternalsOptions(): ColumnInternalsOptions {

--- a/packages/nimble-components/src/table-column/enum-text/models/table-column-enum-text-validator.ts
+++ b/packages/nimble-components/src/table-column/enum-text/models/table-column-enum-text-validator.ts
@@ -1,6 +1,5 @@
 import type { Mapping } from '../../../mapping/base';
 import { MappingText } from '../../../mapping/text';
-import type { ColumnInternals } from '../../base/models/column-internals';
 import {
     TableColumnEnumBaseValidator,
     enumBaseValidityFlagNames
@@ -19,8 +18,8 @@ const enumTextValidityFlagNames = [
 export class TableColumnEnumTextValidator extends TableColumnEnumBaseValidator<
     typeof enumTextValidityFlagNames
 > {
-    public constructor(columnInternals: ColumnInternals<unknown>) {
-        super(columnInternals, enumTextValidityFlagNames);
+    public constructor() {
+        super(enumTextValidityFlagNames);
     }
 
     private static isSupportedMappingElement(

--- a/packages/nimble-components/src/table-column/icon/index.ts
+++ b/packages/nimble-components/src/table-column/icon/index.ts
@@ -6,7 +6,7 @@ import {
 } from '../enum-base';
 import { styles } from '../enum-base/styles';
 import { template } from '../enum-base/template';
-import { TableColumnSortOperation, TableColumnValidity } from '../base/types';
+import { TableColumnSortOperation } from '../base/types';
 import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
 import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
 import { MappingSpinner } from '../../mapping/spinner';
@@ -31,9 +31,7 @@ declare global {
  */
 export class TableColumnIcon extends mixinGroupableColumnAPI(
     mixinFractionalWidthColumnAPI(
-        TableColumnEnumBase<
-        TableColumnEnumColumnConfig
-        >
+        TableColumnEnumBase<TableColumnEnumColumnConfig>
     )
 ) {
     protected override getColumnInternalsOptions(): ColumnInternalsOptions {

--- a/packages/nimble-components/src/table-column/icon/index.ts
+++ b/packages/nimble-components/src/table-column/icon/index.ts
@@ -32,26 +32,18 @@ declare global {
 export class TableColumnIcon extends mixinGroupableColumnAPI(
     mixinFractionalWidthColumnAPI(
         TableColumnEnumBase<
-        TableColumnEnumColumnConfig,
-        TableColumnIconValidator
+        TableColumnEnumColumnConfig
         >
     )
 ) {
-    public override createValidator(): TableColumnIconValidator {
-        return new TableColumnIconValidator(this.columnInternals);
-    }
-
-    public override get validity(): TableColumnValidity {
-        return this.validator.getValidity();
-    }
-
     protected override getColumnInternalsOptions(): ColumnInternalsOptions {
         return {
             cellRecordFieldNames: ['value'],
             cellViewTag: tableColumnIconCellViewTag,
             groupHeaderViewTag: tableColumnIconGroupHeaderViewTag,
             delegatedEvents: [],
-            sortOperation: TableColumnSortOperation.basic
+            sortOperation: TableColumnSortOperation.basic,
+            validator: new TableColumnIconValidator()
         };
     }
 

--- a/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
+++ b/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
@@ -1,7 +1,6 @@
 import type { Mapping } from '../../../mapping/base';
 import { MappingIcon } from '../../../mapping/icon';
 import { MappingSpinner } from '../../../mapping/spinner';
-import type { ColumnInternals } from '../../base/models/column-internals';
 import {
     TableColumnEnumBaseValidator,
     enumBaseValidityFlagNames
@@ -21,8 +20,8 @@ const iconValidityFlagNames = [
 export class TableColumnIconValidator extends TableColumnEnumBaseValidator<
     typeof iconValidityFlagNames
 > {
-    public constructor(columnInternals: ColumnInternals<unknown>) {
-        super(columnInternals, iconValidityFlagNames);
+    public constructor() {
+        super(iconValidityFlagNames);
     }
 
     private static isIconMappingElement(

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -80,10 +80,6 @@ export class TableColumnNumberText extends TableColumnTextBase {
         };
     }
 
-    private get validator(): TableColumnNumberTextValidator {
-        return this.columnInternals.validator as TableColumnNumberTextValidator;
-    }
-
     private formatChanged(): void {
         this.updateColumnConfig();
     }
@@ -101,18 +97,20 @@ export class TableColumnNumberText extends TableColumnTextBase {
     }
 
     private updateColumnConfig(): void {
-        this.validator.validateDecimalDigits(this.format, this.decimalDigits);
-        this.validator.validateDecimalMaximumDigits(
+        const validator = this.getTypedValidator(TableColumnNumberTextValidator);
+
+        validator.validateDecimalDigits(this.format, this.decimalDigits);
+        validator.validateDecimalMaximumDigits(
             this.format,
             this.decimalMaximumDigits
         );
-        this.validator.validateNoMutuallyExclusiveProperties(
+        validator.validateNoMutuallyExclusiveProperties(
             this.format,
             this.decimalDigits,
             this.decimalMaximumDigits
         );
 
-        if (this.validator.isValid()) {
+        if (validator.isValid()) {
             const columnConfig: TableColumnNumberTextColumnConfig = {
                 formatter: this.createFormatter(),
                 alignment: this.determineCellContentAlignment()

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -37,9 +37,6 @@ const defaultDecimalDigits = 2;
  * The table column for displaying numbers as text.
  */
 export class TableColumnNumberText extends TableColumnTextBase {
-    /** @internal */
-    public validator = new TableColumnNumberTextValidator(this.columnInternals);
-
     @attr
     public format: NumberTextFormat;
 
@@ -72,18 +69,19 @@ export class TableColumnNumberText extends TableColumnTextBase {
         lang.unsubscribe(this.langSubscriber, this);
     }
 
-    public override get validity(): TableColumnValidity {
-        return this.validator.getValidity();
-    }
-
     protected override getColumnInternalsOptions(): ColumnInternalsOptions {
         return {
             cellRecordFieldNames: ['value'],
             cellViewTag: tableColumnNumberTextCellViewTag,
             groupHeaderViewTag: tableColumnNumberTextGroupHeaderTag,
             delegatedEvents: [],
-            sortOperation: TableColumnSortOperation.basic
+            sortOperation: TableColumnSortOperation.basic,
+            validator: new TableColumnNumberTextValidator()
         };
+    }
+
+    private get validator(): TableColumnNumberTextValidator {
+        return this.columnInternals.validator as TableColumnNumberTextValidator;
     }
 
     private formatChanged(): void {

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -7,7 +7,7 @@ import { styles } from '../base/styles';
 import { template } from '../base/template';
 import type { TableNumberField } from '../../table/types';
 import { TableColumnTextBase } from '../text-base';
-import { TableColumnSortOperation, TableColumnValidity } from '../base/types';
+import { TableColumnSortOperation } from '../base/types';
 import { tableColumnNumberTextGroupHeaderTag } from './group-header-view';
 import { tableColumnNumberTextCellViewTag } from './cell-view';
 import type { ColumnInternalsOptions } from '../base/models/column-internals';

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -97,7 +97,9 @@ export class TableColumnNumberText extends TableColumnTextBase {
     }
 
     private updateColumnConfig(): void {
-        const validator = this.getTypedValidator(TableColumnNumberTextValidator);
+        const validator = this.getTypedValidator(
+            TableColumnNumberTextValidator
+        );
 
         validator.validateDecimalDigits(this.format, this.decimalDigits);
         validator.validateDecimalMaximumDigits(

--- a/packages/nimble-components/src/table-column/number-text/models/table-column-number-text-validator.ts
+++ b/packages/nimble-components/src/table-column/number-text/models/table-column-number-text-validator.ts
@@ -1,4 +1,3 @@
-import type { ColumnInternals } from '../../base/models/column-internals';
 import { ColumnValidator } from '../../base/models/column-validator';
 import { NumberTextFormat } from '../types';
 
@@ -19,8 +18,8 @@ const maximumValidDecimalDigits = 20;
 export class TableColumnNumberTextValidator extends ColumnValidator<
     typeof numberTextValidityFlagNames
 > {
-    public constructor(columnInternals: ColumnInternals<unknown>) {
-        super(columnInternals, numberTextValidityFlagNames);
+    public constructor() {
+        super(numberTextValidityFlagNames);
     }
 
     public validateDecimalDigits(

--- a/packages/nimble-components/src/table-column/number-text/models/tests/table-column-number-text-validator.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/models/tests/table-column-number-text-validator.spec.ts
@@ -1,23 +1,11 @@
-import { ColumnInternals } from '../../../base/models/column-internals';
 import { TableColumnNumberTextValidator } from '../table-column-number-text-validator';
-import { TableColumnSortOperation } from '../../../base/types';
 import { NumberTextFormat } from '../../types';
-import { tableColumnNumberTextCellViewTag } from '../../cell-view';
-import { tableColumnNumberTextGroupHeaderTag } from '../../group-header-view';
 
 describe('TableColumnNumberTextValidator', () => {
     let validator: TableColumnNumberTextValidator;
 
     beforeEach(() => {
-        const fakeColumnInternals = new ColumnInternals({
-            cellRecordFieldNames: ['value'],
-            cellViewTag: tableColumnNumberTextCellViewTag,
-            groupHeaderViewTag: tableColumnNumberTextGroupHeaderTag,
-            delegatedEvents: [],
-            sortOperation: TableColumnSortOperation.basic
-        });
-
-        validator = new TableColumnNumberTextValidator(fakeColumnInternals);
+        validator = new TableColumnNumberTextValidator();
     });
 
     it('is valid with valid "decimal-digits" and "decimal" format', () => {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #1389 

## 👩‍💻 Implementation

Previously, any column that had validation associated with it would:
1. Create a validator class that derives from `ColumnValidator`
1. Create a class member within the column that was the validator, making sure that it was defined in the appropriate order within the file so that it got instantiated before it was used in any change handlers
1. Override the base `TableColumn` implementation of the `validity` getter to return the `validity` object from the class member's validator

With these changes, a column that has validation associated with it will:
1. Create a validator class that derives from `ColumnValidator`
1. Create an instance of the validator as part of creating its `ColumnInternalsOptions`, and return it as the `validator` property in the `ColumnInternalsOptions`
1. Use the validator returned from `getTypedValidator` on the base `TableColumn` to perform validation
    1. Note, the validator is owned by the column's `columnInternals` instance, but the column is the one that knows the type of the validator instance. Making `TableColumn` generic on the type of the validator proved problematic because of the way the mixins work. Similar to the fact that a given table column instance isn't strongly typed for `TColumnConfig`, it also isn't strongly typed for the validator type. Therefore, calling the new `getTypedValidator` utility allows columns to be written with a strong assertion that the validator has the expected type.

## 🧪 Testing

- Mostly relying on unit tests still passing for table columns and the table
- Manually spot checked a few table columns to make sure validation still worked as expected

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
