### PR TITLE
Try to address label provider storybook instability

### DIFF
--- a/change/@ni-nimble-components-dcaefd37-ce75-4d9d-b95f-8fd90e678ab5.json
+++ b/change/@ni-nimble-components-dcaefd37-ce75-4d9d-b95f-8fd90e678ab5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove code element from stories used for formatting",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/label-provider/base/tests/label-provider-stories-utils.ts
+++ b/packages/nimble-components/src/label-provider/base/tests/label-provider-stories-utils.ts
@@ -23,7 +23,7 @@ const createTemplate = (
     labelProviderTag: string
 ): ViewTemplate<LabelProviderArgs> => html<LabelProviderArgs>`
 <${labelProviderTag}></${labelProviderTag}>
-<p>Element name: <code>${x => x.labelProviderTag}</code></p>
+<p>Element name: ${x => x.labelProviderTag}</p>
 <${tableTag}
     ${ref('tableRef')}
     data-unused="${x => x.updateData(x)}"


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The label stories keep showing diffs in Chrome around the element name which is in `<code>` tags.
Removing the code tags which were used for font formatting to see if it behaves better

![image](https://github.com/ni/nimble/assets/1588923/476c8805-9d72-4c92-a85b-a7886958096c)


## 👩‍💻 Implementation

Remove the code tags for font formatting and just rely on the nimble font tokens

## 🧪 Testing

Relying on story checks

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
