### PR TITLE
Angular column placeholder

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/table-column/anchor/nimble-table-column-anchor.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/anchor/nimble-table-column-anchor.directive.ts
@@ -31,6 +31,14 @@ export class NimbleTableColumnAnchorDirective extends NimbleTableColumnBaseDirec
         this.renderer.setProperty(this.elementRef.nativeElement, 'hrefFieldName', value);
     }
 
+    public get placeholder(): string | undefined {
+        return this.elementRef.nativeElement.placeholder;
+    }
+
+    @Input() public set placeholder(value: string | undefined) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'placeholder', value);
+    }
+
     public get appearance(): AnchorAppearance {
         return this.elementRef.nativeElement.appearance;
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/anchor/tests/nimble-table-column-anchor.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/anchor/tests/nimble-table-column-anchor.directive.spec.ts
@@ -160,6 +160,11 @@ describe('Nimble anchor table column', () => {
             expect(directive.groupingDisabled).toBeFalse();
             expect(nativeElement.groupingDisabled).toBeFalse();
         });
+
+        it('has expected defaults for placeholder', () => {
+            expect(directive.placeholder).toBeUndefined();
+            expect(nativeElement.placeholder).toBeUndefined();
+        });
     });
 
     describe('with template string values', () => {
@@ -187,6 +192,7 @@ describe('Nimble anchor table column', () => {
                     min-pixel-width="40"
                     group-index="0"
                     grouping-disabled
+                    placeholder="Custom placeholder"
                     >
                 </nimble-table-column-anchor>
             `
@@ -315,6 +321,11 @@ describe('Nimble anchor table column', () => {
             expect(directive.groupingDisabled).toBeTrue();
             expect(nativeElement.groupingDisabled).toBeTrue();
         });
+
+        it('will use template string values for placeholder', () => {
+            expect(directive.placeholder).toBe('Custom placeholder');
+            expect(nativeElement.placeholder).toBe('Custom placeholder');
+        });
     });
 
     describe('with property bound values', () => {
@@ -342,6 +353,7 @@ describe('Nimble anchor table column', () => {
                     [min-pixel-width]="minPixelWidth"
                     [group-index]="groupIndex"
                     [grouping-disabled]="groupingDisabled"
+                    [placeholder]="placeholder"
                     >
                     </nimble-table-column-anchor>
             `
@@ -370,6 +382,7 @@ describe('Nimble anchor table column', () => {
             public minPixelWidth: number | null = 40;
             public groupIndex: number | null = 0;
             public groupingDisabled = false;
+            public placeholder = 'Custom placeholder';
         }
 
         let fixture: ComponentFixture<TestHostComponent>;
@@ -661,6 +674,17 @@ describe('Nimble anchor table column', () => {
             expect(directive.groupingDisabled).toBeTrue();
             expect(nativeElement.groupingDisabled).toBeTrue();
         });
+
+        it('can be configured with property binding for placeholder', () => {
+            expect(directive.placeholder).toBe('Custom placeholder');
+            expect(nativeElement.placeholder).toBe('Custom placeholder');
+
+            fixture.componentInstance.placeholder = 'Updated placeholder';
+            fixture.detectChanges();
+
+            expect(directive.placeholder).toBe('Updated placeholder');
+            expect(nativeElement.placeholder).toBe('Updated placeholder');
+        });
     });
 
     describe('with attribute bound values', () => {
@@ -688,6 +712,7 @@ describe('Nimble anchor table column', () => {
                     [attr.min-pixel-width]="minPixelWidth"
                     [attr.group-index]="groupIndex"
                     [attr.grouping-disabled]="groupingDisabled"
+                    [attr.placeholder]="placeholder"
                     >
                 </nimble-table-column-anchor>
             `
@@ -716,6 +741,7 @@ describe('Nimble anchor table column', () => {
             public minPixelWidth: number | null = 40;
             public groupIndex: number | null = 0;
             public groupingDisabled = false;
+            public placeholder = 'Custom placeholder';
         }
 
         let fixture: ComponentFixture<TestHostComponent>;
@@ -1006,6 +1032,17 @@ describe('Nimble anchor table column', () => {
 
             expect(directive.groupingDisabled).toBe(true);
             expect(nativeElement.groupingDisabled).toBe(true);
+        });
+
+        it('can be configured with attribute binding for placeholder', () => {
+            expect(directive.placeholder).toBe('Custom placeholder');
+            expect(nativeElement.placeholder).toBe('Custom placeholder');
+
+            fixture.componentInstance.placeholder = 'Updated placeholder';
+            fixture.detectChanges();
+
+            expect(directive.placeholder).toBe('Updated placeholder');
+            expect(nativeElement.placeholder).toBe('Updated placeholder');
         });
     });
 });

--- a/angular-workspace/projects/ni/nimble-angular/table-column/date-text/nimble-table-column-date-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/date-text/nimble-table-column-date-text.directive.ts
@@ -55,6 +55,14 @@ export class NimbleTableColumnDateTextDirective extends NimbleTableColumnBaseDir
         this.renderer.setProperty(this.elementRef.nativeElement, 'fieldName', value);
     }
 
+    public get placeholder(): string | undefined {
+        return this.elementRef.nativeElement.placeholder;
+    }
+
+    @Input() public set placeholder(value: string | undefined) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'placeholder', value);
+    }
+
     public get format(): DateTextFormat {
         return this.elementRef.nativeElement.format;
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/date-text/tests/nimble-table-column-date-text.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/date-text/tests/nimble-table-column-date-text.directive.spec.ts
@@ -115,6 +115,7 @@ describe('NimbleTableColumnDateText', () => {
                         custom-date-style="medium"
                         custom-time-style="full"
                         custom-hour-cycle="h23"
+                        placeholder="Custom placeholder"
                     ></nimble-table-column-date-text>
                 </nimble-table>
             `
@@ -293,6 +294,11 @@ describe('NimbleTableColumnDateText', () => {
             expect(directive.customHourCycle).toBe('h23');
             expect(nativeElement.customHourCycle).toBe('h23');
         });
+
+        it('will use template string values for placeholder', () => {
+            expect(directive.placeholder).toBe('Custom placeholder');
+            expect(nativeElement.placeholder).toBe('Custom placeholder');
+        });
     });
 
     describe('with property bound values', () => {
@@ -332,6 +338,7 @@ describe('NimbleTableColumnDateText', () => {
                         [custom-date-style]="customDateStyle"
                         [custom-time-style]="customTimeStyle"
                         [custom-hour-cycle]="customHourCycle"
+                        [placeholder]="placeholder"
                     ></nimble-table-column-date-text>
                 </nimble-table>
             `
@@ -370,6 +377,7 @@ describe('NimbleTableColumnDateText', () => {
             public customDateStyle: DateStyle = 'medium';
             public customTimeStyle: TimeStyle = 'full';
             public customHourCycle: HourCycleFormat = 'h23';
+            public placeholder = 'Custom placeholder';
         }
 
         let fixture: ComponentFixture<TestHostComponent>;
@@ -980,6 +988,17 @@ describe('NimbleTableColumnDateText', () => {
             expect(directive.customHourCycle).toBeUndefined();
             expect(nativeElement.customHourCycle).toBeUndefined();
         });
+
+        it('can be configured with property binding for placeholder', () => {
+            expect(directive.placeholder).toBe('Custom placeholder');
+            expect(nativeElement.placeholder).toBe('Custom placeholder');
+
+            fixture.componentInstance.placeholder = 'Updated placeholder';
+            fixture.detectChanges();
+
+            expect(directive.placeholder).toBe('Updated placeholder');
+            expect(nativeElement.placeholder).toBe('Updated placeholder');
+        });
     });
 
     describe('with attribute bound values', () => {
@@ -1019,6 +1038,7 @@ describe('NimbleTableColumnDateText', () => {
                         [attr.custom-date-style]="customDateStyle"
                         [attr.custom-time-style]="customTimeStyle"
                         [attr.custom-hour-cycle]="customHourCycle"
+                        [attr.placeholder]="placeholder"
                     ></nimble-table-column-date-text>
                 </nimble-table>
             `
@@ -1057,6 +1077,7 @@ describe('NimbleTableColumnDateText', () => {
             public customDateStyle: DateStyle = 'medium';
             public customTimeStyle: TimeStyle = 'full';
             public customHourCycle: HourCycleFormat = 'h23';
+            public placeholder = 'Custom placeholder';
         }
 
         let fixture: ComponentFixture<TestHostComponent>;
@@ -1666,6 +1687,17 @@ describe('NimbleTableColumnDateText', () => {
 
             expect(directive.customHourCycle).toBeNull();
             expect(nativeElement.customHourCycle).toBeNull();
+        });
+
+        it('can be configured with attribute binding for placeholder', () => {
+            expect(directive.placeholder).toBe('Custom placeholder');
+            expect(nativeElement.placeholder).toBe('Custom placeholder');
+
+            fixture.componentInstance.placeholder = 'Updated placeholder';
+            fixture.detectChanges();
+
+            expect(directive.placeholder).toBe('Updated placeholder');
+            expect(nativeElement.placeholder).toBe('Updated placeholder');
         });
     });
 });

--- a/angular-workspace/projects/ni/nimble-angular/table-column/duration-text/nimble-table-column-duration-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/duration-text/nimble-table-column-duration-text.directive.ts
@@ -21,6 +21,14 @@ export class NimbleTableColumnDurationTextDirective extends NimbleTableColumnBas
         this.renderer.setProperty(this.elementRef.nativeElement, 'fieldName', value);
     }
 
+    public get placeholder(): string | undefined {
+        return this.elementRef.nativeElement.placeholder;
+    }
+
+    @Input() public set placeholder(value: string | undefined) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'placeholder', value);
+    }
+
     public get fractionalWidth(): number | null | undefined {
         return this.elementRef.nativeElement.fractionalWidth;
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/duration-text/tests/nimble-table-column-duration-text.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/duration-text/tests/nimble-table-column-duration-text.directive.spec.ts
@@ -35,6 +35,7 @@ describe('NimbleTableColumnDurationText', () => {
                         sort-index="0"
                         group-index="0"
                         grouping-disabled
+                        placeholder="Custom placeholder"
                     ></nimble-table-column-duration-text>
                 </nimble-table>
             `
@@ -113,6 +114,11 @@ describe('NimbleTableColumnDurationText', () => {
             expect(directive.groupingDisabled).toBeTrue();
             expect(nativeElement.groupingDisabled).toBeTrue();
         });
+
+        it('will use template string values for placeholder', () => {
+            expect(directive.placeholder).toBe('Custom placeholder');
+            expect(nativeElement.placeholder).toBe('Custom placeholder');
+        });
     });
 
     describe('with property bound values', () => {
@@ -132,6 +138,7 @@ describe('NimbleTableColumnDurationText', () => {
                         [sort-index]="sortIndex"
                         [group-index]="groupIndex"
                         [grouping-disabled]="groupingDisabled"
+                        [placeholder]="placeholder"
                     ></nimble-table-column-duration-text>
                 </nimble-table>
             `
@@ -150,6 +157,7 @@ describe('NimbleTableColumnDurationText', () => {
             public sortIndex: number | null = 0;
             public groupIndex: number | null = 0;
             public groupingDisabled = false;
+            public placeholder = 'Custom placeholder';
         }
 
         let fixture: ComponentFixture<TestHostComponent>;
@@ -331,6 +339,17 @@ describe('NimbleTableColumnDurationText', () => {
             expect(directive.groupingDisabled).toBeTrue();
             expect(nativeElement.groupingDisabled).toBeTrue();
         });
+
+        it('can be configured with property binding for placeholder', () => {
+            expect(directive.placeholder).toBe('Custom placeholder');
+            expect(nativeElement.placeholder).toBe('Custom placeholder');
+
+            fixture.componentInstance.placeholder = 'Updated placeholder';
+            fixture.detectChanges();
+
+            expect(directive.placeholder).toBe('Updated placeholder');
+            expect(nativeElement.placeholder).toBe('Updated placeholder');
+        });
     });
 
     describe('with attribute bound values', () => {
@@ -350,6 +369,7 @@ describe('NimbleTableColumnDurationText', () => {
                         [attr.sort-index]="sortIndex"
                         [attr.group-index]="groupIndex"
                         [attr.grouping-disabled]="groupingDisabled"
+                        [attr.placeholder]="placeholder"
                     ></nimble-table-column-duration-text>
                 </nimble-table>
             `
@@ -368,6 +388,7 @@ describe('NimbleTableColumnDurationText', () => {
             public sortIndex: number | null = 0;
             public groupIndex: number | null = 0;
             public groupingDisabled = false;
+            public placeholder = 'Custom placeholder';
         }
 
         let fixture: ComponentFixture<TestHostComponent>;
@@ -548,6 +569,17 @@ describe('NimbleTableColumnDurationText', () => {
 
             expect(directive.groupingDisabled).toBe(true);
             expect(nativeElement.groupingDisabled).toBe(true);
+        });
+
+        it('can be configured with attribute binding for placeholder', () => {
+            expect(directive.placeholder).toBe('Custom placeholder');
+            expect(nativeElement.placeholder).toBe('Custom placeholder');
+
+            fixture.componentInstance.placeholder = 'Updated placeholder';
+            fixture.detectChanges();
+
+            expect(directive.placeholder).toBe('Updated placeholder');
+            expect(nativeElement.placeholder).toBe('Updated placeholder');
         });
     });
 });

--- a/angular-workspace/projects/ni/nimble-angular/table-column/number-text/nimble-table-column-number-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/number-text/nimble-table-column-number-text.directive.ts
@@ -22,6 +22,14 @@ export class NimbleTableColumnNumberTextDirective extends NimbleTableColumnBaseD
         this.renderer.setProperty(this.elementRef.nativeElement, 'fieldName', value);
     }
 
+    public get placeholder(): string | undefined {
+        return this.elementRef.nativeElement.placeholder;
+    }
+
+    @Input() public set placeholder(value: string | undefined) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'placeholder', value);
+    }
+
     public get format(): NumberTextFormat {
         return this.elementRef.nativeElement.format;
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/number-text/tests/nimble-table-column-number-text.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/number-text/tests/nimble-table-column-number-text.directive.spec.ts
@@ -79,6 +79,7 @@ describe('NimbleTableColumnNumberText', () => {
                         decimal-digits="6"
                         decimal-maximum-digits="7"
                         alignment="${NumberTextAlignment.left}"
+                        placeholder="Custom placeholder"
                     ></nimble-table-column-number-text>
                 </nimble-table>
             `
@@ -177,6 +178,11 @@ describe('NimbleTableColumnNumberText', () => {
             expect(directive.decimalMaximumDigits).toBe(7);
             expect(nativeElement.decimalMaximumDigits).toBe(7);
         });
+
+        it('will use template string values for placeholder', () => {
+            expect(directive.placeholder).toBe('Custom placeholder');
+            expect(nativeElement.placeholder).toBe('Custom placeholder');
+        });
     });
 
     describe('with property bound values', () => {
@@ -200,6 +206,7 @@ describe('NimbleTableColumnNumberText', () => {
                         [decimal-digits]="decimalDigits"
                         [decimal-maximum-digits]="decimalMaximumDigits"
                         [alignment]="alignment"
+                        [placeholder]="placeholder"
                     ></nimble-table-column-number-text>
                 </nimble-table>
             `
@@ -222,6 +229,7 @@ describe('NimbleTableColumnNumberText', () => {
             public decimalDigits: number | null = 9;
             public decimalMaximumDigits: number | null = 10;
             public alignment: NumberTextAlignment = NumberTextAlignment.left;
+            public placeholder = 'Custom placeholder';
         }
 
         let fixture: ComponentFixture<TestHostComponent>;
@@ -469,6 +477,17 @@ describe('NimbleTableColumnNumberText', () => {
             expect(directive.decimalMaximumDigits).toBeNull();
             expect(nativeElement.decimalMaximumDigits).toBeNull();
         });
+
+        it('can be configured with property binding for placeholder', () => {
+            expect(directive.placeholder).toBe('Custom placeholder');
+            expect(nativeElement.placeholder).toBe('Custom placeholder');
+
+            fixture.componentInstance.placeholder = 'Updated placeholder';
+            fixture.detectChanges();
+
+            expect(directive.placeholder).toBe('Updated placeholder');
+            expect(nativeElement.placeholder).toBe('Updated placeholder');
+        });
     });
 
     describe('with attribute bound values', () => {
@@ -492,6 +511,7 @@ describe('NimbleTableColumnNumberText', () => {
                         [attr.decimal-digits]="decimalDigits"
                         [attr.decimal-maximum-digits]="decimalMaximumDigits"
                         [attr.alignment]="alignment"
+                        [attr.placeholder]="placeholder"
                     ></nimble-table-column-number-text>
                 </nimble-table>
             `
@@ -514,6 +534,7 @@ describe('NimbleTableColumnNumberText', () => {
             public decimalDigits: number | null = 9;
             public decimalMaximumDigits: number | null = 10;
             public alignment: NumberTextAlignment = NumberTextAlignment.left;
+            public placeholder = 'Custom placeholder';
         }
 
         let fixture: ComponentFixture<TestHostComponent>;
@@ -743,7 +764,7 @@ describe('NimbleTableColumnNumberText', () => {
             expect(nativeElement.decimalDigits).toBeNull();
         });
 
-        it('can be configured with property binding for decimalMaximumDigits', () => {
+        it('can be configured with attribute binding for decimalMaximumDigits', () => {
             expect(directive.decimalMaximumDigits).toBe(10);
             expect(nativeElement.decimalMaximumDigits).toBe(10);
 
@@ -754,7 +775,7 @@ describe('NimbleTableColumnNumberText', () => {
             expect(nativeElement.decimalMaximumDigits).toBe(7);
         });
 
-        it('can be configured with property binding for decimalMaximumDigits updated to null', () => {
+        it('can be configured with attribute binding for decimalMaximumDigits updated to null', () => {
             expect(directive.decimalMaximumDigits).toBe(10);
             expect(nativeElement.decimalMaximumDigits).toBe(10);
 
@@ -763,6 +784,17 @@ describe('NimbleTableColumnNumberText', () => {
 
             expect(directive.decimalMaximumDigits).toBeNull();
             expect(nativeElement.decimalMaximumDigits).toBeNull();
+        });
+
+        it('can be configured with attribute binding for placeholder', () => {
+            expect(directive.placeholder).toBe('Custom placeholder');
+            expect(nativeElement.placeholder).toBe('Custom placeholder');
+
+            fixture.componentInstance.placeholder = 'Updated placeholder';
+            fixture.detectChanges();
+
+            expect(directive.placeholder).toBe('Updated placeholder');
+            expect(nativeElement.placeholder).toBe('Updated placeholder');
         });
     });
 });

--- a/angular-workspace/projects/ni/nimble-angular/table-column/text/nimble-table-column-text.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/text/nimble-table-column-text.directive.ts
@@ -21,6 +21,14 @@ export class NimbleTableColumnTextDirective extends NimbleTableColumnBaseDirecti
         this.renderer.setProperty(this.elementRef.nativeElement, 'fieldName', value);
     }
 
+    public get placeholder(): string | undefined {
+        return this.elementRef.nativeElement.placeholder;
+    }
+
+    @Input() public set placeholder(value: string | undefined) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'placeholder', value);
+    }
+
     public get fractionalWidth(): number | null | undefined {
         return this.elementRef.nativeElement.fractionalWidth;
     }

--- a/angular-workspace/projects/ni/nimble-angular/table-column/text/tests/nimble-table-column-text.directive.spec.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/text/tests/nimble-table-column-text.directive.spec.ts
@@ -35,6 +35,7 @@ describe('NimbleTableColumnText', () => {
                         sort-index="0"
                         group-index="0"
                         grouping-disabled
+                        placeholder="Custom placeholder"
                     ></nimble-table-column-text>
                 </nimble-table>
             `
@@ -113,6 +114,11 @@ describe('NimbleTableColumnText', () => {
             expect(directive.groupingDisabled).toBeTrue();
             expect(nativeElement.groupingDisabled).toBeTrue();
         });
+
+        it('will use template string values for placeholder', () => {
+            expect(directive.placeholder).toBe('Custom placeholder');
+            expect(nativeElement.placeholder).toBe('Custom placeholder');
+        });
     });
 
     describe('with property bound values', () => {
@@ -132,6 +138,7 @@ describe('NimbleTableColumnText', () => {
                         [sort-index]="sortIndex"
                         [group-index]="groupIndex"
                         [grouping-disabled]="groupingDisabled"
+                        [placeholder]="placeholder"
                     ></nimble-table-column-text>
                 </nimble-table>
             `
@@ -150,6 +157,7 @@ describe('NimbleTableColumnText', () => {
             public sortIndex: number | null = 0;
             public groupIndex: number | null = 0;
             public groupingDisabled = false;
+            public placeholder = 'Custom placeholder';
         }
 
         let fixture: ComponentFixture<TestHostComponent>;
@@ -331,6 +339,17 @@ describe('NimbleTableColumnText', () => {
             expect(directive.groupingDisabled).toBeTrue();
             expect(nativeElement.groupingDisabled).toBeTrue();
         });
+
+        it('can be configured with property binding for placeholder', () => {
+            expect(directive.placeholder).toBe('Custom placeholder');
+            expect(nativeElement.placeholder).toBe('Custom placeholder');
+
+            fixture.componentInstance.placeholder = 'Updated placeholder';
+            fixture.detectChanges();
+
+            expect(directive.placeholder).toBe('Updated placeholder');
+            expect(nativeElement.placeholder).toBe('Updated placeholder');
+        });
     });
 
     describe('with attribute bound values', () => {
@@ -350,6 +369,7 @@ describe('NimbleTableColumnText', () => {
                         [attr.sort-index]="sortIndex"
                         [attr.group-index]="groupIndex"
                         [attr.grouping-disabled]="groupingDisabled"
+                        [attr.placeholder]="placeholder"
                     ></nimble-table-column-text>
                 </nimble-table>
             `
@@ -368,6 +388,7 @@ describe('NimbleTableColumnText', () => {
             public sortIndex: number | null = 0;
             public groupIndex: number | null = 0;
             public groupingDisabled = false;
+            public placeholder = 'Custom placeholder';
         }
 
         let fixture: ComponentFixture<TestHostComponent>;
@@ -548,6 +569,17 @@ describe('NimbleTableColumnText', () => {
 
             expect(directive.groupingDisabled).toBe(true);
             expect(nativeElement.groupingDisabled).toBe(true);
+        });
+
+        it('can be configured with attribute binding for placeholder', () => {
+            expect(directive.placeholder).toBe('Custom placeholder');
+            expect(nativeElement.placeholder).toBe('Custom placeholder');
+
+            fixture.componentInstance.placeholder = 'Updated placeholder';
+            fixture.detectChanges();
+
+            expect(directive.placeholder).toBe('Updated placeholder');
+            expect(nativeElement.placeholder).toBe('Updated placeholder');
         });
     });
 });

--- a/change/@ni-nimble-angular-a238e91b-0109-4e07-b89a-aba8b2d19387.json
+++ b/change/@ni-nimble-angular-a238e91b-0109-4e07-b89a-aba8b2d19387.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for column placeholders",
+  "packageName": "@ni/nimble-angular",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Adds Angular support for column placeholders, which is part of #1538.

## 👩‍💻 Implementation

Add `placeholder` to the 5 columns that support that property.

## 🧪 Testing

Added unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
