### PR TITLE
Workaround lighthouse build

### DIFF
--- a/angular-workspace/lighthouserc.js
+++ b/angular-workspace/lighthouserc.js
@@ -16,9 +16,7 @@ module.exports = {
         assert: {
             assertions: {
                 'categories:performance': ['warn', { minScore: 0.9 }],
-                // TODO: reset to 0.9 as part of https://github.com/ni/nimble/issues/1090
-                // TODO: reset to error as part of https://github.com/ni/nimble/issues/1650
-                'categories:accessibility': ['warn', { minScore: 0.88 }]
+                'categories:accessibility': ['error', { minScore: 0.8 }]
             }
         },
         upload: {

--- a/angular-workspace/projects/example-client-app/src/app/customapp/customapp.component.html
+++ b/angular-workspace/projects/example-client-app/src/app/customapp/customapp.component.html
@@ -42,6 +42,7 @@
             <nimble-anchor-button nimbleRouterLink="/customapp" appearance="block">Block Anchor Button</nimble-anchor-button>
             <nimble-anchor-button nimbleRouterLink="/customapp" appearance="ghost">Ghost Anchor Button</nimble-anchor-button>
         </div>
+        <!-- Disabled as it breaks accessibility tooling, see: https://github.com/ni/nimble/issues/1650
         <div class="sub-container">
             <div class="container-label">Card</div>
             <nimble-card>
@@ -55,6 +56,7 @@
                 </nimble-select>
             </nimble-card>
         </div>
+        -->
         <div class="sub-container">
             <div class="container-label">Card Button</div>
             <nimble-card-button>

--- a/change/@ni-nimble-blazor-0a673d50-ebba-46fb-88fe-798054175141.json
+++ b/change/@ni-nimble-blazor-0a673d50-ebba-46fb-88fe-798054175141.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Disable card in example apps",
+  "packageName": "@ni/nimble-blazor",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-blazor/Examples/Demo.Shared/Pages/ComponentsDemo.razor
+++ b/packages/nimble-blazor/Examples/Demo.Shared/Pages/ComponentsDemo.razor
@@ -59,6 +59,7 @@
                 Icon Toggle Button
             </NimbleToggleButton>
         </div>
+        <!-- Disabled as it breaks accessibility tooling, see: https://github.com/ni/nimble/issues/1650
         <div class="sub-container">
             <div class="container-label">Card</div>
             <NimbleCard>
@@ -72,6 +73,7 @@
                 </NimbleSelect>
             </NimbleCard>
         </div>
+        -->
         <div class="sub-container">
             <div class="container-label">Card Button</div>
             <NimbleCardButton>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Disables the Card in the Angular and Blazor example apps as it breaks axe-core tooling used by lighthouse, see: https://github.com/ni/nimble/issues/1650

## 👩‍💻 Implementation

Disabled the nimble-card in the Angular and Blazor apps

Re-enabled the accessibility lighthouse error. The thought is that with this change the accessibility score will be reliably calculated and not cause intermittent blocking of merges, only blocks on merges that further regress the score. If it is not the case and lighthouse becomes unreliable calculating the score we can disable it again.

Removed the exisiting comment for an issue to get us back to 0.9 score as there are multiple issues impacting our score now.

## 🧪 Testing

Relying on lighthouse CI execution.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
