### PR TITLE
Improve TColumnConfig typing on columns that extend TableColumnTextBase

### DIFF
--- a/change/@ni-nimble-components-c9468196-58c9-4afc-b6b4-d40fe360015e.json
+++ b/change/@ni-nimble-components-c9468196-58c9-4afc-b6b4-d40fe360015e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve TColumnConfig typing on columns that extend TableColumnTextBase",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table-column/date-text/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/index.ts
@@ -6,7 +6,7 @@ import { attr } from '@microsoft/fast-element';
 import { styles } from '../base/styles';
 import { template } from '../base/template';
 import type { TableNumberField } from '../../table/types';
-import { mixinTextBase } from '../text-base';
+import { TableColumnTextBase, mixinTextBase } from '../text-base';
 import { TableColumnSortOperation, TableColumnValidity } from '../base/types';
 import { tableColumnDateTextGroupHeaderViewTag } from './group-header-view';
 import { tableColumnDateTextCellViewTag } from './cell-view';
@@ -49,7 +49,7 @@ declare global {
 /**
  * The table column for displaying dates/times as text.
  */
-export class TableColumnDateText extends mixinTextBase<TableColumnDateTextColumnConfig>() {
+export class TableColumnDateText extends mixinTextBase(TableColumnTextBase<TableColumnDateTextColumnConfig>) {
     /** @internal */
     public validator = new TableColumnDateTextValidator(this.columnInternals);
 

--- a/packages/nimble-components/src/table-column/date-text/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/index.ts
@@ -6,7 +6,7 @@ import { attr } from '@microsoft/fast-element';
 import { styles } from '../base/styles';
 import { template } from '../base/template';
 import type { TableNumberField } from '../../table/types';
-import { TableColumnTextBase } from '../text-base';
+import { mixinTextBase } from '../text-base';
 import { TableColumnSortOperation, TableColumnValidity } from '../base/types';
 import { tableColumnDateTextGroupHeaderViewTag } from './group-header-view';
 import { tableColumnDateTextCellViewTag } from './cell-view';
@@ -33,9 +33,6 @@ import { TableColumnDateTextValidator } from './models/table-column-date-text-va
 import { lang } from '../../theme-provider';
 import { optionalBooleanConverter } from '../../utilities/models/converter';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
-import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
-import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
-import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 export type TableColumnDateTextCellRecord = TableNumberField<'value'>;
 export interface TableColumnDateTextColumnConfig
@@ -52,13 +49,7 @@ declare global {
 /**
  * The table column for displaying dates/times as text.
  */
-export class TableColumnDateText extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(
-        mixinColumnWithPlaceholderAPI(
-            TableColumnTextBase<TableColumnDateTextColumnConfig>
-        )
-    )
-) {
+export class TableColumnDateText extends mixinTextBase<TableColumnDateTextColumnConfig>() {
     /** @internal */
     public validator = new TableColumnDateTextValidator(this.columnInternals);
 

--- a/packages/nimble-components/src/table-column/date-text/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/index.ts
@@ -33,6 +33,9 @@ import { TableColumnDateTextValidator } from './models/table-column-date-text-va
 import { lang } from '../../theme-provider';
 import { optionalBooleanConverter } from '../../utilities/models/converter';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
+import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
+import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
+import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 export type TableColumnDateTextCellRecord = TableNumberField<'value'>;
 export interface TableColumnDateTextColumnConfig
@@ -49,7 +52,9 @@ declare global {
 /**
  * The table column for displaying dates/times as text.
  */
-export class TableColumnDateText extends TableColumnTextBase {
+export class TableColumnDateText extends mixinGroupableColumnAPI(
+    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumnTextBase<TableColumnDateTextColumnConfig>))
+) {
     /** @internal */
     public validator = new TableColumnDateTextValidator(this.columnInternals);
 

--- a/packages/nimble-components/src/table-column/date-text/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/index.ts
@@ -53,7 +53,11 @@ declare global {
  * The table column for displaying dates/times as text.
  */
 export class TableColumnDateText extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumnTextBase<TableColumnDateTextColumnConfig>))
+    mixinFractionalWidthColumnAPI(
+        mixinColumnWithPlaceholderAPI(
+            TableColumnTextBase<TableColumnDateTextColumnConfig>
+        )
+    )
 ) {
     /** @internal */
     public validator = new TableColumnDateTextValidator(this.columnInternals);

--- a/packages/nimble-components/src/table-column/date-text/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/index.ts
@@ -49,7 +49,9 @@ declare global {
 /**
  * The table column for displaying dates/times as text.
  */
-export class TableColumnDateText extends mixinTextBase(TableColumnTextBase<TableColumnDateTextColumnConfig>) {
+export class TableColumnDateText extends mixinTextBase(
+    TableColumnTextBase<TableColumnDateTextColumnConfig>
+) {
     /** @internal */
     public validator = new TableColumnDateTextValidator(this.columnInternals);
 

--- a/packages/nimble-components/src/table-column/duration-text/index.ts
+++ b/packages/nimble-components/src/table-column/duration-text/index.ts
@@ -29,7 +29,9 @@ declare global {
 /**
  * The table column for displaying a duration value as text.
  */
-export class TableColumnDurationText extends mixinTextBase(TableColumnTextBase<TableColumnDurationTextColumnConfig>) {
+export class TableColumnDurationText extends mixinTextBase(
+    TableColumnTextBase<TableColumnDurationTextColumnConfig>
+) {
     private readonly langSubscriber: DesignTokenSubscriber<typeof lang> = {
         handleChange: () => {
             this.updateColumnConfig();

--- a/packages/nimble-components/src/table-column/duration-text/index.ts
+++ b/packages/nimble-components/src/table-column/duration-text/index.ts
@@ -5,7 +5,6 @@ import {
 import { styles } from '../base/styles';
 import { template } from '../base/template';
 import type { TableNumberField } from '../../table/types';
-import { TableColumnTextBase } from '../text-base';
 import { TableColumnSortOperation } from '../base/types';
 import { tableColumnDurationTextCellViewTag } from './cell-view';
 import type { ColumnInternalsOptions } from '../base/models/column-internals';
@@ -13,9 +12,7 @@ import { lang } from '../../theme-provider';
 import { DurationFormatter } from './models/duration-formatter';
 import { tableColumnDurationTextGroupHeaderViewTag } from './group-header-view';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
-import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
-import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
-import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
+import { mixinTextBase } from '../text-base';
 
 export type TableColumnDurationTextCellRecord = TableNumberField<'value'>;
 export interface TableColumnDurationTextColumnConfig
@@ -32,13 +29,7 @@ declare global {
 /**
  * The table column for displaying a duration value as text.
  */
-export class TableColumnDurationText extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(
-        mixinColumnWithPlaceholderAPI(
-            TableColumnTextBase<TableColumnDurationTextColumnConfig>
-        )
-    )
-) {
+export class TableColumnDurationText extends mixinTextBase<TableColumnDurationTextColumnConfig>() {
     private readonly langSubscriber: DesignTokenSubscriber<typeof lang> = {
         handleChange: () => {
             this.updateColumnConfig();

--- a/packages/nimble-components/src/table-column/duration-text/index.ts
+++ b/packages/nimble-components/src/table-column/duration-text/index.ts
@@ -33,7 +33,11 @@ declare global {
  * The table column for displaying a duration value as text.
  */
 export class TableColumnDurationText extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumnTextBase<TableColumnDurationTextColumnConfig>))
+    mixinFractionalWidthColumnAPI(
+        mixinColumnWithPlaceholderAPI(
+            TableColumnTextBase<TableColumnDurationTextColumnConfig>
+        )
+    )
 ) {
     private readonly langSubscriber: DesignTokenSubscriber<typeof lang> = {
         handleChange: () => {

--- a/packages/nimble-components/src/table-column/duration-text/index.ts
+++ b/packages/nimble-components/src/table-column/duration-text/index.ts
@@ -13,6 +13,9 @@ import { lang } from '../../theme-provider';
 import { DurationFormatter } from './models/duration-formatter';
 import { tableColumnDurationTextGroupHeaderViewTag } from './group-header-view';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
+import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
+import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
+import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 export type TableColumnDurationTextCellRecord = TableNumberField<'value'>;
 export interface TableColumnDurationTextColumnConfig
@@ -29,7 +32,9 @@ declare global {
 /**
  * The table column for displaying a duration value as text.
  */
-export class TableColumnDurationText extends TableColumnTextBase {
+export class TableColumnDurationText extends mixinGroupableColumnAPI(
+    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumnTextBase<TableColumnDurationTextColumnConfig>))
+) {
     private readonly langSubscriber: DesignTokenSubscriber<typeof lang> = {
         handleChange: () => {
             this.updateColumnConfig();

--- a/packages/nimble-components/src/table-column/duration-text/index.ts
+++ b/packages/nimble-components/src/table-column/duration-text/index.ts
@@ -12,7 +12,7 @@ import { lang } from '../../theme-provider';
 import { DurationFormatter } from './models/duration-formatter';
 import { tableColumnDurationTextGroupHeaderViewTag } from './group-header-view';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
-import { mixinTextBase } from '../text-base';
+import { TableColumnTextBase, mixinTextBase } from '../text-base';
 
 export type TableColumnDurationTextCellRecord = TableNumberField<'value'>;
 export interface TableColumnDurationTextColumnConfig
@@ -29,7 +29,7 @@ declare global {
 /**
  * The table column for displaying a duration value as text.
  */
-export class TableColumnDurationText extends mixinTextBase<TableColumnDurationTextColumnConfig>() {
+export class TableColumnDurationText extends mixinTextBase(TableColumnTextBase<TableColumnDurationTextColumnConfig>) {
     private readonly langSubscriber: DesignTokenSubscriber<typeof lang> = {
         handleChange: () => {
             this.updateColumnConfig();

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -44,7 +44,9 @@ declare global {
 /**
  * The table column for displaying numbers as text.
  */
-export class TableColumnNumberText extends mixinTextBase(TableColumnTextBase<TableColumnNumberTextColumnConfig>) {
+export class TableColumnNumberText extends mixinTextBase(
+    TableColumnTextBase<TableColumnNumberTextColumnConfig>
+) {
     /** @internal */
     public validator = new TableColumnNumberTextValidator(this.columnInternals);
 

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -13,7 +13,7 @@ import {
 import { styles } from '../base/styles';
 import { template } from './template';
 import type { TableNumberField } from '../../table/types';
-import { TableColumnTextBase } from '../text-base';
+import { mixinTextBase } from '../text-base';
 import { TableColumnSortOperation, TableColumnValidity } from '../base/types';
 import { tableColumnNumberTextGroupHeaderTag } from './group-header-view';
 import { tableColumnNumberTextCellViewTag } from './cell-view';
@@ -27,9 +27,6 @@ import { lang } from '../../theme-provider';
 import { Unit } from '../../unit/base/unit';
 import { waitUntilCustomElementsDefinedAsync } from '../../utilities/wait-until-custom-elements-defined-async';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
-import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
-import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
-import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 export type TableColumnNumberTextCellRecord = TableNumberField<'value'>;
 export interface TableColumnNumberTextColumnConfig
@@ -47,13 +44,7 @@ declare global {
 /**
  * The table column for displaying numbers as text.
  */
-export class TableColumnNumberText extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(
-        mixinColumnWithPlaceholderAPI(
-            TableColumnTextBase<TableColumnNumberTextColumnConfig>
-        )
-    )
-) {
+export class TableColumnNumberText extends mixinTextBase<TableColumnNumberTextColumnConfig>() {
     /** @internal */
     public validator = new TableColumnNumberTextValidator(this.columnInternals);
 

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -13,7 +13,7 @@ import {
 import { styles } from '../base/styles';
 import { template } from './template';
 import type { TableNumberField } from '../../table/types';
-import { mixinTextBase } from '../text-base';
+import { TableColumnTextBase, mixinTextBase } from '../text-base';
 import { TableColumnSortOperation, TableColumnValidity } from '../base/types';
 import { tableColumnNumberTextGroupHeaderTag } from './group-header-view';
 import { tableColumnNumberTextCellViewTag } from './cell-view';
@@ -44,7 +44,7 @@ declare global {
 /**
  * The table column for displaying numbers as text.
  */
-export class TableColumnNumberText extends mixinTextBase<TableColumnNumberTextColumnConfig>() {
+export class TableColumnNumberText extends mixinTextBase(TableColumnTextBase<TableColumnNumberTextColumnConfig>) {
     /** @internal */
     public validator = new TableColumnNumberTextValidator(this.columnInternals);
 

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -48,7 +48,11 @@ declare global {
  * The table column for displaying numbers as text.
  */
 export class TableColumnNumberText extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumnTextBase<TableColumnNumberTextColumnConfig>))
+    mixinFractionalWidthColumnAPI(
+        mixinColumnWithPlaceholderAPI(
+            TableColumnTextBase<TableColumnNumberTextColumnConfig>
+        )
+    )
 ) {
     /** @internal */
     public validator = new TableColumnNumberTextValidator(this.columnInternals);

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -27,6 +27,9 @@ import { lang } from '../../theme-provider';
 import { Unit } from '../../unit/base/unit';
 import { waitUntilCustomElementsDefinedAsync } from '../../utilities/wait-until-custom-elements-defined-async';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
+import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
+import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
+import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 export type TableColumnNumberTextCellRecord = TableNumberField<'value'>;
 export interface TableColumnNumberTextColumnConfig
@@ -44,7 +47,9 @@ declare global {
 /**
  * The table column for displaying numbers as text.
  */
-export class TableColumnNumberText extends TableColumnTextBase {
+export class TableColumnNumberText extends mixinGroupableColumnAPI(
+    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumnTextBase<TableColumnNumberTextColumnConfig>))
+) {
     /** @internal */
     public validator = new TableColumnNumberTextValidator(this.columnInternals);
 

--- a/packages/nimble-components/src/table-column/text-base/index.ts
+++ b/packages/nimble-components/src/table-column/text-base/index.ts
@@ -1,5 +1,8 @@
 import { attr } from '@microsoft/fast-element';
 import { TableColumn } from '../base';
+import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
+import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
+import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 /**
  * The base class for table columns that display fields of any type as text.
@@ -14,4 +17,13 @@ export abstract class TableColumnTextBase<
         this.columnInternals.dataRecordFieldNames = [this.fieldName];
         this.columnInternals.operandDataRecordFieldName = this.fieldName;
     }
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type
+export function mixinTextBase<TColumnConfig>() {
+    return mixinGroupableColumnAPI(
+        mixinFractionalWidthColumnAPI(
+            mixinColumnWithPlaceholderAPI(TableColumnTextBase<TColumnConfig>)
+        )
+    );
 }

--- a/packages/nimble-components/src/table-column/text-base/index.ts
+++ b/packages/nimble-components/src/table-column/text-base/index.ts
@@ -19,11 +19,14 @@ export abstract class TableColumnTextBase<
     }
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type
-export function mixinTextBase<TColumnConfig>() {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TableColumnBaseConstructor<TColumnConfig> = abstract new (...args: any[]) => TableColumnTextBase<TColumnConfig>;
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type, @typescript-eslint/no-explicit-any
+export function mixinTextBase<TBase extends TableColumnBaseConstructor<TColumnConfig>, TColumnConfig>(base: TBase) {
     return mixinGroupableColumnAPI(
         mixinFractionalWidthColumnAPI(
-            mixinColumnWithPlaceholderAPI(TableColumnTextBase<TColumnConfig>)
+            mixinColumnWithPlaceholderAPI(base)
         )
     );
 }

--- a/packages/nimble-components/src/table-column/text-base/index.ts
+++ b/packages/nimble-components/src/table-column/text-base/index.ts
@@ -4,7 +4,9 @@ import { TableColumn } from '../base';
 /**
  * The base class for table columns that display fields of any type as text.
  */
-export abstract class TableColumnTextBase<TColumnConfig> extends TableColumn<TColumnConfig> {
+export abstract class TableColumnTextBase<
+    TColumnConfig
+> extends TableColumn<TColumnConfig> {
     @attr({ attribute: 'field-name' })
     public fieldName?: string;
 

--- a/packages/nimble-components/src/table-column/text-base/index.ts
+++ b/packages/nimble-components/src/table-column/text-base/index.ts
@@ -19,14 +19,17 @@ export abstract class TableColumnTextBase<
     }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type TableColumnBaseConstructor<TColumnConfig> = abstract new (...args: any[]) => TableColumnTextBase<TColumnConfig>;
+type TableColumnBaseConstructor<TColumnConfig> = abstract new (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...args: any[]
+) => TableColumnTextBase<TColumnConfig>;
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type, @typescript-eslint/no-explicit-any
-export function mixinTextBase<TBase extends TableColumnBaseConstructor<TColumnConfig>, TColumnConfig>(base: TBase) {
+export function mixinTextBase<
+    TBase extends TableColumnBaseConstructor<TColumnConfig>,
+    TColumnConfig
+>(base: TBase) {
     return mixinGroupableColumnAPI(
-        mixinFractionalWidthColumnAPI(
-            mixinColumnWithPlaceholderAPI(base)
-        )
+        mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(base))
     );
 }

--- a/packages/nimble-components/src/table-column/text-base/index.ts
+++ b/packages/nimble-components/src/table-column/text-base/index.ts
@@ -1,15 +1,10 @@
 import { attr } from '@microsoft/fast-element';
-import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
 import { TableColumn } from '../base';
-import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
-import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 /**
  * The base class for table columns that display fields of any type as text.
  */
-export abstract class TableColumnTextBase extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumn))
-) {
+export abstract class TableColumnTextBase<TColumnConfig> extends TableColumn<TColumnConfig> {
     @attr({ attribute: 'field-name' })
     public fieldName?: string;
 

--- a/packages/nimble-components/src/table-column/text/index.ts
+++ b/packages/nimble-components/src/table-column/text/index.ts
@@ -24,7 +24,9 @@ declare global {
 /**
  * The table column for displaying string fields as text.
  */
-export class TableColumnText extends mixinTextBase(TableColumnTextBase<TableColumnTextColumnConfig>) {
+export class TableColumnText extends mixinTextBase(
+    TableColumnTextBase<TableColumnTextColumnConfig>
+) {
     public placeholderChanged(): void {
         this.columnInternals.columnConfig = {
             placeholder: this.placeholder

--- a/packages/nimble-components/src/table-column/text/index.ts
+++ b/packages/nimble-components/src/table-column/text/index.ts
@@ -2,7 +2,7 @@ import { DesignSystem } from '@microsoft/fast-foundation';
 import { styles } from '../base/styles';
 import { template } from '../base/template';
 import type { TableStringField } from '../../table/types';
-import { mixinTextBase } from '../text-base';
+import { TableColumnTextBase, mixinTextBase } from '../text-base';
 import { TableColumnSortOperation } from '../base/types';
 import { tableColumnTextGroupHeaderViewTag } from './group-header-view';
 import { tableColumnTextCellViewTag } from './cell-view';
@@ -24,11 +24,13 @@ declare global {
 /**
  * The table column for displaying string fields as text.
  */
-export class TableColumnText extends mixinTextBase<TableColumnTextColumnConfig>() {
+export class TableColumnText extends mixinTextBase(TableColumnTextBase<TableColumnTextColumnConfig>) {
     public placeholderChanged(): void {
         this.columnInternals.columnConfig = {
             placeholder: this.placeholder
         };
+
+        this.templateChanged();
     }
 
     protected override getColumnInternalsOptions(): ColumnInternalsOptions {

--- a/packages/nimble-components/src/table-column/text/index.ts
+++ b/packages/nimble-components/src/table-column/text/index.ts
@@ -28,7 +28,11 @@ declare global {
  * The table column for displaying string fields as text.
  */
 export class TableColumnText extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumnTextBase<TableColumnTextColumnConfig>))
+    mixinFractionalWidthColumnAPI(
+        mixinColumnWithPlaceholderAPI(
+            TableColumnTextBase<TableColumnTextColumnConfig>
+        )
+    )
 ) {
     public placeholderChanged(): void {
         this.columnInternals.columnConfig = {

--- a/packages/nimble-components/src/table-column/text/index.ts
+++ b/packages/nimble-components/src/table-column/text/index.ts
@@ -2,15 +2,12 @@ import { DesignSystem } from '@microsoft/fast-foundation';
 import { styles } from '../base/styles';
 import { template } from '../base/template';
 import type { TableStringField } from '../../table/types';
-import { TableColumnTextBase } from '../text-base';
+import { mixinTextBase } from '../text-base';
 import { TableColumnSortOperation } from '../base/types';
 import { tableColumnTextGroupHeaderViewTag } from './group-header-view';
 import { tableColumnTextCellViewTag } from './cell-view';
 import type { ColumnInternalsOptions } from '../base/models/column-internals';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
-import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
-import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
-import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 export type TableColumnTextCellRecord = TableStringField<'value'>;
 
@@ -27,13 +24,7 @@ declare global {
 /**
  * The table column for displaying string fields as text.
  */
-export class TableColumnText extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(
-        mixinColumnWithPlaceholderAPI(
-            TableColumnTextBase<TableColumnTextColumnConfig>
-        )
-    )
-) {
+export class TableColumnText extends mixinTextBase<TableColumnTextColumnConfig>() {
     public placeholderChanged(): void {
         this.columnInternals.columnConfig = {
             placeholder: this.placeholder

--- a/packages/nimble-components/src/table-column/text/index.ts
+++ b/packages/nimble-components/src/table-column/text/index.ts
@@ -8,6 +8,9 @@ import { tableColumnTextGroupHeaderViewTag } from './group-header-view';
 import { tableColumnTextCellViewTag } from './cell-view';
 import type { ColumnInternalsOptions } from '../base/models/column-internals';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
+import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
+import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
+import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 export type TableColumnTextCellRecord = TableStringField<'value'>;
 
@@ -24,7 +27,9 @@ declare global {
 /**
  * The table column for displaying string fields as text.
  */
-export class TableColumnText extends TableColumnTextBase {
+export class TableColumnText extends mixinGroupableColumnAPI(
+    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumnTextBase<TableColumnTextColumnConfig>))
+) {
     public placeholderChanged(): void {
         this.columnInternals.columnConfig = {
             placeholder: this.placeholder

--- a/packages/nimble-components/src/table-column/text/index.ts
+++ b/packages/nimble-components/src/table-column/text/index.ts
@@ -29,8 +29,6 @@ export class TableColumnText extends mixinTextBase(TableColumnTextBase<TableColu
         this.columnInternals.columnConfig = {
             placeholder: this.placeholder
         };
-
-        this.templateChanged();
     }
 
     protected override getColumnInternalsOptions(): ColumnInternalsOptions {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #1964 

## 👩‍💻 Implementation

`TableColumnTextBase` cannot simply be made generic because TypeScript doesn't support generics and mixins together: https://github.com/microsoft/TypeScript/issues/26154.

Therefore, each concrete instance of `TableColumnTextBase` should add its own mixins in a way that they get mixed into `TableColumnTextBase<TColumnConfig>` rather than `TableColumn`. To avoid code duplicate, I created a function, `mixinTextBase`,  that mixes in the appropriate mixins for `TableColumnTextBase`.

## 🧪 Testing

- Unit tests still pass
- Manually verified that the type of `this.columnInternals.columnConfig` is correct for a column using `mixinTextBase`
- Sanity tested examples in storybook to make sure columns still behave as expected

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
