### PR TITLE
Clean up @ni/jasmine-paramaterized package metadata and examples

### DIFF
--- a/change/@ni-jasmine-parameterized-5d135b15-d9c6-410c-8cba-5784b0eda870.json
+++ b/change/@ni-jasmine-parameterized-5d135b15-d9c6-410c-8cba-5784b0eda870.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Add keywords to package metadata",
+  "comment": "Add keywords to package metadata and fix typo in examples",
   "packageName": "@ni/jasmine-parameterized",
   "email": "jattasNI@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@ni-jasmine-parameterized-5d135b15-d9c6-410c-8cba-5784b0eda870.json
+++ b/change/@ni-jasmine-parameterized-5d135b15-d9c6-410c-8cba-5784b0eda870.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add keywords to package metadata",
+  "packageName": "@ni/jasmine-parameterized",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/jasmine-parameterized/README.md
+++ b/packages/jasmine-parameterized/README.md
@@ -26,7 +26,7 @@ In the following example:
 import { parameterizeSpec } from '@ni/jasmine-parameterized';
 const rainTests = [
     { name: 'cats-and-dogs', type: 'idiom' },
-    { name: 'frogs' type: 'idiom'},
+    { name: 'frogs', type: 'idiom'},
     { name: 'men', type: 'lyrics'}
 ] as const;
 describe('Different rains', () => {

--- a/packages/jasmine-parameterized/package.json
+++ b/packages/jasmine-parameterized/package.json
@@ -2,6 +2,7 @@
   "name": "@ni/jasmine-parameterized",
   "version": "0.2.1",
   "description": "A utility to write parameterized jasmine tests",
+  "keywords": ["jasmine", "parameterised", "parameterized", "test", "testing"],
   "scripts": {
     "build": "tsc -b",
     "lint": "eslint .",

--- a/packages/jasmine-parameterized/src/parameterized.ts
+++ b/packages/jasmine-parameterized/src/parameterized.ts
@@ -85,7 +85,7 @@ type ObjectFromNamedList<T extends readonly { name: string }[]> = {
  * @example
  * const rainTests = [
  *   { name: 'cats-and-dogs', type: 'idiom' },
- *   { name: 'frogs' type: 'idiom'},
+ *   { name: 'frogs', type: 'idiom'},
  *   { name: 'men', type: 'lyrics'}
  * ] as const;
  * describe('Different rains', () => {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

npmjs allows searching for packages by keywords but this package didn't specify any so its SEO performance was sub-optimal 😔.
https://www.npmjs.com/search?q=keywords%3Ajasmine

There was also a typo in the examples.


## 👩‍💻 Implementation

Add some keywords borrowed from jasmine core packages and the unscoped jasmine-paramaterized package

Fix typos in README and code comment.

## 🧪 Testing

N/A

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
