### PR TITLE
Fix storybook backgrounds in MDX

### DIFF
--- a/change/@ni-nimble-components-d2bcd216-9379-4164-aabb-5137f31fc546.json
+++ b/change/@ni-nimble-components-d2bcd216-9379-4164-aabb-5137f31fc546.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix sb mdx backgrounds",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/.storybook/preview.js
+++ b/packages/nimble-components/.storybook/preview.js
@@ -61,6 +61,33 @@ export const parameters = {
     }
 };
 
+const createOrUpdateBackgroundWorkaround = style => {
+    let styleElement = document.querySelector('.nimble-background-workaround');
+    if (!styleElement) {
+        styleElement = document.createElement('style');
+        styleElement.classList.add('nimble-background-workaround');
+        document.head.append(styleElement);
+    }
+    styleElement.innerHTML = style;
+};
+
+// Storybook background plugin does not support mdx
+// Workaround based on: https://github.com/storybookjs/storybook/issues/13323#issuecomment-876296801
+export default {
+    decorators: [
+        (story, context) => {
+            const defaultBackgroundColorKey = context?.parameters?.backgrounds?.default;
+            const defaultBackgroundColor = context?.parameters?.backgrounds?.values?.find(v => v.name === defaultBackgroundColorKey)?.value;
+            const currentBackgroundColor = context?.globals?.backgrounds?.value ?? defaultBackgroundColor;
+            const style = `.docs-story {
+                background-color: ${currentBackgroundColor}
+            }`;
+            createOrUpdateBackgroundWorkaround(style);
+            return story();
+        }
+    ]
+};
+
 // Storybook's default serialization of events includes the serialized event target. This can
 // be quite large, such as in a table with a lot of records. Therefore, the serialization depth
 // should be limited to avoid poor performance.


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Backgrounds don't work in the storybook mdx docs.

## 👩‍💻 Implementation

Apply the workaround tweaked for html stories discussed in the following issue: https://github.com/storybookjs/storybook/issues/13323#issuecomment-876296801

## 🧪 Testing

Checked on a couple pages that the canvas and docs views were working.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
