### PR TITLE
Green column divider

### DIFF
--- a/change/@ni-nimble-components-24dcfac0-abab-41bf-b3f8-c3821e2a18ed.json
+++ b/change/@ni-nimble-components-24dcfac0-abab-41bf-b3f8-c3821e2a18ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update column divider color on hover",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -439,7 +439,7 @@ export class Table<
         if (event.button === 0) {
             this.layoutManager.beginColumnInteractiveSize(
                 event.clientX,
-                columnIndex * 2
+                this.getRightDividerIndex(columnIndex)
             );
         }
     }
@@ -452,9 +452,19 @@ export class Table<
         if (event.button === 0) {
             this.layoutManager.beginColumnInteractiveSize(
                 event.clientX,
-                columnIndex * 2 - 1
+                this.getLeftDividerIndex(columnIndex)
             );
         }
+    }
+
+    /** @internal */
+    public getLeftDividerIndex(columnIndex: number): number {
+        return columnIndex * 2 - 1;
+    }
+
+    /** @internal */
+    public getRightDividerIndex(columnIndex: number): number {
+        return columnIndex * 2;
     }
 
     /** @internal */

--- a/packages/nimble-components/src/table/models/table-layout-manager.ts
+++ b/packages/nimble-components/src/table/models/table-layout-manager.ts
@@ -14,7 +14,9 @@ export class TableLayoutManager<TData extends TableRecord> {
     @observable
     public activeColumnIndex?: number;
 
-    private activeColumnDivider?: number;
+    @observable
+    public activeColumnDivider?: number;
+
     private gridSizedColumns?: TableColumn[];
     private visibleColumns: TableColumn[] = [];
     private initialTableScrollableWidth?: number;
@@ -111,6 +113,7 @@ export class TableLayoutManager<TData extends TableRecord> {
         this.resetGridSizedColumns();
         this.isColumnBeingSized = false;
         this.activeColumnIndex = undefined;
+        this.activeColumnDivider = undefined;
     };
 
     private getTotalColumnFixedWidth(): number {

--- a/packages/nimble-components/src/table/styles.ts
+++ b/packages/nimble-components/src/table/styles.ts
@@ -116,25 +116,18 @@ export const styles = css`
         height: ${controlSlimHeight};
         cursor: col-resize;
         position: absolute;
-    }
-
-    .column-divider:hover {
-        border-color: ${borderHoverColor};
-    }
-
-    .column-divider.visible {
-        display: block;
         z-index: ${ZIndexLevels.zIndex1};
     }
 
-    .column-divider.active {
+    .column-divider:hover,
+    .column-divider.divider-active {
         border-color: ${borderHoverColor};
     }
 
-    .header-container:hover .column-divider.left,
-    .header-container:hover .column-divider.right {
+    .column-divider.column-active,
+    .header-container:hover .column-divider,
+    .header-container:hover .column-divider {
         display: block;
-        z-index: ${ZIndexLevels.zIndex1};
     }
 
     .column-divider::before {

--- a/packages/nimble-components/src/table/styles.ts
+++ b/packages/nimble-components/src/table/styles.ts
@@ -125,7 +125,6 @@ export const styles = css`
     }
 
     .column-divider.column-active,
-    .header-container:hover .column-divider,
     .header-container:hover .column-divider {
         display: block;
     }

--- a/packages/nimble-components/src/table/styles.ts
+++ b/packages/nimble-components/src/table/styles.ts
@@ -9,7 +9,8 @@ import {
     controlSlimHeight,
     mediumPadding,
     standardPadding,
-    tableRowBorderColor
+    tableRowBorderColor,
+    borderHoverColor
 } from '../theme-provider/design-tokens';
 import { Theme } from '../theme-provider/types';
 import { hexToRgbaCssColor } from '../utilities/style/colors';
@@ -117,6 +118,25 @@ export const styles = css`
         position: absolute;
     }
 
+    .column-divider:hover {
+        border-color: ${borderHoverColor};
+    }
+
+    .column-divider.visible {
+        display: block;
+        z-index: ${ZIndexLevels.zIndex1};
+    }
+
+    .column-divider.active {
+        border-color: ${borderHoverColor};
+    }
+
+    .header-container:hover .column-divider.left,
+    .header-container:hover .column-divider.right {
+        display: block;
+        z-index: ${ZIndexLevels.zIndex1};
+    }
+
     .column-divider::before {
         content: '';
         position: absolute;
@@ -129,17 +149,6 @@ export const styles = css`
             -1 * (var(--ni-private-column-divider-width) +
                         var(--ni-private-column-divider-padding))
         );
-    }
-
-    .column-divider.active {
-        display: block;
-        z-index: ${ZIndexLevels.zIndex1};
-    }
-
-    .header-container:hover .column-divider.left,
-    .header-container:hover .column-divider.right {
-        display: block;
-        z-index: ${ZIndexLevels.zIndex1};
     }
 
     .column-divider.left {

--- a/packages/nimble-components/src/table/template.ts
+++ b/packages/nimble-components/src/table/template.ts
@@ -87,8 +87,8 @@ export const template = html<Table>`
                                             class="
                                                 column-divider
                                                 left
-                                                ${(_, c) => `${c.parent.layoutManager.activeColumnIndex === c.index ? 'visible' : ''}`}
-                                                ${(_, c) => `${c.parent.layoutManager.activeColumnDivider === c.parent.getLeftDividerIndex(c.index) ? 'active' : ''}`}
+                                                ${(_, c) => `${c.parent.layoutManager.activeColumnIndex === c.index ? 'column-active' : ''}`}
+                                                ${(_, c) => `${c.parent.layoutManager.activeColumnDivider === c.parent.getLeftDividerIndex(c.index) ? 'divider-active' : ''}`}
                                             "
                                             @mousedown="${(_, c) => c.parent.onLeftDividerMouseDown(c.event as MouseEvent, c.index)}">
                                         </div>
@@ -107,8 +107,8 @@ export const template = html<Table>`
                                             class="
                                                 column-divider
                                                 right
-                                                ${(_, c) => `${c.parent.layoutManager.activeColumnIndex === c.index ? 'visible' : ''}`}
-                                                ${(_, c) => `${c.parent.layoutManager.activeColumnDivider === c.parent.getRightDividerIndex(c.index) ? 'active' : ''}`}
+                                                ${(_, c) => `${c.parent.layoutManager.activeColumnIndex === c.index ? 'column-active' : ''}`}
+                                                ${(_, c) => `${c.parent.layoutManager.activeColumnDivider === c.parent.getRightDividerIndex(c.index) ? 'divider-active' : ''}`}
                                             "
                                              @mousedown="${(_, c) => c.parent.onRightDividerMouseDown(c.event as MouseEvent, c.index)}">
                                         </div>

--- a/packages/nimble-components/src/table/template.ts
+++ b/packages/nimble-components/src/table/template.ts
@@ -83,8 +83,14 @@ export const template = html<Table>`
                             ${repeat(x => x.visibleColumns, html<TableColumn, Table>`
                                 <div class="header-container">
                                     ${when((_, c) => c.index > 0, html<TableColumn, Table>`
-                                        <div class="column-divider left ${(_, c) => `${c.parent.layoutManager.activeColumnIndex === c.index ? 'active' : ''}`}" 
-                                             @mousedown="${(_, c) => c.parent.onLeftDividerMouseDown(c.event as MouseEvent, c.index)}">
+                                        <div
+                                            class="
+                                                column-divider
+                                                left
+                                                ${(_, c) => `${c.parent.layoutManager.activeColumnIndex === c.index ? 'visible' : ''}`}
+                                                ${(_, c) => `${c.parent.layoutManager.activeColumnDivider === c.parent.getLeftDividerIndex(c.index) ? 'active' : ''}`}
+                                            "
+                                            @mousedown="${(_, c) => c.parent.onLeftDividerMouseDown(c.event as MouseEvent, c.index)}">
                                         </div>
                                     `)}
                                         <${tableHeaderTag}
@@ -97,7 +103,13 @@ export const template = html<Table>`
                                             <slot name="${x => x.slot}"></slot>
                                         </${tableHeaderTag}>
                                     ${when((_, c) => c.index < c.length - 1, html<TableColumn, Table>`
-                                        <div class="column-divider right ${(_, c) => `${c.parent.layoutManager.activeColumnIndex === c.index ? 'active' : ''}`}"
+                                        <div
+                                            class="
+                                                column-divider
+                                                right
+                                                ${(_, c) => `${c.parent.layoutManager.activeColumnIndex === c.index ? 'visible' : ''}`}
+                                                ${(_, c) => `${c.parent.layoutManager.activeColumnDivider === c.parent.getRightDividerIndex(c.index) ? 'active' : ''}`}
+                                            "
                                              @mousedown="${(_, c) => c.parent.onRightDividerMouseDown(c.event as MouseEvent, c.index)}">
                                         </div>
                                     `)}                        

--- a/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
@@ -782,35 +782,42 @@ describe('Table Interactive Column Sizing', () => {
             }
         ] as const;
         parameterizeSpec(dividerActiveTests, (spec, name, value) => {
-            spec(`${name} updates expected dividers as "divider-active" and "column-active"`, async () => {
-                const dividers = Array.from(
-                    element.shadowRoot!.querySelectorAll('.column-divider')
-                );
-                const divider = dividers[value.dividerClickIndex]!;
-                const dividerRect = divider.getBoundingClientRect();
-                const mouseDownEvent = new MouseEvent('mousedown', {
-                    clientX: (dividerRect.x + dividerRect.width) / 2,
-                    clientY: (dividerRect.y + dividerRect.height) / 2
-                });
-                const mouseUpEvent = new MouseEvent('mouseup');
-                divider.dispatchEvent(mouseDownEvent);
-                await waitForUpdatesAsync();
-                const dividerActiveDividers = [];
-                const columnActiveDividers = [];
-                for (let i = 0; i < dividers.length; i++) {
-                    if (dividers[i]!.classList.contains('divider-active')) {
-                        dividerActiveDividers.push(i);
+            spec(
+                `${name} updates expected dividers as "divider-active" and "column-active"`,
+                async () => {
+                    const dividers = Array.from(
+                        element.shadowRoot!.querySelectorAll('.column-divider')
+                    );
+                    const divider = dividers[value.dividerClickIndex]!;
+                    const dividerRect = divider.getBoundingClientRect();
+                    const mouseDownEvent = new MouseEvent('mousedown', {
+                        clientX: (dividerRect.x + dividerRect.width) / 2,
+                        clientY: (dividerRect.y + dividerRect.height) / 2
+                    });
+                    const mouseUpEvent = new MouseEvent('mouseup');
+                    divider.dispatchEvent(mouseDownEvent);
+                    await waitForUpdatesAsync();
+                    const dividerActiveDividers = [];
+                    const columnActiveDividers = [];
+                    for (let i = 0; i < dividers.length; i++) {
+                        if (dividers[i]!.classList.contains('divider-active')) {
+                            dividerActiveDividers.push(i);
+                        }
+                        if (dividers[i]!.classList.contains('column-active')) {
+                            columnActiveDividers.push(i);
+                        }
                     }
-                    if (dividers[i]!.classList.contains('column-active')) {
-                        columnActiveDividers.push(i);
-                    }
-                }
-                document.dispatchEvent(mouseUpEvent); // clean up registered event handlers
+                    document.dispatchEvent(mouseUpEvent); // clean up registered event handlers
 
-                expect(dividerActiveDividers.length).toEqual(1);
-                expect(dividerActiveDividers[0]).toEqual(value.dividerClickIndex);
-                expect(columnActiveDividers).toEqual(value.expectedColumnActiveDividerIndexes);
-            });
+                    expect(dividerActiveDividers.length).toEqual(1);
+                    expect(dividerActiveDividers[0]).toEqual(
+                        value.dividerClickIndex
+                    );
+                    expect(columnActiveDividers).toEqual(
+                        value.expectedColumnActiveDividerIndexes
+                    );
+                }
+            );
         });
 
         it('first column only has right divider', () => {

--- a/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
@@ -750,39 +750,39 @@ describe('Table Interactive Column Sizing', () => {
     describe('active divider tests', () => {
         const dividerActiveTests = [
             {
-                name: 'click on first column right divider only results in one active and one visible divider',
+                name: 'click on first column right divider',
                 dividerClickIndex: 0,
                 leftDividerClick: false,
-                expectedVisibleIndexes: [0]
+                expectedColumnActiveDividerIndexes: [0]
             },
             {
-                name: 'click on second column left divider results in one active and two visible dividers',
+                name: 'click on second column left divider',
                 dividerClickIndex: 1,
-                expectedVisibleIndexes: [1, 2]
+                expectedColumnActiveDividerIndexes: [1, 2]
             },
             {
-                name: 'click on second column right divider results in one active and two visible dividers',
+                name: 'click on second column right divider',
                 dividerClickIndex: 2,
-                expectedVisibleIndexes: [1, 2]
+                expectedColumnActiveDividerIndexes: [1, 2]
             },
             {
-                name: 'click on third column left divider results in one active and two visible dividers',
+                name: 'click on third column left divider',
                 dividerClickIndex: 3,
-                expectedVisibleIndexes: [3, 4]
+                expectedColumnActiveDividerIndexes: [3, 4]
             },
             {
-                name: 'click on third column right divider results in one active and two visible dividers',
+                name: 'click on third column right divider',
                 dividerClickIndex: 4,
-                expectedVisibleIndexes: [3, 4]
+                expectedColumnActiveDividerIndexes: [3, 4]
             },
             {
-                name: 'click on last column left divider only results in one active and one visible divider',
+                name: 'click on last column left divider',
                 dividerClickIndex: 5,
-                expectedVisibleIndexes: [5]
+                expectedColumnActiveDividerIndexes: [5]
             }
         ] as const;
         parameterizeSpec(dividerActiveTests, (spec, name, value) => {
-            spec(name, async () => {
+            spec(`${name} updates expected dividers as "divider-active" and "column-active"`, async () => {
                 const dividers = Array.from(
                     element.shadowRoot!.querySelectorAll('.column-divider')
                 );
@@ -795,21 +795,21 @@ describe('Table Interactive Column Sizing', () => {
                 const mouseUpEvent = new MouseEvent('mouseup');
                 divider.dispatchEvent(mouseDownEvent);
                 await waitForUpdatesAsync();
-                const activeDividers = [];
-                const visibleDividers = [];
+                const dividerActiveDividers = [];
+                const columnActiveDividers = [];
                 for (let i = 0; i < dividers.length; i++) {
-                    if (dividers[i]!.classList.contains('active')) {
-                        activeDividers.push(i);
+                    if (dividers[i]!.classList.contains('divider-active')) {
+                        dividerActiveDividers.push(i);
                     }
-                    if (dividers[i]!.classList.contains('visible')) {
-                        visibleDividers.push(i);
+                    if (dividers[i]!.classList.contains('column-active')) {
+                        columnActiveDividers.push(i);
                     }
                 }
                 document.dispatchEvent(mouseUpEvent); // clean up registered event handlers
 
-                expect(activeDividers.length).toEqual(1);
-                expect(activeDividers[0]).toEqual(value.dividerClickIndex);
-                expect(visibleDividers).toEqual(value.expectedVisibleIndexes);
+                expect(dividerActiveDividers.length).toEqual(1);
+                expect(dividerActiveDividers[0]).toEqual(value.dividerClickIndex);
+                expect(columnActiveDividers).toEqual(value.expectedColumnActiveDividerIndexes);
             });
         });
 
@@ -838,12 +838,12 @@ describe('Table Interactive Column Sizing', () => {
             });
             divider.dispatchEvent(mouseDownEvent);
             await waitForUpdatesAsync();
-            expect(divider.classList.contains('active')).toBeTruthy();
+            expect(divider.classList.contains('divider-active')).toBeTruthy();
 
             const mouseUpEvent = new MouseEvent('mouseup');
             document.dispatchEvent(mouseUpEvent);
             await waitForUpdatesAsync();
-            expect(divider.classList.contains('active')).toBeFalsy();
+            expect(divider.classList.contains('divider-active')).toBeFalsy();
         });
     });
 

--- a/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
@@ -750,35 +750,35 @@ describe('Table Interactive Column Sizing', () => {
     describe('active divider tests', () => {
         const dividerActiveTests = [
             {
-                name: 'click on first column right divider only results in one active divider',
+                name: 'click on first column right divider only results in one active and one visible divider',
                 dividerClickIndex: 0,
                 leftDividerClick: false,
-                expectedActiveIndexes: [0]
+                expectedVisibleIndexes: [0]
             },
             {
-                name: 'click on second column left divider results in two active dividers',
+                name: 'click on second column left divider results in one active and two visible dividers',
                 dividerClickIndex: 1,
-                expectedActiveIndexes: [1, 2]
+                expectedVisibleIndexes: [1, 2]
             },
             {
-                name: 'click on second column right divider results in two active dividers',
+                name: 'click on second column right divider results in one active and two visible dividers',
                 dividerClickIndex: 2,
-                expectedActiveIndexes: [1, 2]
+                expectedVisibleIndexes: [1, 2]
             },
             {
-                name: 'click on third column left divider results in two active dividers',
+                name: 'click on third column left divider results in one active and two visible dividers',
                 dividerClickIndex: 3,
-                expectedActiveIndexes: [3, 4]
+                expectedVisibleIndexes: [3, 4]
             },
             {
-                name: 'click on third column right divider results in two active dividers',
+                name: 'click on third column right divider results in one active and two visible dividers',
                 dividerClickIndex: 4,
-                expectedActiveIndexes: [3, 4]
+                expectedVisibleIndexes: [3, 4]
             },
             {
-                name: 'click on last column left divider only results in one active divider',
+                name: 'click on last column left divider only results in one active and one visible divider',
                 dividerClickIndex: 5,
-                expectedActiveIndexes: [5]
+                expectedVisibleIndexes: [5]
             }
         ] as const;
         parameterizeSpec(dividerActiveTests, (spec, name, value) => {
@@ -796,13 +796,20 @@ describe('Table Interactive Column Sizing', () => {
                 divider.dispatchEvent(mouseDownEvent);
                 await waitForUpdatesAsync();
                 const activeDividers = [];
+                const visibleDividers = [];
                 for (let i = 0; i < dividers.length; i++) {
                     if (dividers[i]!.classList.contains('active')) {
                         activeDividers.push(i);
                     }
+                    if (dividers[i]!.classList.contains('visible')) {
+                        visibleDividers.push(i);
+                    }
                 }
                 document.dispatchEvent(mouseUpEvent); // clean up registered event handlers
-                expect(activeDividers).toEqual(value.expectedActiveIndexes);
+
+                expect(activeDividers.length).toEqual(1);
+                expect(activeDividers[0]).toEqual(value.dividerClickIndex);
+                expect(visibleDividers).toEqual(value.expectedVisibleIndexes);
             });
         });
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #1880 

## 👩‍💻 Implementation

- A hovered column divider is now `borderHoverColor`
- The column divider that is being dragged is styled using the `active` class to be `borderHoverColor`
- The second column divider of the column being resized (assuming it exists) is styled using the `visible` class to be visible

## 🧪 Testing

- Manually tested in storybook
- Update unit tests that check for the correct CSS classes to be applied to dividers during a drag operation

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
