### PR TITLE
Fix markdown formatting in jasmine-parameterized README

### DIFF
--- a/change/@ni-jasmine-parameterized-5a96624d-3d95-4e06-a86d-1609cb99fae8.json
+++ b/change/@ni-jasmine-parameterized-5a96624d-3d95-4e06-a86d-1609cb99fae8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix README markdown formatting",
+  "packageName": "@ni/jasmine-parameterized",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ni-private/nimble",
+  "name": "@ni-private/nimble", 
   "version": "1.0.0",
   "private": true,
   "description": "The NI Nimble Design System Monorepo",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ni-private/nimble", 
+  "name": "@ni-private/nimble",
   "version": "1.0.0",
   "private": true,
   "description": "The NI Nimble Design System Monorepo",

--- a/packages/jasmine-parameterized/README.md
+++ b/packages/jasmine-parameterized/README.md
@@ -16,6 +16,7 @@ The `@ni/jasmine-parameterized` library provides utility functions for writing [
 Use `parameterizeSpec` to create a parameterized test using an array of tests with names.
 
 In the following example:
+
     - the test named `cats-and-dogs` is focused for debugging
     - the test named `frogs` is configured to always be disabled
     - the test named `men` will run normally as it has no override

--- a/packages/jasmine-parameterized/README.md
+++ b/packages/jasmine-parameterized/README.md
@@ -13,13 +13,14 @@ The `@ni/jasmine-parameterized` library provides utility functions for writing [
 2. Use `parameterizeSpec` to write strictly-typed jasmine tests that run for different test scenarios, where each test can be focused or excluded as needed by name.
 
 ### `parameterizeSpec`
+
 Use `parameterizeSpec` to create a parameterized test using an array of tests with names.
 
 In the following example:
 
-    - the test named `cats-and-dogs` is focused for debugging
-    - the test named `frogs` is configured to always be disabled
-    - the test named `men` will run normally as it has no override
+- the test named `cats-and-dogs` is focused for debugging
+- the test named `frogs` is configured to always be disabled
+- the test named `men` will run normally as it has no override
 
 ```ts
 import { parameterizeSpec } from '@ni/jasmine-parameterized';


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

I noticed on npmjs.com and GitHub that one of the lists in the README isn't formatted correctly
https://www.npmjs.com/package/@ni/jasmine-parameterized
https://github.com/ni/nimble/blob/main/packages/jasmine-parameterized/README.md


## 👩‍💻 Implementation

Add a newline and change indentation

## 🧪 Testing

Verified that it renders correctly in GitHub
https://github.com/ni/nimble/blob/readme-jasmine-parameterized/packages/jasmine-parameterized/README.md

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
