### PR TITLE
Remove @angular-eslint/no-input-rename from nimble angular

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/.eslintrc.js
+++ b/angular-workspace/projects/ni/nimble-angular/.eslintrc.js
@@ -46,7 +46,10 @@ module.exports = {
             ],
             rules: {
                 // Use package.json from angular-workspace root
-                'import/no-extraneous-dependencies': ['error', { packageDir: path.resolve(__dirname, '../../../') }]
+                'import/no-extraneous-dependencies': ['error', { packageDir: path.resolve(__dirname, '../../../') }],
+                // Nimble Angular Components follow web component naming conventions
+                // where the attribute and property names are different formats
+                '@angular-eslint/no-input-rename': 'off'
             }
         },
         {

--- a/angular-workspace/projects/ni/nimble-angular/label-provider/core/nimble-label-provider-core.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/label-provider/core/nimble-label-provider-core.directive.ts
@@ -18,7 +18,6 @@ export class NimbleLabelProviderCoreDirective {
         return this.elementRef.nativeElement.popupDismiss;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('popup-dismiss') public set popupDismiss(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'popupDismiss', value);
     }
@@ -27,7 +26,6 @@ export class NimbleLabelProviderCoreDirective {
         return this.elementRef.nativeElement.numericDecrement;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('numeric-decrement') public set numericDecrement(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'numericDecrement', value);
     }
@@ -36,7 +34,6 @@ export class NimbleLabelProviderCoreDirective {
         return this.elementRef.nativeElement.numericIncrement;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('numeric-increment') public set numericIncrement(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'numericIncrement', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/label-provider/core/nimble-label-provider-core.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/label-provider/core/nimble-label-provider-core.directive.ts
@@ -19,7 +19,6 @@ export class NimbleLabelProviderCoreDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('popup-dismiss') public set popupDismiss(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'popupDismiss', value);
     }
@@ -29,7 +28,6 @@ export class NimbleLabelProviderCoreDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('numeric-decrement') public set numericDecrement(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'numericDecrement', value);
     }
@@ -39,7 +37,6 @@ export class NimbleLabelProviderCoreDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('numeric-increment') public set numericIncrement(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'numericIncrement', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/label-provider/rich-text/nimble-label-provider-rich-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/label-provider/rich-text/nimble-label-provider-rich-text.directive.ts
@@ -18,7 +18,6 @@ export class NimbleLabelProviderRichTextDirective {
         return this.elementRef.nativeElement.toggleBold;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('toggle-bold') public set toggleBold(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'toggleBold', value);
     }
@@ -27,7 +26,6 @@ export class NimbleLabelProviderRichTextDirective {
         return this.elementRef.nativeElement.toggleItalics;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('toggle-italics') public set toggleItalics(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'toggleItalics', value);
     }
@@ -36,7 +34,6 @@ export class NimbleLabelProviderRichTextDirective {
         return this.elementRef.nativeElement.toggleBulletedList;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('toggle-bulleted-list') public set toggleBulletedList(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'toggleBulletedList', value);
     }
@@ -45,7 +42,6 @@ export class NimbleLabelProviderRichTextDirective {
         return this.elementRef.nativeElement.toggleNumberedList;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('toggle-numbered-list') public set toggleNumberedList(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'toggleNumberedList', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/label-provider/rich-text/nimble-label-provider-rich-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/label-provider/rich-text/nimble-label-provider-rich-text.directive.ts
@@ -19,7 +19,6 @@ export class NimbleLabelProviderRichTextDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('toggle-bold') public set toggleBold(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'toggleBold', value);
     }
@@ -29,7 +28,6 @@ export class NimbleLabelProviderRichTextDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('toggle-italics') public set toggleItalics(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'toggleItalics', value);
     }
@@ -39,7 +37,6 @@ export class NimbleLabelProviderRichTextDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('toggle-bulleted-list') public set toggleBulletedList(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'toggleBulletedList', value);
     }
@@ -49,7 +46,6 @@ export class NimbleLabelProviderRichTextDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('toggle-numbered-list') public set toggleNumberedList(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'toggleNumberedList', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/label-provider/table/nimble-label-provider-table.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/label-provider/table/nimble-label-provider-table.directive.ts
@@ -19,7 +19,6 @@ export class NimbleLabelProviderTableDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('group-collapse') public set groupCollapse(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupCollapse', value);
     }
@@ -29,7 +28,6 @@ export class NimbleLabelProviderTableDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('group-expand') public set groupExpand(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupExpand', value);
     }
@@ -39,7 +37,6 @@ export class NimbleLabelProviderTableDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('groups-collapse-all') public set groupsCollapseAll(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupsCollapseAll', value);
     }
@@ -49,7 +46,6 @@ export class NimbleLabelProviderTableDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('cell-action-menu') public set cellActionMenu(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'cellActionMenu', value);
     }
@@ -59,7 +55,6 @@ export class NimbleLabelProviderTableDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('column-header-grouped') public set columnHeaderGrouped(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'columnHeaderGrouped', value);
     }
@@ -69,7 +64,6 @@ export class NimbleLabelProviderTableDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('column-header-sorted-ascending') public set columnHeaderSortedAscending(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'columnHeaderSortedAscending', value);
     }
@@ -79,7 +73,6 @@ export class NimbleLabelProviderTableDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('column-header-sorted-descending') public set columnHeaderSortedDescending(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'columnHeaderSortedDescending', value);
     }
@@ -89,7 +82,6 @@ export class NimbleLabelProviderTableDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('select-all') public set selectAll(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'selectAll', value);
     }
@@ -99,7 +91,6 @@ export class NimbleLabelProviderTableDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('group-select-all') public set groupSelectAll(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupSelectAll', value);
     }
@@ -109,7 +100,6 @@ export class NimbleLabelProviderTableDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('row-select') public set rowSelect(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'rowSelect', value);
     }
@@ -119,7 +109,6 @@ export class NimbleLabelProviderTableDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('row-operation-column') public set rowOperationColumn(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'rowOperationColumn', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/label-provider/table/nimble-label-provider-table.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/label-provider/table/nimble-label-provider-table.directive.ts
@@ -18,7 +18,6 @@ export class NimbleLabelProviderTableDirective {
         return this.elementRef.nativeElement.groupCollapse;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('group-collapse') public set groupCollapse(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupCollapse', value);
     }
@@ -27,7 +26,6 @@ export class NimbleLabelProviderTableDirective {
         return this.elementRef.nativeElement.groupExpand;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('group-expand') public set groupExpand(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupExpand', value);
     }
@@ -36,7 +34,6 @@ export class NimbleLabelProviderTableDirective {
         return this.elementRef.nativeElement.groupsCollapseAll;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('groups-collapse-all') public set groupsCollapseAll(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupsCollapseAll', value);
     }
@@ -45,7 +42,6 @@ export class NimbleLabelProviderTableDirective {
         return this.elementRef.nativeElement.cellActionMenu;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('cell-action-menu') public set cellActionMenu(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'cellActionMenu', value);
     }
@@ -54,7 +50,6 @@ export class NimbleLabelProviderTableDirective {
         return this.elementRef.nativeElement.columnHeaderGrouped;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('column-header-grouped') public set columnHeaderGrouped(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'columnHeaderGrouped', value);
     }
@@ -63,7 +58,6 @@ export class NimbleLabelProviderTableDirective {
         return this.elementRef.nativeElement.columnHeaderSortedAscending;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('column-header-sorted-ascending') public set columnHeaderSortedAscending(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'columnHeaderSortedAscending', value);
     }
@@ -72,7 +66,6 @@ export class NimbleLabelProviderTableDirective {
         return this.elementRef.nativeElement.columnHeaderSortedDescending;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('column-header-sorted-descending') public set columnHeaderSortedDescending(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'columnHeaderSortedDescending', value);
     }
@@ -81,7 +74,6 @@ export class NimbleLabelProviderTableDirective {
         return this.elementRef.nativeElement.selectAll;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('select-all') public set selectAll(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'selectAll', value);
     }
@@ -90,7 +82,6 @@ export class NimbleLabelProviderTableDirective {
         return this.elementRef.nativeElement.groupSelectAll;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('group-select-all') public set groupSelectAll(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupSelectAll', value);
     }
@@ -99,7 +90,6 @@ export class NimbleLabelProviderTableDirective {
         return this.elementRef.nativeElement.rowSelect;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('row-select') public set rowSelect(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'rowSelect', value);
     }
@@ -108,7 +98,6 @@ export class NimbleLabelProviderTableDirective {
         return this.elementRef.nativeElement.rowOperationColumn;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('row-operation-column') public set rowOperationColumn(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'rowOperationColumn', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/mapping/user/nimble-mapping-user.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/mapping/user/nimble-mapping-user.directive.ts
@@ -24,7 +24,6 @@ export class NimbleMappingUserDirective {
         return this.elementRef.nativeElement.displayName;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('display-name') public set displayName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'displayName', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/mapping/user/nimble-mapping-user.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/mapping/user/nimble-mapping-user.directive.ts
@@ -25,7 +25,6 @@ export class NimbleMappingUserDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('display-name') public set displayName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'displayName', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/rich-text-mention/nimble-rich-text-mention-base.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/rich-text-mention/nimble-rich-text-mention-base.directive.ts
@@ -23,7 +23,6 @@ export class NimbleRichTextMentionDirective<T extends RichTextMention> {
         return this.elementRef.nativeElement.buttonLabel;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('button-label') public set buttonLabel(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'buttonLabel', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/rich-text-mention/nimble-rich-text-mention-base.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/rich-text-mention/nimble-rich-text-mention-base.directive.ts
@@ -24,7 +24,6 @@ export class NimbleRichTextMentionDirective<T extends RichTextMention> {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('button-label') public set buttonLabel(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'buttonLabel', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/rich-text/editor/nimble-rich-text-editor.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/rich-text/editor/nimble-rich-text-editor.directive.ts
@@ -27,7 +27,6 @@ export class NimbleRichTextEditorDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('footer-hidden') public set footerHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'footerHidden', toBooleanProperty(value));
     }
@@ -37,7 +36,6 @@ export class NimbleRichTextEditorDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('error-visible') public set errorVisible(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorVisible', toBooleanProperty(value));
     }
@@ -47,7 +45,6 @@ export class NimbleRichTextEditorDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('error-text') public set errorText(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorText', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/rich-text/editor/nimble-rich-text-editor.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/rich-text/editor/nimble-rich-text-editor.directive.ts
@@ -26,7 +26,6 @@ export class NimbleRichTextEditorDirective {
         return this.elementRef.nativeElement.footerHidden;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('footer-hidden') public set footerHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'footerHidden', toBooleanProperty(value));
     }
@@ -35,7 +34,6 @@ export class NimbleRichTextEditorDirective {
         return this.elementRef.nativeElement.errorVisible;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('error-visible') public set errorVisible(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorVisible', toBooleanProperty(value));
     }
@@ -44,7 +42,6 @@ export class NimbleRichTextEditorDirective {
         return this.elementRef.nativeElement.errorText;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('error-text') public set errorText(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorText', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/anchor-button/nimble-anchor-button.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/anchor-button/nimble-anchor-button.directive.ts
@@ -26,7 +26,6 @@ export class NimbleAnchorButtonDirective extends NimbleAnchorBaseDirective<Ancho
         return this.elementRef.nativeElement.appearanceVariant;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('appearance-variant') public set appearanceVariant(value: ButtonAppearanceVariant) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'appearanceVariant', value);
     }
@@ -35,7 +34,6 @@ export class NimbleAnchorButtonDirective extends NimbleAnchorBaseDirective<Ancho
         return this.elementRef.nativeElement.contentHidden;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('content-hidden') public set contentHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'contentHidden', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/anchor-button/nimble-anchor-button.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/anchor-button/nimble-anchor-button.directive.ts
@@ -27,7 +27,6 @@ export class NimbleAnchorButtonDirective extends NimbleAnchorBaseDirective<Ancho
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('appearance-variant') public set appearanceVariant(value: ButtonAppearanceVariant) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'appearanceVariant', value);
     }
@@ -37,7 +36,6 @@ export class NimbleAnchorButtonDirective extends NimbleAnchorBaseDirective<Ancho
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('content-hidden') public set contentHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'contentHidden', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/anchor/nimble-anchor.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/anchor/nimble-anchor.directive.ts
@@ -27,7 +27,6 @@ export class NimbleAnchorDirective extends NimbleAnchorBaseDirective<Anchor> {
         return this.elementRef.nativeElement.underlineHidden;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('underline-hidden') public set underlineHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'underlineHidden', toBooleanProperty(value));
     }
@@ -36,7 +35,6 @@ export class NimbleAnchorDirective extends NimbleAnchorBaseDirective<Anchor> {
         return this.elementRef.nativeElement.contentEditable;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('contenteditable') public set contentEditable(value: string) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'contentEditable', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/anchor/nimble-anchor.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/anchor/nimble-anchor.directive.ts
@@ -28,7 +28,6 @@ export class NimbleAnchorDirective extends NimbleAnchorBaseDirective<Anchor> {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('underline-hidden') public set underlineHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'underlineHidden', toBooleanProperty(value));
     }
@@ -38,7 +37,6 @@ export class NimbleAnchorDirective extends NimbleAnchorBaseDirective<Anchor> {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('contenteditable') public set contentEditable(value: string) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'contentEditable', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/banner/nimble-banner.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/banner/nimble-banner.directive.ts
@@ -37,7 +37,6 @@ export class NimbleBannerDirective {
         return this.elementRef.nativeElement.titleHidden;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('title-hidden') public set titleHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'titleHidden', toBooleanProperty(value));
     }
@@ -46,7 +45,6 @@ export class NimbleBannerDirective {
         return this.elementRef.nativeElement.preventDismiss;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('prevent-dismiss') public set preventDismiss(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'preventDismiss', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/banner/nimble-banner.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/banner/nimble-banner.directive.ts
@@ -38,7 +38,6 @@ export class NimbleBannerDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('title-hidden') public set titleHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'titleHidden', toBooleanProperty(value));
     }
@@ -48,7 +47,6 @@ export class NimbleBannerDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('prevent-dismiss') public set preventDismiss(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'preventDismiss', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/button/nimble-button.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/button/nimble-button.directive.ts
@@ -27,7 +27,6 @@ export class NimbleButtonDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('appearance-variant') public set appearanceVariant(value: ButtonAppearanceVariant) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'appearanceVariant', value);
     }
@@ -53,7 +52,6 @@ export class NimbleButtonDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('content-hidden') public set contentHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'contentHidden', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/button/nimble-button.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/button/nimble-button.directive.ts
@@ -26,7 +26,6 @@ export class NimbleButtonDirective {
         return this.elementRef.nativeElement.appearanceVariant;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('appearance-variant') public set appearanceVariant(value: ButtonAppearanceVariant) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'appearanceVariant', value);
     }
@@ -51,7 +50,6 @@ export class NimbleButtonDirective {
         return this.elementRef.nativeElement.contentHidden;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('content-hidden') public set contentHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'contentHidden', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/combobox/nimble-combobox.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/combobox/nimble-combobox.directive.ts
@@ -51,7 +51,6 @@ export class NimbleComboboxDirective {
         return this.elementRef.nativeElement.errorText;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('error-text') public set errorText(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorText', value);
     }
@@ -60,7 +59,6 @@ export class NimbleComboboxDirective {
         return this.elementRef.nativeElement.errorVisible;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('error-visible') public set errorVisible(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorVisible', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/combobox/nimble-combobox.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/combobox/nimble-combobox.directive.ts
@@ -52,7 +52,6 @@ export class NimbleComboboxDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('error-text') public set errorText(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorText', value);
     }
@@ -62,7 +61,6 @@ export class NimbleComboboxDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('error-visible') public set errorVisible(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorVisible', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/dialog/nimble-dialog.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/dialog/nimble-dialog.directive.ts
@@ -23,7 +23,6 @@ export class NimbleDialogDirective<CloseReason = void> {
         return this.elementRef.nativeElement.preventDismiss;
     }
 
-    // preventDismiss property intentionally maps to the prevent-dismiss attribute
     @Input('prevent-dismiss') public set preventDismiss(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'preventDismiss', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/dialog/nimble-dialog.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/dialog/nimble-dialog.directive.ts
@@ -24,7 +24,6 @@ export class NimbleDialogDirective<CloseReason = void> {
     }
 
     // preventDismiss property intentionally maps to the prevent-dismiss attribute
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('prevent-dismiss') public set preventDismiss(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'preventDismiss', toBooleanProperty(value));
     }
@@ -34,7 +33,6 @@ export class NimbleDialogDirective<CloseReason = void> {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('header-hidden') public set headerHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'headerHidden', toBooleanProperty(value));
     }
@@ -44,7 +42,6 @@ export class NimbleDialogDirective<CloseReason = void> {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('footer-hidden') public set footerHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'footerHidden', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/dialog/nimble-dialog.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/dialog/nimble-dialog.directive.ts
@@ -32,7 +32,6 @@ export class NimbleDialogDirective<CloseReason = void> {
         return this.elementRef.nativeElement.headerHidden;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('header-hidden') public set headerHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'headerHidden', toBooleanProperty(value));
     }
@@ -41,7 +40,6 @@ export class NimbleDialogDirective<CloseReason = void> {
         return this.elementRef.nativeElement.footerHidden;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('footer-hidden') public set footerHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'footerHidden', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/drawer/nimble-drawer.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/drawer/nimble-drawer.directive.ts
@@ -34,7 +34,6 @@ export class NimbleDrawerDirective<CloseReason = void> {
     }
 
     // preventDismiss property intentionally maps to the prevent-dismiss attribute
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('prevent-dismiss') public set preventDismiss(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'preventDismiss', toBooleanProperty(value));
     }
@@ -44,7 +43,6 @@ export class NimbleDrawerDirective<CloseReason = void> {
     }
 
     // ariaLabel property intentionally maps to the aria-label attribute
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('aria-label') public set ariaLabel(value: string | null) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'ariaLabel', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/drawer/nimble-drawer.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/drawer/nimble-drawer.directive.ts
@@ -33,7 +33,6 @@ export class NimbleDrawerDirective<CloseReason = void> {
         return this.elementRef.nativeElement.preventDismiss;
     }
 
-    // preventDismiss property intentionally maps to the prevent-dismiss attribute
     @Input('prevent-dismiss') public set preventDismiss(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'preventDismiss', toBooleanProperty(value));
     }
@@ -42,7 +41,6 @@ export class NimbleDrawerDirective<CloseReason = void> {
         return this.elementRef.nativeElement.ariaLabel;
     }
 
-    // ariaLabel property intentionally maps to the aria-label attribute
     @Input('aria-label') public set ariaLabel(value: string | null) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'ariaLabel', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/menu-button/nimble-menu-button.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/menu-button/nimble-menu-button.directive.ts
@@ -34,7 +34,6 @@ export class NimbleMenuButtonDirective {
         return this.elementRef.nativeElement.contentHidden;
     }
 
-    // contentHidden property intentionally maps to the content-hidden attribute
     @Input('content-hidden') public set contentHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'contentHidden', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/menu-button/nimble-menu-button.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/menu-button/nimble-menu-button.directive.ts
@@ -35,7 +35,6 @@ export class NimbleMenuButtonDirective {
     }
 
     // contentHidden property intentionally maps to the content-hidden attribute
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('content-hidden') public set contentHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'contentHidden', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/number-field/nimble-number-field.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/number-field/nimble-number-field.directive.ts
@@ -60,7 +60,6 @@ export class NimbleNumberFieldDirective {
         return this.elementRef.nativeElement.hideStep;
     }
 
-    // hideStep property maps to the hide-step attribute
     @Input('hide-step') public set hideStep(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'hideStep', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/number-field/nimble-number-field.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/number-field/nimble-number-field.directive.ts
@@ -77,7 +77,6 @@ export class NimbleNumberFieldDirective {
         return this.elementRef.nativeElement.errorText;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('error-text') public set errorText(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorText', value);
     }
@@ -86,7 +85,6 @@ export class NimbleNumberFieldDirective {
         return this.elementRef.nativeElement.errorVisible;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('error-visible') public set errorVisible(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorVisible', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/number-field/nimble-number-field.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/number-field/nimble-number-field.directive.ts
@@ -28,7 +28,6 @@ export class NimbleNumberFieldDirective {
 
     // readOnly property maps to the readonly attribute
     // https://github.com/microsoft/fast/blob/46bb6d9aab2c37105f4434db3795e176c2354a4f/packages/web-components/fast-foundation/src/number-field/number-field.ts#L38
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('readonly') public set readOnly(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'readOnly', toBooleanProperty(value));
     }
@@ -62,7 +61,6 @@ export class NimbleNumberFieldDirective {
     }
 
     // hideStep property maps to the hide-step attribute
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('hide-step') public set hideStep(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'hideStep', toBooleanProperty(value));
     }
@@ -80,7 +78,6 @@ export class NimbleNumberFieldDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('error-text') public set errorText(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorText', value);
     }
@@ -90,7 +87,6 @@ export class NimbleNumberFieldDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('error-visible') public set errorVisible(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorVisible', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/select/nimble-select.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/select/nimble-select.directive.ts
@@ -34,7 +34,6 @@ export class NimbleSelectDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('error-text') public set errorText(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorText', value);
     }
@@ -44,7 +43,6 @@ export class NimbleSelectDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('error-visible') public set errorVisible(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorVisible', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/select/nimble-select.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/select/nimble-select.directive.ts
@@ -33,7 +33,6 @@ export class NimbleSelectDirective {
         return this.elementRef.nativeElement.errorText;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('error-text') public set errorText(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorText', value);
     }
@@ -42,7 +41,6 @@ export class NimbleSelectDirective {
         return this.elementRef.nativeElement.errorVisible;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('error-visible') public set errorVisible(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorVisible', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/text-area/nimble-text-area.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/text-area/nimble-text-area.directive.ts
@@ -28,7 +28,6 @@ export class NimbleTextAreaDirective {
 
     // readOnly property maps to the readonly attribute
     // See: https://github.com/microsoft/fast/blob/46bb6d9aab2c37105f4434db3795e176c2354a4f/packages/web-components/fast-foundation/src/text-area/text-area.ts#L22
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('readonly') public set readOnly(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'readOnly', toBooleanProperty(value));
     }
@@ -62,7 +61,6 @@ export class NimbleTextAreaDirective {
     }
 
     // errorVisible property maps to the error-visible attribute
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('error-visible') public set errorVisible(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorVisible', toBooleanProperty(value));
     }
@@ -72,7 +70,6 @@ export class NimbleTextAreaDirective {
     }
 
     // errorText property maps to the error-text attribute
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('error-text') public set errorText(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorText', value);
     }
@@ -91,7 +88,6 @@ export class NimbleTextAreaDirective {
 
     // formId property maps to the form attribute
     // See: https://github.com/microsoft/fast/blob/46bb6d9aab2c37105f4434db3795e176c2354a4f/packages/web-components/fast-foundation/src/text-area/text-area.ts#L63
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('form') public set formId(value: string) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'formId', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/text-area/nimble-text-area.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/text-area/nimble-text-area.directive.ts
@@ -60,7 +60,6 @@ export class NimbleTextAreaDirective {
         return this.elementRef.nativeElement.errorVisible;
     }
 
-    // errorVisible property maps to the error-visible attribute
     @Input('error-visible') public set errorVisible(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorVisible', toBooleanProperty(value));
     }
@@ -69,7 +68,6 @@ export class NimbleTextAreaDirective {
         return this.elementRef.nativeElement.errorText;
     }
 
-    // errorText property maps to the error-text attribute
     @Input('error-text') public set errorText(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorText', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/text-field/nimble-text-field.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/text-field/nimble-text-field.directive.ts
@@ -100,7 +100,6 @@ export class NimbleTextFieldDirective {
         return this.elementRef.nativeElement.errorText;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('error-text') public set errorText(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorText', value);
     }
@@ -109,7 +108,6 @@ export class NimbleTextFieldDirective {
         return this.elementRef.nativeElement.errorVisible;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('error-visible') public set errorVisible(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorVisible', toBooleanProperty(value));
     }
@@ -134,7 +132,6 @@ export class NimbleTextFieldDirective {
         return this.elementRef.nativeElement.fullBleed;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('full-bleed') public set fullBleed(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fullBleed', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/text-field/nimble-text-field.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/text-field/nimble-text-field.directive.ts
@@ -28,7 +28,6 @@ export class NimbleTextFieldDirective {
 
     // readOnly property maps to the readonly attribute
     // See: https://github.com/microsoft/fast/blob/46bb6d9aab2c37105f4434db3795e176c2354a4f/packages/web-components/fast-foundation/src/text-field/text-field.ts#L33
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('readonly') public set readOnly(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'readOnly', toBooleanProperty(value));
     }
@@ -102,7 +101,6 @@ export class NimbleTextFieldDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('error-text') public set errorText(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorText', value);
     }
@@ -112,7 +110,6 @@ export class NimbleTextFieldDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('error-visible') public set errorVisible(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorVisible', toBooleanProperty(value));
     }
@@ -138,7 +135,6 @@ export class NimbleTextFieldDirective {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('full-bleed') public set fullBleed(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fullBleed', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/toggle-button/nimble-toggle-button.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/toggle-button/nimble-toggle-button.directive.ts
@@ -33,7 +33,6 @@ export class NimbleToggleButtonDirective {
         return this.elementRef.nativeElement.contentHidden;
     }
 
-    // contentHidden property intentionally maps to the content-hidden attribute
     @Input('content-hidden') public set contentHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'contentHidden', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/toggle-button/nimble-toggle-button.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/toggle-button/nimble-toggle-button.directive.ts
@@ -34,7 +34,6 @@ export class NimbleToggleButtonDirective {
     }
 
     // contentHidden property intentionally maps to the content-hidden attribute
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('content-hidden') public set contentHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'contentHidden', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/tooltip/nimble-tooltip.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/tooltip/nimble-tooltip.directive.ts
@@ -43,7 +43,6 @@ export class NimbleTooltipDirective {
     }
 
     // iconVisible property intentionally maps to the icon-visible attribute
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('icon-visible') public set iconVisible(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'iconVisible', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/tooltip/nimble-tooltip.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/tooltip/nimble-tooltip.directive.ts
@@ -42,7 +42,6 @@ export class NimbleTooltipDirective {
         return this.elementRef.nativeElement.iconVisible;
     }
 
-    // iconVisible property intentionally maps to the icon-visible attribute
     @Input('icon-visible') public set iconVisible(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'iconVisible', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/tree-view/nimble-tree-view.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/tree-view/nimble-tree-view.directive.ts
@@ -18,7 +18,6 @@ export class NimbleTreeViewDirective {
     }
 
     // selectionMode property intentionally maps to the selection-mode attribute
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('selection-mode') public set selectionMode(value: TreeViewSelectionMode) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'selectionMode', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/tree-view/nimble-tree-view.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/tree-view/nimble-tree-view.directive.ts
@@ -17,7 +17,6 @@ export class NimbleTreeViewDirective {
         return this.elementRef.nativeElement.selectionMode;
     }
 
-    // selectionMode property intentionally maps to the selection-mode attribute
     @Input('selection-mode') public set selectionMode(value: TreeViewSelectionMode) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'selectionMode', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/anchor/nimble-table-column-anchor.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/anchor/nimble-table-column-anchor.directive.ts
@@ -20,7 +20,6 @@ export class NimbleTableColumnAnchorDirective extends NimbleTableColumnBaseDirec
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('label-field-name') public set labelFieldName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'labelFieldName', value);
     }
@@ -30,7 +29,6 @@ export class NimbleTableColumnAnchorDirective extends NimbleTableColumnBaseDirec
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('href-field-name') public set hrefFieldName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'hrefFieldName', value);
     }
@@ -48,7 +46,6 @@ export class NimbleTableColumnAnchorDirective extends NimbleTableColumnBaseDirec
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('underline-hidden') public set underlineHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'underlineHidden', toBooleanProperty(value));
     }
@@ -114,7 +111,6 @@ export class NimbleTableColumnAnchorDirective extends NimbleTableColumnBaseDirec
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('fractional-width') public set fractionalWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fractionalWidth', toNullableNumberProperty(value));
     }
@@ -124,7 +120,6 @@ export class NimbleTableColumnAnchorDirective extends NimbleTableColumnBaseDirec
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('min-pixel-width') public set minPixelWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'minPixelWidth', toNullableNumberProperty(value));
     }
@@ -134,7 +129,6 @@ export class NimbleTableColumnAnchorDirective extends NimbleTableColumnBaseDirec
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('group-index') public set groupIndex(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupIndex', toNullableNumberProperty(value));
     }
@@ -144,7 +138,6 @@ export class NimbleTableColumnAnchorDirective extends NimbleTableColumnBaseDirec
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('grouping-disabled') public set groupingDisabled(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupingDisabled', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/anchor/nimble-table-column-anchor.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/anchor/nimble-table-column-anchor.directive.ts
@@ -19,7 +19,6 @@ export class NimbleTableColumnAnchorDirective extends NimbleTableColumnBaseDirec
         return this.elementRef.nativeElement.labelFieldName;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('label-field-name') public set labelFieldName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'labelFieldName', value);
     }
@@ -28,7 +27,6 @@ export class NimbleTableColumnAnchorDirective extends NimbleTableColumnBaseDirec
         return this.elementRef.nativeElement.hrefFieldName;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('href-field-name') public set hrefFieldName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'hrefFieldName', value);
     }
@@ -45,7 +43,6 @@ export class NimbleTableColumnAnchorDirective extends NimbleTableColumnBaseDirec
         return this.elementRef.nativeElement.underlineHidden;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('underline-hidden') public set underlineHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'underlineHidden', toBooleanProperty(value));
     }
@@ -110,7 +107,6 @@ export class NimbleTableColumnAnchorDirective extends NimbleTableColumnBaseDirec
         return this.elementRef.nativeElement.fractionalWidth;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('fractional-width') public set fractionalWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fractionalWidth', toNullableNumberProperty(value));
     }
@@ -119,7 +115,6 @@ export class NimbleTableColumnAnchorDirective extends NimbleTableColumnBaseDirec
         return this.elementRef.nativeElement.minPixelWidth;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('min-pixel-width') public set minPixelWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'minPixelWidth', toNullableNumberProperty(value));
     }
@@ -128,7 +123,6 @@ export class NimbleTableColumnAnchorDirective extends NimbleTableColumnBaseDirec
         return this.elementRef.nativeElement.groupIndex;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('group-index') public set groupIndex(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupIndex', toNullableNumberProperty(value));
     }
@@ -137,7 +131,6 @@ export class NimbleTableColumnAnchorDirective extends NimbleTableColumnBaseDirec
         return this.elementRef.nativeElement.groupingDisabled;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('grouping-disabled') public set groupingDisabled(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupingDisabled', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/date-text/nimble-table-column-date-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/date-text/nimble-table-column-date-text.directive.ts
@@ -51,7 +51,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.fieldName;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('field-name') public set fieldName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fieldName', value);
     }
@@ -68,7 +67,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customLocaleMatcher;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-locale-matcher') public set customLocaleMatcher(value: LocaleMatcherAlgorithm) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customLocaleMatcher', value);
     }
@@ -77,7 +75,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customWeekday;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-weekday') public set customWeekday(value: WeekdayFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customWeekday', value);
     }
@@ -86,7 +83,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customEra;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-era') public set customEra(value: EraFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customEra', value);
     }
@@ -95,7 +91,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customYear;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-year') public set customYear(value: YearFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customYear', value);
     }
@@ -104,7 +99,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customMonth;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-month') public set customMonth(value: MonthFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customMonth', value);
     }
@@ -113,7 +107,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customDay;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-day') public set customDay(value: DayFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customDay', value);
     }
@@ -122,7 +115,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customHour;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-hour') public set customHour(value: HourFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customHour', value);
     }
@@ -131,7 +123,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customMinute;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-minute') public set customMinute(value: MinuteFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customMinute', value);
     }
@@ -140,7 +131,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customSecond;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-second') public set customSecond(value: SecondFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customSecond', value);
     }
@@ -149,7 +139,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customTimeZoneName;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-time-zone-name') public set customTimeZoneName(value: TimeZoneNameFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customTimeZoneName', value);
     }
@@ -158,7 +147,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customFormatMatcher;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-format-matcher') public set customFormatMatcher(value: FormatMatcherAlgorithm) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customFormatMatcher', value);
     }
@@ -167,7 +155,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customHour12;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-hour12') public set customHour12(value: boolean | 'true' | 'false' | undefined) {
         let convertedValue;
         if (typeof value === 'boolean') {
@@ -184,7 +171,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customTimeZone;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-time-zone') public set customTimeZone(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customTimeZone', value);
     }
@@ -193,7 +179,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customCalendar;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-calendar') public set customCalendar(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customCalendar', value);
     }
@@ -202,7 +187,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customDayPeriod;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-day-period') public set customDayPeriod(value: DayPeriodFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customDayPeriod', value);
     }
@@ -211,7 +195,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customNumberingSystem;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-numbering-system') public set customNumberingSystem(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customNumberingSystem', value);
     }
@@ -220,7 +203,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customDateStyle;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-date-style') public set customDateStyle(value: DateStyle) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customDateStyle', value);
     }
@@ -229,7 +211,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customTimeStyle;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-time-style') public set customTimeStyle(value: TimeStyle) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customTimeStyle', value);
     }
@@ -238,7 +219,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.customHourCycle;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('custom-hour-cycle') public set customHourCycle(value: HourCycleFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customHourCycle', value);
     }
@@ -247,7 +227,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.fractionalWidth;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('fractional-width') public set fractionalWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fractionalWidth', toNullableNumberProperty(value));
     }
@@ -256,7 +235,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.minPixelWidth;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('min-pixel-width') public set minPixelWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'minPixelWidth', toNullableNumberProperty(value));
     }
@@ -265,7 +243,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.groupIndex;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('group-index') public set groupIndex(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupIndex', toNullableNumberProperty(value));
     }
@@ -274,7 +251,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.groupingDisabled;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('grouping-disabled') public set groupingDisabled(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupingDisabled', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/date-text/nimble-table-column-date-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/date-text/nimble-table-column-date-text.directive.ts
@@ -52,7 +52,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('field-name') public set fieldName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fieldName', value);
     }
@@ -70,7 +69,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-locale-matcher') public set customLocaleMatcher(value: LocaleMatcherAlgorithm) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customLocaleMatcher', value);
     }
@@ -80,7 +78,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-weekday') public set customWeekday(value: WeekdayFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customWeekday', value);
     }
@@ -90,7 +87,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-era') public set customEra(value: EraFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customEra', value);
     }
@@ -100,7 +96,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-year') public set customYear(value: YearFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customYear', value);
     }
@@ -110,7 +105,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-month') public set customMonth(value: MonthFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customMonth', value);
     }
@@ -120,7 +114,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-day') public set customDay(value: DayFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customDay', value);
     }
@@ -130,7 +123,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-hour') public set customHour(value: HourFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customHour', value);
     }
@@ -140,7 +132,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-minute') public set customMinute(value: MinuteFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customMinute', value);
     }
@@ -150,7 +141,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-second') public set customSecond(value: SecondFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customSecond', value);
     }
@@ -160,7 +150,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-time-zone-name') public set customTimeZoneName(value: TimeZoneNameFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customTimeZoneName', value);
     }
@@ -170,7 +159,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-format-matcher') public set customFormatMatcher(value: FormatMatcherAlgorithm) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customFormatMatcher', value);
     }
@@ -180,7 +168,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-hour12') public set customHour12(value: boolean | 'true' | 'false' | undefined) {
         let convertedValue;
         if (typeof value === 'boolean') {
@@ -198,7 +185,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-time-zone') public set customTimeZone(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customTimeZone', value);
     }
@@ -208,7 +194,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-calendar') public set customCalendar(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customCalendar', value);
     }
@@ -218,7 +203,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-day-period') public set customDayPeriod(value: DayPeriodFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customDayPeriod', value);
     }
@@ -228,7 +212,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-numbering-system') public set customNumberingSystem(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customNumberingSystem', value);
     }
@@ -238,7 +221,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-date-style') public set customDateStyle(value: DateStyle) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customDateStyle', value);
     }
@@ -248,7 +230,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-time-style') public set customTimeStyle(value: TimeStyle) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customTimeStyle', value);
     }
@@ -258,7 +239,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('custom-hour-cycle') public set customHourCycle(value: HourCycleFormat) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'customHourCycle', value);
     }
@@ -268,7 +248,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('fractional-width') public set fractionalWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fractionalWidth', toNullableNumberProperty(value));
     }
@@ -278,7 +257,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('min-pixel-width') public set minPixelWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'minPixelWidth', toNullableNumberProperty(value));
     }
@@ -288,7 +266,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('group-index') public set groupIndex(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupIndex', toNullableNumberProperty(value));
     }
@@ -298,7 +275,6 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('grouping-disabled') public set groupingDisabled(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupingDisabled', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/duration-text/nimble-table-column-duration-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/duration-text/nimble-table-column-duration-text.directive.ts
@@ -18,7 +18,6 @@ export class NimbleTableColumnDurationTextDirective extends NimbleTableColumnBas
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('field-name') public set fieldName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fieldName', value);
     }
@@ -28,7 +27,6 @@ export class NimbleTableColumnDurationTextDirective extends NimbleTableColumnBas
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('fractional-width') public set fractionalWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fractionalWidth', toNullableNumberProperty(value));
     }
@@ -38,7 +36,6 @@ export class NimbleTableColumnDurationTextDirective extends NimbleTableColumnBas
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('min-pixel-width') public set minPixelWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'minPixelWidth', toNullableNumberProperty(value));
     }
@@ -48,7 +45,6 @@ export class NimbleTableColumnDurationTextDirective extends NimbleTableColumnBas
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('group-index') public set groupIndex(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupIndex', toNullableNumberProperty(value));
     }
@@ -58,7 +54,6 @@ export class NimbleTableColumnDurationTextDirective extends NimbleTableColumnBas
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('grouping-disabled') public set groupingDisabled(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupingDisabled', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/duration-text/nimble-table-column-duration-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/duration-text/nimble-table-column-duration-text.directive.ts
@@ -17,7 +17,6 @@ export class NimbleTableColumnDurationTextDirective extends NimbleTableColumnBas
         return this.elementRef.nativeElement.fieldName;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('field-name') public set fieldName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fieldName', value);
     }
@@ -26,7 +25,6 @@ export class NimbleTableColumnDurationTextDirective extends NimbleTableColumnBas
         return this.elementRef.nativeElement.fractionalWidth;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('fractional-width') public set fractionalWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fractionalWidth', toNullableNumberProperty(value));
     }
@@ -35,7 +33,6 @@ export class NimbleTableColumnDurationTextDirective extends NimbleTableColumnBas
         return this.elementRef.nativeElement.minPixelWidth;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('min-pixel-width') public set minPixelWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'minPixelWidth', toNullableNumberProperty(value));
     }
@@ -44,7 +41,6 @@ export class NimbleTableColumnDurationTextDirective extends NimbleTableColumnBas
         return this.elementRef.nativeElement.groupIndex;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('group-index') public set groupIndex(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupIndex', toNullableNumberProperty(value));
     }
@@ -53,7 +49,6 @@ export class NimbleTableColumnDurationTextDirective extends NimbleTableColumnBas
         return this.elementRef.nativeElement.groupingDisabled;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('grouping-disabled') public set groupingDisabled(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupingDisabled', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/enum-text/nimble-table-column-enum-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/enum-text/nimble-table-column-enum-text.directive.ts
@@ -20,7 +20,6 @@ export class NimbleTableColumnEnumTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('field-name') public set fieldName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fieldName', value);
     }
@@ -30,7 +29,6 @@ export class NimbleTableColumnEnumTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('key-type') public set keyType(value: MappingKeyType) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'keyType', value);
     }
@@ -40,7 +38,6 @@ export class NimbleTableColumnEnumTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('fractional-width') public set fractionalWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fractionalWidth', toNullableNumberProperty(value));
     }
@@ -50,7 +47,6 @@ export class NimbleTableColumnEnumTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('min-pixel-width') public set minPixelWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'minPixelWidth', toNullableNumberProperty(value));
     }
@@ -60,7 +56,6 @@ export class NimbleTableColumnEnumTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('group-index') public set groupIndex(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupIndex', toNullableNumberProperty(value));
     }
@@ -70,7 +65,6 @@ export class NimbleTableColumnEnumTextDirective extends NimbleTableColumnBaseDir
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('grouping-disabled') public set groupingDisabled(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupingDisabled', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/enum-text/nimble-table-column-enum-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/enum-text/nimble-table-column-enum-text.directive.ts
@@ -19,7 +19,6 @@ export class NimbleTableColumnEnumTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.fieldName;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('field-name') public set fieldName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fieldName', value);
     }
@@ -28,7 +27,6 @@ export class NimbleTableColumnEnumTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.keyType;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('key-type') public set keyType(value: MappingKeyType) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'keyType', value);
     }
@@ -37,7 +35,6 @@ export class NimbleTableColumnEnumTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.fractionalWidth;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('fractional-width') public set fractionalWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fractionalWidth', toNullableNumberProperty(value));
     }
@@ -46,7 +43,6 @@ export class NimbleTableColumnEnumTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.minPixelWidth;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('min-pixel-width') public set minPixelWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'minPixelWidth', toNullableNumberProperty(value));
     }
@@ -55,7 +51,6 @@ export class NimbleTableColumnEnumTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.groupIndex;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('group-index') public set groupIndex(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupIndex', toNullableNumberProperty(value));
     }
@@ -64,7 +59,6 @@ export class NimbleTableColumnEnumTextDirective extends NimbleTableColumnBaseDir
         return this.elementRef.nativeElement.groupingDisabled;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('grouping-disabled') public set groupingDisabled(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupingDisabled', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/icon/nimble-table-column-icon.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/icon/nimble-table-column-icon.directive.ts
@@ -19,7 +19,6 @@ export class NimbleTableColumnIconDirective extends NimbleTableColumnBaseDirecti
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('field-name') public set fieldName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fieldName', value);
     }
@@ -29,7 +28,6 @@ export class NimbleTableColumnIconDirective extends NimbleTableColumnBaseDirecti
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('key-type') public set keyType(value: MappingKeyType) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'keyType', value);
     }
@@ -39,7 +37,6 @@ export class NimbleTableColumnIconDirective extends NimbleTableColumnBaseDirecti
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('fractional-width') public set fractionalWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fractionalWidth', toNullableNumberProperty(value));
     }
@@ -49,7 +46,6 @@ export class NimbleTableColumnIconDirective extends NimbleTableColumnBaseDirecti
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('min-pixel-width') public set minPixelWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'minPixelWidth', toNullableNumberProperty(value));
     }
@@ -59,7 +55,6 @@ export class NimbleTableColumnIconDirective extends NimbleTableColumnBaseDirecti
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('group-index') public set groupIndex(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupIndex', toNullableNumberProperty(value));
     }
@@ -69,7 +64,6 @@ export class NimbleTableColumnIconDirective extends NimbleTableColumnBaseDirecti
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('grouping-disabled') public set groupingDisabled(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupingDisabled', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/icon/nimble-table-column-icon.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/icon/nimble-table-column-icon.directive.ts
@@ -18,7 +18,6 @@ export class NimbleTableColumnIconDirective extends NimbleTableColumnBaseDirecti
         return this.elementRef.nativeElement.fieldName;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('field-name') public set fieldName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fieldName', value);
     }
@@ -27,7 +26,6 @@ export class NimbleTableColumnIconDirective extends NimbleTableColumnBaseDirecti
         return this.elementRef.nativeElement.keyType;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('key-type') public set keyType(value: MappingKeyType) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'keyType', value);
     }
@@ -36,7 +34,6 @@ export class NimbleTableColumnIconDirective extends NimbleTableColumnBaseDirecti
         return this.elementRef.nativeElement.fractionalWidth;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('fractional-width') public set fractionalWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fractionalWidth', toNullableNumberProperty(value));
     }
@@ -45,7 +42,6 @@ export class NimbleTableColumnIconDirective extends NimbleTableColumnBaseDirecti
         return this.elementRef.nativeElement.minPixelWidth;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('min-pixel-width') public set minPixelWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'minPixelWidth', toNullableNumberProperty(value));
     }
@@ -54,7 +50,6 @@ export class NimbleTableColumnIconDirective extends NimbleTableColumnBaseDirecti
         return this.elementRef.nativeElement.groupIndex;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('group-index') public set groupIndex(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupIndex', toNullableNumberProperty(value));
     }
@@ -63,7 +58,6 @@ export class NimbleTableColumnIconDirective extends NimbleTableColumnBaseDirecti
         return this.elementRef.nativeElement.groupingDisabled;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('grouping-disabled') public set groupingDisabled(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupingDisabled', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/nimble-table-column-base.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/nimble-table-column-base.directive.ts
@@ -16,7 +16,6 @@ export class NimbleTableColumnBaseDirective<T extends TableColumn> {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('column-id') public set columnId(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'columnId', value);
     }
@@ -26,7 +25,6 @@ export class NimbleTableColumnBaseDirective<T extends TableColumn> {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('action-menu-slot') public set actionMenuSlot(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'actionMenuSlot', value);
     }
@@ -36,7 +34,6 @@ export class NimbleTableColumnBaseDirective<T extends TableColumn> {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('action-menu-label') public set actionMenuLabel(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'actionMenuLabel', value);
     }
@@ -46,7 +43,6 @@ export class NimbleTableColumnBaseDirective<T extends TableColumn> {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('column-hidden') public set columnHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'columnHidden', toBooleanProperty(value));
     }
@@ -56,7 +52,6 @@ export class NimbleTableColumnBaseDirective<T extends TableColumn> {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('sort-direction') public set sortDirection(value: TableColumnSortDirection) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'sortDirection', value);
     }
@@ -66,7 +61,6 @@ export class NimbleTableColumnBaseDirective<T extends TableColumn> {
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('sort-index') public set sortIndex(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'sortIndex', toNullableNumberProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/nimble-table-column-base.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/nimble-table-column-base.directive.ts
@@ -15,7 +15,6 @@ export class NimbleTableColumnBaseDirective<T extends TableColumn> {
         return this.elementRef.nativeElement.columnId;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('column-id') public set columnId(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'columnId', value);
     }
@@ -24,7 +23,6 @@ export class NimbleTableColumnBaseDirective<T extends TableColumn> {
         return this.elementRef.nativeElement.actionMenuSlot;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('action-menu-slot') public set actionMenuSlot(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'actionMenuSlot', value);
     }
@@ -33,7 +31,6 @@ export class NimbleTableColumnBaseDirective<T extends TableColumn> {
         return this.elementRef.nativeElement.actionMenuLabel;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('action-menu-label') public set actionMenuLabel(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'actionMenuLabel', value);
     }
@@ -42,7 +39,6 @@ export class NimbleTableColumnBaseDirective<T extends TableColumn> {
         return this.elementRef.nativeElement.columnHidden;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('column-hidden') public set columnHidden(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'columnHidden', toBooleanProperty(value));
     }
@@ -51,7 +47,6 @@ export class NimbleTableColumnBaseDirective<T extends TableColumn> {
         return this.elementRef.nativeElement.sortDirection;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('sort-direction') public set sortDirection(value: TableColumnSortDirection) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'sortDirection', value);
     }
@@ -60,7 +55,6 @@ export class NimbleTableColumnBaseDirective<T extends TableColumn> {
         return this.elementRef.nativeElement.sortIndex;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('sort-index') public set sortIndex(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'sortIndex', toNullableNumberProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/number-text/nimble-table-column-number-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/number-text/nimble-table-column-number-text.directive.ts
@@ -19,7 +19,6 @@ export class NimbleTableColumnNumberTextDirective extends NimbleTableColumnBaseD
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('field-name') public set fieldName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fieldName', value);
     }
@@ -45,7 +44,6 @@ export class NimbleTableColumnNumberTextDirective extends NimbleTableColumnBaseD
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('decimal-digits') public set decimalDigits(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'decimalDigits', toNullableNumberProperty(value));
     }
@@ -55,7 +53,6 @@ export class NimbleTableColumnNumberTextDirective extends NimbleTableColumnBaseD
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('decimal-maximum-digits') public set decimalMaximumDigits(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'decimalMaximumDigits', toNullableNumberProperty(value));
     }
@@ -65,7 +62,6 @@ export class NimbleTableColumnNumberTextDirective extends NimbleTableColumnBaseD
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('fractional-width') public set fractionalWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fractionalWidth', toNullableNumberProperty(value));
     }
@@ -75,7 +71,6 @@ export class NimbleTableColumnNumberTextDirective extends NimbleTableColumnBaseD
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('min-pixel-width') public set minPixelWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'minPixelWidth', toNullableNumberProperty(value));
     }
@@ -85,7 +80,6 @@ export class NimbleTableColumnNumberTextDirective extends NimbleTableColumnBaseD
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('group-index') public set groupIndex(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupIndex', toNullableNumberProperty(value));
     }
@@ -95,7 +89,6 @@ export class NimbleTableColumnNumberTextDirective extends NimbleTableColumnBaseD
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('grouping-disabled') public set groupingDisabled(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupingDisabled', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/number-text/nimble-table-column-number-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/number-text/nimble-table-column-number-text.directive.ts
@@ -18,7 +18,6 @@ export class NimbleTableColumnNumberTextDirective extends NimbleTableColumnBaseD
         return this.elementRef.nativeElement.fieldName;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('field-name') public set fieldName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fieldName', value);
     }
@@ -43,7 +42,6 @@ export class NimbleTableColumnNumberTextDirective extends NimbleTableColumnBaseD
         return this.elementRef.nativeElement.decimalDigits;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('decimal-digits') public set decimalDigits(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'decimalDigits', toNullableNumberProperty(value));
     }
@@ -52,7 +50,6 @@ export class NimbleTableColumnNumberTextDirective extends NimbleTableColumnBaseD
         return this.elementRef.nativeElement.decimalMaximumDigits;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('decimal-maximum-digits') public set decimalMaximumDigits(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'decimalMaximumDigits', toNullableNumberProperty(value));
     }
@@ -61,7 +58,6 @@ export class NimbleTableColumnNumberTextDirective extends NimbleTableColumnBaseD
         return this.elementRef.nativeElement.fractionalWidth;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('fractional-width') public set fractionalWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fractionalWidth', toNullableNumberProperty(value));
     }
@@ -70,7 +66,6 @@ export class NimbleTableColumnNumberTextDirective extends NimbleTableColumnBaseD
         return this.elementRef.nativeElement.minPixelWidth;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('min-pixel-width') public set minPixelWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'minPixelWidth', toNullableNumberProperty(value));
     }
@@ -79,7 +74,6 @@ export class NimbleTableColumnNumberTextDirective extends NimbleTableColumnBaseD
         return this.elementRef.nativeElement.groupIndex;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('group-index') public set groupIndex(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupIndex', toNullableNumberProperty(value));
     }
@@ -88,7 +82,6 @@ export class NimbleTableColumnNumberTextDirective extends NimbleTableColumnBaseD
         return this.elementRef.nativeElement.groupingDisabled;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('grouping-disabled') public set groupingDisabled(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupingDisabled', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/text/nimble-table-column-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/text/nimble-table-column-text.directive.ts
@@ -18,7 +18,6 @@ export class NimbleTableColumnTextDirective extends NimbleTableColumnBaseDirecti
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('field-name') public set fieldName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fieldName', value);
     }
@@ -28,7 +27,6 @@ export class NimbleTableColumnTextDirective extends NimbleTableColumnBaseDirecti
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('fractional-width') public set fractionalWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fractionalWidth', toNullableNumberProperty(value));
     }
@@ -38,7 +36,6 @@ export class NimbleTableColumnTextDirective extends NimbleTableColumnBaseDirecti
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('min-pixel-width') public set minPixelWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'minPixelWidth', toNullableNumberProperty(value));
     }
@@ -48,7 +45,6 @@ export class NimbleTableColumnTextDirective extends NimbleTableColumnBaseDirecti
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('group-index') public set groupIndex(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupIndex', toNullableNumberProperty(value));
     }
@@ -58,7 +54,6 @@ export class NimbleTableColumnTextDirective extends NimbleTableColumnBaseDirecti
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('grouping-disabled') public set groupingDisabled(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupingDisabled', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/text/nimble-table-column-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/text/nimble-table-column-text.directive.ts
@@ -17,7 +17,6 @@ export class NimbleTableColumnTextDirective extends NimbleTableColumnBaseDirecti
         return this.elementRef.nativeElement.fieldName;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('field-name') public set fieldName(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fieldName', value);
     }
@@ -26,7 +25,6 @@ export class NimbleTableColumnTextDirective extends NimbleTableColumnBaseDirecti
         return this.elementRef.nativeElement.fractionalWidth;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('fractional-width') public set fractionalWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'fractionalWidth', toNullableNumberProperty(value));
     }
@@ -35,7 +33,6 @@ export class NimbleTableColumnTextDirective extends NimbleTableColumnBaseDirecti
         return this.elementRef.nativeElement.minPixelWidth;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('min-pixel-width') public set minPixelWidth(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'minPixelWidth', toNullableNumberProperty(value));
     }
@@ -44,7 +41,6 @@ export class NimbleTableColumnTextDirective extends NimbleTableColumnBaseDirecti
         return this.elementRef.nativeElement.groupIndex;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('group-index') public set groupIndex(value: NumberValueOrAttribute | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupIndex', toNullableNumberProperty(value));
     }
@@ -53,7 +49,6 @@ export class NimbleTableColumnTextDirective extends NimbleTableColumnBaseDirecti
         return this.elementRef.nativeElement.groupingDisabled;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('grouping-disabled') public set groupingDisabled(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'groupingDisabled', toBooleanProperty(value));
     }

--- a/angular-workspace/projects/ni/nimble-angular/table/nimble-table.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table/nimble-table.directive.ts
@@ -46,7 +46,6 @@ export class NimbleTableDirective<TData extends TableRecord = TableRecord> imple
         return this.elementRef.nativeElement.idFieldName;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('id-field-name') public set idFieldName(value: string | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'idFieldName', value);
     }
@@ -55,7 +54,6 @@ export class NimbleTableDirective<TData extends TableRecord = TableRecord> imple
         return this.elementRef.nativeElement.selectionMode;
     }
 
-    // Renaming because property should have camel casing, but attribute should not
     @Input('selection-mode') public set selectionMode(value: TableRowSelectionMode) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'selectionMode', value);
     }

--- a/angular-workspace/projects/ni/nimble-angular/table/nimble-table.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table/nimble-table.directive.ts
@@ -47,7 +47,6 @@ export class NimbleTableDirective<TData extends TableRecord = TableRecord> imple
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('id-field-name') public set idFieldName(value: string | null | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'idFieldName', value);
     }
@@ -57,7 +56,6 @@ export class NimbleTableDirective<TData extends TableRecord = TableRecord> imple
     }
 
     // Renaming because property should have camel casing, but attribute should not
-    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('selection-mode') public set selectionMode(value: TableRowSelectionMode) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'selectionMode', value);
     }

--- a/change/@ni-nimble-angular-f02a7a22-1bf1-447b-8ffb-025ce2034b24.json
+++ b/change/@ni-nimble-angular-f02a7a22-1bf1-447b-8ffb-025ce2034b24.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Disable @angular-eslint/no-input-rename for nimble angular",
+  "packageName": "@ni/nimble-angular",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Nimble Angular uses a directive naming convention that aligns with  web components. This results in the template name differing from the property input name. This is expected for nimble angular directives targeting Nimble components which are based on web component apis but not for other angular components, i.e. in the example app.

## 👩‍💻 Implementation

Disable the `@angular-eslint/no-input-rename` rule for nimble angular which is almost exclusively web component directive definitions. The Angular Components defined in the example app will keep the NI Style Guide Angular Component naming conventions.

## 🧪 Testing

Rely on CI

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
