### PR TITLE
Fix bug with indentation of nested parent rows

### DIFF
--- a/change/@ni-nimble-components-3bbc3e1f-cc55-43d0-9f8a-96229d247ce8.json
+++ b/change/@ni-nimble-components-3bbc3e1f-cc55-43d0-9f8a-96229d247ce8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bug where nesting level of rows sometimes gets out of sync with data",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/components/row/index.ts
+++ b/packages/nimble-components/src/table/components/row/index.ts
@@ -128,6 +128,11 @@ export class TableRow<
         return this.isParentRow && this.nestingLevel === 0;
     }
 
+    @volatile
+    public get isNestedParent(): boolean {
+        return this.isParentRow && this.nestingLevel > 0;
+    }
+
     // Programmatically updating the selection state of a checkbox fires the 'change' event.
     // Therefore, selection change events that occur due to programmatically updating
     // the selection checkbox 'checked' value should be ingored.

--- a/packages/nimble-components/src/table/components/row/template.ts
+++ b/packages/nimble-components/src/table/components/row/template.ts
@@ -69,7 +69,7 @@ export const template = html<TableRow>`
         `)}
 
         <span ${ref('cellContainer')} 
-            class="cell-container ${x => (x.isParentRow && x.nestingLevel > 0 ? 'nested-parent' : '')}"
+            class="cell-container ${x => (x.isNestedParent ? 'nested-parent' : '')}"
         >
             ${repeat(x => x.columns, html<TableColumn, TableRow>`
                 ${when(x => !x.columnHidden, html<TableColumn, TableRow>`


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This fixes a bug I found where the indentation of nested parent rows can sometimes be incorrect, particularly when the order of rows changes (such as when sorting a column) in a way that changes the nesting level that is set on a `nimble-table-row` element that is getting reused during a binding update.

The problematic binding was this condition in the table row's template: `x.isParentRow && x.nestingLevel > 0`. That statement is volatile, but it cannot be marked as such in the template. Therefore, I moved the evaluation into a getter named `isNestedParent` that could be marked as `@volatile`.

## 👩‍💻 Implementation

See _Rationale_ section above

## 🧪 Testing

Manually tested in storybook with a problematic set of data that I found the problem with

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
