### PR TITLE
Update mapping base

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/mapping/base/ng-package.json
+++ b/angular-workspace/projects/ni/nimble-angular/mapping/base/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+      "entryFile": "public-api.ts"
+    }
+}

--- a/angular-workspace/projects/ni/nimble-angular/mapping/base/nimble-mapping-base.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/mapping/base/nimble-mapping-base.directive.ts
@@ -1,0 +1,18 @@
+import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
+import type { Mapping } from '@ni/nimble-components/dist/esm/mapping/base';
+
+/**
+ * Base class for mapping configuration elements
+ */
+@Directive()
+export class NimbleMappingDirective<T> {
+    public get key(): T | undefined {
+        return this.elementRef.nativeElement.key;
+    }
+
+    @Input() public set key(value: T | undefined) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'key', value);
+    }
+
+    public constructor(protected readonly renderer: Renderer2, protected readonly elementRef: ElementRef<Mapping<T>>) {}
+}

--- a/angular-workspace/projects/ni/nimble-angular/mapping/base/public-api.ts
+++ b/angular-workspace/projects/ni/nimble-angular/mapping/base/public-api.ts
@@ -1,0 +1,1 @@
+export * from './nimble-mapping-base.directive';

--- a/angular-workspace/projects/ni/nimble-angular/mapping/icon/nimble-mapping-icon.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/mapping/icon/nimble-mapping-icon.directive.ts
@@ -1,4 +1,5 @@
 import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
+import { NimbleMappingDirective } from '@ni/nimble-angular/mapping/base';
 import { type MappingIcon, mappingIconTag } from '@ni/nimble-components/dist/esm/mapping/icon';
 import type { MappingKey } from '@ni/nimble-components/dist/esm/mapping/base/types';
 import type { IconSeverity } from '@ni/nimble-components/dist/esm/icon-base/types';
@@ -12,15 +13,7 @@ export { mappingIconTag };
 @Directive({
     selector: 'nimble-mapping-icon'
 })
-export class NimbleMappingIconDirective {
-    public get key(): MappingKey | undefined {
-        return this.elementRef.nativeElement.key;
-    }
-
-    @Input() public set key(value: MappingKey | undefined) {
-        this.renderer.setProperty(this.elementRef.nativeElement, 'key', value);
-    }
-
+export class NimbleMappingIconDirective extends NimbleMappingDirective<MappingKey> {
     public get text(): string | undefined {
         return this.elementRef.nativeElement.text;
     }
@@ -45,5 +38,7 @@ export class NimbleMappingIconDirective {
         this.renderer.setProperty(this.elementRef.nativeElement, 'severity', value);
     }
 
-    public constructor(protected readonly renderer: Renderer2, protected readonly elementRef: ElementRef<MappingIcon>) {}
+    public constructor(protected readonly renderer: Renderer2, protected readonly elementRef: ElementRef<MappingIcon>) {
+        super(renderer, elementRef);
+    }
 }

--- a/angular-workspace/projects/ni/nimble-angular/mapping/spinner/nimble-mapping-spinner.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/mapping/spinner/nimble-mapping-spinner.directive.ts
@@ -1,4 +1,5 @@
 import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
+import { NimbleMappingDirective } from '@ni/nimble-angular/mapping/base';
 import { type MappingSpinner, mappingSpinnerTag } from '@ni/nimble-components/dist/esm/mapping/spinner';
 import type { MappingKey } from '@ni/nimble-components/dist/esm/mapping/base/types';
 
@@ -11,15 +12,7 @@ export { mappingSpinnerTag };
 @Directive({
     selector: 'nimble-mapping-spinner'
 })
-export class NimbleMappingSpinnerDirective {
-    public get key(): MappingKey | undefined {
-        return this.elementRef.nativeElement.key;
-    }
-
-    @Input() public set key(value: MappingKey | undefined) {
-        this.renderer.setProperty(this.elementRef.nativeElement, 'key', value);
-    }
-
+export class NimbleMappingSpinnerDirective extends NimbleMappingDirective<MappingKey> {
     public get text(): string | undefined {
         return this.elementRef.nativeElement.text;
     }
@@ -28,5 +21,7 @@ export class NimbleMappingSpinnerDirective {
         this.renderer.setProperty(this.elementRef.nativeElement, 'text', value);
     }
 
-    public constructor(protected readonly renderer: Renderer2, protected readonly elementRef: ElementRef<MappingSpinner>) {}
+    public constructor(protected readonly renderer: Renderer2, protected readonly elementRef: ElementRef<MappingSpinner>) {
+        super(renderer, elementRef);
+    }
 }

--- a/angular-workspace/projects/ni/nimble-angular/mapping/text/nimble-mapping-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/mapping/text/nimble-mapping-text.directive.ts
@@ -1,4 +1,5 @@
 import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
+import { NimbleMappingDirective } from '@ni/nimble-angular/mapping/base';
 import { type MappingText, mappingTextTag } from '@ni/nimble-components/dist/esm/mapping/text';
 import type { MappingKey } from '@ni/nimble-components/dist/esm/mapping/base/types';
 
@@ -11,15 +12,7 @@ export { mappingTextTag };
 @Directive({
     selector: 'nimble-mapping-text'
 })
-export class NimbleMappingTextDirective {
-    public get key(): MappingKey | undefined {
-        return this.elementRef.nativeElement.key;
-    }
-
-    @Input() public set key(value: MappingKey | undefined) {
-        this.renderer.setProperty(this.elementRef.nativeElement, 'key', value);
-    }
-
+export class NimbleMappingTextDirective extends NimbleMappingDirective<MappingKey> {
     public get text(): string | undefined {
         return this.elementRef.nativeElement.text;
     }
@@ -28,5 +21,7 @@ export class NimbleMappingTextDirective {
         this.renderer.setProperty(this.elementRef.nativeElement, 'text', value);
     }
 
-    public constructor(protected readonly renderer: Renderer2, protected readonly elementRef: ElementRef<MappingText>) {}
+    public constructor(protected readonly renderer: Renderer2, protected readonly elementRef: ElementRef<MappingText>) {
+        super(renderer, elementRef);
+    }
 }

--- a/change/@ni-nimble-angular-000f19bc-14b2-4843-b366-43ceba40fad6.json
+++ b/change/@ni-nimble-angular-000f19bc-14b2-4843-b366-43ceba40fad6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Create base mapping class in Angular",
+  "packageName": "@ni/nimble-angular",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-blazor-7ac7d291-6c90-4d08-9062-0d3b98a73d88.json
+++ b/change/@ni-nimble-blazor-7ac7d291-6c90-4d08-9062-0d3b98a73d88.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update Blazor mapping base class",
+  "packageName": "@ni/nimble-blazor",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleMappingIcon.razor.cs
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleMappingIcon.razor.cs
@@ -15,4 +15,10 @@ public partial class NimbleMappingIcon<TKey> : NimbleMappingBase<TKey>
     /// </summary>
     [Parameter]
     public IconSeverity? Severity { get; set; }
+
+    /// <summary>
+    /// Gets or sets text that is either the mapped value, or a value that can be used for the tooltip and accessible name.
+    /// </summary>
+    [Parameter]
+    public string? Text { get; set; }
 }

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleMappingSpinner.razor.cs
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleMappingSpinner.razor.cs
@@ -1,5 +1,12 @@
-﻿namespace NimbleBlazor;
+﻿using Microsoft.AspNetCore.Components;
+
+namespace NimbleBlazor;
 
 public partial class NimbleMappingSpinner<TKey> : NimbleMappingBase<TKey>
 {
+    /// <summary>
+    /// Gets or sets text that can be used for the tooltip and accessible name.
+    /// </summary>
+    [Parameter]
+    public string? Text { get; set; }
 }

--- a/packages/nimble-blazor/NimbleBlazor/Components/NimbleMappingText.razor.cs
+++ b/packages/nimble-blazor/NimbleBlazor/Components/NimbleMappingText.razor.cs
@@ -1,5 +1,12 @@
-﻿namespace NimbleBlazor;
+﻿using Microsoft.AspNetCore.Components;
+
+namespace NimbleBlazor;
 
 public partial class NimbleMappingText<TKey> : NimbleMappingBase<TKey>
 {
+    /// <summary>
+    /// Gets or sets text that is either the mapped value, or a value that can be used for the tooltip and accessible name.
+    /// </summary>
+    [Parameter]
+    public string? Text { get; set; }
 }

--- a/packages/nimble-blazor/NimbleBlazor/NimbleMappingBase.cs
+++ b/packages/nimble-blazor/NimbleBlazor/NimbleMappingBase.cs
@@ -13,12 +13,6 @@ public abstract class NimbleMappingBase<TKey> : ComponentBase
     public string? FormattedKey => (Key is bool b) ? (b ? "true" : "false") : Key?.ToString();
 
     /// <summary>
-    /// Gets or sets text that is either the mapped value, or a value that can be used for the tooltip and accessible name.
-    /// </summary>
-    [Parameter]
-    public string? Text { get; set; }
-
-    /// <summary>
     /// Gets or sets a collection of additional attributes that will be applied to the created element.
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #1666 

## 👩‍💻 Implementation

**Blazor**
- Update `NimbleMappingBase` to not have `Text` property
- Update `NimbleMappingIcon`, `NimbleMappingSpinner`, and `NimbleMappingText` to have `Text` property

**Angular**
- Create `@ni/nimble-angular/mapping/base` entry point that contains `NimbleMappingDirective` with a `key` `@Input`
- Update `NimbleMappingIconDirective`, `NimbleMappingSpinnerDirective`, and `NimbleMappingTextDirective` to extend `NimbleMappingDirective` and to remove duplicated `key` definition

## 🧪 Testing

Ran auto tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
