### PR TITLE
Autodocs to MDX cleanup

### DIFF
--- a/change/@ni-nimble-components-bb23a576-eed9-4333-9a75-c53e7b0bb086.json
+++ b/change/@ni-nimble-components-bb23a576-eed9-4333-9a75-c53e7b0bb086.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update import of <Tag> component to match other layout components",
+  "packageName": "@ni/nimble-components",
+  "email": "1458528+fredvisser@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/.storybook/preview.js
+++ b/packages/nimble-components/.storybook/preview.js
@@ -12,7 +12,8 @@ import {
     Do,
     Dont,
     Frame,
-    Divider
+    Divider,
+    Tag
 } from './blocks/StoryLayout.tsx';
 
 export const parameters = {
@@ -54,7 +55,8 @@ export const parameters = {
             Do,
             Dont,
             Frame,
-            Divider
+            Divider,
+            Tag
         }
     }
 };

--- a/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.mdx
+++ b/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.mdx
@@ -1,5 +1,4 @@
 import { Controls, Canvas, Meta, Title } from '@storybook/blocks';
-import { Tag } from '../../../.storybook/blocks/StoryLayout';
 import TargetDocs from '../../patterns/anchor/tests/target-docs.mdx';
 import { anchorTabTag } from '../../anchor-tab';
 import * as anchorTabsStories from './anchor-tabs.stories';

--- a/packages/nimble-components/src/button/tests/button.mdx
+++ b/packages/nimble-components/src/button/tests/button.mdx
@@ -1,5 +1,4 @@
 import { Canvas, Meta, Controls, Title } from '@storybook/blocks';
-import { Tag } from '../../../.storybook/blocks/StoryLayout';
 import ContentHiddenDocs from '../../patterns/button/tests/content-hidden-docs.mdx';
 import { NimbleButton } from './button.react';
 import { NimbleIconKey } from '../../icons/tests/key.react';

--- a/packages/nimble-components/src/card-button/tests/card-button.mdx
+++ b/packages/nimble-components/src/card-button/tests/card-button.mdx
@@ -1,5 +1,4 @@
 import { Canvas, Meta, Controls, Title } from '@storybook/blocks';
-import { Tag } from '../../../.storybook/blocks/StoryLayout';
 import { NimbleCardButton } from './card-button.react';
 import { cardButtonTag } from '..';
 import { buttonTag } from '../../button';

--- a/packages/nimble-components/src/card/tests/card.mdx
+++ b/packages/nimble-components/src/card/tests/card.mdx
@@ -1,5 +1,4 @@
 import { Canvas, Meta, Controls, Title } from '@storybook/blocks';
-import { Tag } from '../../../.storybook/blocks/StoryLayout';
 import { NimbleCard } from './card.react';
 import { cardTag } from '..';
 import * as cardStories from './card.stories';

--- a/packages/nimble-components/src/combobox/tests/combobox.mdx
+++ b/packages/nimble-components/src/combobox/tests/combobox.mdx
@@ -1,5 +1,4 @@
 import { Controls, Canvas, Meta, Title, Description } from '@storybook/blocks';
-import { Tag } from '../../../.storybook/blocks/StoryLayout';
 import * as comboboxStories from './combobox.stories';
 import { listOptionTag } from '../../list-option/';
 

--- a/packages/nimble-components/src/dialog/tests/dialog.mdx
+++ b/packages/nimble-components/src/dialog/tests/dialog.mdx
@@ -4,7 +4,9 @@ import * as dialogStories from './dialog.stories';
 <Meta of={dialogStories} />
 <Title of={dialogStories} />
 
-A modal dialog that appears centered on top of all other windows, blocking other interaction until dismissed.\n\nBy default, the first focusable control gets focus when the dialog is opened. To focus a specific element instead, set the `autofocus` attribute on that element.
+A modal dialog that appears centered on top of all other windows, blocking other interaction until dismissed.
+
+By default, the first focusable control gets focus when the dialog is opened. To focus a specific element instead, set the `autofocus` attribute on that element.
 
 <Canvas of={dialogStories.dialog} />
 <Controls of={dialogStories.dialog} />

--- a/packages/nimble-components/src/icon-base/tests/icons.mdx
+++ b/packages/nimble-components/src/icon-base/tests/icons.mdx
@@ -1,5 +1,4 @@
 import { Meta, Controls, Canvas, Title } from '@storybook/blocks';
-import { Tag } from '../../../.storybook/blocks/StoryLayout';
 import * as iconsStories from './icons.stories';
 import { iconAddTag } from '../../icons/add';
 

--- a/packages/nimble-components/src/menu/tests/menu.mdx
+++ b/packages/nimble-components/src/menu/tests/menu.mdx
@@ -1,5 +1,4 @@
 import { Controls, Canvas, Meta, Title } from '@storybook/blocks';
-import { Tag } from '../../../.storybook/blocks/StoryLayout';
 import TargetDocs from '../../patterns/anchor/tests/target-docs.mdx';
 import * as menuStories from './menu.stories';
 import { menuTag } from '..';

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.mdx
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.mdx
@@ -1,5 +1,4 @@
 import { Controls, Canvas, Meta, Title, Description } from '@storybook/blocks';
-import { Tag } from '../../../../.storybook/blocks/StoryLayout';
 import * as editorStories from './rich-text-editor.stories';
 import * as mentionUserStories from '../../../rich-text-mention/users/tests/rich-text-mention-users.stories';
 import * as userMappingStories from '../../../mapping/user/tests/mapping-user.stories';

--- a/packages/nimble-components/src/rich-text/viewer/tests/rich-text-viewer.mdx
+++ b/packages/nimble-components/src/rich-text/viewer/tests/rich-text-viewer.mdx
@@ -1,5 +1,4 @@
 import { Controls, Canvas, Meta, Title, Description } from '@storybook/blocks';
-import { Tag } from '../../../../.storybook/blocks/StoryLayout';
 import * as viewerStories from './rich-text-viewer.stories';
 import * as mentionUserStories from '../../../rich-text-mention/users/tests/rich-text-mention-users.stories';
 import * as userMappingStories from '../../../mapping/user/tests/mapping-user.stories';

--- a/packages/nimble-components/src/select/tests/select.mdx
+++ b/packages/nimble-components/src/select/tests/select.mdx
@@ -1,5 +1,4 @@
 import { Canvas, Meta, Controls, Title } from '@storybook/blocks';
-import { Tag } from '../../../.storybook/blocks/StoryLayout';
 import { NimbleSelect } from './select.react';
 import * as selectStories from './select.stories';
 import { listOptionTag } from '../../list-option';

--- a/packages/nimble-components/src/spinner/tests/spinner.mdx
+++ b/packages/nimble-components/src/spinner/tests/spinner.mdx
@@ -1,5 +1,4 @@
 import { Canvas, Meta, Controls, Title } from '@storybook/blocks';
-import { Tag } from '../../../.storybook/blocks/StoryLayout';
 import * as spinnerStories from './spinner.stories';
 import { spinnerTag } from '..';
 

--- a/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.mdx
+++ b/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.mdx
@@ -1,5 +1,4 @@
 import { Controls, Canvas, Meta, Title } from '@storybook/blocks';
-import { Tag } from '../../../../.storybook/blocks/StoryLayout';
 import TargetDocs from '../../../patterns/anchor/tests/target-docs.mdx';
 import * as tableColumnAnchorStories from './table-column-anchor.stories';
 import { tableColumnAnchorTag } from '..';

--- a/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.mdx
+++ b/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.mdx
@@ -1,5 +1,4 @@
 import { Canvas, Meta, Controls, Title } from '@storybook/blocks';
-import { Tag } from '../../../../.storybook/blocks/StoryLayout';
 import { NimbleTableColumnDateText } from './table-column-date-text.react';
 import * as tableColumnDateTextStories from './table-column-date-text.stories';
 import { tableColumnDateTextTag } from '..';

--- a/packages/nimble-components/src/table-column/duration-text/tests/table-column-duration-text.mdx
+++ b/packages/nimble-components/src/table-column/duration-text/tests/table-column-duration-text.mdx
@@ -1,5 +1,4 @@
 import { Controls, Canvas, Meta, Title } from '@storybook/blocks';
-import { Tag } from '../../../../.storybook/blocks/StoryLayout';
 import * as tableColumnDurationTextStories from './table-column-duration-text.stories';
 import { tableColumnDurationTextTag } from '..';
 import { tableTag } from '../../../table';

--- a/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text.mdx
+++ b/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text.mdx
@@ -1,5 +1,4 @@
 import { Canvas, Meta, Controls, Title, Description } from '@storybook/blocks';
-import { Tag } from '../../../../.storybook/blocks/StoryLayout';
 import { columnOperationBehavior } from '../../base/tests/table-column-stories-utils';
 import * as tableColumnEnumTextStories from './table-column-enum-text.stories';
 import * as textMappingStories from '../../../mapping/text/tests/mapping-text.stories';

--- a/packages/nimble-components/src/table-column/icon/tests/table-column-icon.mdx
+++ b/packages/nimble-components/src/table-column/icon/tests/table-column-icon.mdx
@@ -1,5 +1,4 @@
 import { Canvas, Meta, Controls, Title, Description } from '@storybook/blocks';
-import { Tag } from '../../../../.storybook/blocks/StoryLayout';
 import { columnOperationBehavior } from '../../base/tests/table-column-stories-utils';
 import * as tableColumnIconStories from './table-column-icon.stories';
 import * as iconMappingStories from '../../../mapping/icon/tests/mapping-icon.stories';

--- a/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.mdx
+++ b/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.mdx
@@ -1,5 +1,4 @@
 import { Canvas, Meta, Controls, Title } from '@storybook/blocks';
-import { Tag } from '../../../../.storybook/blocks/StoryLayout';
 import { NimbleTableColumnNumberText } from './table-column-number-text.react';
 import { columnOperationBehavior } from '../../base/tests/table-column-stories-utils';
 import * as tableColumnNumberTextStories from './table-column-number-text.stories';

--- a/packages/nimble-components/src/table-column/text/tests/table-column-text.mdx
+++ b/packages/nimble-components/src/table-column/text/tests/table-column-text.mdx
@@ -1,5 +1,4 @@
 import { Canvas, Meta, Controls, Title } from '@storybook/blocks';
-import { Tag } from '../../../../.storybook/blocks/StoryLayout';
 import { NimbleTableColumnText } from './table-column-text.react';
 import * as tableColumnTextStories from './table-column-text.stories';
 import { tableColumnTextTag } from '..';

--- a/packages/nimble-components/src/table/tests/table.mdx
+++ b/packages/nimble-components/src/table/tests/table.mdx
@@ -1,5 +1,4 @@
 import { Controls, Canvas, Meta, Title } from '@storybook/blocks';
-import { Tag } from '../../../.storybook/blocks/StoryLayout';
 import * as tableStories from './table.stories';
 import { tableTag } from '..';
 

--- a/packages/nimble-components/src/tree-view/tests/tree-view.mdx
+++ b/packages/nimble-components/src/tree-view/tests/tree-view.mdx
@@ -1,5 +1,4 @@
 import { Controls, Canvas, Meta, Title } from '@storybook/blocks';
-import { Tag } from '../../../.storybook/blocks/StoryLayout';
 import TargetDocs from '../../patterns/anchor/tests/target-docs.mdx';
 import * as treeViewStories from './tree-view.stories';
 import { treeViewTag } from '..';


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

In the [original PR](https://github.com/ni/nimble/pull/1793), I created a new React `<Tag>` component, and imported it directly into the Stories where it was needed. I should have followed the existing pattern, and imported it along with the other layout components in the `preview.js` file.

## 👩‍💻 Implementation

- Remove `import { Tag } from '../../../.storybook/blocks/StoryLayout';` from each story
- `import { Tag }` in `preview.js` 

## 🧪 Testing

- Manual Storybook build and review

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
