### PR TITLE
Reverting Combobox changes.

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/src/directives/combobox/nimble-combobox-control-value-accessor.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/src/directives/combobox/nimble-combobox-control-value-accessor.directive.ts
@@ -132,9 +132,7 @@ export class NimbleComboboxControlValueAccessorDirective implements ControlValue
             this._displayTextToOptionsMap.set(option.text, [option]);
         }
 
-        if (modelValue === this._modelValue) {
-            this.updateDisplayValue();
-        }
+        this.updateDisplayValue();
     }
 
     /**

--- a/change/@ni-nimble-angular-5e8bc8ae-e90c-4807-b538-a3b19fa2527d.json
+++ b/change/@ni-nimble-angular-5e8bc8ae-e90c-4807-b538-a3b19fa2527d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Reverting changes.",
+  "packageName": "@ni/nimble-angular",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-c29b9820-0a40-4fdf-9733-bc6c0b30e831.json
+++ b/change/@ni-nimble-components-c29b9820-0a40-4fdf-9733-bc6c0b30e831.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Reverting changes.",
+  "packageName": "@ni/nimble-components",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/combobox/index.ts
+++ b/packages/nimble-components/src/combobox/index.ts
@@ -17,14 +17,10 @@ import { iconExclamationMarkTag } from '../icons/exclamation-mark';
 
 import { styles } from './styles';
 import type { ErrorPattern } from '../patterns/error/types';
-import type {
-    DropdownPattern,
-    ListOptionOwner
-} from '../patterns/dropdown/types';
+import type { DropdownPattern } from '../patterns/dropdown/types';
 import { DropdownAppearance } from '../patterns/dropdown/types';
 import type { AnchoredRegion } from '../anchored-region';
 import { template } from './template';
-import type { ListOption } from '../list-option';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -37,7 +33,7 @@ declare global {
  */
 export class Combobox
     extends FoundationCombobox
-    implements DropdownPattern, ErrorPattern, ListOptionOwner {
+    implements DropdownPattern, ErrorPattern {
     @attr
     public appearance: DropdownAppearance = DropdownAppearance.underline;
 
@@ -209,23 +205,6 @@ export class Combobox
         this.open = false;
         this.emitChangeIfValueUpdated();
         return returnValue;
-    }
-
-    /**
-     * @internal
-     */
-    public registerOption(option: ListOption): void {
-        if (this.options.includes(option)) {
-            return;
-        }
-
-        // Adding an option to the end, ultimately, isn't the correct
-        // thing to do, as this will mean the option's index in the options,
-        // at least temporarily, does not match the DOM order. However, it
-        // is expected that a successive run of `slottedOptionsChanged` will
-        // correct this order issue. See 'https://github.com/ni/nimble/issues/1915'
-        // for more info.
-        this.options.push(option);
     }
 
     protected override focusAndScrollOptionIntoView(): void {

--- a/packages/nimble-components/src/combobox/tests/combobox.spec.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox.spec.ts
@@ -127,33 +127,6 @@ describe('Combobox', () => {
         await disconnect();
     });
 
-    it('option added directly to DOM synchronously registers with Combobox', async () => {
-        const { element, connect, disconnect } = await setup();
-        await connect();
-        element.selectedIndex = 0;
-        await waitForUpdatesAsync();
-        const newOption = new ListOption('foo', 'foo');
-        const registerOptionSpy = spyOn(
-            element,
-            'registerOption'
-        ).and.callThrough();
-        registerOptionSpy.calls.reset();
-        element.insertBefore(newOption, element.options[0]!);
-
-        expect(registerOptionSpy.calls.count()).toBe(1);
-        expect(element.options).toContain(newOption);
-
-        // While the option is registered synchronously as shown above,
-        // properties like selectedIndex will only be correct asynchronously
-        // See https://github.com/ni/nimble/issues/1915
-        expect(element.selectedIndex).toBe(0);
-        await waitForUpdatesAsync();
-        // This assertion shows that after 'slottedOptionsChanged' runs, the
-        // 'selectedIndex' state has been corrected to expected DOM order.
-        expect(element.selectedIndex).toBe(1);
-        await disconnect();
-    });
-
     const ariaTestData: {
         attrName: string,
         propSetter: (x: Combobox, value: string) => void

--- a/packages/nimble-components/src/combobox/tests/combobox.spec.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox.spec.ts
@@ -9,7 +9,7 @@ import {
     waitAnimationFrame
 } from '../../utilities/tests/component';
 import { checkFullyInViewport } from '../../utilities/tests/intersection-observer';
-import { ListOption, listOptionTag } from '../../list-option';
+import { listOptionTag } from '../../list-option';
 
 async function setup(
     position?: string,


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

My [recent PR](https://github.com/ni/nimble/pull/1991) that re-introduced the `ListOptionOwner` interface implementation to the `Combobox` resulted in an [integration error](https://dev.azure.com/ni/DevCentral/_git/Skyline/pullrequest/685577?discussionId=6019938) with one of the consumer apps.

It seems best to just revert these changes, and revisit the combobox implementation after we transition the relevant usages of the `Combobox` to use the `Select`. 

## 👩‍💻 Implementation

Just reverting changes.

## 🧪 Testing

Removed the added test.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
