### PR TITLE
Fix performance issue for table with many grouped columns

### DIFF
--- a/change/@ni-nimble-components-32b76060-325a-409d-a3de-37feb9bbbf93.json
+++ b/change/@ni-nimble-components-32b76060-325a-409d-a3de-37feb9bbbf93.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix performance issue for table with many grouped columns",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -981,23 +981,11 @@ export class Table<
     private getGroupedRowSelectionState(
         groupedRow: TanStackRow<TableNode<TData>>
     ): TableRowSelectionState {
-        const leafRows = groupedRow.getLeafRows() ?? [];
+        const leafRows = groupedRow.getLeafRows().filter(x => !x.getIsGrouped()) ?? [];
         let foundSelectedRow = false;
         let foundNotSelectedRow = false;
         for (const row of leafRows) {
-            if (row.getIsGrouped()) {
-                const subGroupRowSelectionState = this.getGroupedRowSelectionState(row);
-                switch (subGroupRowSelectionState) {
-                    case TableRowSelectionState.notSelected:
-                        foundNotSelectedRow = true;
-                        break;
-                    case TableRowSelectionState.selected:
-                        foundSelectedRow = true;
-                        break;
-                    default:
-                        return TableRowSelectionState.partiallySelected;
-                }
-            } else if (row.getIsSelected()) {
+            if (row.getIsSelected()) {
                 foundSelectedRow = true;
             } else {
                 foundNotSelectedRow = true;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #1819

## 👩‍💻 Implementation

TanStack's `getLeafRows()` returns all descendants. We were unnecessarily doing an N^2 operation. We only have to look at the actual leaf rows (i.e. `!x.getIsGrouped()`), so we can remove the recursion altogether.

## 🧪 Testing

Tested in local build of TestInsights.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
