### PR TITLE
Card accessibility tweak

### DIFF
--- a/angular-workspace/projects/example-client-app/src/app/customapp/customapp.component.html
+++ b/angular-workspace/projects/example-client-app/src/app/customapp/customapp.component.html
@@ -42,7 +42,6 @@
             <nimble-anchor-button nimbleRouterLink="/customapp" appearance="block">Block Anchor Button</nimble-anchor-button>
             <nimble-anchor-button nimbleRouterLink="/customapp" appearance="ghost">Ghost Anchor Button</nimble-anchor-button>
         </div>
-        <!-- Disabled as it breaks accessibility tooling, see: https://github.com/ni/nimble/issues/1650
         <div class="sub-container">
             <div class="container-label">Card</div>
             <nimble-card>
@@ -56,7 +55,6 @@
                 </nimble-select>
             </nimble-card>
         </div>
-        -->
         <div class="sub-container">
             <div class="container-label">Card Button</div>
             <nimble-card-button>

--- a/change/@ni-nimble-blazor-218838f9-dad2-4f22-b68f-fd127b64a9d7.json
+++ b/change/@ni-nimble-blazor-218838f9-dad2-4f22-b68f-fd127b64a9d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Re-enable card example",
+  "packageName": "@ni/nimble-blazor",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-nimble-components-2efd396c-db08-4b88-96f0-9eacb3cf04bd.json
+++ b/change/@ni-nimble-components-2efd396c-db08-4b88-96f0-9eacb3cf04bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Tweak card to workaround lighthouse issue",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-blazor/Examples/Demo.Shared/Pages/ComponentsDemo.razor
+++ b/packages/nimble-blazor/Examples/Demo.Shared/Pages/ComponentsDemo.razor
@@ -59,7 +59,6 @@
                 Icon Toggle Button
             </NimbleToggleButton>
         </div>
-        <!-- Disabled as it breaks accessibility tooling, see: https://github.com/ni/nimble/issues/1650
         <div class="sub-container">
             <div class="container-label">Card</div>
             <NimbleCard>
@@ -73,7 +72,6 @@
                 </NimbleSelect>
             </NimbleCard>
         </div>
-        -->
         <div class="sub-container">
             <div class="container-label">Card Button</div>
             <NimbleCardButton>

--- a/packages/nimble-components/src/card/template.ts
+++ b/packages/nimble-components/src/card/template.ts
@@ -2,11 +2,8 @@ import { html } from '@microsoft/fast-element';
 import type { Card } from '.';
 
 export const template = html<Card>`
-    ${
-    '' /* Explicitly set role to work around Lighthouse error. See https://github.com/ni/nimble/issues/1650. */
-}
-    <section role="region" aria-labelledby="title-slot">
-        <slot name="title" id="title-slot"></slot>
+    <section aria-labelledby="title-slot">
+        <span id="title-slot"><slot name="title"></slot></span>
         <slot></slot>
     </section>
 `;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The card was previously disabled after it started resulting in axe-core completely failing. After reporting to axe-core their comment in https://github.com/dequelabs/axe-core/issues/4335#issuecomment-1959646970 made me think we can workaround the axe-core issue by wrapping the slot in a span and targeting that instead for aria.

While not necessary for runtime behavior or accessibility, the workaround adds minimal overhead and complexity. Does not need to be removed after the axe-core fix. Fixes #1650 

## 👩‍💻 Implementation

Wraps the slot in a span and use that as the aria target. 

## 🧪 Testing

Can see the PR has a passing lighthouse score with the card re-enabled.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
