### PR TITLE
Small change to design token naming scheme

### DIFF
--- a/change/@ni-nimble-components-6a977921-7b82-4c0c-936b-fb4e855c103e.json
+++ b/change/@ni-nimble-components-6a977921-7b82-4c0c-936b-fb4e855c103e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Small change to design token naming scheme",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/CONTRIBUTING.md
+++ b/packages/nimble-components/CONTRIBUTING.md
@@ -490,12 +490,13 @@ To modify the generated tokens, complete these steps:
 
 Public names for theme-aware tokens are specified in `src/theme-provider/design-token-names.ts`. Use the following structure when creating new tokens.
 
-`[element]-[part]-[state]-[token_type]`
+`[element]-[part]-[state]-[variant]-[token_type]`
 
 1. Where **element** is the type to which the token applies (e.g. 'application', 'body', or 'title-plus-1').
 2. Where **part** is the specific part of the element to which the token applies (e.g. 'border', 'background', or shadow).
-3. Where **state** is the more specific state descriptor (e.g. 'selected' or 'disabled'). Multiple states should be sorted alphabetically.
-4. Where **token_type** is the token category (e.g. 'color', 'font', 'font-color', 'height', 'width', or 'size').
+3. Where **state** is one or more of the following interaction states: 'active', 'disabled', 'hover', or 'selected'. Multiple states should be sorted alphabetically.
+4. Where **variant** is any other distinguishing descriptor (e.g. 'accent', 'primary, or 'large'). Multiple variants should be sorted alphabetically.
+5. Where **token_type** is the token category (e.g. 'color', 'font', 'font-color', 'height', 'width', or 'size').
 
 ### Size ramp
 

--- a/packages/nimble-components/CONTRIBUTING.md
+++ b/packages/nimble-components/CONTRIBUTING.md
@@ -490,12 +490,12 @@ To modify the generated tokens, complete these steps:
 
 Public names for theme-aware tokens are specified in `src/theme-provider/design-token-names.ts`. Use the following structure when creating new tokens.
 
-`[element]-[part]-[state]-[variant]-[token_type]`
+`[element]-[part]-[interaction_state]-[other_state]-[token_type]`
 
 1. Where **element** is the type to which the token applies (e.g. 'application', 'body', or 'title-plus-1').
 2. Where **part** is the specific part of the element to which the token applies (e.g. 'border', 'background', or shadow).
-3. Where **state** is one or more of the following interaction states: 'active', 'disabled', 'hover', or 'selected'. Multiple states should be sorted alphabetically.
-4. Where **variant** is any other distinguishing descriptor (e.g. 'accent', 'primary, or 'large'). Multiple variants should be sorted alphabetically.
+3. Where **interaction_state** is one or more interaction states (e.g. 'active', 'disabled', 'hover', or 'selected'). Multiple values should be sorted alphabetically.
+4. Where **other_state** is any other distinguishing state (e.g. 'accent', 'primary, or 'large'). Multiple values should be sorted alphabetically.
 5. Where **token_type** is the token category (e.g. 'color', 'font', 'font-color', 'height', 'width', or 'size').
 
 ### Size ramp

--- a/packages/nimble-components/CONTRIBUTING.md
+++ b/packages/nimble-components/CONTRIBUTING.md
@@ -490,12 +490,12 @@ To modify the generated tokens, complete these steps:
 
 Public names for theme-aware tokens are specified in `src/theme-provider/design-token-names.ts`. Use the following structure when creating new tokens.
 
-`[element]-[part]-[interaction_state]-[other_state]-[token_type]`
+`[element]-[part]-[interaction_states]-[remaining_states]-[token_type]`
 
 1. Where **element** is the type to which the token applies (e.g. 'application', 'body', or 'title-plus-1').
 2. Where **part** is the specific part of the element to which the token applies (e.g. 'border', 'background', or shadow).
-3. Where **interaction_state** is one or more interaction states (e.g. 'active', 'disabled', 'hover', or 'selected'). Multiple values should be sorted alphabetically.
-4. Where **other_state** is any other distinguishing state (e.g. 'accent', 'primary, or 'large'). Multiple values should be sorted alphabetically.
+3. Where **interaction_states** is one or more interaction states (e.g. 'active', 'disabled', 'hover', or 'selected'). Multiple values should be sorted alphabetically.
+4. Where **remaining_states** the remaining, non-interaction states (e.g. 'accent', 'primary, or 'large'). Multiple values should be sorted alphabetically.
 5. Where **token_type** is the token category (e.g. 'color', 'font', 'font-color', 'height', 'width', or 'size').
 
 ### Size ramp


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

I encountered a couple design tokens with names that felt inconsistent:
`buttonFillActivePrimaryColor`
`buttonFillAccentActiveColor`

It seemed like the appearance variant ("accent" or "primary") should be in the same relative position within the name, but our naming convention dictated these names instead.

## 👩‍💻 Implementation

Treat common state descriptors ("active", "disabled", "hover", and "selected") as a separate category of name segment than other distinguishing descriptors (like "accent" and "primary"). So instead of our old structure:

`[element]-[part]-[state]-[token_type]`

we now have:

`[element]-[part]-[state]-[variant]-[token_type]`

Luckily, the only existing token that violates this updated naming scheme is `buttonFillAccentActiveColor` (which should instead be `buttonFillActiveAccentColor`) and that token is being removed in [another PR](https://github.com/ni/nimble/pull/1934).

## 🧪 Testing

N/A

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
