### PR TITLE
Allow a childless row to be expanded

### DIFF
--- a/change/@ni-nimble-components-6653cda2-ff6f-489e-accf-68cec27fb146.json
+++ b/change/@ni-nimble-components-6653cda2-ff6f-489e-accf-68cec27fb146.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow a row with a state of `canLoadChildren` to be expanded when it does not have children",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/models/expansion-manager.ts
+++ b/packages/nimble-components/src/table/models/expansion-manager.ts
@@ -72,7 +72,10 @@ export class ExpansionManager<TData extends TableRecord> {
     }
 
     public processDataUpdate(rows: TanStackRow<TableNode<TData>>[]): void {
-        if (this.modifiedCollapsedStates.size === 0 && this.hierarchyOptions.size === 0) {
+        if (
+            this.modifiedCollapsedStates.size === 0
+            && this.hierarchyOptions.size === 0
+        ) {
             return;
         }
 
@@ -141,7 +144,9 @@ export class ExpansionManager<TData extends TableRecord> {
         );
     }
 
-    private getDefaultExpansionState(row: TanStackRow<TableNode<TData>>): boolean {
+    private getDefaultExpansionState(
+        row: TanStackRow<TableNode<TData>>
+    ): boolean {
         // Rows with children (group rows and parent rows with populated children)
         // default to expanded. Other rows (parent rows with lazy-loaded children)
         // default to collapsed.

--- a/packages/nimble-components/src/table/specs/data-hierarchy-hld.md
+++ b/packages/nimble-components/src/table/specs/data-hierarchy-hld.md
@@ -94,7 +94,6 @@ Some notes about the `setRecordHierarchyOptions` API:
 -   the options passed to `setRecordHierarchyOptions` will override any options previously set to become the complete set of options configured on the table
 -   the table will not render delayed hierarchy state (loading or expandable) if the table's `parentIdFieldName` is not configured; however, the options will remain cached within the table if the `parentIdFieldName` becomes `undefined`, and that cached configuration will render in the table if the table's `parentIdFieldName` is changed back to a non-`undefined` value
 -   calling `setData` will clear options associated with IDs that are no longer present in the data
--   a row with no children and a `delayedHierarchyState` of `canLoadChildren` will always be collapsed
 
 The expected usage of the dynamically loaded hierarchy is as follows:
 

--- a/packages/nimble-components/src/table/tests/table.mdx
+++ b/packages/nimble-components/src/table/tests/table.mdx
@@ -52,7 +52,6 @@ The expected usage of the dynamically loaded hierarchy is as follows:
 -   the options passed to `setRecordHierarchyOptions` will override any options previously set to become the complete set of options configured on the table
 -   the table will not render delayed hierarchy state (loading or expandable) if the table's `parentIdFieldName` is not configured; however, the options will remain cached within the table if the `parentIdFieldName` becomes `undefined`, and that cached configuration will render in the table if the table's `parentIdFieldName` is changed back to a non-`undefined` value
 -   calling `setData` will clear options associated with IDs that are no longer present in the data
--   a row with no children and a `delayedHierarchyState` of `canLoadChildren` will always be collapsed
 
 {/* ## Appearances */}
 

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -1908,6 +1908,96 @@ describe('Table', () => {
                     pageObject.isDataRowExpandCollapseButtonVisible(0)
                 ).toBeTrue();
             });
+
+            it('row with delayedHierarchyState of canLoadChildren becomes expanded when its expand/collapse button is clicked', async () => {
+                await element.setRecordHierarchyOptions([
+                    {
+                        recordId: '3',
+                        options: {
+                            delayedHierarchyState:
+                                TableRecordDelayedHierarchyState.canLoadChildren
+                        }
+                    }
+                ]);
+                await waitForUpdatesAsync();
+
+                expect(pageObject.getRenderedRowCount()).toBe(4);
+                pageObject.clickDataRowExpandCollapseButton(3);
+                await waitForUpdatesAsync();
+
+                expect(pageObject.getRenderedRowCount()).toBe(4);
+                expect(pageObject.getAllDataRowsExpandedState()).toEqual([
+                    false,
+                    false,
+                    false,
+                    true
+                ]);
+            });
+
+            it('modifying expansion state of a row with children leaves a row with delayedHierarchyState of canLoadChildren collapsed', async () => {
+                await element.setData([
+                    ...initialData,
+                    { id: 'child-row', parentId: '0', stringData: 'a' }
+                ]);
+                await element.setRecordHierarchyOptions([
+                    {
+                        recordId: '3',
+                        options: {
+                            delayedHierarchyState:
+                                TableRecordDelayedHierarchyState.canLoadChildren
+                        }
+                    }
+                ]);
+                await waitForUpdatesAsync();
+
+                expect(pageObject.getRenderedRowCount()).toBe(5);
+                pageObject.clickDataRowExpandCollapseButton(0);
+                await waitForUpdatesAsync();
+
+                expect(pageObject.getRenderedRowCount()).toBe(4);
+                expect(pageObject.getAllDataRowsExpandedState()).toEqual([
+                    false,
+                    false,
+                    false,
+                    false
+                ]);
+            });
+
+            it('child rows are not shown for row with delayedHierarchyState of canLoadChildren when data is updated with child rows if row was previously collapsed', async () => {
+                await element.setRecordHierarchyOptions([
+                    {
+                        recordId: '3',
+                        options: {
+                            delayedHierarchyState:
+                                TableRecordDelayedHierarchyState.canLoadChildren
+                        }
+                    }
+                ]);
+                await waitForUpdatesAsync();
+
+                // Expand the row
+                pageObject.clickDataRowExpandCollapseButton(3);
+                await waitForUpdatesAsync();
+
+                // Collapse the row
+                pageObject.clickDataRowExpandCollapseButton(3);
+                await waitForUpdatesAsync();
+
+                await element.setData([
+                    ...initialData,
+                    { id: 'child-record-0', parentId: '3', stringData: 'a' },
+                    { id: 'child-record-1', parentId: '3', stringData: 'b' }
+                ]);
+                await waitForUpdatesAsync();
+
+                expect(pageObject.getRenderedRowCount()).toBe(4);
+                expect(pageObject.getAllDataRowsExpandedState()).toEqual([
+                    false,
+                    false,
+                    false,
+                    false
+                ]);
+            });
         });
     });
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

When a row has a state of `canLoadChildren`, clicking the expand button does not actually expand the row. The `row-expand-toggle` event is fired, but the row stays collapsed until children are provided in the data. This isn't ideal because the row state isn't consistent with what it should be given the user action and the details of the `row-expand-toggle` event. Therefore, this PR allows the childless row to be expanded. It also automatically collapses rows if they are still expandable when transitioning into a state where they have no children.

This is part of #1758, and this specific issue was discussed in [this PR thread](https://github.com/ni/nimble/pull/1794#discussion_r1481996663).

## 👩‍💻 Implementation

Refactor of the expansion manager to accomplish the following:
- Allow each row to be in an explicitly expanded, explicitly collapsed, or default state
    - Purpose: The previous code in the expansion manager only tracked two things: (1) whether every row was in a default state, and (2) which rows were collapsed. This made it difficult to manage the state when some rows defaulted to expanded and other to collapsed.
- Track which rows are expandable but have no children.
    - Purpose: We want to collapse rows that transition into have no children. Therefore, on a data update, we need to know whether or not a row previously had children.

## 🧪 Testing

- Manually tested in storybook
- Wrote new unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
