### PR TITLE
Pin playwright in jasmine-parameterized

### DIFF
--- a/change/@ni-jasmine-parameterized-5ea52984-eaf4-4d4f-958f-f44c22077ff2.json
+++ b/change/@ni-jasmine-parameterized-5ea52984-eaf4-4d4f-958f-f44c22077ff2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Align playwright version across packages",
+  "packageName": "@ni/jasmine-parameterized",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33836,7 +33836,7 @@
         "karma-jasmine": "^5.1.0",
         "karma-jasmine-html-reporter": "^2.0.0",
         "karma-spec-reporter": "^0.0.36",
-        "playwright": "^1.30.0",
+        "playwright": "1.40.0",
         "typescript": "~4.8.2"
       }
     },

--- a/packages/jasmine-parameterized/package.json
+++ b/packages/jasmine-parameterized/package.json
@@ -51,7 +51,7 @@
     "karma-jasmine": "^5.1.0",
     "karma-jasmine-html-reporter": "^2.0.0",
     "karma-spec-reporter": "^0.0.36",
-    "playwright": "^1.30.0",
+    "playwright": "1.40.0",
     "typescript": "~4.8.2"
   }
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The [renovate PR](https://github.com/ni/nimble/pull/1896) was trying to bump the playwright version in lock only mode even though it's locked. Believe it's because the jasmine-parameterize playwright version was not locked.

## 👩‍💻 Implementation

Locked the playwright version in jasmine-parameterized as well.

## 🧪 Testing

Relying on CI.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
