### PR TITLE
Pin fast-foundation version to avoid regression

### DIFF
--- a/change/@ni-nimble-components-c66f815e-5fec-4b75-81e9-23933eac4752.json
+++ b/change/@ni-nimble-components-c66f815e-5fec-4b75-81e9-23933eac4752.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Pin fast-foundation version to avoid regression",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36415,7 +36415,7 @@
       "dependencies": {
         "@microsoft/fast-colors": "^5.3.1",
         "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "^2.49.3",
+        "@microsoft/fast-foundation": "2.49.4",
         "@microsoft/fast-web-utilities": "^6.0.0",
         "@ni/nimble-tokens": "^6.9.1",
         "@tanstack/table-core": "^8.10.7",

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@microsoft/fast-colors": "^5.3.1",
     "@microsoft/fast-element": "^1.12.0",
-    "@microsoft/fast-foundation": "^2.49.3",
+    "@microsoft/fast-foundation": "2.49.4",
     "@microsoft/fast-web-utilities": "^6.0.0",
     "@ni/nimble-tokens": "^6.9.1",
     "@tanstack/table-core": "^8.10.7",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The latest version of fast-foundation (2.49.5) introduces a regression that causes chrome and edge to crash. This PR pins the foundation version to a known working version (2.49.4).

See discussion: https://github.com/ni/nimble/pull/1775#discussion_r1465648273

## 👩‍💻 Implementation

Pin the fast foundation version to prevent apps from upgrading to the latest. 

## 🧪 Testing

Relying on CI and manual validation of the crash not occurring in storybook by opening the example Angular app and changing the mode to dark without a crash.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
