### PR TITLE
Make renovate only update semver compatible versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,31 +14,10 @@
       "enabled": false
     },
     {
-      "groupName": "npm dependencies",
+      "groupName": "npm all dependencies",
       "matchManagers": ["npm"],
-      "rangeStrategy": "update-lockfile",
-      "matchDepTypes": ["dependencies"],
-      "matchPackagePatterns":[
-        "^@microsoft/fast",
-        "^@tanstack/",
-        "^@tiptap/",
-        "@types/markdown-it",
-        "comlink",
-        "d3-",
-        "prosemirror-"
-      ],
-      "enabled": true
-    },
-    {
-      "groupName": "npm dev dependencies",
-      "matchManagers": ["npm"],
-      "rangeStrategy": "update-lockfile",
-      "matchDepTypes": ["devDependencies"],
-      "matchPackagePatterns":[
-        "^@ni/eslint-config",
-        "beachball",
-        "storybook"
-      ],
+      "rangeStrategy": "in-range-only",
+      "matchDepTypes": ["dependencies", "devDependencies"],
       "enabled": true
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,22 +10,19 @@
   ],
   "packageRules": [
     {
-      "matchManagers": ["npm"],
+      "matchManagers": ["npm", "nuget"],
       "enabled": false
     },
     {
-      "groupName": "npm all dependencies",
+      "groupName": "npm dependencies",
       "matchManagers": ["npm"],
       "rangeStrategy": "in-range-only",
       "matchDepTypes": ["dependencies", "devDependencies"],
       "enabled": true
     },
     {
-      "groupName": "nuget bunit dependencies",
+      "groupName": "nuget dependencies",
       "matchManagers": ["nuget"],
-      "matchPackagePatterns":[
-        "^bunit"
-      ],
       "enabled": true
     }
   ]


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

### NPM

Switching the renovate behavior to just use semver compatible ranges for npm (in-range-only) and target all npm managed packages while doing so.

Benefits:
- All deps get managed instead of a select subset
- Single PR (for dev and devDeps) modifying the lockfile at a time
- Can likely be merged without any changes
- Future potential changes
  - We can potentially increase the rate for the PRs if they behave well

Cons:
- Not getting semver incompatible updates (i.e. updates to the package.json that require a beachball change)

Future potential changes:
  - Add back a select list of packages we are interested in getting latest changes beyond semver ranges
  - Run it less often, once a cycle or monthly
  - Make a manual task to manually go through and bump outdated semver ranges being careful to track typescript versions, etc., once a cycle?

### Nuget

- Think I followed the pattern npm was doing to disable generally and make a group for the nuget packages to reduce the number of separate PRs.

## 👩‍💻 Implementation

See above

## 🧪 Testing

Can try it out for a while

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
