### PR TITLE
Add loadingChildren delayed hierarchy state

### DIFF
--- a/change/@ni-nimble-components-b14e0836-5d4d-40a6-b22c-a77d7106e234.json
+++ b/change/@ni-nimble-components-b14e0836-5d4d-40a6-b22c-a77d7106e234.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add `loadingChildren` delayed hierarchy state",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/label-provider/table/index.ts
+++ b/packages/nimble-components/src/label-provider/table/index.ts
@@ -14,7 +14,8 @@ import {
     tableRowExpandLabel,
     tableRowOperationColumnLabel,
     tableRowSelectLabel,
-    tableSelectAllLabel
+    tableSelectAllLabel,
+    tableRowLoadingLabel
 } from './label-tokens';
 
 declare global {
@@ -36,7 +37,8 @@ const supportedLabels = {
     selectAll: tableSelectAllLabel,
     groupSelectAll: tableGroupSelectAllLabel,
     rowSelect: tableRowSelectLabel,
-    rowOperationColumn: tableRowOperationColumnLabel
+    rowOperationColumn: tableRowOperationColumnLabel,
+    rowLoading: tableRowLoadingLabel
 } as const;
 
 /**
@@ -83,6 +85,9 @@ export class LabelProviderTable
 
     @attr({ attribute: 'row-operation-column' })
     public rowOperationColumn: string | undefined;
+
+    @attr({ attribute: 'row-loading' })
+    public rowLoading: string | undefined;
 
     protected override readonly supportedLabels = supportedLabels;
 }

--- a/packages/nimble-components/src/label-provider/table/label-token-defaults.ts
+++ b/packages/nimble-components/src/label-provider/table/label-token-defaults.ts
@@ -15,5 +15,6 @@ export const tableLabelDefaults: { readonly [key in TokenName]: string } = {
     tableSelectAllLabel: 'Select all rows',
     tableGroupSelectAllLabel: 'Select all rows in group',
     tableRowSelectLabel: 'Select row',
-    tableRowOperationColumnLabel: 'Row operations'
+    tableRowOperationColumnLabel: 'Row operations',
+    tableRowLoadingLabel: 'Loading'
 };

--- a/packages/nimble-components/src/label-provider/table/label-tokens.ts
+++ b/packages/nimble-components/src/label-provider/table/label-tokens.ts
@@ -67,3 +67,8 @@ export const tableRowOperationColumnLabel = DesignToken.create<string>({
     name: 'table-row-operation-column-label',
     cssCustomPropertyName: null
 }).withDefault(tableLabelDefaults.tableRowOperationColumnLabel);
+
+export const tableRowLoadingLabel = DesignToken.create<string>({
+    name: 'table-row-loading-label',
+    cssCustomPropertyName: null
+}).withDefault(tableLabelDefaults.tableRowLoadingLabel);

--- a/packages/nimble-components/src/table/components/row/index.ts
+++ b/packages/nimble-components/src/table/components/row/index.ts
@@ -86,6 +86,9 @@ export class TableRow<
     @attr({ attribute: 'row-operation-grid-cell-hidden', mode: 'boolean' })
     public rowOperationGridCellHidden = false;
 
+    @attr({ mode: 'boolean' })
+    public loading = false;
+
     /**
      * @internal
      * An array that parallels the `columns` array and contains the indent

--- a/packages/nimble-components/src/table/components/row/styles.ts
+++ b/packages/nimble-components/src/table/components/row/styles.ts
@@ -5,6 +5,7 @@ import {
     applicationBackgroundColor,
     borderWidth,
     controlHeight,
+    controlSlimHeight,
     fillHoverColor,
     fillHoverSelectedColor,
     fillSelectedColor,
@@ -52,14 +53,26 @@ export const styles = css`
         background-color: ${fillHoverSelectedColor};
     }
 
+    .spinner-container,
     .expand-collapse-button {
+        flex: 0 0 auto;
         padding-left: calc(
             ${mediumPadding} + (var(--ni-private-table-row-indent-level) - 1) *
                 ${controlHeight}
         );
     }
 
+    .spinner-container {
+        width: ${controlSlimHeight};
+        height: ${controlSlimHeight};
+        align-self: center;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
     .row-operations-container {
+        flex: 0 0 auto;
         display: flex;
     }
 

--- a/packages/nimble-components/src/table/components/row/template.ts
+++ b/packages/nimble-components/src/table/components/row/template.ts
@@ -9,11 +9,14 @@ import { checkboxTag } from '../../../checkbox';
 import {
     tableRowCollapseLabel,
     tableRowExpandLabel,
+    tableRowLoadingLabel,
     tableRowSelectLabel
 } from '../../../label-provider/table/label-tokens';
 import type { TableColumn } from '../../../table-column/base';
 import { buttonTag } from '../../../button';
 import { iconArrowExpanderRightTag } from '../../../icons/arrow-expander-right';
+import { spinnerTag } from '../../../spinner';
+import { SpinnerAppearance } from '../../../spinner/types';
 
 // prettier-ignore
 export const template = html<TableRow>`
@@ -40,17 +43,29 @@ export const template = html<TableRow>`
         `)}
         <span class="row-front-spacer ${x => (x.isTopLevelParentRow ? 'top-level-parent' : '')}"></span>
         ${when(x => x.isParentRow, html<TableRow>`
-            <${buttonTag}
-                appearance="${ButtonAppearance.ghost}"
-                content-hidden
-                class="expand-collapse-button"
-                tabindex="-1"
-                @click="${(x, c) => x.onRowExpandToggle(c.event)}"
-                title="${x => (x.expanded ? tableRowCollapseLabel.getValueFor(x) : tableRowExpandLabel.getValueFor(x))}"
-                aria-hidden="true"
-            >
-                <${iconArrowExpanderRightTag} ${ref('expandIcon')} slot="start" class="expander-icon ${x => x.animationClass}"></${iconArrowExpanderRightTag}>
-            </${buttonTag}>
+            ${when(x => x.loading, html<TableRow>`
+                <span class="spinner-container">
+                    <${spinnerTag}
+                        appearance="${SpinnerAppearance.accent}"
+                        aria-label="${x => tableRowLoadingLabel.getValueFor(x)}"
+                        title="${x => tableRowLoadingLabel.getValueFor(x)}"
+                    >
+                    <${spinnerTag}>
+                </span>
+            `)}
+            ${when(x => !x.loading, html<TableRow>`
+                <${buttonTag}
+                    appearance="${ButtonAppearance.ghost}"
+                    content-hidden
+                    class="expand-collapse-button"
+                    tabindex="-1"
+                    @click="${(x, c) => x.onRowExpandToggle(c.event)}"
+                    title="${x => (x.expanded ? tableRowCollapseLabel.getValueFor(x) : tableRowExpandLabel.getValueFor(x))}"
+                    aria-hidden="true"
+                >
+                    <${iconArrowExpanderRightTag} ${ref('expandIcon')} slot="start" class="expander-icon ${x => x.animationClass}"></${iconArrowExpanderRightTag}>
+                </${buttonTag}>
+            `)}
         `)}
 
         <span ${ref('cellContainer')} 

--- a/packages/nimble-components/src/table/components/row/tests/table-row.pageobject.ts
+++ b/packages/nimble-components/src/table/components/row/tests/table-row.pageobject.ts
@@ -1,4 +1,5 @@
 import type { TableRow } from '..';
+import { spinnerTag } from '../../../../spinner';
 import type { TableRecord } from '../../../types';
 import { tableCellTag, TableCell } from '../../cell';
 
@@ -26,6 +27,12 @@ export class TableRowPageObject<T extends TableRecord = TableRecord> {
     public getExpandCollapseButton(): HTMLElement | null {
         return this.tableRowElement.shadowRoot!.querySelector<HTMLElement>(
             '.expand-collapse-button'
+        );
+    }
+
+    public getLoadingSpinner(): HTMLElement | null {
+        return this.tableRowElement.shadowRoot!.querySelector<HTMLElement>(
+            `${spinnerTag}`
         );
     }
 }

--- a/packages/nimble-components/src/table/components/row/tests/table-row.spec.ts
+++ b/packages/nimble-components/src/table/components/row/tests/table-row.spec.ts
@@ -300,6 +300,50 @@ describe('TableRow', () => {
             const event = listener.spy.calls.first().args[0] as CustomEvent;
             expect(event.detail).toEqual(collapseDetails);
         });
+
+        it('shows spinner instead of expand-collapse button when loading and isParentRow are true', async () => {
+            const pageObject = new TableRowPageObject(element);
+            await connect();
+            element.isParentRow = true;
+            element.loading = true;
+            await waitForUpdatesAsync();
+
+            expect(pageObject.getLoadingSpinner()).toBeTruthy();
+            expect(pageObject.getExpandCollapseButton()).toBeFalsy();
+        });
+
+        it('hides spinner and shows expand-collapse button when isParentRow is true and loading is false', async () => {
+            const pageObject = new TableRowPageObject(element);
+            await connect();
+            element.isParentRow = true;
+            element.loading = false;
+            await waitForUpdatesAsync();
+
+            expect(pageObject.getLoadingSpinner()).toBeFalsy();
+            expect(pageObject.getExpandCollapseButton()).toBeTruthy();
+        });
+
+        it('loading spinner has expected aria-label', async () => {
+            const pageObject = new TableRowPageObject(element);
+            await connect();
+            element.isParentRow = true;
+            element.loading = true;
+            await waitForUpdatesAsync();
+
+            const spinner = pageObject.getLoadingSpinner();
+            expect(spinner?.ariaLabel).toBe('Loading');
+        });
+
+        it('loading spinner has expected title', async () => {
+            const pageObject = new TableRowPageObject(element);
+            await connect();
+            element.isParentRow = true;
+            element.loading = true;
+            await waitForUpdatesAsync();
+
+            const spinner = pageObject.getLoadingSpinner();
+            expect(spinner?.title).toBe('Loading');
+        });
     });
 
     describe('in table', () => {

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -946,7 +946,8 @@ export class Table<
                     : row.depth,
                 isParentRow: isParent,
                 immediateChildCount: row.subRows.length,
-                groupColumn: this.getGroupRowColumn(row)
+                groupColumn: this.getGroupRowColumn(row),
+                isLoadingChildren: this.expansionManager.isLoadingChildren(row.id)
             };
             hasDataHierarchy = hasDataHierarchy || isParent;
             return rowState;

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -947,7 +947,9 @@ export class Table<
                 isParentRow: isParent,
                 immediateChildCount: row.subRows.length,
                 groupColumn: this.getGroupRowColumn(row),
-                isLoadingChildren: this.expansionManager.isLoadingChildren(row.id)
+                isLoadingChildren: this.expansionManager.isLoadingChildren(
+                    row.id
+                )
             };
             hasDataHierarchy = hasDataHierarchy || isParent;
             return rowState;

--- a/packages/nimble-components/src/table/models/expansion-manager.ts
+++ b/packages/nimble-components/src/table/models/expansion-manager.ts
@@ -126,14 +126,23 @@ export class ExpansionManager<TData extends TableRecord> {
         this.isHierarchyEnabled = isHierarchyEnabled;
     }
 
-    private canLoadDelayedChildren(id: string): boolean {
+    public isLoadingChildren(id: string): boolean {
         if (!this.isHierarchyEnabled) {
             return false;
         }
 
         return (
             this.hierarchyOptions.get(id)?.delayedHierarchyState
-                === TableRecordDelayedHierarchyState.canLoadChildren ?? false
+                === TableRecordDelayedHierarchyState.loadingChildren ?? false
         );
+    }
+
+    private canLoadDelayedChildren(id: string): boolean {
+        if (!this.isHierarchyEnabled) {
+            return false;
+        }
+
+        const delayedHierarchyState = this.hierarchyOptions.get(id)?.delayedHierarchyState;
+        return delayedHierarchyState !== TableRecordDelayedHierarchyState.none;
     }
 }

--- a/packages/nimble-components/src/table/template.ts
+++ b/packages/nimble-components/src/table/template.ts
@@ -141,6 +141,7 @@ export const template = html<Table>`
                                         :isParentRow="${(x, c) => c.parent.tableData[x.index]?.isParentRow}"
                                         :nestingLevel="${(x, c) => c.parent.tableData[x.index]?.nestingLevel}"
                                         ?row-operation-grid-cell-hidden="${(_, c) => !c.parent.showRowOperationColumn}"
+                                        ?loading="${(x, c) => c.parent.tableData[x.index]?.isLoadingChildren}"
                                         @click="${(x, c) => c.parent.onRowClick(x.index, c.event as MouseEvent)}"
                                         @row-selection-toggle="${(x, c) => c.parent.onRowSelectionToggle(x.index, c.event as CustomEvent<TableRowSelectionToggleEventDetail>)}"
                                         @row-action-menu-beforetoggle="${(x, c) => c.parent.onRowActionMenuBeforeToggle(x.index, c.event as CustomEvent<TableActionMenuToggleEventDetail>)}"

--- a/packages/nimble-components/src/table/testing/table.pageobject.ts
+++ b/packages/nimble-components/src/table/testing/table.pageobject.ts
@@ -17,7 +17,7 @@ import { Anchor, anchorTag } from '../../anchor';
 import type { TableGroupRow } from '../components/group-row';
 import type { Button } from '../../button';
 import { Icon } from '../../icon-base';
-import { Spinner } from '../../spinner';
+import { Spinner, spinnerTag } from '../../spinner';
 
 /**
  * Summary information about a column that is sorted in the table for use in the `TablePageObject`.
@@ -471,6 +471,12 @@ export class TablePageObject<T extends TableRecord> {
     public isDataRowExpandCollapseButtonVisible(rowIndex: number): boolean {
         const expandCollapseButton = this.getExpandCollapseButtonForRow(rowIndex);
         return expandCollapseButton !== null;
+    }
+
+    public isDataRowLoadingSpinnerVisible(rowIndex: number): boolean {
+        const row = this.getRow(rowIndex);
+        const spinner = row.shadowRoot!.querySelector<Spinner>(spinnerTag);
+        return spinner !== null;
     }
 
     public isTableSelectionCheckboxVisible(): boolean {

--- a/packages/nimble-components/src/table/tests/table-matrix.stories.ts
+++ b/packages/nimble-components/src/table/tests/table-matrix.stories.ts
@@ -17,6 +17,7 @@ import {
     TableRowSelectionMode
 } from '../types';
 import { tableColumnNumberTextTag } from '../../table-column/number-text';
+import { isChromatic } from '../../utilities/tests/isChromatic';
 
 const metadata: Meta = {
     title: 'Tests/Table',
@@ -104,7 +105,12 @@ const component = (
     [hierarchyStateName, hierarchyState]: HierarchyState
 ): ViewTemplate => html`
     <span>${() => `Selection mode: ${selectionMode ?? 'none'}, ${groupedStateName}, ${hierarchyStateName}`} </span>
-    <${tableTag} selection-mode="${() => selectionMode}"" id-field-name="id" parent-id-field-name="${() => (hierarchyState ? 'parentId' : undefined)}">
+    <${tableTag}
+        selection-mode="${() => selectionMode}"
+        id-field-name="id"
+        parent-id-field-name="${() => (hierarchyState ? 'parentId' : undefined)}"
+        style="${isChromatic() ? '--ni-private-spinner-animation-play-state:paused' : ''}"
+    >
         <${tableColumnTextTag} field-name="firstName" sort-direction="ascending" sort-index="0" group-index="${() => (groupedState ? '0' : undefined)}"><${iconUserTag}></${iconUserTag}></${tableColumnTextTag}>
         <${tableColumnTextTag} field-name="lastName">Last Name</${tableColumnTextTag}>
         <${tableColumnNumberTextTag} field-name="age" sort-direction="descending" sort-index="1" fractional-width=".5">Age</${tableColumnNumberTextTag}>
@@ -123,6 +129,13 @@ const playFunction = async (): Promise<void> => {
                         options: {
                             delayedHierarchyState:
                                 TableRecordDelayedHierarchyState.canLoadChildren
+                        }
+                    },
+                    {
+                        recordId: '1',
+                        options: {
+                            delayedHierarchyState:
+                                TableRecordDelayedHierarchyState.loadingChildren
                         }
                     }
                 ]);

--- a/packages/nimble-components/src/table/tests/table.mdx
+++ b/packages/nimble-components/src/table/tests/table.mdx
@@ -14,9 +14,6 @@ For information about configuring table columns, see **Table Column Configuratio
 
 ## Delay-loaded Hierarchy
 
-**Note:** The feature for delayed hierarchy is still in development, so it should not be used yet in production. Specifically,
-the feature to show a loading indicator while the child rows are being loaded has not been implemented. Therefore, the user experience is not optimal.
-
 In some cases, it may be known that a record has children, but the records for those children are not known. For performance reasons, it may be preferred to load
 the children on demand when a user expands the parent row. To accomplish this, use the `setRecordHierarchyOptions()` function on the table to set the hierarchy
 options associated with records in the data.

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -1908,6 +1908,41 @@ describe('Table', () => {
                     pageObject.isDataRowExpandCollapseButtonVisible(0)
                 ).toBeTrue();
             });
+
+            it('setting a record to loadingChildren shows a spinner on its row', async () => {
+                await element.setRecordHierarchyOptions([
+                    {
+                        recordId: '0',
+                        options: {
+                            delayedHierarchyState:
+                                TableRecordDelayedHierarchyState.loadingChildren
+                        }
+                    }
+                ]);
+                await waitForUpdatesAsync();
+
+                expect(
+                    pageObject.isDataRowLoadingSpinnerVisible(0)
+                ).toBeTrue();
+            });
+
+            it('removing the state from a record that was loadingChildren does not show a spinner on its row', async () => {
+                await element.setRecordHierarchyOptions([
+                    {
+                        recordId: '0',
+                        options: {
+                            delayedHierarchyState:
+                                TableRecordDelayedHierarchyState.loadingChildren
+                        }
+                    }
+                ]);
+                await element.setRecordHierarchyOptions([]);
+                await waitForUpdatesAsync();
+
+                expect(
+                    pageObject.isDataRowLoadingSpinnerVisible(0)
+                ).toBeFalse();
+            });
         });
     });
 

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -1921,9 +1921,7 @@ describe('Table', () => {
                 ]);
                 await waitForUpdatesAsync();
 
-                expect(
-                    pageObject.isDataRowLoadingSpinnerVisible(0)
-                ).toBeTrue();
+                expect(pageObject.isDataRowLoadingSpinnerVisible(0)).toBeTrue();
             });
 
             it('removing the state from a record that was loadingChildren does not show a spinner on its row', async () => {

--- a/packages/nimble-components/src/table/tests/table.stories.ts
+++ b/packages/nimble-components/src/table/tests/table.stories.ts
@@ -18,6 +18,7 @@ import {
 } from '../../label-provider/base/tests/label-user-stories-utils';
 import { labelProviderTableTag } from '../../label-provider/table';
 import { tableColumnNumberTextTag } from '../../table-column/number-text';
+import { isChromatic } from '../../utilities/tests/isChromatic';
 
 interface BaseTableArgs extends LabelUserArgs {
     tableRef: Table;
@@ -408,6 +409,7 @@ export const delayedHierarchy: Meta<DelayedHierarchyTableArgs> = {
             id-field-name="id"
             data-unused="${x => x.updateData(x)}"
             parent-id-field-name="parentId"
+            style="${isChromatic() ? '--ni-private-spinner-animation-play-state:paused' : ''}"
         >
             <${tableColumnTextTag}
                 column-id="first-name-column"

--- a/packages/nimble-components/src/table/types.ts
+++ b/packages/nimble-components/src/table/types.ts
@@ -95,7 +95,8 @@ export interface TableRecordHierarchyOptions {
 
 export const TableRecordDelayedHierarchyState = {
     none: undefined,
-    canLoadChildren: 'canLoadChildren'
+    canLoadChildren: 'canLoadChildren',
+    loadingChildren: 'loadingChildren'
 } as const;
 export type TableRecordDelayedHierarchyState =
     (typeof TableRecordDelayedHierarchyState)[keyof typeof TableRecordDelayedHierarchyState];
@@ -209,4 +210,5 @@ export interface TableRowState<TData extends TableRecord = TableRecord> {
     immediateChildCount?: number;
     groupColumn?: TableColumn;
     isParentRow: boolean;
+    isLoadingChildren: boolean;
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This is part of #1758. It adds support for showing a loading spinner on rows that are currently loading its children.

## 👩‍💻 Implementation

- Extend `TableRecordDelayedHierarchyState` to include `loadingChildren`
- Add `loading` attribute to the `nimble-table-row` that controls the visibility of the spinner
- Add a new label to the table-label-provider for the "Loading" string that is used to label the spinner

## 🧪 Testing

- Manually tested in storybook
- Added new unit tests for the table and for the table row

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
