### PR TITLE
Use parameterizeSpec in nimble-angular

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/pipes/tests/duration.pipe.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/pipes/tests/duration.pipe.spec.ts
@@ -1,3 +1,4 @@
+import { parameterizeSpec } from '@ni/jasmine-parameterized';
 import { DurationPipe } from '../duration.pipe';
 
 describe('DurationPipe', () => {
@@ -78,12 +79,12 @@ describe('DurationPipe', () => {
                 value: Number.NaN,
                 expected: ''
             },
-        ];
+        ] as const;
 
-        testCases.forEach(test => {
-            it(`${test.name} transforms to ${test.expected}`, () => {
-                const result = pipe.transform(test.value);
-                expect(result).toEqual(test.expected);
+        parameterizeSpec(testCases, (spec, name, value) => {
+            spec(`${name} transforms to ${value.expected}`, () => {
+                const result = pipe.transform(value.value);
+                expect(result).toEqual(value.expected);
             });
         });
     });

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/anchor-button/tests/nimble-anchor-button-router-link-with-href.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/anchor-button/tests/nimble-anchor-button-router-link-with-href.directive.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { Router } from '@angular/router';
 import { CommonModule, Location } from '@angular/common';
 import { RouterTestingModule } from '@angular/router/testing';
+import { parameterizeSpec } from '@ni/jasmine-parameterized';
 import { processUpdates } from '../../../testing/async-helpers';
 import { NimbleAnchorButtonModule } from '../nimble-anchor-button.module';
 import type { AnchorButton } from '../nimble-anchor-button.directive';
@@ -94,18 +95,18 @@ describe('Nimble anchor button RouterLinkWithHrefDirective', () => {
         expect(routerNavigateByUrlSpy).not.toHaveBeenCalled();
     }));
 
-    const secondaryClickTests: { testName: string, clickArgs: { [key: string]: unknown } }[] = [
-        { testName: 'middle mouse click', clickArgs: { button: 1 } },
-        { testName: 'Ctrl + left-click', clickArgs: { button: 0, ctrlKey: true } }
-    ];
-    secondaryClickTests.forEach(test => {
-        it(`does not do router navigation for non-primary-mouse link clicks for ${test.testName}`, fakeAsync(() => {
+    const secondaryClickTests = [
+        { name: 'middle mouse click', clickArgs: { button: 1 } },
+        { name: 'Ctrl + left-click', clickArgs: { button: 0, ctrlKey: true } }
+    ] as const;
+    parameterizeSpec(secondaryClickTests, (spec, name, value) => {
+        spec(`does not do router navigation for non-primary-mouse link clicks for ${name}`, fakeAsync(() => {
             innerAnchor!.dispatchEvent(new MouseEvent('click', {
                 ...{
                     bubbles: true,
                     cancelable: true
                 },
-                ...test.clickArgs
+                ...value.clickArgs
             }));
             tick();
 

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/anchor-menu-item/tests/nimble-anchor-menu-item-router-link-with-href.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/anchor-menu-item/tests/nimble-anchor-menu-item-router-link-with-href.directive.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { Router } from '@angular/router';
 import { CommonModule, Location } from '@angular/common';
 import { RouterTestingModule } from '@angular/router/testing';
+import { parameterizeSpec } from '@ni/jasmine-parameterized';
 import { processUpdates } from '../../../testing/async-helpers';
 import { NimbleAnchorMenuItemModule } from '../nimble-anchor-menu-item.module';
 import type { AnchorMenuItem } from '../nimble-anchor-menu-item.directive';
@@ -94,18 +95,18 @@ describe('Nimble anchor menu item RouterLinkWithHrefDirective', () => {
         expect(routerNavigateByUrlSpy).not.toHaveBeenCalled();
     }));
 
-    const secondaryClickTests: { testName: string, clickArgs: { [key: string]: unknown } }[] = [
-        { testName: 'middle mouse click', clickArgs: { button: 1 } },
-        { testName: 'Ctrl + left-click', clickArgs: { button: 0, ctrlKey: true } }
-    ];
-    secondaryClickTests.forEach(test => {
-        it(`does not do router navigation for non-primary-mouse link clicks for ${test.testName}`, fakeAsync(() => {
+    const secondaryClickTests = [
+        { name: 'middle mouse click', clickArgs: { button: 1 } },
+        { name: 'Ctrl + left-click', clickArgs: { button: 0, ctrlKey: true } }
+    ] as const;
+    parameterizeSpec(secondaryClickTests, (spec, name, value) => {
+        spec(`does not do router navigation for non-primary-mouse link clicks for ${name}`, fakeAsync(() => {
             innerAnchor!.dispatchEvent(new MouseEvent('click', {
                 ...{
                     bubbles: true,
                     cancelable: true
                 },
-                ...test.clickArgs
+                ...value.clickArgs
             }));
             tick();
 

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/anchor-tab/tests/nimble-anchor-tab-router-link-with-href.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/anchor-tab/tests/nimble-anchor-tab-router-link-with-href.directive.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { Router } from '@angular/router';
 import { CommonModule, Location } from '@angular/common';
 import { RouterTestingModule } from '@angular/router/testing';
+import { parameterizeSpec } from '@ni/jasmine-parameterized';
 import { processUpdates } from '../../../testing/async-helpers';
 import { NimbleAnchorTabModule } from '../nimble-anchor-tab.module';
 import type { AnchorTab } from '../nimble-anchor-tab.directive';
@@ -94,18 +95,18 @@ describe('Nimble anchor tab RouterLinkWithHrefDirective', () => {
         expect(routerNavigateByUrlSpy).not.toHaveBeenCalled();
     }));
 
-    const secondaryClickTests: { testName: string, clickArgs: { [key: string]: unknown } }[] = [
-        { testName: 'middle mouse click', clickArgs: { button: 1 } },
-        { testName: 'Ctrl + left-click', clickArgs: { button: 0, ctrlKey: true } }
-    ];
-    secondaryClickTests.forEach(test => {
-        it(`does not do router navigation for non-primary-mouse link clicks for ${test.testName}`, fakeAsync(() => {
+    const secondaryClickTests = [
+        { name: 'middle mouse click', clickArgs: { button: 1 } },
+        { name: 'Ctrl + left-click', clickArgs: { button: 0, ctrlKey: true } }
+    ] as const;
+    parameterizeSpec(secondaryClickTests, (spec, name, value) => {
+        spec(`does not do router navigation for non-primary-mouse link clicks for ${name}`, fakeAsync(() => {
             innerAnchor!.dispatchEvent(new MouseEvent('click', {
                 ...{
                     bubbles: true,
                     cancelable: true
                 },
-                ...test.clickArgs
+                ...value.clickArgs
             }));
             tick();
 

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/anchor-tree-item/tests/nimble-anchor-tree-item-router-link-with-href.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/anchor-tree-item/tests/nimble-anchor-tree-item-router-link-with-href.directive.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { Router } from '@angular/router';
 import { CommonModule, Location } from '@angular/common';
 import { RouterTestingModule } from '@angular/router/testing';
+import { parameterizeSpec } from '@ni/jasmine-parameterized';
 import { processUpdates } from '../../../testing/async-helpers';
 import { NimbleAnchorTreeItemModule } from '../nimble-anchor-tree-item.module';
 import type { AnchorTreeItem } from '../nimble-anchor-tree-item.directive';
@@ -94,18 +95,18 @@ describe('Nimble anchor tree item RouterLinkWithHrefDirective', () => {
         expect(routerNavigateByUrlSpy).not.toHaveBeenCalled();
     }));
 
-    const secondaryClickTests: { testName: string, clickArgs: { [key: string]: unknown } }[] = [
-        { testName: 'middle mouse click', clickArgs: { button: 1 } },
-        { testName: 'Ctrl + left-click', clickArgs: { button: 0, ctrlKey: true } }
-    ];
-    secondaryClickTests.forEach(test => {
-        it(`does not do router navigation for non-primary-mouse link clicks for ${test.testName}`, fakeAsync(() => {
+    const secondaryClickTests = [
+        { name: 'middle mouse click', clickArgs: { button: 1 } },
+        { name: 'Ctrl + left-click', clickArgs: { button: 0, ctrlKey: true } }
+    ] as const;
+    parameterizeSpec(secondaryClickTests, (spec, name, value) => {
+        spec(`does not do router navigation for non-primary-mouse link clicks for ${name}`, fakeAsync(() => {
             innerAnchor!.dispatchEvent(new MouseEvent('click', {
                 ...{
                     bubbles: true,
                     cancelable: true
                 },
-                ...test.clickArgs
+                ...value.clickArgs
             }));
             tick();
 

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/anchor/tests/nimble-anchor-router-link-with-href.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/anchor/tests/nimble-anchor-router-link-with-href.directive.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { Router } from '@angular/router';
 import { CommonModule, Location } from '@angular/common';
 import { RouterTestingModule } from '@angular/router/testing';
+import { parameterizeSpec } from '@ni/jasmine-parameterized';
 import { processUpdates } from '../../../testing/async-helpers';
 import { NimbleAnchorModule } from '../nimble-anchor.module';
 import type { Anchor } from '../nimble-anchor.directive';
@@ -86,18 +87,18 @@ describe('Nimble anchor RouterLinkWithHrefDirective', () => {
         expect(location.path()).toEqual(expectedDestinationUrl);
     }));
 
-    const secondaryClickTests: { testName: string, clickArgs: { [key: string]: unknown } }[] = [
-        { testName: 'middle mouse click', clickArgs: { button: 1 } },
-        { testName: 'Ctrl + left-click', clickArgs: { button: 0, ctrlKey: true } }
-    ];
-    secondaryClickTests.forEach(test => {
-        it(`does not do router navigation for non-primary-mouse link clicks for ${test.testName}`, fakeAsync(() => {
+    const secondaryClickTests = [
+        { name: 'middle mouse click', clickArgs: { button: 1 } },
+        { name: 'Ctrl + left-click', clickArgs: { button: 0, ctrlKey: true } }
+    ] as const;
+    parameterizeSpec(secondaryClickTests, (spec, name, value) => {
+        spec(`does not do router navigation for non-primary-mouse link clicks for ${name}`, fakeAsync(() => {
             innerAnchor!.dispatchEvent(new MouseEvent('click', {
                 ...{
                     bubbles: true,
                     cancelable: true
                 },
-                ...test.clickArgs
+                ...value.clickArgs
             }));
             tick();
 

--- a/angular-workspace/projects/ni/nimble-angular/src/directives/breadcrumb-item/tests/nimble-breadcrumb-item-router-link-with-href.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/breadcrumb-item/tests/nimble-breadcrumb-item-router-link-with-href.directive.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { Router } from '@angular/router';
 import { CommonModule, Location } from '@angular/common';
 import { RouterTestingModule } from '@angular/router/testing';
+import { parameterizeSpec } from '@ni/jasmine-parameterized';
 import { processUpdates } from '../../../testing/async-helpers';
 import { NimbleBreadcrumbModule } from '../../breadcrumb/nimble-breadcrumb.module';
 import { NimbleBreadcrumbItemModule } from '../nimble-breadcrumb-item.module';
@@ -102,18 +103,18 @@ describe('Nimble breadcrumb item RouterLinkWithHrefDirective', () => {
         expect(routerNavigateByUrlSpy).not.toHaveBeenCalled();
     }));
 
-    const secondaryClickTests: { testName: string, clickArgs: { [key: string]: unknown } }[] = [
-        { testName: 'middle mouse click', clickArgs: { button: 1 } },
-        { testName: 'Ctrl + left-click', clickArgs: { button: 0, ctrlKey: true } }
-    ];
-    secondaryClickTests.forEach(test => {
-        it(`does not do router navigation for non-primary-mouse link clicks for ${test.testName}`, fakeAsync(() => {
+    const secondaryClickTests = [
+        { name: 'middle mouse click', clickArgs: { button: 1 } },
+        { name: 'Ctrl + left-click', clickArgs: { button: 0, ctrlKey: true } }
+    ] as const;
+    parameterizeSpec(secondaryClickTests, (spec, name, value) => {
+        spec(`does not do router navigation for non-primary-mouse link clicks for ${name}`, fakeAsync(() => {
             anchor!.dispatchEvent(new MouseEvent('click', {
                 ...{
                     bubbles: true,
                     cancelable: true
                 },
-                ...test.clickArgs
+                ...value.clickArgs
             }));
             tick();
 

--- a/angular-workspace/projects/ni/nimble-angular/table-column/anchor/tests/nimble-table-column-anchor-navigation-guard.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/anchor/tests/nimble-table-column-anchor-navigation-guard.directive.spec.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 import { Anchor, processUpdates, waitForUpdatesAsync } from '@ni/nimble-angular';
 import { TablePageObject } from '@ni/nimble-angular/table/testing';
 import { NimbleTableModule, Table } from '@ni/nimble-angular/table';
+import { parameterizeSpec } from '@ni/jasmine-parameterized';
 import { NimbleTableColumnAnchorModule } from '../nimble-table-column-anchor.module';
 
 describe('Nimble anchor table column navigation guard', () => {
@@ -89,18 +90,18 @@ describe('Nimble anchor table column navigation guard', () => {
             expect(onClickSpy).toHaveBeenCalledOnceWith('1');
         }));
 
-        const secondaryClickTests: { testName: string, clickArgs: { [key: string]: unknown } }[] = [
-            { testName: 'middle mouse click', clickArgs: { button: 1 } },
-            { testName: 'Ctrl + left-click', clickArgs: { button: 0, ctrlKey: true } }
-        ];
-        secondaryClickTests.forEach(test => {
-            it(`does not call navigationGuard for non-primary-mouse link clicks for ${test.testName}`, fakeAsync(() => {
+        const secondaryClickTests = [
+            { name: 'middle mouse click', clickArgs: { button: 1 } },
+            { name: 'Ctrl + left-click', clickArgs: { button: 0, ctrlKey: true } }
+        ] as const;
+        parameterizeSpec(secondaryClickTests, (spec, name, value) => {
+            spec(`does not call navigationGuard for non-primary-mouse link clicks for ${name}`, fakeAsync(() => {
                 innerAnchor.dispatchEvent(new MouseEvent('click', {
                     ...{
                         bubbles: true,
                         cancelable: true
                     },
-                    ...test.clickArgs
+                    ...value.clickArgs
                 }));
                 tick();
 

--- a/change/@ni-nimble-angular-f009cca3-0b9a-45b8-bda4-535bcecb789c.json
+++ b/change/@ni-nimble-angular-f009cca3-0b9a-45b8-bda4-535bcecb789c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use jasmine-parameterized in Angular tests",
+  "packageName": "@ni/nimble-angular",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #1551 

The last step of #1551 is to use the new `@ni/jasmine-parameterized` package in the Angular tests.

## 👩‍💻 Implementation

Replace usages of `testCases.forEach` in tests to use `parameterizeSpec` from `@ni/jasmine-parameterize` instead.

## 🧪 Testing

- Verified the same number of tests still run & pass

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
