### PR TITLE
Iniital implementation of Select placeholder

### DIFF
--- a/packages/nimble-components/src/select/index.ts
+++ b/packages/nimble-components/src/select/index.ts
@@ -162,12 +162,6 @@ export class Select extends FormAssociatedSelect implements ErrorPattern {
     public committedSelectedOption?: ListboxOption;
 
     /**
-     * @internal
-     */
-    @observable
-    public placeholderOption?: ListboxOption;
-
-    /**
      * The max height for the listbox when opened.
      *
      * @internal
@@ -188,6 +182,7 @@ export class Select extends FormAssociatedSelect implements ErrorPattern {
     private _value = '';
     private forcedPosition = false;
     private indexWhenOpened?: number;
+    private placeholderText?: string;
 
     /**
      * @internal
@@ -216,8 +211,9 @@ export class Select extends FormAssociatedSelect implements ErrorPattern {
     public override set options(value: ListboxOption[]) {
         const firstOptionIsPlaceholder = value.length > 0 && value[0]?.selected && value[0].disabled;
         if (firstOptionIsPlaceholder) {
-            this.placeholderOption = value.splice(0, 1)[0];
-            this.placeholderOption!.hidden = true;
+            const placeholderOption = value.splice(0, 1)[0];
+            this.placeholderText = placeholderOption!.text;
+            placeholderOption!.hidden = true;
         }
         this._options = value;
         Observable.notify(this, 'options');
@@ -274,7 +270,7 @@ export class Select extends FormAssociatedSelect implements ErrorPattern {
     public get displayValue(): string {
         Observable.track(this, 'displayValue');
         return this.placeholderVisible
-            ? this.placeholderOption!.text
+            ? this.placeholderText!
             : this.committedSelectedOption?.text ?? '';
     }
 
@@ -757,7 +753,7 @@ export class Select extends FormAssociatedSelect implements ErrorPattern {
                 || el.value === this.value
         );
 
-        if (selectedIndex === -1 && this.placeholderOption) {
+        if (selectedIndex === -1 && (typeof this.placeholderText === 'string')) {
             this.selectedIndex = selectedIndex;
             this.placeholderVisible = true;
             return;
@@ -842,7 +838,7 @@ export class Select extends FormAssociatedSelect implements ErrorPattern {
         if (shouldEmit) {
             if (
                 this.placeholderVisible
-                && this.value !== this.placeholderOption!.value
+                && this.value !== this.placeholderText
             ) {
                 this.placeholderVisible = false;
             }

--- a/packages/nimble-components/src/select/styles.ts
+++ b/packages/nimble-components/src/select/styles.ts
@@ -25,6 +25,10 @@ export const styles = css`
         /* We are using flex `order` to define the visual ordering of the selected value,
          error icon, and dropdown arrow because they are not "interactive" i.e. part of the tab order */ ''
     }
+    :host([placeholder-visible]) [part='selected-value'] {
+        color: ${placeholderFontColor};
+    }
+
     [part='selected-value'] {
         order: 1;
     }

--- a/packages/nimble-components/src/select/tests/select.mdx
+++ b/packages/nimble-components/src/select/tests/select.mdx
@@ -6,7 +6,7 @@ import { listOptionTag } from '../../list-option';
 <Meta of={selectStories} />
 <Title of={selectStories} />
 
-Select is a control for selecting amongst a set of options. Its value comes from the `value` of the currently selected <Tag name={listOptionTag}/>, or, if no value exists for that option, the option's content. Upon clicking on the element, the other options are visible. The user cannot manually enter values, and thus the list cannot be filtered.
+Select is a control for selecting amongst a set of options. Its value comes from the `value` of the currently selected <Tag name={listOptionTag}/>, or, if no value exists for that option, the option's content. Upon clicking on the element, the other options are visible.
 
 <Canvas of={selectStories.underlineSelect} />
 <Controls of={selectStories.underlineSelect} />

--- a/packages/nimble-components/src/select/tests/select.stories.ts
+++ b/packages/nimble-components/src/select/tests/select.stories.ts
@@ -1,4 +1,4 @@
-import { html, repeat } from '@microsoft/fast-element';
+import { html, repeat, when } from '@microsoft/fast-element';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { HtmlRenderer, Meta, StoryObj } from '@storybook/html';
 import {
@@ -20,12 +20,14 @@ interface SelectArgs {
     optionsType: ExampleOptionsType;
     appearance: string;
     filterMode: keyof typeof FilterMode;
+    placeholder: boolean;
 }
 
 interface OptionArgs {
     label: string;
     value: string;
     disabled: boolean;
+    selected?: boolean;
 }
 
 const simpleOptions: readonly OptionArgs[] = [
@@ -73,6 +75,10 @@ The act of filtering will use the \`hidden\` attribute on the options to remove 
 It is recommended that if the \`Select\` has 15 or fewer options that you use the \`none\` setting for the \`filter-mode\`.
 `;
 
+const placeholderDescription = `
+To display placeholder text within the \`Select\` you must provide an option before all other options that has both the \`disabled\` and \`selected\` attributes initially set. This option will not be available in the dropdown, and its contents will be used as the placeholder text.
+`;
+
 const metadata: Meta<SelectArgs> = {
     title: 'Components/Select',
     decorators: [withActions<HtmlRenderer>],
@@ -96,10 +102,18 @@ const metadata: Meta<SelectArgs> = {
             filter-mode="${x => (x.filterMode === 'none' ? undefined : x.filterMode)}"
             style="width: var(${menuMinWidth.cssCustomProperty});"
         >
+            ${when(x => x.placeholder, html`
+                <${listOptionTag}
+                    disabled
+                    selected>
+                    Select an option:
+                </${listOptionTag}?
+            `)}
             ${repeat(x => optionSets[x.optionsType], html<OptionArgs>`
                 <${listOptionTag}
                     value="${x => x.value}"
                     ?disabled="${x => x.disabled}"
+                    ?selected="${x => x.selected}"
                 >
                     ${x => x.label}
                 </${listOptionTag}>
@@ -126,6 +140,10 @@ const metadata: Meta<SelectArgs> = {
         errorVisible: {
             name: 'error-visible'
         },
+        placeholder: {
+            name: 'placeholder',
+            description: placeholderDescription
+        },
         optionsType: {
             name: 'options',
             options: Object.values(ExampleOptionsType),
@@ -146,7 +164,8 @@ const metadata: Meta<SelectArgs> = {
         filterMode: 'none',
         dropDownPosition: 'below',
         appearance: DropdownAppearance.underline,
-        optionsType: ExampleOptionsType.simpleOptions
+        optionsType: ExampleOptionsType.simpleOptions,
+        placeholder: false
     }
 };
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

- #1838 

I wanted to get some early feedback on the API design for this feature before writing the tests.

## 👩‍💻 Implementation

The API design present in this PR requires that for a `Select` to show placeholder text, the first option in the set of options in the DOM _must_ set both its `selected` and `disabled` attributes, and that's it. This is distinct from the conventional API that the [HTML `select` spec](https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-required) suggests, where, in addition to the `select` needing to set its `required` attribute, that the first option must have its `value` set to an empty string.

The proposed API seems possibly preferable in that the initial state for the first option (to be a placeholder) is intended to be a "non-possible" state for other options. Whereas the empty string value is a supported state for an option.

The implementation present is essentially doing the following: 
- Determine if the first option is configured to be a placeholder option. If so:
    - Remove that option from the `Select'`s internal notion of its `_options` (this makes it invisible to other things like filtering).
    - Cache the display text for the placeholder option.
- Provide observable state that determines if the placeholder is currently visible, and then show the placeholder text if it is with expected placeholder styling.

## 🧪 Testing

TODO.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
