### PR TITLE
Fix styling of disabled tree items

### DIFF
--- a/change/@ni-nimble-components-84b7a395-1b56-4f91-b4bc-7b277151ba58.json
+++ b/change/@ni-nimble-components-84b7a395-1b56-4f91-b4bc-7b277151ba58.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix disabled styling of tree items",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/anchor-tree-item/styles.ts
+++ b/packages/nimble-components/src/anchor-tree-item/styles.ts
@@ -10,7 +10,9 @@ import {
     fillHoverColor,
     fillHoverSelectedColor,
     fillSelectedColor,
-    bodyFontSize
+    bodyFontSize,
+    bodyDisabledFontColor,
+    iconColor
 } from '../theme-provider/design-tokens';
 import { focusVisible } from '../utilities/style/focus';
 import { userSelectNone } from '../utilities/style/user-select';
@@ -32,20 +34,20 @@ export const styles = css`
         --ni-private-tree-item-nested-width: 0;
     }
 
+    :host([disabled]) {
+        color: ${bodyDisabledFontColor};
+        cursor: default;
+    }
+
     .control {
         display: flex;
         text-decoration: none;
-        color: ${bodyFontColor};
     }
 
     .control${focusVisible} {
         box-shadow: 0px 0px 0px ${borderWidth} ${borderHoverColor} inset;
         outline: ${borderWidth} solid ${borderHoverColor};
         outline-offset: -2px;
-    }
-
-    :host([disabled]) .control {
-        cursor: not-allowed;
     }
 
     .positioning-region {
@@ -58,6 +60,10 @@ export const styles = css`
 
     .positioning-region:hover {
         background: ${fillHoverColor};
+    }
+
+    :host([disabled]) .positioning-region:hover {
+        background: transparent;
     }
 
     :host([selected]) .positioning-region {
@@ -88,11 +94,6 @@ export const styles = css`
         margin-inline-start: ${iconSize};
     }
 
-    :host([disabled]) .content-region {
-        opacity: 0.5;
-        cursor: not-allowed;
-    }
-
     ${
         /* this rule keeps children without an icon text aligned with parents */ ''
     }
@@ -103,12 +104,12 @@ export const styles = css`
     ${/* the start class is applied when the corresponding slot is filled */ ''}
     .start {
         display: flex;
-        fill: currentcolor;
         margin-inline-start: ${iconSize};
         margin-inline-end: ${iconSize};
     }
 
     slot[name='start']::slotted(*) {
+        ${iconColor.cssCustomProperty}: currentcolor;
         width: ${iconSize};
         height: ${iconSize};
     }

--- a/packages/nimble-components/src/anchor-tree-item/styles.ts
+++ b/packages/nimble-components/src/anchor-tree-item/styles.ts
@@ -42,6 +42,7 @@ export const styles = css`
     .control {
         display: flex;
         text-decoration: none;
+        color: currentcolor;
     }
 
     .control${focusVisible} {

--- a/packages/nimble-components/src/tree-item/styles.ts
+++ b/packages/nimble-components/src/tree-item/styles.ts
@@ -12,7 +12,9 @@ import {
     fillHoverSelectedColor,
     borderWidth,
     iconSize,
-    mediumDelay
+    mediumDelay,
+    bodyDisabledFontColor,
+    iconColor
 } from '../theme-provider/design-tokens';
 import { groupSelectedAttribute } from '../tree-view/types';
 import { DirectionalStyleSheetBehavior } from '../utilities/style/direction';
@@ -33,6 +35,11 @@ export const styles = css`
         color: ${bodyFontColor};
         cursor: pointer;
         --ni-private-tree-item-nested-width: 0;
+    }
+
+    :host([disabled]) {
+        color: ${bodyDisabledFontColor};
+        cursor: default;
     }
 
     ${/* this controls the side border */ ''}
@@ -76,6 +83,10 @@ export const styles = css`
         background: ${fillHoverSelectedColor};
     }
 
+    :host([disabled]) .positioning-region:hover {
+        background-color: transparent;
+    }
+
     .positioning-region::before {
         content: '';
         display: block;
@@ -100,11 +111,6 @@ export const styles = css`
         outline: none;
     }
 
-    :host([disabled]) .content-region {
-        opacity: 0.5;
-        cursor: not-allowed;
-    }
-
     .expand-collapse-button {
         background: none;
         border: none;
@@ -114,7 +120,6 @@ export const styles = css`
         padding: 0px;
         justify-content: center;
         align-items: center;
-        cursor: pointer;
         margin-left: 10px;
         position: absolute;
     }
@@ -139,12 +144,12 @@ export const styles = css`
     }
     .start {
         display: flex;
-        fill: currentcolor;
         margin-inline-start: ${iconSize};
         margin-inline-end: ${iconSize};
     }
 
     slot[name='start']::slotted(*) {
+        ${iconColor.cssCustomProperty}: currentcolor;
         width: ${iconSize};
         height: ${iconSize};
     }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #1358 

## 👩‍💻 Implementation

The tree-item and anchor-tree-item disabled styles now match other components (such as the list-option) and the Figma spec. The changes made include:
- Making the cursor `default` rather than `not-allowed` when hovering over a disabled tree item
- Making the hover color on a disabled tree item transparent
- Making the icon & text associated with a tree item `bodyDisabledFontColor` rather than applying a 50% opacity. (Note that `bodyDisabledFontColor` uses 30% opacity, so this did change the rendered color).

## 🧪 Testing

- Manually tested in storybook
- Inspected the chromatic diffs

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
