### PR TITLE
Only handle close events coming from dialog element

### DIFF
--- a/change/@ni-nimble-components-4305503e-0bf0-48f8-b23a-ff4046ed7e0c.json
+++ b/change/@ni-nimble-components-4305503e-0bf0-48f8-b23a-ff4046ed7e0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Only handle close events coming from dialog element",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/dialog/index.ts
+++ b/packages/nimble-components/src/dialog/index.ts
@@ -132,7 +132,10 @@ export class Dialog<CloseReason = void> extends FoundationElement {
     /**
      * @internal
      */
-    public closeHandler(): void {
+    public closeHandler(event: Event): void {
+        if (event.target !== this.dialogElement) {
+            return;
+        }
         if (this.resolveShow) {
             // If
             // - the browser implements dialogs with the CloseWatcher API, and

--- a/packages/nimble-components/src/dialog/template.ts
+++ b/packages/nimble-components/src/dialog/template.ts
@@ -8,7 +8,7 @@ export const template = html<Dialog>`
             role="dialog"
             part="control"
             @cancel="${(x, c) => x.cancelHandler(c.event)}"
-            @close="${x => x.closeHandler()}"
+            @close="${(x, c) => x.closeHandler(c.event)}"
             aria-labelledby="header"
         >
             <header id="header">

--- a/packages/nimble-components/src/dialog/tests/dialog.spec.ts
+++ b/packages/nimble-components/src/dialog/tests/dialog.spec.ts
@@ -18,7 +18,7 @@ async function setup<CloseReason = void>(
     return fixture<Dialog<CloseReason>>(viewTemplate);
 }
 
-describe('Dialog', () => {
+fdescribe('Dialog', () => {
     function nativeDialogElement(nimbleDialogElement: Dialog): ExtendedDialog {
         return nimbleDialogElement.shadowRoot!.querySelector(
             'dialog'
@@ -185,6 +185,20 @@ describe('Dialog', () => {
 
         await expectAsync(dialogPromise).toBeResolvedTo(UserDismissed);
         expect(element.open).toBeFalse();
+
+        await disconnect();
+    });
+
+    it('should not resolve promise when close event bubbles from descendant', async () => {
+        const { element, connect, disconnect } = await setup();
+        await connect();
+        const dialogPromise = element.show();
+        const okButton = document.getElementById('ok')!;
+        okButton.dispatchEvent(new Event('close', { bubbles: true }));
+        await waitForUpdatesAsync();
+
+        await expectAsync(dialogPromise).toBePending();
+        expect(element.open).toBeTrue();
 
         await disconnect();
     });

--- a/packages/nimble-components/src/dialog/tests/dialog.spec.ts
+++ b/packages/nimble-components/src/dialog/tests/dialog.spec.ts
@@ -18,7 +18,7 @@ async function setup<CloseReason = void>(
     return fixture<Dialog<CloseReason>>(viewTemplate);
 }
 
-fdescribe('Dialog', () => {
+describe('Dialog', () => {
     function nativeDialogElement(nimbleDialogElement: Dialog): ExtendedDialog {
         return nimbleDialogElement.shadowRoot!.querySelector(
             'dialog'

--- a/packages/nimble-components/src/drawer/index.ts
+++ b/packages/nimble-components/src/drawer/index.ts
@@ -95,7 +95,10 @@ export class Drawer<CloseReason = void> extends FoundationElement {
     /**
      * @internal
      */
-    public closeHandler(): void {
+    public closeHandler(event: Event): void {
+        if (event.target !== this.dialog) {
+            return;
+        }
         if (this.resolveShow) {
             // If
             // - the browser implements dialogs with the CloseWatcher API, and

--- a/packages/nimble-components/src/drawer/template.ts
+++ b/packages/nimble-components/src/drawer/template.ts
@@ -6,7 +6,7 @@ export const template = html<Drawer>`
         ${ref('dialog')}
         aria-label="${x => x.ariaLabel}"
         @cancel="${(x, c) => x.cancelHandler(c.event)}"
-        @close="${x => x.closeHandler()}"
+        @close="${(x, c) => x.closeHandler(c.event)}"
     >
         <div class="dialog-contents">
             <slot></slot>

--- a/packages/nimble-components/src/drawer/tests/drawer.spec.ts
+++ b/packages/nimble-components/src/drawer/tests/drawer.spec.ts
@@ -3,7 +3,10 @@ import { eventAnimationEnd } from '@microsoft/fast-web-utilities';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Drawer, UserDismissed } from '..';
 import { DrawerLocation } from '../types';
-import { processUpdates, waitForUpdatesAsync } from '../../testing/async-helpers';
+import {
+    processUpdates,
+    waitForUpdatesAsync
+} from '../../testing/async-helpers';
 
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 async function setup<CloseReason = void>(
@@ -20,7 +23,7 @@ async function setup<CloseReason = void>(
     return fixture<Drawer<CloseReason>>(viewTemplate);
 }
 
-fdescribe('Drawer', () => {
+describe('Drawer', () => {
     function nativeDialogElement(
         nimbleDrawerElement: Drawer | Drawer<string>
     ): HTMLDialogElement {

--- a/packages/nimble-components/src/drawer/tests/drawer.spec.ts
+++ b/packages/nimble-components/src/drawer/tests/drawer.spec.ts
@@ -3,7 +3,7 @@ import { eventAnimationEnd } from '@microsoft/fast-web-utilities';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Drawer, UserDismissed } from '..';
 import { DrawerLocation } from '../types';
-import { processUpdates } from '../../testing/async-helpers';
+import { processUpdates, waitForUpdatesAsync } from '../../testing/async-helpers';
 
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 async function setup<CloseReason = void>(
@@ -20,7 +20,7 @@ async function setup<CloseReason = void>(
     return fixture<Drawer<CloseReason>>(viewTemplate);
 }
 
-describe('Drawer', () => {
+fdescribe('Drawer', () => {
     function nativeDialogElement(
         nimbleDrawerElement: Drawer | Drawer<string>
     ): HTMLDialogElement {
@@ -168,6 +168,15 @@ describe('Drawer', () => {
             nativeDialogElement(element).dispatchEvent(new Event('close'));
             await expectAsync(promise).toBeResolvedTo(UserDismissed);
             expect(element.open).toBeFalse();
+        });
+
+        it('should not resolve promise when close event bubbles from descendant', async () => {
+            const promise = element.show();
+            const okButton = document.getElementById('ok')!;
+            okButton.dispatchEvent(new Event('close', { bubbles: true }));
+            await waitForUpdatesAsync();
+            await expectAsync(promise).toBePending();
+            expect(element.open).toBeTrue();
         });
 
         it('throws calling show() a second time', async () => {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

See: https://dev.azure.com/ni/DevCentral/_workitems/edit/2663186

## 👩‍💻 Implementation

In the reported use case, a smart menu's closing was emitting a `close` event that was bubbling up to our native dialog's handler. We need to ignore `close` events that are not fired directly on the dialog element.

## 🧪 Testing

Added test cases.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
