### PR TITLE
Fix spacing between error text and component

### DIFF
--- a/change/@ni-nimble-components-9b36005d-7790-48bb-8717-21198a97490a.json
+++ b/change/@ni-nimble-components-9b36005d-7790-48bb-8717-21198a97490a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix spacing between error text and component",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/patterns/error/styles.ts
+++ b/packages/nimble-components/src/patterns/error/styles.ts
@@ -28,7 +28,7 @@ export const styles = css`
         color: ${failColor};
         width: 100%;
         position: absolute;
-        bottom: calc(-1 * ${errorTextFontLineHeight});
+        bottom: calc(-1 * (${errorTextFontLineHeight} + 2px));
         left: 0px;
         overflow: hidden;
         text-overflow: ellipsis;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #1845 

## 👩‍💻 Implementation

Moved the error text on controls down 2px to create a 2px margin between the bottom of a control and the error text.

## 🧪 Testing

Manually tested in storybook and verified that the error text is no longer visible between the select/combobox and the dropdown.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
