### PR TITLE
Improve table column documentation

### DIFF
--- a/change/@ni-nimble-components-aa878a85-f007-4114-8dad-6bd275152b7b.json
+++ b/change/@ni-nimble-components-aa878a85-f007-4114-8dad-6bd275152b7b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Documentation improvements for table columns",
+  "packageName": "@ni/nimble-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/table-column/base/tests/table-column.mdx
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.mdx
@@ -1,0 +1,50 @@
+import {
+    Controls,
+    DocsStory,
+    Meta,
+    Stories,
+    Title,
+    Description
+} from '@storybook/blocks';
+import * as tableColumnStories from './table-column.stories';
+
+<Meta of={tableColumnStories} />
+
+<Title of={tableColumnStories} />
+<Description of={tableColumnStories} />
+
+## Adding columns to a table
+
+<Description of={tableColumnStories.columnOrder} />
+<DocsStory of={tableColumnStories.columnOrder} expanded={false} />
+<Controls of={tableColumnStories.columnOrder} />
+
+## Setting header content
+
+<Description of={tableColumnStories.headerContent} />
+<DocsStory of={tableColumnStories.headerContent} expanded={false} />
+<Controls of={tableColumnStories.headerContent} />
+
+## Configuring common attributes
+
+<Description of={tableColumnStories.commonAttributes} />
+<DocsStory of={tableColumnStories.commonAttributes} expanded={false} />
+<Controls of={tableColumnStories.commonAttributes} />
+
+## Sorting
+
+<Description of={tableColumnStories.sorting} />
+<DocsStory of={tableColumnStories.sorting} expanded={false} />
+<Controls of={tableColumnStories.sorting} />
+
+## Grouping
+
+<Description of={tableColumnStories.grouping} />
+<DocsStory of={tableColumnStories.grouping} expanded={false} />
+<Controls of={tableColumnStories.grouping} />
+
+## Column Width
+
+<Description of={tableColumnStories.fractionalWidthColumn} />
+<DocsStory of={tableColumnStories.fractionalWidthColumn} expanded={false} />
+<Controls of={tableColumnStories.fractionalWidthColumn} />

--- a/packages/nimble-components/src/table-column/base/tests/table-column.mdx
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.mdx
@@ -13,11 +13,11 @@ import * as tableColumnStories from './table-column.stories';
 <Title of={tableColumnStories} />
 <Description of={tableColumnStories} />
 
-## Adding columns to a table
+## Adding columns
 
-<Description of={tableColumnStories.columnOrder} />
-<DocsStory of={tableColumnStories.columnOrder} expanded={false} />
-<Controls of={tableColumnStories.columnOrder} />
+<Description of={tableColumnStories.addingColumns} />
+<DocsStory of={tableColumnStories.addingColumns} expanded={false} />
+<Controls of={tableColumnStories.addingColumns} />
 
 ## Setting header content
 
@@ -45,6 +45,6 @@ import * as tableColumnStories from './table-column.stories';
 
 ## Column Width
 
-<Description of={tableColumnStories.fractionalWidthColumn} />
-<DocsStory of={tableColumnStories.fractionalWidthColumn} expanded={false} />
-<Controls of={tableColumnStories.fractionalWidthColumn} />
+<Description of={tableColumnStories.width} />
+<DocsStory of={tableColumnStories.width} expanded={false} />
+<Controls of={tableColumnStories.width} />

--- a/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
@@ -142,14 +142,14 @@ interface ColumnOrderTableArgs extends SharedTableArgs {
     columnOrder: ColumnOrderOption;
 }
 
-const columnOrderDescription = `Configure columns by adding column elements as children of the table. 
+const addingColumnsDescription = `Configure columns by adding column elements as children of the table. 
 The order of the elements controls the order that columns will appear in the table.`;
 
-export const columnOrder: StoryObj<ColumnOrderTableArgs> = {
+export const addingColumns: StoryObj<ColumnOrderTableArgs> = {
     parameters: {
         docs: {
             description: {
-                story: columnOrderDescription
+                story: addingColumnsDescription
             }
         }
     },
@@ -192,7 +192,7 @@ export const columnOrder: StoryObj<ColumnOrderTableArgs> = {
     argTypes: {
         columnOrder: {
             name: 'Column order',
-            description: columnOrderDescription,
+            description: addingColumnsDescription,
             options: ['FirstName, LastName', 'LastName, FirstName'],
             control: { type: 'radio' }
         }
@@ -700,18 +700,18 @@ const fractionalWidthOptions = {
     ]
 } as const;
 
-const fractionalWidthDescription = `Configure each column's width relative to the other columns with the \`fractional-width\` property. For example, a column with a \`fractional-width\` set to 2 will be twice as wide as a column with a \`fractional-width\` set to 1. 
+const widthDescription = `Configure each column's width relative to the other columns with the \`fractional-width\` property. For example, a column with a \`fractional-width\` set to 2 will be twice as wide as a column with a \`fractional-width\` set to 1. 
 The default value for \`fractional-width\` is 1, and columns that don't support \`fractional-width\` explicitly, or another API responsible for managing the width of the column, will also behave as if they have a \`fractional-width\` of 1. This value only serves
 as an initial state for a column. Once a column has been manually resized the column will use a fractional width calculated by the table from the resize.`;
 
 const minPixelWidthDescription = `Table columns that support having a \`fractional-width\` can also be configured to have a minimum width such that its width
 will never shrink below the specified pixel width. This applies to both when a table is resized as well as when a column is interactively resized.`;
 
-export const fractionalWidthColumn: StoryObj<ColumnWidthTableArgs> = {
+export const width: StoryObj<ColumnWidthTableArgs> = {
     parameters: {
         docs: {
             description: {
-                story: fractionalWidthDescription
+                story: widthDescription
             }
         }
     },
@@ -757,7 +757,7 @@ export const fractionalWidthColumn: StoryObj<ColumnWidthTableArgs> = {
     argTypes: {
         fractionalWidth: {
             name: 'Fractional width configuration',
-            description: fractionalWidthDescription,
+            description: widthDescription,
             options: Object.values(ExampleColumnFractionalWidthType),
             control: {
                 type: 'radio',

--- a/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
@@ -79,7 +79,6 @@ information about specific types of column.`;
 
 const metadata: Meta<SharedTableArgs> = {
     title: 'Components/Table Column Configuration',
-    tags: ['autodocs'],
     decorators: [withActions],
     parameters: {
         docs: {
@@ -122,7 +121,12 @@ const metadata: Meta<SharedTableArgs> = {
     </${tableTag}>
     `),
     argTypes: {
-        ...sharedTableArgTypes
+        ...sharedTableArgTypes,
+        selectionMode: {
+            table: {
+                disable: true
+            }
+        },
     },
     args: {
         ...sharedTableArgs(simpleData)
@@ -130,22 +134,6 @@ const metadata: Meta<SharedTableArgs> = {
 };
 
 export default metadata;
-
-interface DefaultColumnConfigTableArgs extends SharedTableArgs {
-    columns: string;
-}
-
-// In the Docs tab, Storybook doesn't render the title of the first story
-// This is a placeholder to get the useful ones to render
-export const columns: StoryObj<DefaultColumnConfigTableArgs> = {
-    argTypes: {
-        columns: {
-            name: 'Default column configuration',
-            description:
-                'This example shows columns in their default configuration.'
-        }
-    }
-};
 
 type ColumnOrderOption = 'FirstName, LastName' | 'LastName, FirstName';
 
@@ -578,8 +566,8 @@ function getGroupingDisabledData(
 }
 
 const groupedRowsDescription = `A column can be configured such that all values within that column that have the same value get parented under a collapsible row.
-There will be a collapsible row per unique value in a given column. When group-index is set on a column, that column will be grouped. If more than one column is
-configured with a group-index, the precedence is determined by the value of group-index on each column. Grouping is based on the underlying field values in the column,
+There will be a collapsible row per unique value in a given column. When \`group-index\` is set on a column, that column will be grouped. If more than one column is
+configured with a \`group-index\`, the precedence is determined by the value of \`group-index\` on each column. Grouping is based on the underlying field values in the column,
 not the rendered values.`;
 
 const groupingDisabledDescription = 'A groupable column can disable its ability to be grouped through setting `grouping-disabled`.';

--- a/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
@@ -127,7 +127,7 @@ const metadata: Meta<SharedTableArgs> = {
             table: {
                 disable: true
             }
-        },
+        }
     },
     args: {
         ...sharedTableArgs(simpleData)

--- a/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.stories.ts
@@ -96,7 +96,8 @@ const metadata: Meta<SharedTableArgs> = {
         ${ref('tableRef')}
         data-unused="${x => x.updateData(x)}"
         id-field-name="firstName"
-        selection-mode="${x => TableRowSelectionMode[x.selectionMode]}"
+        style="height: 320px"
+        selection-mode="${x => TableRowSelectionMode[x.selectionMode]}
     >
         <${tableColumnTextTag}
             field-name="firstName"
@@ -158,6 +159,7 @@ export const columnOrder: StoryObj<ColumnOrderTableArgs> = {
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
             id-field-name="firstName"
+            style="height: 320px"
             selection-mode="${x => TableRowSelectionMode[x.selectionMode]}"
         >
             ${when(x => x.columnOrder === 'FirstName, LastName', html`
@@ -230,6 +232,7 @@ export const headerContent: StoryObj<HeaderContentTableArgs> = {
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
             id-field-name="firstName"
+            style="height: 320px"
             selection-mode="${x => TableRowSelectionMode[x.selectionMode]}"
         >
             <${tableColumnTextTag}
@@ -288,6 +291,7 @@ export const commonAttributes: StoryObj<CommonAttributesTableArgs> = {
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
             id-field-name="firstName"
+            style="height: 320px"
             selection-mode="${x => TableRowSelectionMode[x.selectionMode]}"
         >
             <${tableColumnTextTag}
@@ -403,6 +407,7 @@ export const sorting: StoryObj<SortingTableArgs> = {
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
             id-field-name="firstName"
+            style="height: 320px"
             selection-mode="${x => TableRowSelectionMode[x.selectionMode]}"
         >
             <${tableColumnTextTag}
@@ -591,6 +596,7 @@ export const grouping: StoryObj<GroupingTableArgs> = {
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
             id-field-name="firstName"
+            style="height: 320px"
             selection-mode="${x => TableRowSelectionMode[x.selectionMode]}"
         >
             <${tableColumnTextTag}
@@ -715,6 +721,7 @@ export const fractionalWidthColumn: StoryObj<ColumnWidthTableArgs> = {
             ${ref('tableRef')}
             data-unused="${x => x.updateData(x)}"
             id-field-name="firstName"
+            style="height: 320px"
             selection-mode="${x => TableRowSelectionMode[x.selectionMode]}"
         >
            <${tableColumnTextTag}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Some of the story content we'd written for table column configuration was not visible in Storybook.

## 👩‍💻 Implementation

1. Change table column story from autodocs to MDX.
2. Tweak some story names to better match headings I chose in the MDX
3. Clean up some parameter documentation and story sizing

## 🧪 Testing

Manual storybook interaction.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
