### PR TITLE
Update lighthouse url path and categories

### DIFF
--- a/angular-workspace/lighthouserc.js
+++ b/angular-workspace/lighthouserc.js
@@ -1,11 +1,17 @@
 module.exports = {
     ci: {
         collect: {
-            staticDistDir: './dist/example-client-app',
+            // Serve from dist folder so Angular project name is part of url path
+            // and shows up in GitHub status checks
+            staticDistDir: './dist/',
             url: [
-                'http://localhost:58452/#/customapp'
+                'http://localhost/example-client-app/#/customapp'
             ],
             numberOfRuns: 3,
+            settings: {
+                // Omit the pwa category
+                onlyCategories: ['accessibility', 'best-practices', 'performance', 'seo']
+            }
         },
         assert: {
             assertions: {

--- a/packages/performance/lighthouserc.js
+++ b/packages/performance/lighthouserc.js
@@ -1,9 +1,11 @@
 module.exports = {
     ci: {
         collect: {
-            staticDistDir: './dist/',
+            // Serve outside package so that package name is part of url path
+            // and shows up in GitHub status checks
+            staticDistDir: '../',
             url: [
-                'http://localhost/wafer-map/'
+                'http://localhost/performance/dist/wafer-map/'
             ],
             numberOfRuns: 1,
             settings: {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

In the GitHub status checks for lighthouse, the name of the status check is based on the URL of the page. This means two completely different pages that end up with the same url (for example served from `/`) would overwrite the same status check. 

Also, as-is the urls are not very descriptive:
![image](https://github.com/ni/nimble/assets/1588923/23e60c2a-ac58-46e0-84a5-ab537aa6cc06)


## 👩‍💻 Implementation

This PR updates the URLs so that the lighthouse status check includes the package that was analyzed:
![image](https://github.com/ni/nimble/assets/1588923/4289b723-d38e-49f7-b95b-1ce3ad60f96f)

The PR also updates the Angular lighthouse status check to remove the PWA category since that is most useful for applications trying to implement PWA features.

## 🧪 Testing

Ran on CI.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
