### PR TITLE
Preserve spaces between inline elements

### DIFF
--- a/change/@ni-xliff-to-json-converter-03082322-18a9-410a-9e3b-6625f96dc66e.json
+++ b/change/@ni-xliff-to-json-converter-03082322-18a9-410a-9e3b-6625f96dc66e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Preserve spaces between inline elements",
+  "packageName": "@ni/xliff-to-json-converter",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34152,7 +34152,7 @@
       "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
-        "xliff": "^6.0.3",
+        "xliff": "^6.1.0",
         "yargs": "^17.5.1"
       },
       "bin": {

--- a/packages/xliff-to-json-converter/package.json
+++ b/packages/xliff-to-json-converter/package.json
@@ -37,7 +37,7 @@
     "typescript": "~4.8.2"
   },
   "dependencies": {
-    "xliff": "^6.0.3",
+    "xliff": "^6.1.0",
     "yargs": "^17.5.1"
   }
 }

--- a/packages/xliff-to-json-converter/src/convert.spec.ts
+++ b/packages/xliff-to-json-converter/src/convert.spec.ts
@@ -229,6 +229,28 @@ describe('xliff2Json', () => {
         expect(json.translations['5478462691360784268']).toEqual('{$PH}, {$PH_1} + 1 weitere');
     });
 
+    it('preserves spaces between inline elements', async () => {
+        const xliffContents = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+            <file source-language="en-US" datatype="plaintext" original="ng2.template" target-language="de-DE">
+            <body>
+                <trans-unit id="5478462691360784268" datatype="html">
+                    <source><x id="PH" equiv-text="fileName1"/> <x id="PH_1" equiv-text="fileName2"/> + 1 other</source>
+                    <target state="final"><x id="PH" equiv-text="fileName1"/> <x id="PH_1" equiv-text="fileName2"/> + 1 weitere</target>
+                </trans-unit>
+            </body>
+            </file>
+        </xliff>
+        `;
+
+        const xliff = await parseXliff(xliffContents);
+        const json = xliff2Json(xliff);
+
+        expect(Object.keys(json.translations).length).toEqual(1);
+        expect(json.translations['5478462691360784268']).toEqual('{$PH} {$PH_1} + 1 weitere');
+    });
+
     it('can convert trans-unit with custom % placeholders', async () => {
         const xliffContents = `
         <?xml version="1.0" encoding="UTF-8"?>

--- a/packages/xliff-to-json-converter/src/xliff-file.ts
+++ b/packages/xliff-to-json-converter/src/xliff-file.ts
@@ -7,5 +7,5 @@ export async function loadXliff(path: string): Promise<XliffFile> {
 }
 
 export async function parseXliff(contents: string): Promise<XliffFile> {
-    return xliff12ToJs(contents);
+    return xliff12ToJs(contents, { captureSpacesBetweenElements: true });
 }

--- a/packages/xliff-to-json-converter/src/xliff.d.ts
+++ b/packages/xliff-to-json-converter/src/xliff.d.ts
@@ -27,5 +27,5 @@ declare module 'xliff' {
         };
     }
 
-    function xliff12ToJs(contents: string): Promise<XliffFile>;
+    function xliff12ToJs(contents: string, options: { captureSpacesBetweenElements: boolean }): Promise<XliffFile>;
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #1840

## 👩‍💻 Implementation

- Bump the minimum version of the `xliff` dependency to one that supports the `captureSpacesBetweenElements` option
- Pass `{ captureSpacesBetweenElements: true }` as options to `xliff12ToJs`
- Update our type definition for the `xliff12ToJs` to claim it can be passed an option object containing a `captureSpacesBetweenElements` boolean
    - Note: It appears that the `xliff` library supports more option configurations than simply a `captureSpacesBetweenElements`, but I couldn't find a clear definition of what all the options were. Therefore, I decided to define it in our type with only the option we need.

## 🧪 Testing

- Created a new unit test that failed before the change and passes with it

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
