### PR TITLE
Update CODEOWNERS for card component

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,6 @@
 /packages/nimble-components/src/wafer-map @rajsite @jattasNI @DStavilaNI @zszilagy
 /packages/nimble-components/src/rich-text-viewer @rajsite @jattasNI @vikisekarNI
 /packages/nimble-components/src/rich-text-editor @rajsite @jattasNI @vikisekarNI
-/packages/nimble-components/src/card @rajsite @jattasNI @kjohn1922 @mollykreis
 /packages/nimble-tokens @rajsite @jattasNI @fredvisser
 /packages/site @rajsite @jattasNI
 /packages/xliff-to-json-converter @rajsite @TrevorKarjanis @jattasNI


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

One of the owners for the card component is no longer at NI so will likely not be prioritizing Nimble PR reviews. I confirmed with Cameron that their squad is fine with not being included on future reviews.

## 👩‍💻 Implementation

Removed custom owners for card component so it will fall back to default owners for nimble-components.

Note: this means @mollykreis won't be an owner anymore. I'm fine to add you back but I figured the card wasn't unique enough to merit having 3 owners or even having custom owners at all.

## 🧪 Testing

N/A

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [X] I have updated the project documentation to reflect my changes or determined no changes are needed.
