### PR TITLE
Enable github-actions updates on renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,14 +3,14 @@
   "extends": [
     "config:base"
   ],
-  "enabledManagers": ["npm", "nuget"],
+  "enabledManagers": ["npm", "nuget", "github-actions"],
   "rebaseWhen": "conflicted",
   "schedule": [
     "monthly"
   ],
   "packageRules": [
     {
-      "matchManagers": ["npm", "nuget"],
+      "matchManagers": ["npm", "nuget", "github-actions"],
       "enabled": false
     },
     {
@@ -23,6 +23,11 @@
     {
       "groupName": "nuget dependencies",
       "matchManagers": ["nuget"],
+      "enabled": true
+    },
+    {
+      "groupName": "github actions dependencies",
+      "matchManagers": ["github-actions"],
       "enabled": true
     }
   ]


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Enable the renovate [`github-actions`](https://docs.renovatebot.com/modules/manager/github-actions/) manager to update our action versions

## 👩‍💻 Implementation

Enabled in the renovate config following our current pattern of bundling the changes for the manager in a single PR.

## 🧪 Testing

Not sure how to test a PR update to the renovate config. Doing it live

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
