### PR TITLE
Fix issue with underline-hidden on the anchor column

### DIFF
--- a/change/@ni-nimble-components-f76f9ad8-5ecd-4d3a-bbdc-b0eefc70f79a.json
+++ b/change/@ni-nimble-components-f76f9ad8-5ecd-4d3a-bbdc-b0eefc70f79a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bug where setting underline-hidden=false on the anchor column would sometimes still hide the underline",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table-column/anchor/cell-view/template.ts
+++ b/packages/nimble-components/src/table-column/anchor/cell-view/template.ts
@@ -26,7 +26,7 @@ export const template = html<TableColumnAnchorCellView>`
                 target="${x => x.columnConfig?.target}"
                 type="${x => x.columnConfig?.type}"
                 download="${x => x.columnConfig?.download}"
-                underline-hidden="${x => x.columnConfig?.underlineHidden}"
+                ?underline-hidden="${x => x.columnConfig?.underlineHidden}"
                 appearance="${x => x.columnConfig?.appearance}"
                 title=${x => (x.hasOverflow ? x.text : null)}
             >

--- a/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor-matrix.stories.ts
+++ b/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor-matrix.stories.ts
@@ -45,9 +45,9 @@ const appearanceStates: [string, string | undefined][] = Object.entries(
 ).map(([key, value]) => [pascalCase(key), value]);
 type AppearanceState = (typeof appearanceStates)[number];
 
-const underlineHiddenStates: [string, boolean | undefined][] = [
+const underlineHiddenStates: [string, boolean][] = [
     ['Underline Hidden', true],
-    ['', undefined]
+    ['', false]
 ];
 type UnderlineHiddenState = (typeof underlineHiddenStates)[number];
 
@@ -63,7 +63,7 @@ const component = (
             href-field-name="link"
             group-index="0"
             appearance="${() => appearance}"
-            underline-hidden="${() => underlineHidden}"
+            ?underline-hidden="${() => underlineHidden}"
         >
             <${iconUserTag}></${iconUserTag}>
         </${tableColumnAnchorTag}>

--- a/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.spec.ts
+++ b/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.spec.ts
@@ -239,6 +239,21 @@ describe('TableColumnAnchor', () => {
             );
         });
 
+        it('updating underline-hidden from true to false removes the underline-hidden attribute from the anchor', async () => {
+            await element.setData([{ link: 'foo' }]);
+            await connect();
+            await waitForUpdatesAsync();
+
+            const firstColumn = element.columns[0] as TableColumnAnchor;
+            firstColumn.underlineHidden = true;
+            await waitForUpdatesAsync();
+            expect(pageObject.getRenderedCellAnchor(0, 0).hasAttribute('underline-hidden')).toBeTrue();
+
+            firstColumn.underlineHidden = false;
+            await waitForUpdatesAsync();
+            expect(pageObject.getRenderedCellAnchor(0, 0).hasAttribute('underline-hidden')).toBeFalse();
+        });
+
         const linkOptionData = [
             { name: 'hreflang', accessor: (x: Anchor) => x.hreflang },
             { name: 'ping', accessor: (x: Anchor) => x.ping },

--- a/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.spec.ts
+++ b/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.spec.ts
@@ -247,11 +247,19 @@ describe('TableColumnAnchor', () => {
             const firstColumn = element.columns[0] as TableColumnAnchor;
             firstColumn.underlineHidden = true;
             await waitForUpdatesAsync();
-            expect(pageObject.getRenderedCellAnchor(0, 0).hasAttribute('underline-hidden')).toBeTrue();
+            expect(
+                pageObject
+                    .getRenderedCellAnchor(0, 0)
+                    .hasAttribute('underline-hidden')
+            ).toBeTrue();
 
             firstColumn.underlineHidden = false;
             await waitForUpdatesAsync();
-            expect(pageObject.getRenderedCellAnchor(0, 0).hasAttribute('underline-hidden')).toBeFalse();
+            expect(
+                pageObject
+                    .getRenderedCellAnchor(0, 0)
+                    .hasAttribute('underline-hidden')
+            ).toBeFalse();
         });
 
         const linkOptionData = [


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This fixes an issue I noticed with the anchor column where the `underline-hidden` configuration on the anchor column didn't always work as expected. This is because the `underline-hidden` styling is based on the presence of the `underline-hidden` attribute, but the cell-view didn't use `?` when configuring `underline-hidden` on the underlying `nimble-anchor` element.

## 👩‍💻 Implementation

Add `?` in the anchor column's cell-view template when setting `underline-hidden` on the underlying `nimble-anchor`.

## 🧪 Testing

- Manually tested in storybook
- Wrote new unit test that fails without this change and passes with it

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
