### PR TITLE
Fix table scroll tests on WebKit

### DIFF
--- a/change/@ni-nimble-components-e3b02c33-dd73-4a99-824b-cb0b19f706bb.json
+++ b/change/@ni-nimble-components-e3b02c33-dd73-4a99-824b-cb0b19f706bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix table scrolling test on WebKit",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/testing/table.pageobject.ts
+++ b/packages/nimble-components/src/table/testing/table.pageobject.ts
@@ -357,7 +357,7 @@ export class TablePageObject<T extends TableRecord> {
 
     public async scrollToLastRowAsync(): Promise<void> {
         const scrollElement = this.tableElement.viewport;
-        scrollElement.scrollTop = scrollElement.scrollHeight;
+        scrollElement.scroll({ top: scrollElement.scrollHeight });
         await waitForUpdatesAsync();
     }
 

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -677,8 +677,7 @@ describe('Table', () => {
                 verifyRenderedData(dataSubsetAtEnd);
             });
 
-            // WebKit skipped, see https://github.com/ni/nimble/issues/1942
-            it('and calls focusedRecycleCallback on focused cell views when a scroll happens #SkipWebkit', async () => {
+            it('and calls focusedRecycleCallback on focused cell views when a scroll happens', async () => {
                 const focusableColumn = document.createElement(
                     focusableColumnName
                 ) as TestFocusableTableColumn;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #1942 

## 👩‍💻 Implementation

WebKit doesn't appear to fire the `scroll` event when a scroll done by setting `scrollTop` on an element. Therefore, I've updated the page object to scroll using the `scroll()` function, which does cause the event to be fired. As a result, the table's virtualizer correctly detects the change and the tests pass.

## 🧪 Testing

Ran all the table tests in webkit locally and on the pipeline to verify they pass.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
