### PR TITLE
Lighthouse desktop profile

### DIFF
--- a/angular-workspace/lighthouserc.js
+++ b/angular-workspace/lighthouserc.js
@@ -16,7 +16,7 @@ module.exports = {
         },
         assert: {
             assertions: {
-                'categories:performance': ['warn', { minScore: 0.9 }],
+                'categories:performance': ['error', { minScore: 0.9 }],
                 'categories:accessibility': ['error', { minScore: 0.8 }]
             }
         },

--- a/angular-workspace/lighthouserc.js
+++ b/angular-workspace/lighthouserc.js
@@ -9,6 +9,7 @@ module.exports = {
             ],
             numberOfRuns: 3,
             settings: {
+                preset: 'desktop',
                 // Omit the pwa category
                 onlyCategories: ['accessibility', 'best-practices', 'performance', 'seo']
             }

--- a/angular-workspace/projects/example-client-app/src/index.html
+++ b/angular-workspace/projects/example-client-app/src/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <link rel="icon" href="favicon.ico" sizes="any">
   <title>Angular All Components Demo - Nimble Design System - NI</title>
+  <meta name="description" content="Angular demo showing all nimble components">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>

--- a/change/@ni-nimble-blazor-0c67b6b7-27dc-4f6e-9250-bd8d1dcce11f.json
+++ b/change/@ni-nimble-blazor-0c67b6b7-27dc-4f6e-9250-bd8d1dcce11f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Consistent lang and meta description on public pages",
+  "packageName": "@ni/nimble-blazor",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-blazor/Examples/Demo.Client/wwwroot/index.html
+++ b/packages/nimble-blazor/Examples/Demo.Client/wwwroot/index.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>Blazor All Components Demo - Nimble Design System - NI</title>
+    <meta name="description" content="Blazor demo showing all nimble components">
     <link href="css/site.css" rel="stylesheet" />
     <link href="Demo.Client.styles.css" rel="stylesheet" />
     <link href="_content/NimbleBlazor/nimble-tokens/css/fonts.css" rel="stylesheet" />

--- a/packages/performance/lighthouserc.js
+++ b/packages/performance/lighthouserc.js
@@ -9,6 +9,7 @@ module.exports = {
             ],
             numberOfRuns: 1,
             settings: {
+                preset: 'desktop',
                 onlyAudits: ['user-timings']
             }
         },

--- a/packages/performance/src/index.html
+++ b/packages/performance/src/index.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset='utf-8'>
     <meta http-equiv='X-UA-Compatible' content='IE=edge'>
     <title>Performance test index</title>
+    <meta name="description" content="Index of all nimble performance tests">
     <meta name='viewport' content='width=device-width, initial-scale=1'>
 </head>
 <body>

--- a/packages/performance/src/wafer-map/index.html
+++ b/packages/performance/src/wafer-map/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html lang="en-us">
+<html lang="en">
 <head>
     <meta charset='utf-8'>
     <meta http-equiv='X-UA-Compatible' content='IE=edge'>
     <title>Wafer Map Performance Tests</title>
-    <meta name='viewport' content='width=device-width, initial-scale=1'>
     <meta name="description" content="Wafer map performance tests">
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
     <script type="module" src="./index.ts"></script>
 </head>
 <body>

--- a/packages/site/landing/index.html
+++ b/packages/site/landing/index.html
@@ -4,9 +4,9 @@
 <head>
     <meta charset='utf-8'>
     <meta http-equiv='X-UA-Compatible' content='IE=edge'>
+    <title>Nimble Design System - NI</title> 
     <meta name="description" content="The Nimble design system starting page. The Nimble Design System is an easy to use collection of well-designed, styled components
     that can be used in any NI web application.">
-    <title>Nimble Design System - NI</title>
     <meta name='viewport' content='width=device-width, initial-scale=1'>
     <link rel="icon" href="favicon.ico" sizes="any">
     <script type="module" src="index.ts"></script>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Switch lighthouse to using a desktop profile for all current pages.
The default low-powered mobile profile isn't the best for measuring the example angular app with all components listed (not a realistic use-case) or the benchmarking pages.
It would be nice to be performance optimized for mobile but the current performance scores aren't adding much value.

## 👩‍💻 Implementation

Switch lighthouse config to the desktop profile.
Address some of the easy lighthouse complaints on basic page structure.

## 🧪 Testing

Manually ran lighthouse on our published pages.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
