### PR TITLE
Consistent storybook matrix states refactoring

### DIFF
--- a/change/@ni-nimble-components-797c6409-b365-4d44-a205-575326a62af3.json
+++ b/change/@ni-nimble-components-797c6409-b365-4d44-a205-575326a62af3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Matrix stories consistent strict enum pattern and organize states",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs-matrix.stories.ts
+++ b/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs-matrix.stories.ts
@@ -14,6 +14,9 @@ import { anchorTabTag } from '../../anchor-tab';
 import { tabsToolbarTag } from '../../tabs-toolbar';
 import { buttonTag } from '../../button';
 
+const tabsToolbarState = [false, true] as const;
+type TabsToolbarState = (typeof tabsToolbarState)[number];
+
 const metadata: Meta = {
     title: 'Tests/Anchor Tabs',
     parameters: {
@@ -22,9 +25,6 @@ const metadata: Meta = {
 };
 
 export default metadata;
-
-const tabsToolbarState = [false, true] as const;
-type TabsToolbarState = (typeof tabsToolbarState)[number];
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs-matrix.stories.ts
+++ b/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs-matrix.stories.ts
@@ -14,8 +14,8 @@ import { anchorTabTag } from '../../anchor-tab';
 import { tabsToolbarTag } from '../../tabs-toolbar';
 import { buttonTag } from '../../button';
 
-const tabsToolbarState = [false, true] as const;
-type TabsToolbarState = (typeof tabsToolbarState)[number];
+const tabsToolbarStates = [false, true] as const;
+type TabsToolbarState = (typeof tabsToolbarStates)[number];
 
 const metadata: Meta = {
     title: 'Tests/Anchor Tabs',
@@ -47,7 +47,7 @@ const component = (
 `;
 
 export const anchorTabsThemeMatrix: StoryFn = createMatrixThemeStory(
-    createMatrix(component, [tabsToolbarState, disabledStates])
+    createMatrix(component, [tabsToolbarStates, disabledStates])
 );
 
 export const hiddenTabs: StoryFn = createStory(

--- a/packages/nimble-components/src/anchor/tests/anchor-matrix.stories.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor-matrix.stories.ts
@@ -14,7 +14,7 @@ import { anchorTag } from '..';
 
 export const appearanceStates = [
     ['Default', AnchorAppearance.default],
-    ['prominent', AnchorAppearance.prominent]
+    ['Prominent', AnchorAppearance.prominent]
 ] as const;
 type AppearanceState = (typeof appearanceStates)[number];
 

--- a/packages/nimble-components/src/anchor/tests/anchor-matrix.stories.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor-matrix.stories.ts
@@ -12,7 +12,7 @@ import { AnchorAppearance } from '../types';
 import { bodyFont } from '../../theme-provider/design-tokens';
 import { anchorTag } from '..';
 
-export const appearanceStates = [
+const appearanceStates = [
     ['Default', AnchorAppearance.default],
     ['Prominent', AnchorAppearance.prominent]
 ] as const;

--- a/packages/nimble-components/src/anchor/tests/anchor-matrix.stories.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor-matrix.stories.ts
@@ -1,6 +1,5 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import { pascalCase } from '@microsoft/fast-web-utilities';
 import {
     createMatrix,
     sharedMatrixParameters,
@@ -13,14 +12,11 @@ import { AnchorAppearance } from '../types';
 import { bodyFont } from '../../theme-provider/design-tokens';
 import { anchorTag } from '..';
 
-const metadata: Meta = {
-    title: 'Tests/Anchor',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
-export default metadata;
+export const appearanceStates = [
+    ['Default', AnchorAppearance.default],
+    ['prominent', AnchorAppearance.prominent]
+] as const;
+type AppearanceState = (typeof appearanceStates)[number];
 
 const disabledStates = [
     ['', 'https://nimble.ni.dev'],
@@ -34,10 +30,14 @@ const underlineHiddenStates = [
 ] as const;
 type UnderlineHiddenState = (typeof underlineHiddenStates)[number];
 
-const appearanceStates: [string, string | undefined][] = Object.entries(
-    AnchorAppearance
-).map(([key, value]) => [pascalCase(key), value]);
-type AppearanceState = (typeof appearanceStates)[number];
+const metadata: Meta = {
+    title: 'Tests/Anchor',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/anchored-region/tests/anchored-region-matrix.stories.ts
+++ b/packages/nimble-components/src/anchored-region/tests/anchored-region-matrix.stories.ts
@@ -14,15 +14,6 @@ import {
 } from '../../theme-provider/design-tokens';
 import { anchoredRegionTag } from '..';
 
-const metadata: Meta = {
-    title: 'Tests/Anchored Region',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
-export default metadata;
-
 const horizontalPositionStates = [
     ['Start', 'start'],
     ['End', 'end'],
@@ -38,6 +29,15 @@ const verticalPositionStates = [
     ['Center', 'center']
 ] as const;
 type VerticalPositionState = (typeof verticalPositionStates)[number];
+
+const metadata: Meta = {
+    title: 'Tests/Anchored Region',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 const component = (
     [horizontalPositionName, horizontalPosition]: HorizontalPositionState,

--- a/packages/nimble-components/src/banner/tests/banner-matrix.stories.ts
+++ b/packages/nimble-components/src/banner/tests/banner-matrix.stories.ts
@@ -1,6 +1,5 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate, when } from '@microsoft/fast-element';
-import { pascalCase } from '@microsoft/fast-web-utilities';
 import { createStory } from '../../utilities/tests/storybook';
 import {
     createMatrix,
@@ -16,20 +15,6 @@ import { buttonTag } from '../../button';
 import { anchorTag } from '../../anchor';
 import { iconKeyTag } from '../../icons/key';
 
-const metadata: Meta = {
-    title: 'Tests/Banner',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
-export default metadata;
-
-const severityStates: [string, string | undefined][] = Object.entries(
-    BannerSeverity
-).map(([key, value]) => [pascalCase(key), value]);
-type SeverityState = (typeof severityStates)[number];
-
 const actionStates = [
     ['', false, false, undefined],
     ['link', true, false, undefined],
@@ -39,17 +24,34 @@ const actionStates = [
 ] as const;
 type ActionState = (typeof actionStates)[number];
 
+const longTextStates = [
+    ['', false],
+    ['long text', true]
+] as const;
+type LongTextState = (typeof longTextStates)[number];
+
 const partsHiddenStates = [
     ['', false],
     ['parts hidden', true]
 ] as const;
 type PartsHiddenState = (typeof partsHiddenStates)[number];
 
-const longTextStates = [
-    ['', false],
-    ['long text', true]
+const severityStates = [
+    ['Default', BannerSeverity.default],
+    ['Error', BannerSeverity.error],
+    ['Warning', BannerSeverity.warning],
+    ['Information', BannerSeverity.information],
 ] as const;
-type LongTextState = (typeof longTextStates)[number];
+type SeverityState = (typeof severityStates)[number];
+
+const metadata: Meta = {
+    title: 'Tests/Banner',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/banner/tests/banner-matrix.stories.ts
+++ b/packages/nimble-components/src/banner/tests/banner-matrix.stories.ts
@@ -40,7 +40,7 @@ const severityStates = [
     ['Default', BannerSeverity.default],
     ['Error', BannerSeverity.error],
     ['Warning', BannerSeverity.warning],
-    ['Information', BannerSeverity.information],
+    ['Information', BannerSeverity.information]
 ] as const;
 type SeverityState = (typeof severityStates)[number];
 

--- a/packages/nimble-components/src/breadcrumb/tests/breadcrumb-matrix.stories.ts
+++ b/packages/nimble-components/src/breadcrumb/tests/breadcrumb-matrix.stories.ts
@@ -14,7 +14,7 @@ import { breadcrumbItemTag } from '../../breadcrumb-item';
 
 const appearanceStates = [
     ['Default', BreadcrumbAppearance.default],
-    ['Prominent', BreadcrumbAppearance.prominent],
+    ['Prominent', BreadcrumbAppearance.prominent]
 ] as const;
 type AppearanceState = (typeof appearanceStates)[number];
 

--- a/packages/nimble-components/src/breadcrumb/tests/breadcrumb-matrix.stories.ts
+++ b/packages/nimble-components/src/breadcrumb/tests/breadcrumb-matrix.stories.ts
@@ -1,6 +1,5 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import { pascalCase } from '@microsoft/fast-web-utilities';
 import { createStory } from '../../utilities/tests/storybook';
 import {
     createMatrixThemeStory,
@@ -13,6 +12,12 @@ import { textCustomizationWrapper } from '../../utilities/tests/text-customizati
 import { breadcrumbTag } from '..';
 import { breadcrumbItemTag } from '../../breadcrumb-item';
 
+const appearanceStates = [
+    ['Default', BreadcrumbAppearance.default],
+    ['Prominent', BreadcrumbAppearance.prominent],
+] as const;
+type AppearanceState = (typeof appearanceStates)[number];
+
 const metadata: Meta = {
     title: 'Tests/Breadcrumb',
     parameters: {
@@ -21,11 +26,6 @@ const metadata: Meta = {
 };
 
 export default metadata;
-
-const appearanceStates: [string, string | undefined][] = Object.entries(
-    BreadcrumbAppearance
-).map(([key, value]) => [pascalCase(key), value]);
-type AppearanceState = (typeof appearanceStates)[number];
 
 const component = ([
     appearanceName,

--- a/packages/nimble-components/src/card-button/tests/card-button-matrix.stories.ts
+++ b/packages/nimble-components/src/card-button/tests/card-button-matrix.stories.ts
@@ -11,6 +11,12 @@ import { hiddenWrapper } from '../../utilities/tests/hidden';
 import { bodyFont } from '../../theme-provider/design-tokens';
 import { cardButtonTag } from '..';
 
+const selectedStates = [
+    ['Selected', true],
+    ['', false]
+] as const;
+type SelectedState = (typeof selectedStates)[number];
+
 const metadata: Meta = {
     title: 'Tests/Card Button',
     parameters: {
@@ -19,12 +25,6 @@ const metadata: Meta = {
 };
 
 export default metadata;
-
-const selectedStates = [
-    ['Selected', true],
-    ['', false]
-] as const;
-type SelectedState = (typeof selectedStates)[number];
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/checkbox/tests/checkbox-matrix.stories.ts
+++ b/packages/nimble-components/src/checkbox/tests/checkbox-matrix.stories.ts
@@ -11,15 +11,6 @@ import { hiddenWrapper } from '../../utilities/tests/hidden';
 import { textCustomizationWrapper } from '../../utilities/tests/text-customization';
 import { checkboxTag } from '..';
 
-const metadata: Meta = {
-    title: 'Tests/Checkbox',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
-export default metadata;
-
 const checkedStates = [
     ['Checked', true],
     ['Unchecked', false]
@@ -31,6 +22,15 @@ const indeterminateStates = [
     ['', false]
 ] as const;
 type IndeterminateState = (typeof indeterminateStates)[number];
+
+const metadata: Meta = {
+    title: 'Tests/Checkbox',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 const component = (
     [disabledName, disabled]: DisabledState,

--- a/packages/nimble-components/src/combobox/tests/combobox-matrix.stories.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox-matrix.stories.ts
@@ -1,6 +1,5 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import { pascalCase } from '@microsoft/fast-web-utilities';
 import { createStory } from '../../utilities/tests/storybook';
 import {
     createMatrixThemeStory,
@@ -25,6 +24,13 @@ import { comboboxTag } from '..';
 import { listOptionTag } from '../../list-option';
 import { loremIpsum } from '../../utilities/tests/lorem-ipsum';
 
+const appearanceStates = [
+    ['Block', DropdownAppearance.block],
+    ['Outline', DropdownAppearance.outline],
+    ['Underline', DropdownAppearance.underline],
+] as const;
+type AppearanceState = (typeof appearanceStates)[number];
+
 const valueStates = [
     ['No Value', undefined, 'placeholder'],
     ['Short Value', 'Hello', 'placeholder'],
@@ -40,12 +46,6 @@ const metadata: Meta = {
 };
 
 export default metadata;
-
-const appearanceStates = Object.entries(DropdownAppearance).map(
-    ([key, value]) => [pascalCase(key), value]
-);
-
-type AppearanceState = (typeof appearanceStates)[number];
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/combobox/tests/combobox-matrix.stories.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox-matrix.stories.ts
@@ -25,9 +25,9 @@ import { listOptionTag } from '../../list-option';
 import { loremIpsum } from '../../utilities/tests/lorem-ipsum';
 
 const appearanceStates = [
-    ['Block', DropdownAppearance.block],
+    ['Underline', DropdownAppearance.underline],
     ['Outline', DropdownAppearance.outline],
-    ['Underline', DropdownAppearance.underline]
+    ['Block', DropdownAppearance.block]
 ] as const;
 type AppearanceState = (typeof appearanceStates)[number];
 

--- a/packages/nimble-components/src/combobox/tests/combobox-matrix.stories.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox-matrix.stories.ts
@@ -27,7 +27,7 @@ import { loremIpsum } from '../../utilities/tests/lorem-ipsum';
 const appearanceStates = [
     ['Block', DropdownAppearance.block],
     ['Outline', DropdownAppearance.outline],
-    ['Underline', DropdownAppearance.underline],
+    ['Underline', DropdownAppearance.underline]
 ] as const;
 type AppearanceState = (typeof appearanceStates)[number];
 

--- a/packages/nimble-components/src/dialog/tests/dialog-matrix.stories.ts
+++ b/packages/nimble-components/src/dialog/tests/dialog-matrix.stories.ts
@@ -16,8 +16,14 @@ import {
 } from '../../theme-provider/design-tokens';
 
 const sizeStates = [
-    ['Small Dialog', `width: var(${dialogSmallWidth.cssCustomProperty}); height: var(${dialogSmallHeight.cssCustomProperty}); max-height: var(${dialogSmallMaxHeight.cssCustomProperty});`],
-    ['Large Dialog', `width: var(${dialogLargeWidth.cssCustomProperty}); height: var(${dialogLargeHeight.cssCustomProperty}); max-height: var(${dialogLargeMaxHeight.cssCustomProperty});`],
+    [
+        'Small Dialog',
+        `width: var(${dialogSmallWidth.cssCustomProperty}); height: var(${dialogSmallHeight.cssCustomProperty}); max-height: var(${dialogSmallMaxHeight.cssCustomProperty});`
+    ],
+    [
+        'Large Dialog',
+        `width: var(${dialogLargeWidth.cssCustomProperty}); height: var(${dialogLargeHeight.cssCustomProperty}); max-height: var(${dialogLargeMaxHeight.cssCustomProperty});`
+    ]
 ] as const;
 type SizeState = (typeof sizeStates)[number];
 
@@ -43,7 +49,10 @@ const component = html`
     </${dialogTag}>
 `;
 
-const dialogSizingTestCase = ([sizeName, size]: SizeState): ViewTemplate => html`
+const dialogSizingTestCase = ([
+    sizeName,
+    size
+]: SizeState): ViewTemplate => html`
     <p class="spacer">${() => sizeName}</p>
     <style>
         ${dialogTag}::part(control) {

--- a/packages/nimble-components/src/dialog/tests/dialog-matrix.stories.ts
+++ b/packages/nimble-components/src/dialog/tests/dialog-matrix.stories.ts
@@ -15,6 +15,12 @@ import {
     dialogSmallWidth
 } from '../../theme-provider/design-tokens';
 
+const sizeStates = [
+    ['Small Dialog', `width: var(${dialogSmallWidth.cssCustomProperty}); height: var(${dialogSmallHeight.cssCustomProperty}); max-height: var(${dialogSmallMaxHeight.cssCustomProperty});`],
+    ['Large Dialog', `width: var(${dialogLargeWidth.cssCustomProperty}); height: var(${dialogLargeHeight.cssCustomProperty}); max-height: var(${dialogLargeMaxHeight.cssCustomProperty});`],
+] as const;
+type SizeState = (typeof sizeStates)[number];
+
 const metadata: Meta = {
     title: 'Tests/Dialog',
     parameters: {
@@ -23,12 +29,6 @@ const metadata: Meta = {
 };
 
 export default metadata;
-
-const sizeStates = [
-    `width: var(${dialogSmallWidth.cssCustomProperty}); height: var(${dialogSmallHeight.cssCustomProperty}); max-height: var(${dialogSmallMaxHeight.cssCustomProperty});`,
-    `width: var(${dialogLargeWidth.cssCustomProperty}); height: var(${dialogLargeHeight.cssCustomProperty}); max-height: var(${dialogLargeMaxHeight.cssCustomProperty});`
-] as const;
-type SizeState = (typeof sizeStates)[number];
 
 const component = html`
     <${dialogTag}>
@@ -43,8 +43,8 @@ const component = html`
     </${dialogTag}>
 `;
 
-const dialogSizingTestCase = (size: SizeState): ViewTemplate => html`
-    <p class="spacer">${() => size};</p>
+const dialogSizingTestCase = ([sizeName, size]: SizeState): ViewTemplate => html`
+    <p class="spacer">${() => sizeName}</p>
     <style>
         ${dialogTag}::part(control) {
             ${() => size};

--- a/packages/nimble-components/src/icon-base/tests/icon-matrix.stories.ts
+++ b/packages/nimble-components/src/icon-base/tests/icon-matrix.stories.ts
@@ -1,6 +1,5 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import { pascalCase } from '@microsoft/fast-web-utilities';
 import {
     createMatrix,
     sharedMatrixParameters,
@@ -12,6 +11,15 @@ import { bodyFontColor } from '../../theme-provider/design-tokens';
 import { hiddenWrapper } from '../../utilities/tests/hidden';
 import { iconCheckTag } from '../../icons/check';
 
+const severityStates = [
+    ['Default', IconSeverity.default],
+    ['Error', IconSeverity.error],
+    ['Warning', IconSeverity.warning],
+    ['Success', IconSeverity.success],
+    ['Information', IconSeverity.information],
+] as const;
+type SeverityState = (typeof severityStates)[number];
+
 const metadata: Meta = {
     title: 'Tests/Icon',
     parameters: {
@@ -20,11 +28,6 @@ const metadata: Meta = {
 };
 
 export default metadata;
-
-const severityStates: [string, string | undefined][] = Object.entries(
-    IconSeverity
-).map(([key, value]) => [pascalCase(key), value]);
-type SeverityState = (typeof severityStates)[number];
 
 const component = ([stateName, state]: SeverityState): ViewTemplate => html`
     <span style="color: var(${() => bodyFontColor.cssCustomProperty});">

--- a/packages/nimble-components/src/icon-base/tests/icon-matrix.stories.ts
+++ b/packages/nimble-components/src/icon-base/tests/icon-matrix.stories.ts
@@ -16,7 +16,7 @@ const severityStates = [
     ['Error', IconSeverity.error],
     ['Warning', IconSeverity.warning],
     ['Success', IconSeverity.success],
-    ['Information', IconSeverity.information],
+    ['Information', IconSeverity.information]
 ] as const;
 type SeverityState = (typeof severityStates)[number];
 

--- a/packages/nimble-components/src/menu-button/tests/menu-button-matrix.stories.ts
+++ b/packages/nimble-components/src/menu-button/tests/menu-button-matrix.stories.ts
@@ -27,6 +27,12 @@ import {
     partVisibilityStatesOnlyLabel
 } from '../../patterns/button/tests/states';
 
+const openStates = [
+    ['', false],
+    ['Open', true]
+] as const;
+type OpenState = (typeof openStates)[number];
+
 const metadata: Meta = {
     title: 'Tests/Menu Button',
     parameters: {
@@ -35,12 +41,6 @@ const metadata: Meta = {
 };
 
 export default metadata;
-
-const openStates = [
-    ['', false],
-    ['Open', true]
-] as const;
-type OpenState = (typeof openStates)[number];
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/menu-button/tests/menu-button-opened-matrix.stories.ts
+++ b/packages/nimble-components/src/menu-button/tests/menu-button-opened-matrix.stories.ts
@@ -7,6 +7,12 @@ import { menuButtonTag } from '..';
 import { menuTag } from '../../menu';
 import { menuItemTag } from '../../menu-item';
 
+const positionStates = [
+    ['below', 'margin-bottom: 80px; position: relative;'],
+    ['above', 'margin-top: 80px; position: relative;']
+] as const;
+type PositionState = (typeof positionStates)[number];
+
 const metadata: Meta = {
     title: 'Tests/Menu Button',
     parameters: {
@@ -15,12 +21,6 @@ const metadata: Meta = {
 };
 
 export default metadata;
-
-const positionStates = [
-    ['below', 'margin-bottom: 80px; position: relative;'],
-    ['above', 'margin-top: 80px; position: relative;']
-] as const;
-type PositionState = (typeof positionStates)[number];
 
 // prettier-ignore
 const component = ([

--- a/packages/nimble-components/src/menu/tests/menu-matrix.stories.ts
+++ b/packages/nimble-components/src/menu/tests/menu-matrix.stories.ts
@@ -18,15 +18,6 @@ import { iconXmarkTag } from '../../icons/xmark';
 import { menuItemTag } from '../../menu-item';
 import { anchorMenuItemTag } from '../../anchor-menu-item';
 
-const metadata: Meta = {
-    title: 'Tests/Menu',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
-export default metadata;
-
 /* array of showSubMenu, childIcon, advancedSubMenu */
 const subMenuStates = [
     [false, false, false],
@@ -36,6 +27,15 @@ const subMenuStates = [
     [true, true, true]
 ] as const;
 type SubMenuState = (typeof subMenuStates)[number];
+
+const metadata: Meta = {
+    title: 'Tests/Menu',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/number-field/tests/number-field-matrix.stories.ts
+++ b/packages/nimble-components/src/number-field/tests/number-field-matrix.stories.ts
@@ -20,7 +20,7 @@ import { numberFieldTag } from '..';
 const appearanceStates = [
     ['Underline', NumberFieldAppearance.underline],
     ['Outline', NumberFieldAppearance.outline],
-    ['Block', NumberFieldAppearance.block],
+    ['Block', NumberFieldAppearance.block]
 ] as const;
 type AppearanceState = (typeof appearanceStates)[number];
 

--- a/packages/nimble-components/src/number-field/tests/number-field-matrix.stories.ts
+++ b/packages/nimble-components/src/number-field/tests/number-field-matrix.stories.ts
@@ -1,6 +1,5 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import { pascalCase } from '@microsoft/fast-web-utilities';
 import { createStory } from '../../utilities/tests/storybook';
 import {
     createMatrixThemeStory,
@@ -18,6 +17,25 @@ import { NumberFieldAppearance } from '../types';
 import { textCustomizationWrapper } from '../../utilities/tests/text-customization';
 import { numberFieldTag } from '..';
 
+const appearanceStates = [
+    ['Underline', NumberFieldAppearance.underline],
+    ['Outline', NumberFieldAppearance.outline],
+    ['Block', NumberFieldAppearance.block],
+] as const;
+type AppearanceState = (typeof appearanceStates)[number];
+
+const hideStepStates = [
+    ['', false],
+    ['Hide Step', true]
+] as const;
+type HideStepState = (typeof hideStepStates)[number];
+
+const valueStates = [
+    ['Placeholder', null, 'placeholder'],
+    ['Value', '1234', null]
+] as const;
+type ValueState = (typeof valueStates)[number];
+
 const metadata: Meta = {
     title: 'Tests/Number Field',
     parameters: {
@@ -26,22 +44,6 @@ const metadata: Meta = {
 };
 
 export default metadata;
-const valueStates = [
-    ['Placeholder', null, 'placeholder'],
-    ['Value', '1234', null]
-] as const;
-type ValueState = (typeof valueStates)[number];
-
-const appearanceStates = Object.entries(NumberFieldAppearance).map(
-    ([key, value]) => [pascalCase(key), value]
-);
-type AppearanceState = (typeof appearanceStates)[number];
-
-const hideStepStates = [
-    ['', false],
-    ['Hide Step', true]
-] as const;
-type HideStepState = (typeof hideStepStates)[number];
 
 const component = (
     [disabledName, disabled]: DisabledState,

--- a/packages/nimble-components/src/radio-group/tests/radio-group-matrix.stories.ts
+++ b/packages/nimble-components/src/radio-group/tests/radio-group-matrix.stories.ts
@@ -13,6 +13,12 @@ import { textCustomizationWrapper } from '../../utilities/tests/text-customizati
 import { radioGroupTag } from '..';
 import { radioTag } from '../../radio';
 
+const orientationStates = [
+    ['Horizontal', Orientation.horizontal],
+    ['Vertical', Orientation.vertical]
+] as const;
+type OrientationState = (typeof orientationStates)[number];
+
 const metadata: Meta = {
     title: 'Tests/Radio Group',
     parameters: {
@@ -21,12 +27,6 @@ const metadata: Meta = {
 };
 
 export default metadata;
-
-const orientationStates = [
-    ['Horizontal', Orientation.horizontal],
-    ['Vertical', Orientation.vertical]
-] as const;
-type OrientationState = (typeof orientationStates)[number];
 
 const component = (
     [disabledName, disabled]: DisabledState,

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-matrix.stories.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-matrix.stories.ts
@@ -23,15 +23,6 @@ import { toggleButtonTag } from '../../../toggle-button';
 import { menuButtonTag } from '../../../menu-button';
 import { anchorButtonTag } from '../../../anchor-button';
 
-const metadata: Meta = {
-    title: 'Tests/Rich Text Editor',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
-export default metadata;
-
 const richTextMarkdownString = '1. **Bold** *Italics*\n2. Numbered lists\n   1. Option 1\n   \n3. Bulleted lists\n   * Option 1\n   \n4. Absolute link: <https://nimble.ni.dev/>\n 6. @mention:\n    1. User pattern: <user:1>';
 
 const footerHiddenStates = [
@@ -53,6 +44,15 @@ const slotButtons = [
     anchorButtonTag
 ] as const;
 type SlotButtons = (typeof slotButtons)[number];
+
+const metadata: Meta = {
+    title: 'Tests/Rich Text Editor',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/select/tests/select-matrix.stories.ts
+++ b/packages/nimble-components/src/select/tests/select-matrix.stories.ts
@@ -1,6 +1,5 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import { pascalCase } from '@microsoft/fast-web-utilities';
 import { createStory } from '../../utilities/tests/storybook';
 import {
     createMatrixThemeStory,
@@ -26,6 +25,19 @@ import { selectTag } from '..';
 import { listOptionTag } from '../../list-option';
 import { loremIpsum } from '../../utilities/tests/lorem-ipsum';
 
+const appearanceStates = [
+    ['Underline', DropdownAppearance.underline],
+    ['Outline', DropdownAppearance.outline],
+    ['Block', DropdownAppearance.block],
+] as const;
+type AppearanceState = (typeof appearanceStates)[number];
+
+const valueStates = [
+    ['Short Value', 'Option 1'],
+    ['Long Value', loremIpsum]
+] as const;
+type ValueState = (typeof valueStates)[number];
+
 const metadata: Meta = {
     title: 'Tests/Select',
     parameters: {
@@ -34,18 +46,6 @@ const metadata: Meta = {
 };
 
 export default metadata;
-
-const appearanceStates = Object.entries(DropdownAppearance).map(
-    ([key, value]) => [pascalCase(key), value]
-);
-
-type AppearanceState = (typeof appearanceStates)[number];
-
-const valueStates = [
-    ['Short Value', 'Option 1'],
-    ['Long Value', loremIpsum]
-] as const;
-type ValueState = (typeof valueStates)[number];
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/select/tests/select-matrix.stories.ts
+++ b/packages/nimble-components/src/select/tests/select-matrix.stories.ts
@@ -28,7 +28,7 @@ import { loremIpsum } from '../../utilities/tests/lorem-ipsum';
 const appearanceStates = [
     ['Underline', DropdownAppearance.underline],
     ['Outline', DropdownAppearance.outline],
-    ['Block', DropdownAppearance.block],
+    ['Block', DropdownAppearance.block]
 ] as const;
 type AppearanceState = (typeof appearanceStates)[number];
 

--- a/packages/nimble-components/src/spinner/tests/spinner-matrix.stories.ts
+++ b/packages/nimble-components/src/spinner/tests/spinner-matrix.stories.ts
@@ -19,7 +19,7 @@ import { SpinnerAppearance } from '../types';
 
 const appearanceStates = [
     ['Default', SpinnerAppearance.default],
-    ['Accent', SpinnerAppearance.accent],
+    ['Accent', SpinnerAppearance.accent]
 ] as const;
 type AppearanceState = (typeof appearanceStates)[number];
 

--- a/packages/nimble-components/src/spinner/tests/spinner-matrix.stories.ts
+++ b/packages/nimble-components/src/spinner/tests/spinner-matrix.stories.ts
@@ -1,6 +1,5 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import { pascalCase } from '@microsoft/fast-web-utilities';
 import { isChromatic } from '../../utilities/tests/isChromatic';
 
 import {
@@ -18,6 +17,19 @@ import { hiddenWrapper } from '../../utilities/tests/hidden';
 import { spinnerTag } from '..';
 import { SpinnerAppearance } from '../types';
 
+const appearanceStates = [
+    ['Default', SpinnerAppearance.default],
+    ['Accent', SpinnerAppearance.accent],
+] as const;
+type AppearanceState = (typeof appearanceStates)[number];
+
+const sizeStates = [
+    ['Small (16x16)', ''],
+    ['Medium (32x32)', `height: var(${spinnerMediumHeight.cssCustomProperty})`],
+    ['Large (64x64)', `height: var(${spinnerLargeHeight.cssCustomProperty})`]
+] as const;
+type SizeState = (typeof sizeStates)[number];
+
 const metadata: Meta = {
     title: 'Tests/Spinner',
     parameters: {
@@ -26,18 +38,6 @@ const metadata: Meta = {
 };
 
 export default metadata;
-
-const sizeStates = [
-    ['Small (16x16)', ''],
-    ['Medium (32x32)', `height: var(${spinnerMediumHeight.cssCustomProperty})`],
-    ['Large (64x64)', `height: var(${spinnerLargeHeight.cssCustomProperty})`]
-];
-type SizeState = (typeof sizeStates)[number];
-
-const appearanceStates: [string, string | undefined][] = Object.entries(
-    SpinnerAppearance
-).map(([key, value]) => [pascalCase(key), value]);
-type AppearanceState = (typeof appearanceStates)[number];
 
 // Disable animation in Chromatic because it intermittently causes shapshot differences
 // prettier-ignore

--- a/packages/nimble-components/src/switch/tests/switch-matrix.stories.ts
+++ b/packages/nimble-components/src/switch/tests/switch-matrix.stories.ts
@@ -10,15 +10,6 @@ import { createStory } from '../../utilities/tests/storybook';
 import { hiddenWrapper } from '../../utilities/tests/hidden';
 import { switchTag } from '..';
 
-const metadata: Meta = {
-    title: 'Tests/Switch',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
-export default metadata;
-
 const checkedStates = [
     ['Checked', true],
     ['Unchecked', false]
@@ -30,6 +21,15 @@ const messagesStates = [
     ['Without Messages', false]
 ] as const;
 type MessagesState = (typeof messagesStates)[number];
+
+const metadata: Meta = {
+    title: 'Tests/Switch',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor-matrix.stories.ts
+++ b/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor-matrix.stories.ts
@@ -1,6 +1,5 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import { pascalCase } from '@microsoft/fast-web-utilities';
 import {
     createMatrixThemeStory,
     createMatrix,
@@ -18,15 +17,6 @@ import {
     placeholderStates,
     type PlaceholderState
 } from '../../../utilities/tests/states';
-
-const metadata: Meta = {
-    title: 'Tests/Table Column: Anchor',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
-export default metadata;
 
 const data = [
     {
@@ -49,9 +39,10 @@ const data = [
     }
 ] as const;
 
-const appearanceStates: [string, string | undefined][] = Object.entries(
-    AnchorAppearance
-).map(([key, value]) => [pascalCase(key), value]);
+const appearanceStates = [
+    ['Default', AnchorAppearance.default],
+    ['Prominent', AnchorAppearance.prominent]
+] as const;
 type AppearanceState = (typeof appearanceStates)[number];
 
 const underlineHiddenStates = [
@@ -59,6 +50,15 @@ const underlineHiddenStates = [
     ['', false]
 ] as const;
 type UnderlineHiddenState = (typeof underlineHiddenStates)[number];
+
+const metadata: Meta = {
+    title: 'Tests/Table Column: Anchor',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text-matrix.stories.ts
+++ b/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text-matrix.stories.ts
@@ -17,15 +17,6 @@ import {
     type PlaceholderState
 } from '../../../utilities/tests/states';
 
-const metadata: Meta = {
-    title: 'Tests/Table Column: Date Text',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
-export default metadata;
-
 const data = [
     {
         id: '0',
@@ -39,6 +30,15 @@ const data = [
         id: '2'
     }
 ] as const;
+
+const metadata: Meta = {
+    title: 'Tests/Table Column: Date Text',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/table-column/duration-text/tests/table-column-duration-text-matrix.stories.ts
+++ b/packages/nimble-components/src/table-column/duration-text/tests/table-column-duration-text-matrix.stories.ts
@@ -16,15 +16,6 @@ import {
     type PlaceholderState
 } from '../../../utilities/tests/states';
 
-const metadata: Meta = {
-    title: 'Tests/Table Column: Duration Text',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
-export default metadata;
-
 const data = [
     {
         id: '0',
@@ -38,6 +29,15 @@ const data = [
         id: '2'
     }
 ] as const;
+
+const metadata: Meta = {
+    title: 'Tests/Table Column: Duration Text',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text-matrix.stories.ts
+++ b/packages/nimble-components/src/table-column/enum-text/tests/table-column-enum-text-matrix.stories.ts
@@ -8,15 +8,6 @@ import { Table, tableTag } from '../../../table';
 import { tableColumnEnumTextTag } from '..';
 import { mappingTextTag } from '../../../mapping/text';
 
-const metadata: Meta = {
-    title: 'Tests/Table Column: Enum Text',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
-export default metadata;
-
 const data = [
     {
         id: '0',
@@ -31,6 +22,15 @@ const data = [
         code: 2
     }
 ] as const;
+
+const metadata: Meta = {
+    title: 'Tests/Table Column: Enum Text',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 // prettier-ignore
 const component = (): ViewTemplate => html`

--- a/packages/nimble-components/src/table-column/icon/tests/table-column-icon-matrix.stories.ts
+++ b/packages/nimble-components/src/table-column/icon/tests/table-column-icon-matrix.stories.ts
@@ -11,15 +11,6 @@ import { mappingIconTag } from '../../../mapping/icon';
 import { mappingSpinnerTag } from '../../../mapping/spinner';
 import { isChromatic } from '../../../utilities/tests/isChromatic';
 
-const metadata: Meta = {
-    title: 'Tests/Table Column: Icon',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
-export default metadata;
-
 const data = [
     {
         id: '0',
@@ -38,6 +29,15 @@ const data = [
         code: -1
     }
 ] as const;
+
+const metadata: Meta = {
+    title: 'Tests/Table Column: Icon',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 // prettier-ignore
 const component = (): ViewTemplate => html`

--- a/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text-matrix.stories.ts
+++ b/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text-matrix.stories.ts
@@ -1,6 +1,5 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import { pascalCase } from '@microsoft/fast-web-utilities';
 import {
     createMatrixThemeStory,
     createMatrix,
@@ -18,14 +17,12 @@ import {
     type PlaceholderState
 } from '../../../utilities/tests/states';
 
-const metadata: Meta = {
-    title: 'Tests/Table Column: Number Text',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
-export default metadata;
+const alignmentStates = [
+    ['Default', NumberTextAlignment.default],
+    ['Left', NumberTextAlignment.left],
+    ['Right', NumberTextAlignment.right],
+] as const;
+type AlignmentState = (typeof alignmentStates)[number];
 
 const data = [
     {
@@ -41,10 +38,14 @@ const data = [
     }
 ] as const;
 
-const alignmentStates: [string, string | undefined][] = Object.entries(
-    NumberTextAlignment
-).map(([key, value]) => [pascalCase(key), value]);
-type AlignmentState = (typeof alignmentStates)[number];
+const metadata: Meta = {
+    title: 'Tests/Table Column: Number Text',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text-matrix.stories.ts
+++ b/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text-matrix.stories.ts
@@ -20,7 +20,7 @@ import {
 const alignmentStates = [
     ['Default', NumberTextAlignment.default],
     ['Left', NumberTextAlignment.left],
-    ['Right', NumberTextAlignment.right],
+    ['Right', NumberTextAlignment.right]
 ] as const;
 type AlignmentState = (typeof alignmentStates)[number];
 

--- a/packages/nimble-components/src/table-column/text/tests/table-column-text-matrix.stories.ts
+++ b/packages/nimble-components/src/table-column/text/tests/table-column-text-matrix.stories.ts
@@ -16,15 +16,6 @@ import {
     type PlaceholderState
 } from '../../../utilities/tests/states';
 
-const metadata: Meta = {
-    title: 'Tests/Table Column: Text',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
-export default metadata;
-
 const data = [
     {
         id: '0',
@@ -43,6 +34,15 @@ const data = [
         firstName: ''
     }
 ] as const;
+
+const metadata: Meta = {
+    title: 'Tests/Table Column: Text',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/table/tests/table-action-menu-opened-matrix.stories.ts
+++ b/packages/nimble-components/src/table/tests/table-action-menu-opened-matrix.stories.ts
@@ -11,15 +11,6 @@ import { menuTag } from '../../menu';
 import { menuItemTag } from '../../menu-item';
 import { tableColumnTextTag } from '../../table-column/text';
 
-const metadata: Meta = {
-    title: 'Tests/Table',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
-export default metadata;
-
 const data = [
     {
         firstName: 'Ralph',
@@ -37,6 +28,15 @@ const data = [
         favoriteColor: null
     }
 ] as const;
+
+const metadata: Meta = {
+    title: 'Tests/Table',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 // prettier-ignore
 const component = html`

--- a/packages/nimble-components/src/tabs/tests/tabs-matrix.stories.ts
+++ b/packages/nimble-components/src/tabs/tests/tabs-matrix.stories.ts
@@ -16,8 +16,8 @@ import { tabsToolbarTag } from '../../tabs-toolbar';
 import { tabsTag } from '..';
 import { loremIpsum } from '../../utilities/tests/lorem-ipsum';
 
-const tabsToolbarState = [false, true] as const;
-type TabsToolbarState = (typeof tabsToolbarState)[number];
+const tabsToolbarStates = [false, true] as const;
+type TabsToolbarState = (typeof tabsToolbarStates)[number];
 
 const metadata: Meta = {
     title: 'Tests/Tabs',
@@ -52,7 +52,7 @@ const component = (
 `;
 
 export const tabsThemeMatrix: StoryFn = createMatrixThemeStory(
-    createMatrix(component, [tabsToolbarState, disabledStates])
+    createMatrix(component, [tabsToolbarStates, disabledStates])
 );
 
 export const hiddenTabs: StoryFn = createStory(

--- a/packages/nimble-components/src/tabs/tests/tabs-matrix.stories.ts
+++ b/packages/nimble-components/src/tabs/tests/tabs-matrix.stories.ts
@@ -16,6 +16,9 @@ import { tabsToolbarTag } from '../../tabs-toolbar';
 import { tabsTag } from '..';
 import { loremIpsum } from '../../utilities/tests/lorem-ipsum';
 
+const tabsToolbarState = [false, true] as const;
+type TabsToolbarState = (typeof tabsToolbarState)[number];
+
 const metadata: Meta = {
     title: 'Tests/Tabs',
     parameters: {
@@ -24,9 +27,6 @@ const metadata: Meta = {
 };
 
 export default metadata;
-
-const tabsToolbarState = [false, true] as const;
-type TabsToolbarState = (typeof tabsToolbarState)[number];
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/text-area/tests/text-area-matrix.stories.ts
+++ b/packages/nimble-components/src/text-area/tests/text-area-matrix.stories.ts
@@ -20,18 +20,18 @@ import { textCustomizationWrapper } from '../../utilities/tests/text-customizati
 import { loremIpsum } from '../../utilities/tests/lorem-ipsum';
 import { textAreaTag } from '..';
 
+const appearanceStates = [
+    ['Outline', TextAreaAppearance.outline],
+    ['Block', TextAreaAppearance.block]
+] as const;
+type AppearanceState = (typeof appearanceStates)[number];
+
 const valueStates = [
     ['Placeholder', null, 'placeholder'],
     ['Value', 'Hello', null],
     ['Long Value', loremIpsum, null]
 ] as const;
 type ValueState = (typeof valueStates)[number];
-
-const appearanceStates = [
-    ['Outline', TextAreaAppearance.outline],
-    ['Block', TextAreaAppearance.block]
-] as const;
-type AppearanceState = (typeof appearanceStates)[number];
 
 const metadata: Meta = {
     title: 'Tests/Text Area',

--- a/packages/nimble-components/src/text-area/tests/text-area-matrix.stories.ts
+++ b/packages/nimble-components/src/text-area/tests/text-area-matrix.stories.ts
@@ -29,7 +29,7 @@ type ValueState = (typeof valueStates)[number];
 
 const appearanceStates = [
     ['Outline', TextAreaAppearance.outline],
-    ['Block', TextAreaAppearance.block],
+    ['Block', TextAreaAppearance.block]
 ] as const;
 type AppearanceState = (typeof appearanceStates)[number];
 

--- a/packages/nimble-components/src/text-area/tests/text-area-matrix.stories.ts
+++ b/packages/nimble-components/src/text-area/tests/text-area-matrix.stories.ts
@@ -1,6 +1,5 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import { pascalCase } from '@microsoft/fast-web-utilities';
 import { createStory } from '../../utilities/tests/storybook';
 import {
     createMatrixThemeStory,
@@ -21,6 +20,19 @@ import { textCustomizationWrapper } from '../../utilities/tests/text-customizati
 import { loremIpsum } from '../../utilities/tests/lorem-ipsum';
 import { textAreaTag } from '..';
 
+const valueStates = [
+    ['Placeholder', null, 'placeholder'],
+    ['Value', 'Hello', null],
+    ['Long Value', loremIpsum, null]
+] as const;
+type ValueState = (typeof valueStates)[number];
+
+const appearanceStates = [
+    ['Outline', TextAreaAppearance.outline],
+    ['Block', TextAreaAppearance.block],
+] as const;
+type AppearanceState = (typeof appearanceStates)[number];
+
 const metadata: Meta = {
     title: 'Tests/Text Area',
     parameters: {
@@ -29,18 +41,6 @@ const metadata: Meta = {
 };
 
 export default metadata;
-
-const valueStates = [
-    ['Placeholder', null, 'placeholder'],
-    ['Value', 'Hello', null],
-    ['Long Value', loremIpsum, null]
-] as const;
-type ValueState = (typeof valueStates)[number];
-
-const appearanceStates = Object.entries(TextAreaAppearance).map(
-    ([key, value]) => [pascalCase(key), value]
-);
-type AppearanceState = (typeof appearanceStates)[number];
 
 const component = (
     [readOnlyName, readonly]: ReadOnlyState,

--- a/packages/nimble-components/src/text-field/tests/text-field-matrix.stories.ts
+++ b/packages/nimble-components/src/text-field/tests/text-field-matrix.stories.ts
@@ -49,7 +49,7 @@ const appearanceStates = [
     ['Underline', TextFieldAppearance.underline],
     ['Outline', TextFieldAppearance.outline],
     ['Block', TextFieldAppearance.block],
-    ['Frameless', TextFieldAppearance.frameless],
+    ['Frameless', TextFieldAppearance.frameless]
 ] as const;
 type AppearanceState = (typeof appearanceStates)[number];
 

--- a/packages/nimble-components/src/text-field/tests/text-field-matrix.stories.ts
+++ b/packages/nimble-components/src/text-field/tests/text-field-matrix.stories.ts
@@ -1,6 +1,5 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate, when } from '@microsoft/fast-element';
-import { pascalCase } from '@microsoft/fast-web-utilities';
 import {
     createStory,
     createFixedThemeStory
@@ -29,15 +28,6 @@ import { iconPencilTag } from '../../icons/pencil';
 import { iconTagTag } from '../../icons/tag';
 import { iconXmarkTag } from '../../icons/xmark';
 
-const metadata: Meta = {
-    title: 'Tests/Text Field',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
-export default metadata;
-
 const [
     lightThemeWhiteBackground,
     colorThemeDarkGreenBackground,
@@ -49,33 +39,18 @@ if (remaining.length > 0) {
     throw new Error('New backgrounds need to be supported');
 }
 
-const valueStates = [
-    ['No Value', null, 'placeholder'],
-    ['Value', 'Hello', 'placeholder']
-] as const;
-type ValueState = (typeof valueStates)[number];
-
-const typeStates = [
-    ['Text', TextFieldType.text],
-    ['Password', TextFieldType.password]
-] as const;
-type TypeState = (typeof typeStates)[number];
-
 const actionButtonStates = [
     ['', false],
     ['w/ Buttons', true]
 ] as const;
 type ActionButtonState = (typeof actionButtonStates)[number];
 
-const leftIconStates = [
-    ['', false],
-    ['w/ Icon', true]
+const appearanceStates = [
+    ['Underline', TextFieldAppearance.underline],
+    ['Outline', TextFieldAppearance.outline],
+    ['Block', TextFieldAppearance.block],
+    ['Frameless', TextFieldAppearance.frameless],
 ] as const;
-type LeftIconState = (typeof leftIconStates)[number];
-
-const appearanceStates = Object.entries(TextFieldAppearance).map(
-    ([key, value]) => [pascalCase(key), value]
-);
 type AppearanceState = (typeof appearanceStates)[number];
 
 const fullBleedStates = [
@@ -83,6 +58,33 @@ const fullBleedStates = [
     ['Full Bleed', true]
 ] as const;
 type FullBleedState = (typeof fullBleedStates)[number];
+
+const leftIconStates = [
+    ['', false],
+    ['w/ Icon', true]
+] as const;
+type LeftIconState = (typeof leftIconStates)[number];
+
+const typeStates = [
+    ['Text', TextFieldType.text],
+    ['Password', TextFieldType.password]
+] as const;
+type TypeState = (typeof typeStates)[number];
+
+const valueStates = [
+    ['No Value', null, 'placeholder'],
+    ['Value', 'Hello', 'placeholder']
+] as const;
+type ValueState = (typeof valueStates)[number];
+
+const metadata: Meta = {
+    title: 'Tests/Text Field',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/toggle-button/tests/toggle-button-matrix.stories.ts
+++ b/packages/nimble-components/src/toggle-button/tests/toggle-button-matrix.stories.ts
@@ -21,6 +21,12 @@ import {
     partVisibilityStates
 } from '../../patterns/button/tests/states';
 
+const checkedStates = [
+    ['Checked', true],
+    ['Unchecked', false]
+] as const;
+type CheckedState = (typeof checkedStates)[number];
+
 const metadata: Meta = {
     title: 'Tests/Toggle Button',
     parameters: {
@@ -29,12 +35,6 @@ const metadata: Meta = {
 };
 
 export default metadata;
-
-const checkedStates = [
-    ['Checked', true],
-    ['Unchecked', false]
-] as const;
-type CheckedState = (typeof checkedStates)[number];
 
 // prettier-ignore
 const component = (

--- a/packages/nimble-components/src/tooltip/tests/tooltip-matrix.stories.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip-matrix.stories.ts
@@ -28,7 +28,7 @@ type IconVisibleState = (typeof iconVisibleStates)[number];
 const severityStates = [
     ['Default', TooltipSeverity.default],
     ['Error', TooltipSeverity.error],
-    ['Information', TooltipSeverity.information],
+    ['Information', TooltipSeverity.information]
 ] as const;
 type SeverityState = (typeof severityStates)[number];
 

--- a/packages/nimble-components/src/tooltip/tests/tooltip-matrix.stories.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip-matrix.stories.ts
@@ -1,6 +1,5 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import { pascalCase } from '@microsoft/fast-web-utilities';
 import {
     createMatrix,
     sharedMatrixParameters
@@ -20,6 +19,25 @@ import { loremIpsum } from '../../utilities/tests/lorem-ipsum';
 import { TooltipSeverity } from '../types';
 import { tooltipTag } from '..';
 
+const iconVisibleStates = [
+    ['No_Icon', false],
+    ['Icon_Visible', true]
+] as const;
+type IconVisibleState = (typeof iconVisibleStates)[number];
+
+const severityStates = [
+    ['Default', TooltipSeverity.default],
+    ['Error', TooltipSeverity.error],
+    ['Information', TooltipSeverity.information],
+] as const;
+type SeverityState = (typeof severityStates)[number];
+
+const textStates = [
+    ['Short_Text', 'Hello'],
+    ['Long_Text', loremIpsum]
+] as const;
+type TextState = (typeof textStates)[number];
+
 const metadata: Meta = {
     title: 'Tests/Tooltip',
     parameters: {
@@ -28,23 +46,6 @@ const metadata: Meta = {
 };
 
 export default metadata;
-
-const textStates = [
-    ['Short_Text', 'Hello'],
-    ['Long_Text', loremIpsum]
-] as const;
-type TextState = (typeof textStates)[number];
-
-const severityStates: [string, string | undefined][] = Object.entries(
-    TooltipSeverity
-).map(([key, value]) => [pascalCase(key), value]);
-type SeverityState = (typeof severityStates)[number];
-
-const iconVisibleStates = [
-    ['No_Icon', false],
-    ['Icon_Visible', true]
-] as const;
-type IconVisibleState = (typeof iconVisibleStates)[number];
 
 const component = (
     [textName, text]: TextState,

--- a/packages/nimble-components/src/tree-view/tests/tree-view-matrix.stories.ts
+++ b/packages/nimble-components/src/tree-view/tests/tree-view-matrix.stories.ts
@@ -20,13 +20,6 @@ import { iconDatabaseTag } from '../../icons/database';
 import { treeItemTag } from '../../tree-item';
 import { anchorTreeItemTag } from '../../anchor-tree-item';
 
-const metadata: Meta = {
-    title: 'Tests/Tree View',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
 const expandedStates = [
     ['Collapsed', false],
     ['Expanded', true]
@@ -38,6 +31,15 @@ const selectedStates = [
     ['Selected', true]
 ] as const;
 type SelectedState = (typeof selectedStates)[number];
+
+const metadata: Meta = {
+    title: 'Tests/Tree View',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 // prettier-ignore
 const component = (
@@ -74,8 +76,6 @@ const component = (
         </${treeItemTag}>
     </${treeViewTag}>
 `;
-
-export default metadata;
 
 export const treeViewThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [

--- a/packages/nimble-components/src/wafer-map/tests/wafer-map-matrix.stories.ts
+++ b/packages/nimble-components/src/wafer-map/tests/wafer-map-matrix.stories.ts
@@ -9,54 +9,10 @@ import {
 import { createStory } from '../../utilities/tests/storybook';
 import { waferMapTag } from '..';
 
-const metadata: Meta = {
-    title: 'Tests/Wafer Map',
-    parameters: {
-        ...sharedMatrixParameters()
-    }
-};
-
-export default metadata;
-
-const orientationStates = [
-    [WaferMapOrientation.top],
-    [WaferMapOrientation.bottom],
-    [WaferMapOrientation.left],
-    [WaferMapOrientation.right]
-] as const;
-type OrientationState = (typeof orientationStates)[number];
-
-const originLocationStates = [
-    [WaferMapOriginLocation.topLeft],
-    [WaferMapOriginLocation.bottomLeft],
-    [WaferMapOriginLocation.topRight],
-    [WaferMapOriginLocation.bottomRight]
-] as const;
-type OriginLocationStates = (typeof originLocationStates)[number];
-
-const colorsScales = [
-    [
-        {
-            colors: ['red', 'orange', 'green'],
-            values: [1, 50, 100]
-        }
-    ],
-    [
-        {
-            colors: ['red', 'purple', 'blue'],
-            values: [1, 50, 100]
-        }
-    ]
-] as const;
-type ColorScales = (typeof colorsScales)[number];
-
-const defaultColor = {
+const colorScale = {
     colors: ['red', 'blue', 'green'],
     values: [1, 50, 100]
-};
-
-const dieLabelHidden = [[true], [false]] as const;
-type DieLabelHidden = (typeof dieLabelHidden)[number];
+} as const;
 
 const waferMapDie = [
     { x: 0, y: 2, value: '99', tags: ['a'] },
@@ -72,14 +28,28 @@ const waferMapDie = [
     { x: 3, y: 1, value: '10' },
     { x: 3, y: 3, value: '15' },
     { x: 4, y: 2, value: '30' }
-];
+] as const;
 
-const waferMapSizes = [70, 200, 300, 400];
+const colorsScaleStates = [
+    [
+        {
+            colors: ['red', 'orange', 'green'],
+            values: [1, 50, 100]
+        }
+    ],
+    [
+        {
+            colors: ['red', 'purple', 'blue'],
+            values: [1, 50, 100]
+        }
+    ]
+] as const;
+type ColorScaleState = (typeof colorsScaleStates)[number];
 
-const highlightedTags = [['a'], ['b', 'a'], [], ['']];
-type HighlightedTags = string[];
+const dieLabelHiddenStates = [[true], [false]] as const;
+type DieLabelHiddenState = (typeof dieLabelHiddenStates)[number];
 
-const gridDimensions = [
+const gridDimensionStates = [
     [
         {
             gridMinX: undefined,
@@ -121,11 +91,42 @@ const gridDimensions = [
         }
     ]
 ] as const;
-type GridDimensions = (typeof gridDimensions)[number];
+type GridDimensionState = (typeof gridDimensionStates)[number];
+
+const highlightedTagStates = [['a'], ['b', 'a'], [], ['']] as const;
+type HighlightedTagState = (typeof highlightedTagStates)[number];
+
+const orientationStates = [
+    [WaferMapOrientation.top],
+    [WaferMapOrientation.bottom],
+    [WaferMapOrientation.left],
+    [WaferMapOrientation.right]
+] as const;
+type OrientationState = (typeof orientationStates)[number];
+
+const originLocationStates = [
+    [WaferMapOriginLocation.topLeft],
+    [WaferMapOriginLocation.bottomLeft],
+    [WaferMapOriginLocation.topRight],
+    [WaferMapOriginLocation.bottomRight]
+] as const;
+type OriginLocationStates = (typeof originLocationStates)[number];
+
+const sizeStates = [70, 200, 300, 400] as const;
+type SizeState = (typeof sizeStates)[number];
+
+const metadata: Meta = {
+    title: 'Tests/Wafer Map',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
 
 const simpleWaferWithDies = (): ViewTemplate => html`<${waferMapTag}
     :dies="${() => waferMapDie}"
-    :colorScale="${() => defaultColor}"
+    :colorScale="${() => colorScale}"
 >
 </${waferMapTag}>`;
 
@@ -134,15 +135,15 @@ const componentWaferWithOrientation = ([
 ]: OrientationState): ViewTemplate => html`<${waferMapTag}
     orientation="${() => orientation}"
     :dies="${() => waferMapDie}"
-    :colorScale="${() => defaultColor}"
+    :colorScale="${() => colorScale}"
 >
 </${waferMapTag}>`;
 
 const componentWaferWithHiddenDieLabel = (
-    [color]: ColorScales,
-    [dieLabelHidde]: DieLabelHidden
+    [color]: ColorScaleState,
+    [dieLabelHidden]: DieLabelHiddenState
 ): ViewTemplate => html`<${waferMapTag}
-    ?die-labels-hidden=${() => dieLabelHidde}
+    ?die-labels-hidden=${() => dieLabelHidden}
     :dies="${() => waferMapDie}"
     :colorScale="${() => color}"
 >
@@ -153,24 +154,24 @@ const componentWaferWithOriginLocation = ([
 ]: OriginLocationStates): ViewTemplate => html`<${waferMapTag}
     :originLocation="${() => originLocation}"
     :dies="${() => waferMapDie}"
-    :colorScale="${() => defaultColor}"
+    :colorScale="${() => colorScale}"
 >
 </${waferMapTag}>`;
 
 const componentWaferResize = (
-    size: number
+    size: SizeState
 ): ViewTemplate => html`<${waferMapTag}
     style="width: ${size}px; height: ${size}px"
     :dies="${() => waferMapDie}"
-    :colorScale="${() => defaultColor}"
+    :colorScale="${() => colorScale}"
 >
 </${waferMapTag}> `;
 
 const componentWaferWithGridDimensions = ([
     dimensions
-]: GridDimensions): ViewTemplate => html`<${waferMapTag}
+]: GridDimensionState): ViewTemplate => html`<${waferMapTag}
     :dies="${() => waferMapDie}"
-    :colorScale="${() => defaultColor}"
+    :colorScale="${() => colorScale}"
     :gridMaxX=${() => dimensions.gridMaxX}
     :gridMaxY=${() => dimensions.gridMaxY}
     :gridMinX=${() => dimensions.gridMinX}
@@ -179,10 +180,10 @@ const componentWaferWithGridDimensions = ([
 </${waferMapTag}>`;
 
 const componentWaferWithHighlightedTags = (
-    tags: HighlightedTags
+    tags: HighlightedTagState
 ): ViewTemplate => html`<${waferMapTag}
     :dies="${() => waferMapDie}"
-    :colorScale="${() => defaultColor}"
+    :colorScale="${() => colorScale}"
     :highlightedTags="${() => tags}"
 >
 </${waferMapTag}>`;
@@ -197,8 +198,8 @@ export const waferMapDiesAndOrientationTest: StoryFn = createStory(
 
 export const waferMapDieLabelAndColorScaleTest: StoryFn = createStory(
     createMatrix(componentWaferWithHiddenDieLabel, [
-        colorsScales,
-        dieLabelHidden
+        colorsScaleStates,
+        dieLabelHiddenStates
     ])
 );
 
@@ -207,13 +208,13 @@ export const waferMapOriginLocationTest: StoryFn = createStory(
 );
 
 export const waferMapResizeTest: StoryFn = createStory(
-    createMatrix(componentWaferResize, [waferMapSizes])
+    createMatrix(componentWaferResize, [sizeStates])
 );
 
 export const waferMapGridDimensionsTest: StoryFn = createStory(
-    createMatrix(componentWaferWithGridDimensions, [gridDimensions])
+    createMatrix(componentWaferWithGridDimensions, [gridDimensionStates])
 );
 
 export const waferMapHighlightedTest: StoryFn = createStory(
-    createMatrix(componentWaferWithHighlightedTags, [highlightedTags])
+    createMatrix(componentWaferWithHighlightedTags, [highlightedTagStates])
 );


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Makes the following bits more consistent in the storybook matrix tests:
- All the states enums use the normal enum pattern ([instead of programmatic enum definition which looses some typing](https://github.com/ni/nimble/pull/1934#discussion_r1534888401))
- All the states are defined first before the storybook metadata definition
- All the states use the naming convention of `blahStates` for the state dimension and `BlahState` for the individual state type
- File specific states were put in alphabetical order

## 👩‍💻 Implementation

See above.

## 🧪 Testing

Should not result in any changes in stories except for one change in dialogs where I have the state name render on the page instead of the state value which is a long CSS string.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed. Hoping folks just copy and paste the patterns, didn't seem worth a doc update.
