### PR TITLE
Fix sizing test in WebKit

### DIFF
--- a/change/@ni-nimble-components-f0730b00-2a69-4d06-8241-d97c34bf98b1.json
+++ b/change/@ni-nimble-components-f0730b00-2a69-4d06-8241-d97c34bf98b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix column sizing test to pass in webkit",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
@@ -495,16 +495,15 @@ describe('Table Interactive Column Sizing', () => {
             expect(pageObject.isHorizontalScrollbarVisible()).toBeTrue();
         });
 
-        // WebKit skipped, see https://github.com/ni/nimble/issues/1939
-        it('sizing table with a horizontal scrollbar does not change column widths until sized beyond current column pixel widths #SkipWebkit', async () => {
-            // create horizontal scrollbar with total column width of 450
-            pageObject.dragSizeColumnByRightDivider(2, [100]);
+        it('sizing table with a horizontal scrollbar does not change column widths until sized beyond current column pixel widths', async () => {
+            // create horizontal scrollbar with total column width of 500
+            pageObject.dragSizeColumnByRightDivider(2, [150]);
             // size table below threshhold of total column widths
             await pageObject.sizeTableToGivenRowWidth(425, element);
-            expect(pageObject.getTotalCellRenderedWidth()).toBe(450);
-            // size table 50 pixels beyond total column widths
-            await pageObject.sizeTableToGivenRowWidth(500, element);
             expect(pageObject.getTotalCellRenderedWidth()).toBe(500);
+            // size table 100 pixels beyond total column widths
+            await pageObject.sizeTableToGivenRowWidth(600, element);
+            expect(pageObject.getTotalCellRenderedWidth()).toBe(600);
             expect(pageObject.isHorizontalScrollbarVisible()).toBeFalse();
         });
 

--- a/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
@@ -496,7 +496,10 @@ describe('Table Interactive Column Sizing', () => {
         });
 
         it('sizing table with a horizontal scrollbar does not change column widths until sized beyond current column pixel widths', async () => {
-            // create horizontal scrollbar with total column width of 500
+            // Create a horizontal scrollbar with a total column width of 500. This updates the columns'
+            // current fractional widths to 0.8, 0.8, 2, and 0.4, which keeps the columns widths as
+            // integers when the table is resized later in the test. Otherwise, different browsers
+            // may have slightly different rounding behaviors.
             pageObject.dragSizeColumnByRightDivider(2, [150]);
             // size table below threshhold of total column widths
             await pageObject.sizeTableToGivenRowWidth(425, element);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #1939 

## 👩‍💻 Implementation

I updated the test to use sizes that cause the columns to be whole numbers to avoid rounding precision issues as was previously seen. Additionally, the fractional widths now compute to values without repeating decimals, which contributes to the final widths being more consistent across browsers.

## 🧪 Testing

Ran `npm run test-chrome && npm run test-firefox && npm run test-webkit` with the test at hand focused and verified that the test passes in all three browsers

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
