### PR TITLE
Update Microsoft.AspNetCore.Components.Web reference to 6.0.26

### DIFF
--- a/packages/nimble-blazor/NimbleBlazor/NimbleBlazor.csproj
+++ b/packages/nimble-blazor/NimbleBlazor/NimbleBlazor.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.26" />
     <PackageReference Include="NI.CSharp.Analyzers" Version="2.0.4" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The Microsoft.AspNetCore.Components.Web package depends on the Microsoft.AspNetCore.Components package, which has security vulnerabilities until version 6.0.25.  Updating this reference to the latest (6.0.26) prevents us from pulling in packages with known security vulnerabilities.

![image](https://github.com/ni/nimble/assets/1509215/901a366b-958a-47cd-b1ab-5575f58718af)

I ran into this by running `dotnet list <solution> package --vulnerable --include-transitive` against the ASW repo.  [More info](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-list-package) on `dotnet list package`

## 👩‍💻 Implementation

Update the package version.

## 🧪 Testing

None.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
