### PR TITLE
Combobox registerOption reversion to address Angular bug

### DIFF
--- a/change/@ni-nimble-components-54ec9080-33bb-47a6-a37d-d926c42de859.json
+++ b/change/@ni-nimble-components-54ec9080-33bb-47a6-a37d-d926c42de859.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove ListOptionOwner from Combobox to address issue found in Angular",
+  "packageName": "@ni/nimble-components",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/combobox/index.ts
+++ b/packages/nimble-components/src/combobox/index.ts
@@ -17,14 +17,10 @@ import { iconExclamationMarkTag } from '../icons/exclamation-mark';
 
 import { styles } from './styles';
 import type { ErrorPattern } from '../patterns/error/types';
-import type {
-    DropdownPattern,
-    ListOptionOwner
-} from '../patterns/dropdown/types';
+import type { DropdownPattern } from '../patterns/dropdown/types';
 import { DropdownAppearance } from '../patterns/dropdown/types';
 import type { AnchoredRegion } from '../anchored-region';
 import { template } from './template';
-import type { ListOption } from '../list-option';
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/nimble-components/src/combobox/index.ts
+++ b/packages/nimble-components/src/combobox/index.ts
@@ -37,7 +37,7 @@ declare global {
  */
 export class Combobox
     extends FoundationCombobox
-    implements DropdownPattern, ErrorPattern, ListOptionOwner {
+    implements DropdownPattern, ErrorPattern {
     @attr
     public appearance: DropdownAppearance = DropdownAppearance.underline;
 
@@ -209,23 +209,6 @@ export class Combobox
         this.open = false;
         this.emitChangeIfValueUpdated();
         return returnValue;
-    }
-
-    /**
-     * @internal
-     */
-    public registerOption(option: ListOption): void {
-        if (this.options.includes(option)) {
-            return;
-        }
-
-        // Adding an option to the end, ultimately, isn't the correct
-        // thing to do, as this will mean the option's index in the options,
-        // at least temporarily, does not match the DOM order. However, it
-        // is expected that a successive run of `slottedOptionsChanged` will
-        // correct this order issue. See 'https://github.com/ni/nimble/issues/1915'
-        // for more info.
-        this.options.push(option);
     }
 
     protected override focusAndScrollOptionIntoView(): void {

--- a/packages/nimble-components/src/combobox/tests/combobox.spec.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox.spec.ts
@@ -127,33 +127,6 @@ describe('Combobox', () => {
         await disconnect();
     });
 
-    it('option added directly to DOM synchronously registers with Combobox', async () => {
-        const { element, connect, disconnect } = await setup();
-        await connect();
-        element.selectedIndex = 0;
-        await waitForUpdatesAsync();
-        const newOption = new ListOption('foo', 'foo');
-        const registerOptionSpy = spyOn(
-            element,
-            'registerOption'
-        ).and.callThrough();
-        registerOptionSpy.calls.reset();
-        element.insertBefore(newOption, element.options[0]!);
-
-        expect(registerOptionSpy.calls.count()).toBe(1);
-        expect(element.options).toContain(newOption);
-
-        // While the option is registered synchronously as shown above,
-        // properties like selectedIndex will only be correct asynchronously
-        // See https://github.com/ni/nimble/issues/1915
-        expect(element.selectedIndex).toBe(0);
-        await waitForUpdatesAsync();
-        // This assertion shows that after 'slottedOptionsChanged' runs, the
-        // 'selectedIndex' state has been corrected to expected DOM order.
-        expect(element.selectedIndex).toBe(1);
-        await disconnect();
-    });
-
     const ariaTestData: {
         attrName: string,
         propSetter: (x: Combobox, value: string) => void

--- a/packages/nimble-components/src/combobox/tests/combobox.spec.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox.spec.ts
@@ -9,7 +9,7 @@ import {
     waitAnimationFrame
 } from '../../utilities/tests/component';
 import { checkFullyInViewport } from '../../utilities/tests/intersection-observer';
-import { ListOption, listOptionTag } from '../../list-option';
+import { listOptionTag } from '../../list-option';
 
 async function setup(
     position?: string,


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

[AzDO bug 'Nimble combo box | Issue in showing list options'](https://ni.visualstudio.com/DevCentral/_workitems/edit/2687002)

## 👩‍💻 Implementation

Simple reversion of problem code. I've also created a [tech debt item](https://github.com/ni/nimble/issues/1948) to track the work needed to ultimately re-align the `Combobox` and `Select` implementations.

## 🧪 Testing

Just removing the related test.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
