### PR TITLE
Fix a couple issues with anchor styling

### DIFF
--- a/change/@ni-nimble-components-c92408f2-14ec-4254-9aac-0babfa7fbbd1.json
+++ b/change/@ni-nimble-components-c92408f2-14ec-4254-9aac-0babfa7fbbd1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix a couple issues with anchor styling",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/anchor/styles.ts
+++ b/packages/nimble-components/src/anchor/styles.ts
@@ -76,11 +76,6 @@ export const styles = css`
             color: ${linkActiveProminentFontColor};
         }
 
-        ${
-            '' /* It's probably cleaner to add :not(active) to the selector in the 'active' layer (rather
-                than resetting text-decoration back to the value from the 'default' layer), but
-                there's a bug in storybook-addon-pseudo-states where it doesn't handle :not() properly. */
-        }
         :host([underline-hidden]) .control:active {
             text-decoration: none;
         }

--- a/packages/nimble-components/src/anchor/styles.ts
+++ b/packages/nimble-components/src/anchor/styles.ts
@@ -2,102 +2,93 @@ import { css } from '@microsoft/fast-element';
 import { display } from '@microsoft/fast-foundation';
 import { focusVisible } from '../utilities/style/focus';
 import {
-    linkActiveDisabledFontColor,
     linkActiveFontColor,
     linkActiveProminentFontColor,
     linkDisabledFontColor,
     linkFont,
     linkFontColor,
-    linkProminentDisabledFontColor,
     linkProminentFontColor
 } from '../theme-provider/design-tokens';
 
 export const styles = css`
-    ${display('inline')}
+    @layer base, hover, focusVisible, active, disabled;
 
-    :host {
-        box-sizing: border-box;
-        font: ${linkFont};
+    @layer base {
+        ${display('inline')}
+
+        :host {
+            box-sizing: border-box;
+            font: ${linkFont};
+        }
+
+        .top-container {
+            display: contents;
+        }
+
+        [part='start'] {
+            display: none;
+        }
+
+        .control {
+            color: ${linkFontColor};
+            text-decoration: underline;
+        }
+
+        :host([underline-hidden]) .control {
+            text-decoration: none;
+        }
+
+        :host([appearance='prominent']) .control {
+            color: ${linkProminentFontColor};
+        }
+
+        .content {
+            pointer-events: none;
+        }
+
+        [part='end'] {
+            display: none;
+        }
     }
 
-    .top-container {
-        display: contents;
+    @layer hover {
+        .control:any-link:hover {
+            text-decoration: underline;
+        }
     }
 
-    [part='start'] {
-        display: none;
+    @layer focusVisible {
+        .control${focusVisible} {
+            outline: none;
+            box-shadow: inset 0px -1px;
+            text-decoration: underline;
+        }
     }
 
-    .control {
-        color: ${linkFontColor};
-        text-decoration: underline;
+    @layer active {
+        .control:active {
+            color: ${linkActiveFontColor};
+            text-decoration: underline;
+            box-shadow: none;
+        }
+
+        :host([appearance='prominent']) .control:active {
+            color: ${linkActiveProminentFontColor};
+        }
+
+        ${
+            '' /* It's probably cleaner to add :not(active) to the selector in the 'active' layer (rather
+                than resetting text-decoration back to the value from the 'default' layer), but
+                there's a bug in storybook-addon-pseudo-states where it doesn't handle :not() properly. */
+        }
+        :host([underline-hidden]) .control:active {
+            text-decoration: none;
+        }
     }
 
-    .control${focusVisible} {
-        display: inline;
-        outline: none;
-        box-shadow: inset 0px -1px ${linkFontColor};
-    }
-
-    .control:active {
-        color: ${linkActiveFontColor};
-        text-decoration: underline;
-    }
-
-    .control${focusVisible}:active {
-        box-shadow: inset 0px -1px ${linkActiveFontColor};
-    }
-
-    .control:not(:any-link) {
-        color: ${linkDisabledFontColor};
-        text-decoration: none;
-    }
-
-    .control:not(:any-link):active {
-        color: ${linkActiveDisabledFontColor};
-    }
-
-    :host([underline-hidden]) .control {
-        text-decoration: none;
-    }
-
-    :host([underline-hidden]) .control:hover {
-        text-decoration: underline;
-    }
-
-    :host([underline-hidden]) .control${focusVisible} {
-        text-decoration: underline;
-    }
-
-    :host([underline-hidden]) .control:not(:any-link) {
-        text-decoration: none;
-    }
-
-    :host([appearance='prominent']) .control {
-        color: ${linkProminentFontColor};
-    }
-
-    :host([appearance='prominent']) .control:active {
-        color: ${linkActiveProminentFontColor};
-    }
-
-    :host([appearance='prominent']) .control${focusVisible} {
-        box-shadow: inset 0px -1px ${linkProminentFontColor};
-    }
-
-    :host([appearance='prominent']) .control${focusVisible}:active {
-        box-shadow: inset 0px -1px ${linkActiveProminentFontColor};
-    }
-
-    :host([appearance='prominent']) .control:not(:any-link) {
-        color: ${linkProminentDisabledFontColor};
-    }
-
-    .content {
-        pointer-events: none;
-    }
-
-    [part='end'] {
-        display: none;
+    @layer disabled {
+        .control:not(:any-link) {
+            color: ${linkDisabledFontColor};
+        }
     }
 `;

--- a/packages/nimble-components/src/anchor/styles.ts
+++ b/packages/nimble-components/src/anchor/styles.ts
@@ -25,10 +25,6 @@ export const styles = css`
             display: contents;
         }
 
-        [part='start'] {
-            display: none;
-        }
-
         .control {
             color: ${linkFontColor};
             text-decoration: underline;
@@ -40,6 +36,10 @@ export const styles = css`
 
         :host([appearance='prominent']) .control {
             color: ${linkProminentFontColor};
+        }
+
+        [part='start'] {
+            display: none;
         }
 
         .content {

--- a/packages/nimble-components/src/breadcrumb-item/styles.ts
+++ b/packages/nimble-components/src/breadcrumb-item/styles.ts
@@ -54,7 +54,7 @@ export const styles = css`
 
     .control:active {
         color: var(--ni-private-breadcrumb-link-active-font-color);
-        text-decoration: underline;
+        text-decoration: none;
     }
 
     [part='start'] {

--- a/packages/nimble-components/src/rich-text/models/markdown-parser.ts
+++ b/packages/nimble-components/src/rich-text/models/markdown-parser.ts
@@ -148,12 +148,22 @@ export class RichTextMarkdownParser {
                                  * scheme and no matching mention pattern will be rendered as plain text (anchor with no href).
                                  * With this, the user can click the links only when the scheme is HTTP/HTTPS
                                  */
-                                href: /^https?:\/\//i.test(href) ? href : null,
+                                href: RichTextMarkdownParser.startsWithHttpOrHttps(
+                                    href
+                                )
+                                    ? href
+                                    : null,
                                 rel: node.attrs.rel as Attr,
                                 // Adding `class` here is a workaround to render two mentions without a whitespace as display names
                                 // This attribute can be removed when the below issue is resolved
                                 // https://github.com/ni/nimble/issues/1707
-                                class: href
+                                class: href,
+                                'underline-hidden':
+                                    RichTextMarkdownParser.startsWithHttpOrHttps(
+                                        href
+                                    )
+                                        ? null
+                                        : true
                             }
                         ];
                     }
@@ -176,5 +186,9 @@ export class RichTextMarkdownParser {
     private static cleanup(): void {
         RichTextMarkdownParser.mentionConfigs = undefined;
         RichTextMarkdownParser.mentionedHrefs.clear();
+    }
+
+    private static startsWithHttpOrHttps(href: string): boolean {
+        return /^https?:\/\//i.test(href);
     }
 }

--- a/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
+++ b/packages/nimble-components/src/rich-text/models/tests/markdown-parser.spec.ts
@@ -564,7 +564,7 @@ describe('Markdown parser', () => {
                 ] as const;
                 parameterizeSpec(differentProtocolLinks, (spec, name) => {
                     spec(
-                        `string "${name}" renders within nimble-anchor without 'href' attribute`,
+                        `string "${name}" renders within nimble-anchor without 'href' attribute and with 'underline-hidden'`,
                         () => {
                             const doc = RichTextMarkdownParser.parseMarkdownToDOM(
                                 name
@@ -581,6 +581,12 @@ describe('Markdown parser', () => {
                             expect(
                                 lastChildElementHasAttribute('href', doc)
                             ).toBeFalse();
+                            expect(
+                                lastChildElementHasAttribute(
+                                    'underline-hidden',
+                                    doc
+                                )
+                            ).toBeTrue();
                         }
                     );
                 });

--- a/packages/nimble-components/src/rich-text/viewer/styles.ts
+++ b/packages/nimble-components/src/rich-text/viewer/styles.ts
@@ -1,6 +1,10 @@
 import { css } from '@microsoft/fast-element';
 import { display } from '@microsoft/fast-foundation';
-import { bodyFont, bodyFontColor } from '../../theme-provider/design-tokens';
+import {
+    bodyFont,
+    bodyFontColor,
+    linkFontColor
+} from '../../theme-provider/design-tokens';
 
 export const styles = css`
     ${display('flex')}
@@ -40,5 +44,19 @@ export const styles = css`
     }
     li > p:empty {
         display: none;
+    }
+
+    ${
+        /**
+         * When an absolute link is not HTTPS/HTTP, the anchor tag renders without an `href`, appearing as plain text.
+         * However, the `nimble-anchor` displays differently in color when the `href` attribute is absent.
+         * To ensure a consistent appearance, the font color is forced to the default link color regardless of the `href`
+         * attribute's presence.
+         *
+         * See models/markdown-parser.ts where link elements are emitted for more info.
+         */ ''
+    }
+    nimble-anchor::part(control) {
+        color: ${linkFontColor};
     }
 `;

--- a/packages/nimble-components/src/rich-text/viewer/styles.ts
+++ b/packages/nimble-components/src/rich-text/viewer/styles.ts
@@ -1,10 +1,6 @@
 import { css } from '@microsoft/fast-element';
 import { display } from '@microsoft/fast-foundation';
-import {
-    bodyFont,
-    bodyFontColor,
-    linkFontColor
-} from '../../theme-provider/design-tokens';
+import { bodyFont, bodyFontColor } from '../../theme-provider/design-tokens';
 
 export const styles = css`
     ${display('flex')}

--- a/packages/nimble-components/src/rich-text/viewer/styles.ts
+++ b/packages/nimble-components/src/rich-text/viewer/styles.ts
@@ -48,10 +48,13 @@ export const styles = css`
 
     ${
         /**
-         * When an absolute link is not HTTPS/HTTP, the anchor tag renders without an `href`, appearing as plain text.
-         * However, the `nimble-anchor` displays differently in color when the `href` attribute is absent.
-         * To ensure a consistent appearance, the font color is forced to the default link color regardless of the `href`
-         * attribute's presence.
+         * In the rich-text viewer, an absolute link renders as a native anchor, not a `nimble-anchor`. When such a link
+         * is not HTTPS/HTTP, the anchor renders without an `href`, appearing as plain text.
+         * However, in the rich-text viewer, absolute links are rendered as `nimble-anchor`s, and they do not look like
+         * plain text when the `href` attribute is absent. They have a "disabled" color and may have an underline.
+         * To ensure a consistent appearance between the editor and viewer, we force the font color to the default link/
+         * plain text color regardless of the `href` attribute's presence. To remove the underline, the markdown parser
+         * emits an `underline-hidden` attribute when the `href` attribute is absent.
          *
          * See models/markdown-parser.ts where link elements are emitted for more info.
          */ ''

--- a/packages/nimble-components/src/rich-text/viewer/styles.ts
+++ b/packages/nimble-components/src/rich-text/viewer/styles.ts
@@ -48,7 +48,7 @@ export const styles = css`
 
     ${
         /**
-         * In the rich-text viewer, an absolute link renders as a native anchor, not a `nimble-anchor`. When such a link
+         * In the rich-text editor, an absolute link renders as a native anchor, not a `nimble-anchor`. When such a link
          * is not HTTPS/HTTP, the anchor renders without an `href`, appearing as plain text.
          * However, in the rich-text viewer, absolute links are rendered as `nimble-anchor`s, and they do not look like
          * plain text when the `href` attribute is absent. They have a "disabled" color and may have an underline.

--- a/packages/nimble-components/src/rich-text/viewer/styles.ts
+++ b/packages/nimble-components/src/rich-text/viewer/styles.ts
@@ -45,18 +45,4 @@ export const styles = css`
     li > p:empty {
         display: none;
     }
-
-    ${
-        /**
-         * When an absolute link is not HTTPS/HTTP, the anchor tag renders without an `href`, appearing as plain text.
-         * However, the `nimble-anchor` displays differently in color when the `href` attribute is absent.
-         * To ensure a consistent appearance, the font color is forced to the default link color regardless of the `href`
-         * attribute's presence.
-         *
-         * See models/markdown-parser.ts where link elements are emitted for more info.
-         */ ''
-    }
-    nimble-anchor::part(control) {
-        color: ${linkFontColor};
-    }
 `;

--- a/packages/nimble-components/src/theme-provider/design-tokens.ts
+++ b/packages/nimble-components/src/theme-provider/design-tokens.ts
@@ -588,7 +588,7 @@ export const [
         element,
         DigitalGreenLight,
         DigitalGreenLight,
-        PowerGreen
+        hexToRgbaCssColor(White, 0.6)
     ),
     (element: HTMLElement) => hexToRgbaCssColor(getDefaultFontColorForTheme(element), 0.3),
     LinkLightUiFamily,


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

I noticed a few differences between our anchor styling and the [Figma design](https://www.figma.com/file/PO9mFOu5BCl8aJvFchEeuN/Nimble_Components?type=design&node-id=1295-76706&mode=design&t=tRlgHtHiOWeXNCIe-0):
1. Visited links have a distinct color (purple)
2. Keyboard focus is indicated by an outline rather than double underline
3. Disabled links should have underlines unless `underline-hidden` is set
4. Links with `underline-hidden` should not have underlines when clicked/active (despite mouse hover)
5. In the color theme, a clicked/active link should have the same, dim, gray color regardless of whether it has the `prominent` appearance. (Figma does not actually provide a design for the `prominent` appearance under the color theme, but we can extrapolate from the other themes.)

## 👩‍💻 Implementation

I am addressing issues 3-5. Tech debt issue #2011 tracks items 1 and 2.

To simplify things, I rewrote the anchor styles using CSS cascade layers.

## 🧪 Testing

Storybook snapshots

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
