### PR TITLE
Create storybook page for link components

### DIFF
--- a/change/@ni-nimble-components-80f0d7d1-04a3-456f-85b8-c96cf8c59b93.json
+++ b/change/@ni-nimble-components-80f0d7d1-04a3-456f-85b8-c96cf8c59b93.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Create anchor patterns story",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/patterns/anchor/tests/anchor-patterns.mdx
+++ b/packages/nimble-components/src/patterns/anchor/tests/anchor-patterns.mdx
@@ -1,0 +1,22 @@
+import { Controls, Canvas, Meta, Title } from '@storybook/blocks';
+import * as anchorPatternStories from './anchor-patterns.stories';
+
+<Meta of={anchorPatternStories} />
+<Title of={anchorPatternStories} />
+
+Anchor components in nimble should behave like native anchors in a number of different ways that are difficult to unit test in an automated manner.
+Therefore, this story contains a native anchor element along with all of the nimble components that are anchors or contain anchors.
+The following behaviors should be true of the nimble components:
+
+-   Dragging the nimble component should behave like the native anchor
+-   CTRL + CLICK opens in a new tab
+-   Right clicking should open the link menu
+-   Focusing via tab should show the URL preview at the bottom of the browser window
+-   Hovering over the component should show the URL preview at the bottom of the browser window
+-   The hover state of the component and mouse pointer should match the area of the component that navigates when clicked (i.e. clicking the white space around the control should not navigate)
+-   Pressing ENTER or SPACE when focused should activate the link
+-   Pressing the MENU KEY on the keyboard should open the same link menu as a right click
+-   Copying the link through the right-click link menu should result in the expected string to be copied to the clipboard
+
+<Canvas of={anchorPatternStories.anchorPatterns} />
+<Controls of={anchorPatternStories.anchorPatterns} />

--- a/packages/nimble-components/src/patterns/anchor/tests/anchor-patterns.stories.ts
+++ b/packages/nimble-components/src/patterns/anchor/tests/anchor-patterns.stories.ts
@@ -1,0 +1,127 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import { html, ref } from '@microsoft/fast-element';
+import { createUserSelectedThemeStory } from '../../../utilities/tests/storybook';
+import { controlLabelFont, controlLabelFontColor, mediumPadding, standardPadding } from '../../../theme-provider/design-tokens';
+import { anchorTag } from '../../../anchor';
+import { anchorButtonTag } from '../../../anchor-button';
+import { anchorTabsTag } from '../../../anchor-tabs';
+import { anchorTabTag } from '../../../anchor-tab';
+import { breadcrumbTag } from '../../../breadcrumb';
+import { breadcrumbItemTag } from '../../../breadcrumb-item';
+import { RichTextViewer, richTextViewerTag } from '../../../rich-text/viewer';
+import { anchorTreeItemTag } from '../../../anchor-tree-item';
+import { treeViewTag } from '../../../tree-view';
+import { anchorMenuItemTag } from '../../../anchor-menu-item';
+import { menuTag } from '../../../menu';
+
+const hrefDescription = 'To disable the control, remove the `href` attribute.';
+
+interface AnchorPatternsArgs {
+    label: string;
+    href: string;
+    richTextViewerRef: RichTextViewer;
+    setRichTextViewerData: (args: AnchorPatternsArgs) => void;
+}
+
+const metadata: Meta<AnchorPatternsArgs> = {
+    title: 'Tests/Anchor Patterns',
+    parameters: {
+        actions: {}
+    },
+    // prettier-ignore
+    render: createUserSelectedThemeStory(html`
+        <style class='code-hide'>
+            .control-container {
+                margin: var(${standardPadding.cssCustomProperty});
+            }
+
+            .label {
+                font: var(${controlLabelFont.cssCustomProperty});
+                color: var(${controlLabelFontColor.cssCustomProperty});
+                margin-bottom: var(${mediumPadding.cssCustomProperty});
+            }
+        </style>
+        <div class="control-container">
+            <div class="label">Native anchor</div>
+            <a href="${x => x.href}">${x => x.label}</a>
+        </div>
+
+        <div class="control-container">
+            <div class="label">${anchorTag}</div>
+            <${anchorTag} href="${x => x.href}">${x => x.label}</${anchorTag}>
+        </div>
+
+        <div class="control-container">
+            <div class="label">${anchorButtonTag}</div>
+            <${anchorButtonTag} href="${x => x.href}">${x => x.label}</${anchorButtonTag}>
+        </div>
+
+        <div class="control-container">
+            <div class="label">${anchorTabsTag}</div>
+            <${anchorTabsTag}>
+                <${anchorTabTag} href="${x => x.href}">${x => x.label} - 1</${anchorTabTag}>
+                <${anchorTabTag} href="${x => x.href}">${x => x.label} - 2</${anchorTabTag}>
+            </${anchorTabsTag}>            
+        </div>
+
+        <div class="control-container">
+            <div class="label">${breadcrumbTag}</div>
+            <${breadcrumbTag}>
+                <${breadcrumbItemTag} href="${x => x.href}">${x => x.label}</${breadcrumbItemTag}>
+                <${breadcrumbItemTag}>Current page (no link)</${breadcrumbItemTag}>
+            </${breadcrumbTag}>
+        </div>
+
+        <div class="control-container">
+            <div class="label">${anchorTreeItemTag}</div>
+            <${treeViewTag}>
+                <${anchorTreeItemTag} href="${x => x.href}">${x => x.label}</${anchorTreeItemTag}>
+            </${treeViewTag}>
+        </div>
+
+        <div class="control-container">
+            <div class="label">${anchorMenuItemTag}</div>
+            <${menuTag}>
+                <${anchorMenuItemTag} href="${x => x.href}">${x => x.label}</${anchorMenuItemTag}>
+            </${menuTag}>
+        </div>
+
+        <div class="control-container">
+            <div class="label">${richTextViewerTag}</div>
+            <${richTextViewerTag} ${ref('richTextViewerRef')}
+                href="${x => x.href}"
+                data-unused="${x => x.setRichTextViewerData(x)}"
+            >
+                ${x => x.label}
+            </${richTextViewerTag}>
+        </div>
+    `),
+    argTypes: {
+        href: {
+            description: hrefDescription
+        },
+        richTextViewerRef: {
+            table: { disable: true }
+        },
+        setRichTextViewerData: {
+            table: { disable: true }
+        }
+    },
+    args: {
+        label: 'link',
+        href: 'https://nimble.ni.dev',
+        setRichTextViewerData: x => {
+            void (async () => {
+                // Safari workaround: the nimble-rich-text-viewer element instance is made at this point
+                // but doesn't seem to be upgraded to a custom element yet
+                await customElements.whenDefined('nimble-rich-text-viewer');
+                const data = `Absolute link: <${x.href}>`;
+                x.richTextViewerRef.markdown = data;
+            })();
+        },
+    }
+};
+
+export default metadata;
+
+export const anchorPatterns: StoryObj<AnchorPatternsArgs> = {};

--- a/packages/nimble-components/src/patterns/anchor/tests/anchor-patterns.stories.ts
+++ b/packages/nimble-components/src/patterns/anchor/tests/anchor-patterns.stories.ts
@@ -1,7 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { html, ref } from '@microsoft/fast-element';
 import { createUserSelectedThemeStory } from '../../../utilities/tests/storybook';
-import { controlLabelFont, controlLabelFontColor, mediumPadding, standardPadding } from '../../../theme-provider/design-tokens';
+import {
+    controlLabelFont,
+    controlLabelFontColor,
+    mediumPadding,
+    standardPadding
+} from '../../../theme-provider/design-tokens';
 import { anchorTag } from '../../../anchor';
 import { anchorButtonTag } from '../../../anchor-button';
 import { anchorTabsTag } from '../../../anchor-tabs';
@@ -118,7 +123,7 @@ const metadata: Meta<AnchorPatternsArgs> = {
                 const data = `Absolute link: <${x.href}>`;
                 x.richTextViewerRef.markdown = data;
             })();
-        },
+        }
     }
 };
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

There are a number of browser interactions that are expected to work in certain ways for link components that are difficult to test in an automated manner. Therefore, we decided that we should have a storybook page that contains all of nimble's link components next to a native anchor element to facilitate manual testing of link behaviors.
 
This is follow-on work from #1910, specifically [this comment](https://github.com/ni/nimble/pull/1910#discussion_r1518327840).

## 👩‍💻 Implementation

Create storybook page that includes the following elements:
- native anchor
- nimble-anchor
- nimble-anchor-button
- nimble-anchor-tabs
- nimble-breadcrumb
- nimble-anchor-tree-item
- nimble-anchor-menu-item
- nimble-rich-text-viewer

## 🧪 Testing

Manually verified that the storybook page rendered as expected.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
