### PR TITLE
Move column validator into columnInternals

### DIFF
--- a/change/@ni-nimble-components-90fb9043-d42e-4be9-827d-e6f94ab7b96b.json
+++ b/change/@ni-nimble-components-90fb9043-d42e-4be9-827d-e6f94ab7b96b.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Improve TColumnConfig typing on columns that extend TableColumnTextBase",
+  "comment": "Move validator into ColumnInternals",
   "packageName": "@ni/nimble-components",
   "email": "20542556+mollykreis@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@ni-nimble-components-c9468196-58c9-4afc-b6b4-d40fe360015e.json
+++ b/change/@ni-nimble-components-c9468196-58c9-4afc-b6b4-d40fe360015e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve TColumnConfig typing on columns that extend TableColumnTextBase",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table-column/anchor/index.ts
+++ b/packages/nimble-components/src/table-column/anchor/index.ts
@@ -12,6 +12,7 @@ import { tableColumnAnchorCellViewTag } from './cell-view';
 import { tableColumnTextGroupHeaderViewTag } from '../text/group-header-view';
 import type { AnchorAppearance } from '../../anchor/types';
 import type { ColumnInternalsOptions } from '../base/models/column-internals';
+import { ColumnValidator } from '../base/models/column-validator';
 
 export type TableColumnAnchorCellRecord = TableStringField<'label' | 'href'>;
 export interface TableColumnAnchorColumnConfig {
@@ -86,7 +87,8 @@ export class TableColumnAnchor extends mixinGroupableColumnAPI(
             cellViewTag: tableColumnAnchorCellViewTag,
             groupHeaderViewTag: tableColumnTextGroupHeaderViewTag,
             delegatedEvents: ['click'],
-            sortOperation: TableColumnSortOperation.localeAwareCaseSensitive
+            sortOperation: TableColumnSortOperation.localeAwareCaseSensitive,
+            validator: new ColumnValidator<[]>([])
         };
     }
 

--- a/packages/nimble-components/src/table-column/base/index.ts
+++ b/packages/nimble-components/src/table-column/base/index.ts
@@ -24,7 +24,10 @@ export abstract class TableColumn<
      *
      * Column properties configurable by plugin authors
      */
-    public readonly columnInternals: ColumnInternals<TColumnConfig, TColumnValidator> = new ColumnInternals(this.getColumnInternalsOptions());
+    public readonly columnInternals: ColumnInternals<
+    TColumnConfig,
+    TColumnValidator
+    > = new ColumnInternals(this.getColumnInternalsOptions());
 
     @attr({ attribute: 'column-id' })
     public columnId?: string;

--- a/packages/nimble-components/src/table-column/base/index.ts
+++ b/packages/nimble-components/src/table-column/base/index.ts
@@ -59,7 +59,7 @@ export abstract class TableColumn<
     }
 
     public get validity(): TableColumnValidity {
-        return this.columnInternals.validator?.getValidity() ?? {};
+        return this.columnInternals.validator.getValidity();
     }
 
     /** @internal */

--- a/packages/nimble-components/src/table-column/base/index.ts
+++ b/packages/nimble-components/src/table-column/base/index.ts
@@ -58,7 +58,7 @@ export abstract class TableColumn<
     public contentSlot!: HTMLSlotElement;
 
     public checkValidity(): boolean {
-        return this.columnInternals.validConfiguration;
+        return this.columnInternals.validator.isColumnValid;
     }
 
     public get validity(): TableColumnValidity {

--- a/packages/nimble-components/src/table-column/base/index.ts
+++ b/packages/nimble-components/src/table-column/base/index.ts
@@ -10,19 +10,21 @@ import {
     ColumnInternalsOptions
 } from './models/column-internals';
 import type { TableColumnValidity } from './types';
+import type { ColumnValidator } from './models/column-validator';
 
 /**
  * The base class for table columns
  */
 export abstract class TableColumn<
-    TColumnConfig = unknown
+    TColumnConfig = unknown,
+    TColumnValidator extends ColumnValidator<[]> = ColumnValidator<[]>
 > extends FoundationElement {
     /**
      * @internal
      *
      * Column properties configurable by plugin authors
      */
-    public readonly columnInternals: ColumnInternals<TColumnConfig> = new ColumnInternals(this.getColumnInternalsOptions());
+    public readonly columnInternals: ColumnInternals<TColumnConfig, TColumnValidator> = new ColumnInternals(this.getColumnInternalsOptions());
 
     @attr({ attribute: 'column-id' })
     public columnId?: string;
@@ -57,7 +59,7 @@ export abstract class TableColumn<
     }
 
     public get validity(): TableColumnValidity {
-        return {};
+        return this.columnInternals.validator?.getValidity() ?? {};
     }
 
     /** @internal */
@@ -75,7 +77,7 @@ export abstract class TableColumn<
         this.setAttribute('slot', this.columnInternals.uniqueId);
     }
 
-    protected abstract getColumnInternalsOptions(): ColumnInternalsOptions;
+    protected abstract getColumnInternalsOptions(): ColumnInternalsOptions<TColumnValidator>;
 
     protected sortDirectionChanged(): void {
         if (!this.sortingDisabled) {

--- a/packages/nimble-components/src/table-column/base/models/column-internals.ts
+++ b/packages/nimble-components/src/table-column/base/models/column-internals.ts
@@ -1,5 +1,5 @@
 import { uniqueId } from '@microsoft/fast-web-utilities';
-import { Observable, ViewTemplate, observable } from '@microsoft/fast-element';
+import { ViewTemplate, observable } from '@microsoft/fast-element';
 import { TableColumnSortDirection, TableFieldName } from '../../../table/types';
 import type { TableCell } from '../../../table/components/cell';
 import {
@@ -10,7 +10,7 @@ import {
 import type { TableGroupRow } from '../../../table/components/group-row';
 import { createGroupHeaderViewTemplate } from '../group-header-view/template';
 import { createCellViewTemplate } from '../cell-view/template';
-import { ColumnValidator } from './column-validator';
+import type { ColumnValidator } from './column-validator';
 
 export interface ColumnInternalsOptions<
     TColumnValidator extends ColumnValidator<[]> = ColumnValidator<[]>
@@ -82,12 +82,6 @@ export class ColumnInternals<
      */
     @observable
     public columnConfig?: TColumnConfig;
-
-    /**
-     * Whether this column has a valid configuration.
-     */
-    @observable
-    public validConfiguration = true;
 
     /**
      * The name of the data field that will be used for operations on the table, such as sorting and grouping.
@@ -185,16 +179,6 @@ export class ColumnInternals<
         this.delegatedEvents = options.delegatedEvents;
         this.sortOperation = options.sortOperation ?? TableColumnSortOperation.basic;
         this.validator = options.validator;
-
-        const notifier = Observable.getNotifier(this.validator);
-        notifier.subscribe(this);
-    }
-
-    /** @internal */
-    public handleChange(source: unknown, args: unknown): void {
-        if (source instanceof ColumnValidator && args === 'isColumnValid') {
-            this.validConfiguration = this.validator.isColumnValid;
-        }
     }
 
     protected fractionalWidthChanged(): void {

--- a/packages/nimble-components/src/table-column/base/models/column-internals.ts
+++ b/packages/nimble-components/src/table-column/base/models/column-internals.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-classes-per-file */
 import { uniqueId } from '@microsoft/fast-web-utilities';
 import { Observable, ViewTemplate, observable } from '@microsoft/fast-element';
 import { TableColumnSortDirection, TableFieldName } from '../../../table/types';
@@ -13,7 +12,9 @@ import { createGroupHeaderViewTemplate } from '../group-header-view/template';
 import { createCellViewTemplate } from '../cell-view/template';
 import { ColumnValidator } from './column-validator';
 
-export interface ColumnInternalsOptions<TColumnValidator extends ColumnValidator<[]> = ColumnValidator<[]>> {
+export interface ColumnInternalsOptions<
+    TColumnValidator extends ColumnValidator<[]> = ColumnValidator<[]>
+> {
     /**
      * The tag (element name) of the custom element that renders the cell content for the column.
      * That element should derive from TableCellView<TCellRecord, TColumnConfig>.
@@ -43,8 +44,8 @@ export interface ColumnInternalsOptions<TColumnValidator extends ColumnValidator
     readonly sortOperation?: TableColumnSortOperation;
 
     /**
-    * The validator for the column
-    */
+     * The validator for the column
+     */
     readonly validator: TColumnValidator;
 }
 
@@ -52,7 +53,10 @@ export interface ColumnInternalsOptions<TColumnValidator extends ColumnValidator
  * Internal column state configured by plugin authors
  * @internal
  */
-export class ColumnInternals<TColumnConfig, TColumnValidator extends ColumnValidator<[]>> {
+export class ColumnInternals<
+    TColumnConfig,
+    TColumnValidator extends ColumnValidator<[]>
+> {
     /**
      * @see ColumnInternalsOptions.cellRecordFieldNames
      */
@@ -212,161 +216,4 @@ export function isColumnInternalsProperty(
         }
     }
     return false;
-}
-
-/**
- * Internal column state configured by plugin authors
- * @internal
- */
-export class ColumnInternals2<TColumnConfig, TColumnValidator extends ColumnValidator<[]>> {
-    /**
-     * @see ColumnInternalsOptions.cellRecordFieldNames
-     */
-    public readonly cellRecordFieldNames: readonly TableFieldName[];
-
-    /**
-     * A unique id used internally in the table to identify specific column instances
-     */
-    public readonly uniqueId = uniqueId('table-column-slot');
-
-    /**
-     * Template for the cell view
-     */
-    public readonly cellViewTemplate: ViewTemplate<TableCell>;
-
-    /**
-     * The names of events that should be delegated from the cell view to the column.
-     */
-    public readonly delegatedEvents: readonly string[];
-
-    /**
-     * The relevant, static configuration a column requires its cell view to have access to.
-     */
-    @observable
-    public columnConfig?: TColumnConfig;
-
-    /**
-     * Whether this column has a valid configuration.
-     */
-    @observable
-    public validConfiguration = true;
-
-    /**
-     * The name of the data field that will be used for operations on the table, such as sorting and grouping.
-     */
-    @observable
-    public operandDataRecordFieldName?: TableFieldName;
-
-    /**
-     * The operation to use when sorting the table by this column.
-     */
-    @observable
-    public sortOperation: TableColumnSortOperation = TableColumnSortOperation.basic;
-
-    /**
-     * The names of the fields from the row's record that correlate to the data that will be in TCellRecord.
-     * This array is parallel with the field names specified by `cellRecordFieldNames`.
-     */
-    @observable
-    public dataRecordFieldNames: readonly (TableFieldName | undefined)[] = [];
-
-    /**
-     * Template for the group header view
-     */
-    public readonly groupHeaderViewTemplate: ViewTemplate<TableGroupRow>;
-
-    /**
-     * Whether or not this column can be used to group rows by
-     */
-    @observable
-    public groupingDisabled = false;
-
-    /**
-     * Specifies the grouping precedence of the column within the set of all columns participating in grouping.
-     * Columns are rendered in the grouping tree from lowest group-index as the tree root to highest
-     * group-index as tree leaves.
-     */
-    @observable
-    public groupIndex?: number;
-
-    /**
-     * Used by column plugins to set a specific pixel width. Sets currentPixelWidth when changed.
-     */
-    @observable
-    public pixelWidth?: number;
-
-    /**
-     * Used by column plugins to size a column proportionally to the available
-     * width of a row. Sets currentFractionalWidth when changed.
-     */
-    @observable
-    public fractionalWidth = defaultFractionalWidth;
-
-    /**
-     * The minimum size in pixels according to the design doc
-     */
-    @observable
-    public minPixelWidth = defaultMinPixelWidth;
-
-    /**
-     * @internal Do not write to this value directly. It is used by the Table in order to store
-     * the resolved value of the fractionalWidth after updates programmatic or interactive updates.
-     */
-    @observable
-    public currentFractionalWidth = defaultFractionalWidth;
-
-    /**
-     * @internal Do not write to this value directly. It is used by the Table in order to store
-     * the resolved value of the pixelWidth after programmatic or interactive updates.
-     */
-    @observable
-    public currentPixelWidth?: number;
-
-    /**
-     * @internal Do not write to this value directly. It is used by the Table in order to store
-     * the resolved value of the sortIndex after programmatic or interactive updates.
-     */
-    @observable
-    public currentSortIndex?: number | null;
-
-    /**
-     * @internal Do not write to this value directly. It is used by the Table in order to store
-     * the resolved value of the sortDirection after programmatic or interactive updates.
-     */
-    @observable
-    public currentSortDirection: TableColumnSortDirection = TableColumnSortDirection.none;
-
-    public readonly validator?: TColumnValidator;
-
-    public constructor(options: ColumnInternalsOptions<TColumnValidator>) {
-        this.cellRecordFieldNames = options.cellRecordFieldNames;
-        this.cellViewTemplate = createCellViewTemplate(options.cellViewTag);
-        this.groupHeaderViewTemplate = createGroupHeaderViewTemplate(
-            options.groupHeaderViewTag
-        );
-        this.delegatedEvents = options.delegatedEvents;
-        this.sortOperation = options.sortOperation ?? TableColumnSortOperation.basic;
-        this.validator = options.validator;
-
-        if (this.validator) {
-            const notifier = Observable.getNotifier(this.validator);
-            notifier.subscribe(this);
-        }
-    }
-
-    /** @internal */
-    public handleChange(source: unknown, args: unknown): void {
-        if (source instanceof ColumnValidator && args === 'isColumnValid') {
-            const validator = source as ColumnValidator<[]>;
-            this.validConfiguration = validator.isColumnValid;
-        }
-    }
-
-    protected fractionalWidthChanged(): void {
-        this.currentFractionalWidth = this.fractionalWidth;
-    }
-
-    protected pixelWidthChanged(): void {
-        this.currentPixelWidth = this.pixelWidth;
-    }
 }

--- a/packages/nimble-components/src/table-column/base/models/column-internals.ts
+++ b/packages/nimble-components/src/table-column/base/models/column-internals.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 import { uniqueId } from '@microsoft/fast-web-utilities';
 import { Observable, ViewTemplate, observable } from '@microsoft/fast-element';
 import { TableColumnSortDirection, TableFieldName } from '../../../table/types';
@@ -44,7 +45,7 @@ export interface ColumnInternalsOptions<TColumnValidator extends ColumnValidator
     /**
     * The validator for the column
     */
-    readonly validator?: TColumnValidator;
+    readonly validator: TColumnValidator;
 }
 
 /**
@@ -52,6 +53,172 @@ export interface ColumnInternalsOptions<TColumnValidator extends ColumnValidator
  * @internal
  */
 export class ColumnInternals<TColumnConfig, TColumnValidator extends ColumnValidator<[]>> {
+    /**
+     * @see ColumnInternalsOptions.cellRecordFieldNames
+     */
+    public readonly cellRecordFieldNames: readonly TableFieldName[];
+
+    /**
+     * A unique id used internally in the table to identify specific column instances
+     */
+    public readonly uniqueId = uniqueId('table-column-slot');
+
+    /**
+     * Template for the cell view
+     */
+    public readonly cellViewTemplate: ViewTemplate<TableCell>;
+
+    /**
+     * The names of events that should be delegated from the cell view to the column.
+     */
+    public readonly delegatedEvents: readonly string[];
+
+    /**
+     * The relevant, static configuration a column requires its cell view to have access to.
+     */
+    @observable
+    public columnConfig?: TColumnConfig;
+
+    /**
+     * Whether this column has a valid configuration.
+     */
+    @observable
+    public validConfiguration = true;
+
+    /**
+     * The name of the data field that will be used for operations on the table, such as sorting and grouping.
+     */
+    @observable
+    public operandDataRecordFieldName?: TableFieldName;
+
+    /**
+     * The operation to use when sorting the table by this column.
+     */
+    @observable
+    public sortOperation: TableColumnSortOperation = TableColumnSortOperation.basic;
+
+    /**
+     * The names of the fields from the row's record that correlate to the data that will be in TCellRecord.
+     * This array is parallel with the field names specified by `cellRecordFieldNames`.
+     */
+    @observable
+    public dataRecordFieldNames: readonly (TableFieldName | undefined)[] = [];
+
+    /**
+     * Template for the group header view
+     */
+    public readonly groupHeaderViewTemplate: ViewTemplate<TableGroupRow>;
+
+    /**
+     * Whether or not this column can be used to group rows by
+     */
+    @observable
+    public groupingDisabled = false;
+
+    /**
+     * Specifies the grouping precedence of the column within the set of all columns participating in grouping.
+     * Columns are rendered in the grouping tree from lowest group-index as the tree root to highest
+     * group-index as tree leaves.
+     */
+    @observable
+    public groupIndex?: number;
+
+    /**
+     * Used by column plugins to set a specific pixel width. Sets currentPixelWidth when changed.
+     */
+    @observable
+    public pixelWidth?: number;
+
+    /**
+     * Used by column plugins to size a column proportionally to the available
+     * width of a row. Sets currentFractionalWidth when changed.
+     */
+    @observable
+    public fractionalWidth = defaultFractionalWidth;
+
+    /**
+     * The minimum size in pixels according to the design doc
+     */
+    @observable
+    public minPixelWidth = defaultMinPixelWidth;
+
+    /**
+     * @internal Do not write to this value directly. It is used by the Table in order to store
+     * the resolved value of the fractionalWidth after updates programmatic or interactive updates.
+     */
+    @observable
+    public currentFractionalWidth = defaultFractionalWidth;
+
+    /**
+     * @internal Do not write to this value directly. It is used by the Table in order to store
+     * the resolved value of the pixelWidth after programmatic or interactive updates.
+     */
+    @observable
+    public currentPixelWidth?: number;
+
+    /**
+     * @internal Do not write to this value directly. It is used by the Table in order to store
+     * the resolved value of the sortIndex after programmatic or interactive updates.
+     */
+    @observable
+    public currentSortIndex?: number | null;
+
+    /**
+     * @internal Do not write to this value directly. It is used by the Table in order to store
+     * the resolved value of the sortDirection after programmatic or interactive updates.
+     */
+    @observable
+    public currentSortDirection: TableColumnSortDirection = TableColumnSortDirection.none;
+
+    public readonly validator: TColumnValidator;
+
+    public constructor(options: ColumnInternalsOptions<TColumnValidator>) {
+        this.cellRecordFieldNames = options.cellRecordFieldNames;
+        this.cellViewTemplate = createCellViewTemplate(options.cellViewTag);
+        this.groupHeaderViewTemplate = createGroupHeaderViewTemplate(
+            options.groupHeaderViewTag
+        );
+        this.delegatedEvents = options.delegatedEvents;
+        this.sortOperation = options.sortOperation ?? TableColumnSortOperation.basic;
+        this.validator = options.validator;
+
+        const notifier = Observable.getNotifier(this.validator);
+        notifier.subscribe(this);
+    }
+
+    /** @internal */
+    public handleChange(source: unknown, args: unknown): void {
+        if (source instanceof ColumnValidator && args === 'isColumnValid') {
+            this.validConfiguration = this.validator.isColumnValid;
+        }
+    }
+
+    protected fractionalWidthChanged(): void {
+        this.currentFractionalWidth = this.fractionalWidth;
+    }
+
+    protected pixelWidthChanged(): void {
+        this.currentPixelWidth = this.pixelWidth;
+    }
+}
+
+export function isColumnInternalsProperty(
+    changedProperty: string,
+    ...args: (keyof ColumnInternals<unknown, ColumnValidator<[]>>)[]
+): boolean {
+    for (const arg of args) {
+        if (changedProperty === arg) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Internal column state configured by plugin authors
+ * @internal
+ */
+export class ColumnInternals2<TColumnConfig, TColumnValidator extends ColumnValidator<[]>> {
     /**
      * @see ColumnInternalsOptions.cellRecordFieldNames
      */
@@ -202,16 +369,4 @@ export class ColumnInternals<TColumnConfig, TColumnValidator extends ColumnValid
     protected pixelWidthChanged(): void {
         this.currentPixelWidth = this.pixelWidth;
     }
-}
-
-export function isColumnInternalsProperty(
-    changedProperty: string,
-    ...args: (keyof ColumnInternals<unknown, ColumnValidator<[]>>)[]
-): boolean {
-    for (const arg of args) {
-        if (changedProperty === arg) {
-            return true;
-        }
-    }
-    return false;
 }

--- a/packages/nimble-components/src/table-column/base/models/column-validator.ts
+++ b/packages/nimble-components/src/table-column/base/models/column-validator.ts
@@ -11,9 +11,7 @@ export class ColumnValidator<
     @observable
     public isColumnValid = true;
 
-    public constructor(
-        configValidityKeys: ValidityFlagNames
-    ) {
+    public constructor(configValidityKeys: ValidityFlagNames) {
         super(configValidityKeys);
     }
 

--- a/packages/nimble-components/src/table-column/base/models/column-validator.ts
+++ b/packages/nimble-components/src/table-column/base/models/column-validator.ts
@@ -1,6 +1,6 @@
+import { observable } from '@microsoft/fast-element';
 import { Validator } from '../../../utilities/models/validator';
 import type { TableColumnValidity } from '../types';
-import type { ColumnInternals } from './column-internals';
 
 /**
  * Base column validator
@@ -8,8 +8,10 @@ import type { ColumnInternals } from './column-internals';
 export class ColumnValidator<
     ValidityFlagNames extends readonly string[]
 > extends Validator<ValidityFlagNames> {
+    @observable
+    public isColumnValid = true;
+
     public constructor(
-        private readonly columnInternals: ColumnInternals<unknown>,
         configValidityKeys: ValidityFlagNames
     ) {
         super(configValidityKeys);
@@ -38,6 +40,6 @@ export class ColumnValidator<
     }
 
     private updateColumnInternalsFlag(): void {
-        this.columnInternals.validConfiguration = this.isValid();
+        this.isColumnValid = this.isValid();
     }
 }

--- a/packages/nimble-components/src/table-column/base/tests/table-cell-view.spec.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-cell-view.spec.ts
@@ -13,6 +13,7 @@ import {
     tableColumnEmptyTag
 } from './table-column.fixtures';
 import type { ColumnInternalsOptions } from '../models/column-internals';
+import { ColumnValidator } from '../models/column-validator';
 
 async function setup(): Promise<Fixture<TableCellView>> {
     return fixture(tableColumnEmptyCellViewTag);
@@ -36,7 +37,8 @@ describe('TableCellView', () => {
                 cellRecordFieldNames: [],
                 cellViewTag: tableColumnEmptyCellViewTag,
                 groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-                delegatedEvents: ['click', 'keydown']
+                delegatedEvents: ['click', 'keydown'],
+                validator: new ColumnValidator<[]>([])
             };
         }
     }

--- a/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
@@ -55,7 +55,8 @@ export class TableColumnEmpty extends TableColumn {
             cellRecordFieldNames: [],
             cellViewTag: tableColumnEmptyCellViewTag,
             groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-            delegatedEvents: []
+            delegatedEvents: [],
+            validator: new ColumnValidator<[]>([])
         };
     }
 }
@@ -112,10 +113,10 @@ export class TableColumnValidationTest extends TableColumn<unknown, TestColumnVa
     }
 
     private fooChanged(): void {
-        this.columnInternals.validator!.validateFoo(this.foo);
+        this.columnInternals.validator.validateFoo(this.foo);
     }
 
     private barChanged(): void {
-        this.columnInternals.validator!.validateBar(this.bar);
+        this.columnInternals.validator.validateBar(this.bar);
     }
 }

--- a/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
@@ -5,8 +5,7 @@ import { TableCellView } from '../cell-view';
 import { TableGroupHeaderView } from '../group-header-view';
 import { TableColumn } from '..';
 import type {
-    ColumnInternalsOptions,
-    ColumnInternals
+    ColumnInternalsOptions
 } from '../models/column-internals';
 import { ColumnValidator } from '../models/column-validator';
 
@@ -69,8 +68,8 @@ const configValidity = ['invalidFoo', 'invalidBar'] as const;
 export class TestColumnValidator extends ColumnValidator<
     typeof configValidity
 > {
-    public constructor(columnInternals: ColumnInternals<unknown>) {
-        super(columnInternals, configValidity);
+    public constructor() {
+        super(configValidity);
     }
 
     public validateFoo(isValid: boolean): void {
@@ -95,30 +94,28 @@ declare global {
 @customElement({
     name: tableColumnValidationTestTag
 })
-export class TableColumnValidationTest extends TableColumn {
-    /* @internal */
-    public readonly validator = new TestColumnValidator(this.columnInternals);
-
+export class TableColumnValidationTest extends TableColumn<unknown, TestColumnValidator> {
     @attr({ mode: 'boolean' })
     public foo = false;
 
     @attr({ mode: 'boolean' })
     public bar = false;
 
-    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions<TestColumnValidator> {
         return {
             cellRecordFieldNames: [],
             cellViewTag: tableColumnEmptyCellViewTag,
             groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-            delegatedEvents: []
+            delegatedEvents: [],
+            validator: new TestColumnValidator()
         };
     }
 
     private fooChanged(): void {
-        this.validator.validateFoo(this.foo);
+        this.columnInternals.validator!.validateFoo(this.foo);
     }
 
     private barChanged(): void {
-        this.validator.validateBar(this.bar);
+        this.columnInternals.validator!.validateBar(this.bar);
     }
 }

--- a/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
@@ -4,9 +4,7 @@ import { attr, customElement } from '@microsoft/fast-element';
 import { TableCellView } from '../cell-view';
 import { TableGroupHeaderView } from '../group-header-view';
 import { TableColumn } from '..';
-import type {
-    ColumnInternalsOptions
-} from '../models/column-internals';
+import type { ColumnInternalsOptions } from '../models/column-internals';
 import { ColumnValidator } from '../models/column-validator';
 
 export const tableColumnEmptyCellViewTag = 'nimble-test-table-column-empty-cell-view';
@@ -95,7 +93,10 @@ declare global {
 @customElement({
     name: tableColumnValidationTestTag
 })
-export class TableColumnValidationTest extends TableColumn<unknown, TestColumnValidator> {
+export class TableColumnValidationTest extends TableColumn<
+unknown,
+TestColumnValidator
+> {
     @attr({ mode: 'boolean' })
     public foo = false;
 

--- a/packages/nimble-components/src/table-column/base/tests/table-column.spec.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.spec.ts
@@ -14,6 +14,7 @@ import {
 import { TableColumn } from '..';
 import { TableColumnSortDirection } from '../../../table/types';
 import type { ColumnInternalsOptions } from '../models/column-internals';
+import { ColumnValidator } from '../models/column-validator';
 
 async function setup(): Promise<Fixture<TableColumnEmpty>> {
     return fixture(tableColumnEmptyTag);
@@ -123,7 +124,8 @@ describe('TableColumn', () => {
                         cellRecordFieldNames: [],
                         cellViewTag: 'div',
                         groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-                        delegatedEvents: []
+                        delegatedEvents: [],
+                        validator: new ColumnValidator<[]>([])
                     };
                 }
             }
@@ -153,7 +155,8 @@ describe('TableColumn', () => {
                         cellRecordFieldNames: [],
                         cellViewTag: tableColumnEmptyCellViewTag,
                         groupHeaderViewTag: 'div',
-                        delegatedEvents: []
+                        delegatedEvents: [],
+                        validator: new ColumnValidator<[]>([])
                     };
                 }
             }

--- a/packages/nimble-components/src/table-column/date-text/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/index.ts
@@ -50,7 +50,10 @@ declare global {
  * The table column for displaying dates/times as text.
  */
 export class TableColumnDateText extends mixinTextBase(
-    TableColumnTextBase<TableColumnDateTextColumnConfig, TableColumnDateTextValidator>
+    TableColumnTextBase<
+    TableColumnDateTextColumnConfig,
+    TableColumnDateTextValidator
+    >
 ) {
     @attr
     public format: DateTextFormat;

--- a/packages/nimble-components/src/table-column/date-text/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/index.ts
@@ -49,10 +49,7 @@ declare global {
 /**
  * The table column for displaying dates/times as text.
  */
-export class TableColumnDateText extends mixinTextBase<TableColumnDateTextColumnConfig>() {
-    /** @internal */
-    public validator = new TableColumnDateTextValidator(this.columnInternals);
-
+export class TableColumnDateText extends mixinTextBase<TableColumnDateTextColumnConfig, TableColumnDateTextValidator>() {
     @attr
     public format: DateTextFormat;
 
@@ -133,21 +130,18 @@ export class TableColumnDateText extends mixinTextBase<TableColumnDateTextColumn
         lang.unsubscribe(this.langSubscriber, this);
     }
 
-    public override get validity(): TableColumnValidity {
-        return this.validator.getValidity();
-    }
-
     public placeholderChanged(): void {
         this.updateColumnConfig();
     }
 
-    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions<TableColumnDateTextValidator> {
         return {
             cellRecordFieldNames: ['value'],
             cellViewTag: tableColumnDateTextCellViewTag,
             groupHeaderViewTag: tableColumnDateTextGroupHeaderViewTag,
             delegatedEvents: [],
-            sortOperation: TableColumnSortOperation.basic
+            sortOperation: TableColumnSortOperation.basic,
+            validator: new TableColumnDateTextValidator()
         };
     }
 
@@ -240,10 +234,10 @@ export class TableColumnDateText extends mixinTextBase<TableColumnDateTextColumn
                 placeholder: this.placeholder
             };
             this.columnInternals.columnConfig = columnConfig;
-            this.validator.setCustomOptionsValidity(true);
+            this.columnInternals.validator!.setCustomOptionsValidity(true);
         } else {
             this.columnInternals.columnConfig = undefined;
-            this.validator.setCustomOptionsValidity(false);
+            this.columnInternals.validator!.setCustomOptionsValidity(false);
         }
     }
 

--- a/packages/nimble-components/src/table-column/date-text/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/index.ts
@@ -6,7 +6,7 @@ import { attr } from '@microsoft/fast-element';
 import { styles } from '../base/styles';
 import { template } from '../base/template';
 import type { TableNumberField } from '../../table/types';
-import { TableColumnTextBase } from '../text-base';
+import { mixinTextBase } from '../text-base';
 import { TableColumnSortOperation, TableColumnValidity } from '../base/types';
 import { tableColumnDateTextGroupHeaderViewTag } from './group-header-view';
 import { tableColumnDateTextCellViewTag } from './cell-view';
@@ -33,9 +33,6 @@ import { TableColumnDateTextValidator } from './models/table-column-date-text-va
 import { lang } from '../../theme-provider';
 import { optionalBooleanConverter } from '../../utilities/models/converter';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
-import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
-import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
-import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 export type TableColumnDateTextCellRecord = TableNumberField<'value'>;
 export interface TableColumnDateTextColumnConfig
@@ -52,13 +49,7 @@ declare global {
 /**
  * The table column for displaying dates/times as text.
  */
-export class TableColumnDateText extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(
-        mixinColumnWithPlaceholderAPI(
-            TableColumnTextBase<TableColumnDateTextColumnConfig>
-        )
-    )
-) {
+export class TableColumnDateText extends mixinTextBase<TableColumnDateTextColumnConfig>() {
     /** @internal */
     public validator = new TableColumnDateTextValidator(this.columnInternals);
 

--- a/packages/nimble-components/src/table-column/date-text/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/index.ts
@@ -7,7 +7,7 @@ import { styles } from '../base/styles';
 import { template } from '../base/template';
 import type { TableNumberField } from '../../table/types';
 import { mixinTextBase } from '../text-base';
-import { TableColumnSortOperation, TableColumnValidity } from '../base/types';
+import { TableColumnSortOperation } from '../base/types';
 import { tableColumnDateTextGroupHeaderViewTag } from './group-header-view';
 import { tableColumnDateTextCellViewTag } from './cell-view';
 import type { ColumnInternalsOptions } from '../base/models/column-internals';
@@ -49,7 +49,10 @@ declare global {
 /**
  * The table column for displaying dates/times as text.
  */
-export class TableColumnDateText extends mixinTextBase<TableColumnDateTextColumnConfig, TableColumnDateTextValidator>() {
+export class TableColumnDateText extends mixinTextBase<
+TableColumnDateTextColumnConfig,
+TableColumnDateTextValidator
+>() {
     @attr
     public format: DateTextFormat;
 

--- a/packages/nimble-components/src/table-column/date-text/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/index.ts
@@ -33,6 +33,9 @@ import { TableColumnDateTextValidator } from './models/table-column-date-text-va
 import { lang } from '../../theme-provider';
 import { optionalBooleanConverter } from '../../utilities/models/converter';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
+import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
+import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
+import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 export type TableColumnDateTextCellRecord = TableNumberField<'value'>;
 export interface TableColumnDateTextColumnConfig
@@ -49,7 +52,9 @@ declare global {
 /**
  * The table column for displaying dates/times as text.
  */
-export class TableColumnDateText extends TableColumnTextBase {
+export class TableColumnDateText extends mixinGroupableColumnAPI(
+    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumnTextBase<TableColumnDateTextColumnConfig>))
+) {
     /** @internal */
     public validator = new TableColumnDateTextValidator(this.columnInternals);
 

--- a/packages/nimble-components/src/table-column/date-text/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/index.ts
@@ -53,7 +53,11 @@ declare global {
  * The table column for displaying dates/times as text.
  */
 export class TableColumnDateText extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumnTextBase<TableColumnDateTextColumnConfig>))
+    mixinFractionalWidthColumnAPI(
+        mixinColumnWithPlaceholderAPI(
+            TableColumnTextBase<TableColumnDateTextColumnConfig>
+        )
+    )
 ) {
     /** @internal */
     public validator = new TableColumnDateTextValidator(this.columnInternals);

--- a/packages/nimble-components/src/table-column/date-text/index.ts
+++ b/packages/nimble-components/src/table-column/date-text/index.ts
@@ -234,10 +234,10 @@ export class TableColumnDateText extends mixinTextBase<TableColumnDateTextColumn
                 placeholder: this.placeholder
             };
             this.columnInternals.columnConfig = columnConfig;
-            this.columnInternals.validator!.setCustomOptionsValidity(true);
+            this.columnInternals.validator.setCustomOptionsValidity(true);
         } else {
             this.columnInternals.columnConfig = undefined;
-            this.columnInternals.validator!.setCustomOptionsValidity(false);
+            this.columnInternals.validator.setCustomOptionsValidity(false);
         }
     }
 

--- a/packages/nimble-components/src/table-column/date-text/models/table-column-date-text-validator.ts
+++ b/packages/nimble-components/src/table-column/date-text/models/table-column-date-text-validator.ts
@@ -1,4 +1,3 @@
-import type { ColumnInternals } from '../../base/models/column-internals';
 import { ColumnValidator } from '../../base/models/column-validator';
 
 const dateTextValidityFlagNames = ['invalidCustomOptionsCombination'] as const;
@@ -9,8 +8,8 @@ const dateTextValidityFlagNames = ['invalidCustomOptionsCombination'] as const;
 export class TableColumnDateTextValidator extends ColumnValidator<
     typeof dateTextValidityFlagNames
 > {
-    public constructor(columnInternals: ColumnInternals<unknown>) {
-        super(columnInternals, dateTextValidityFlagNames);
+    public constructor() {
+        super(dateTextValidityFlagNames);
     }
 
     public setCustomOptionsValidity(valid: boolean): void {

--- a/packages/nimble-components/src/table-column/duration-text/index.ts
+++ b/packages/nimble-components/src/table-column/duration-text/index.ts
@@ -13,7 +13,7 @@ import { DurationFormatter } from './models/duration-formatter';
 import { tableColumnDurationTextGroupHeaderViewTag } from './group-header-view';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
 import { mixinTextBase } from '../text-base';
-import type { ColumnValidator } from '../base/models/column-validator';
+import { ColumnValidator } from '../base/models/column-validator';
 
 export type TableColumnDurationTextCellRecord = TableNumberField<'value'>;
 export interface TableColumnDurationTextColumnConfig
@@ -58,7 +58,8 @@ export class TableColumnDurationText extends mixinTextBase<TableColumnDurationTe
             cellViewTag: tableColumnDurationTextCellViewTag,
             groupHeaderViewTag: tableColumnDurationTextGroupHeaderViewTag,
             delegatedEvents: [],
-            sortOperation: TableColumnSortOperation.basic
+            sortOperation: TableColumnSortOperation.basic,
+            validator: new ColumnValidator<[]>([])
         };
     }
 

--- a/packages/nimble-components/src/table-column/duration-text/index.ts
+++ b/packages/nimble-components/src/table-column/duration-text/index.ts
@@ -5,7 +5,6 @@ import {
 import { styles } from '../base/styles';
 import { template } from '../base/template';
 import type { TableNumberField } from '../../table/types';
-import { TableColumnTextBase } from '../text-base';
 import { TableColumnSortOperation } from '../base/types';
 import { tableColumnDurationTextCellViewTag } from './cell-view';
 import type { ColumnInternalsOptions } from '../base/models/column-internals';
@@ -13,9 +12,7 @@ import { lang } from '../../theme-provider';
 import { DurationFormatter } from './models/duration-formatter';
 import { tableColumnDurationTextGroupHeaderViewTag } from './group-header-view';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
-import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
-import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
-import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
+import { mixinTextBase } from '../text-base';
 
 export type TableColumnDurationTextCellRecord = TableNumberField<'value'>;
 export interface TableColumnDurationTextColumnConfig
@@ -32,13 +29,7 @@ declare global {
 /**
  * The table column for displaying a duration value as text.
  */
-export class TableColumnDurationText extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(
-        mixinColumnWithPlaceholderAPI(
-            TableColumnTextBase<TableColumnDurationTextColumnConfig>
-        )
-    )
-) {
+export class TableColumnDurationText extends mixinTextBase<TableColumnDurationTextColumnConfig>() {
     private readonly langSubscriber: DesignTokenSubscriber<typeof lang> = {
         handleChange: () => {
             this.updateColumnConfig();

--- a/packages/nimble-components/src/table-column/duration-text/index.ts
+++ b/packages/nimble-components/src/table-column/duration-text/index.ts
@@ -33,7 +33,11 @@ declare global {
  * The table column for displaying a duration value as text.
  */
 export class TableColumnDurationText extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumnTextBase<TableColumnDurationTextColumnConfig>))
+    mixinFractionalWidthColumnAPI(
+        mixinColumnWithPlaceholderAPI(
+            TableColumnTextBase<TableColumnDurationTextColumnConfig>
+        )
+    )
 ) {
     private readonly langSubscriber: DesignTokenSubscriber<typeof lang> = {
         handleChange: () => {

--- a/packages/nimble-components/src/table-column/duration-text/index.ts
+++ b/packages/nimble-components/src/table-column/duration-text/index.ts
@@ -13,6 +13,9 @@ import { lang } from '../../theme-provider';
 import { DurationFormatter } from './models/duration-formatter';
 import { tableColumnDurationTextGroupHeaderViewTag } from './group-header-view';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
+import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
+import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
+import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 export type TableColumnDurationTextCellRecord = TableNumberField<'value'>;
 export interface TableColumnDurationTextColumnConfig
@@ -29,7 +32,9 @@ declare global {
 /**
  * The table column for displaying a duration value as text.
  */
-export class TableColumnDurationText extends TableColumnTextBase {
+export class TableColumnDurationText extends mixinGroupableColumnAPI(
+    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumnTextBase<TableColumnDurationTextColumnConfig>))
+) {
     private readonly langSubscriber: DesignTokenSubscriber<typeof lang> = {
         handleChange: () => {
             this.updateColumnConfig();

--- a/packages/nimble-components/src/table-column/duration-text/index.ts
+++ b/packages/nimble-components/src/table-column/duration-text/index.ts
@@ -13,6 +13,7 @@ import { DurationFormatter } from './models/duration-formatter';
 import { tableColumnDurationTextGroupHeaderViewTag } from './group-header-view';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
 import { mixinTextBase } from '../text-base';
+import type { ColumnValidator } from '../base/models/column-validator';
 
 export type TableColumnDurationTextCellRecord = TableNumberField<'value'>;
 export interface TableColumnDurationTextColumnConfig

--- a/packages/nimble-components/src/table-column/enum-base/index.ts
+++ b/packages/nimble-components/src/table-column/enum-base/index.ts
@@ -36,13 +36,8 @@ export abstract class TableColumnEnumBase<
     TColumnConfig extends TableColumnEnumColumnConfig,
     TEnumValidator extends TableColumnEnumBaseValidator<[]>
 >
-    extends TableColumn<TColumnConfig>
+    extends TableColumn<TColumnConfig, TEnumValidator>
     implements Subscriber {
-    // To ensure the validator is available when other properties get initialized
-    // (which can trigger validation), declare the validator first.
-    /** @internal */
-    public validator = this.createValidator();
-
     /** @internal */
     public mappingNotifiers: Notifier[] = [];
 
@@ -68,8 +63,6 @@ export abstract class TableColumnEnumBase<
         }
     }
 
-    public abstract createValidator(): TEnumValidator;
-
     /**
      * Implementations should throw an error if an invalid Mapping is passed.
      */
@@ -85,8 +78,8 @@ export abstract class TableColumnEnumBase<
      * Called when any Mapping related state has changed.
      */
     private updateColumnConfig(): void {
-        this.validator.validate(this.mappings, this.keyType);
-        this.columnInternals.columnConfig = this.validator.isValid()
+        this.columnInternals.validator?.validate(this.mappings, this.keyType);
+        this.columnInternals.columnConfig = this.checkValidity()
             ? this.createColumnConfig(this.getMappingConfigs())
             : undefined;
     }

--- a/packages/nimble-components/src/table-column/enum-base/index.ts
+++ b/packages/nimble-components/src/table-column/enum-base/index.ts
@@ -78,7 +78,7 @@ export abstract class TableColumnEnumBase<
      * Called when any Mapping related state has changed.
      */
     private updateColumnConfig(): void {
-        this.columnInternals.validator?.validate(this.mappings, this.keyType);
+        this.columnInternals.validator.validate(this.mappings, this.keyType);
         this.columnInternals.columnConfig = this.checkValidity()
             ? this.createColumnConfig(this.getMappingConfigs())
             : undefined;

--- a/packages/nimble-components/src/table-column/enum-base/models/table-column-enum-base-validator.ts
+++ b/packages/nimble-components/src/table-column/enum-base/models/table-column-enum-base-validator.ts
@@ -1,5 +1,4 @@
 import { ColumnValidator } from '../../base/models/column-validator';
-import type { ColumnInternals } from '../../base/models/column-internals';
 import type { Mapping } from '../../../mapping/base';
 import type { MappingKeyType } from '../types';
 import { resolveKeyWithType } from './mapping-key-resolver';
@@ -19,10 +18,9 @@ export abstract class TableColumnEnumBaseValidator<
     typeof enumBaseValidityFlagNames | ValidityFlagNames
     > {
     public constructor(
-        columnInternals: ColumnInternals<unknown>,
         configValidityKeys: ValidityFlagNames
     ) {
-        super(columnInternals, configValidityKeys);
+        super(configValidityKeys);
     }
 
     public validate(

--- a/packages/nimble-components/src/table-column/enum-base/models/table-column-enum-base-validator.ts
+++ b/packages/nimble-components/src/table-column/enum-base/models/table-column-enum-base-validator.ts
@@ -17,9 +17,7 @@ export abstract class TableColumnEnumBaseValidator<
 > extends ColumnValidator<
     typeof enumBaseValidityFlagNames | ValidityFlagNames
     > {
-    public constructor(
-        configValidityKeys: ValidityFlagNames
-    ) {
+    public constructor(configValidityKeys: ValidityFlagNames) {
         super(configValidityKeys);
     }
 

--- a/packages/nimble-components/src/table-column/enum-text/index.ts
+++ b/packages/nimble-components/src/table-column/enum-text/index.ts
@@ -35,21 +35,14 @@ export class TableColumnEnumText extends mixinGroupableColumnAPI(
         >
     )
 ) {
-    public override createValidator(): TableColumnEnumTextValidator {
-        return new TableColumnEnumTextValidator(this.columnInternals);
-    }
-
-    public override get validity(): TableColumnValidity {
-        return this.validator.getValidity();
-    }
-
-    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions<TableColumnEnumTextValidator> {
         return {
             cellRecordFieldNames: ['value'],
             cellViewTag: tableColumnEnumTextCellViewTag,
             groupHeaderViewTag: tableColumnEnumTextGroupHeaderViewTag,
             delegatedEvents: [],
-            sortOperation: TableColumnSortOperation.basic
+            sortOperation: TableColumnSortOperation.basic,
+            validator: new TableColumnEnumTextValidator()
         };
     }
 

--- a/packages/nimble-components/src/table-column/enum-text/index.ts
+++ b/packages/nimble-components/src/table-column/enum-text/index.ts
@@ -6,7 +6,7 @@ import {
 } from '../enum-base';
 import { styles } from '../enum-base/styles';
 import { template } from '../enum-base/template';
-import { TableColumnSortOperation, TableColumnValidity } from '../base/types';
+import { TableColumnSortOperation } from '../base/types';
 import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
 import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
 import { MappingText } from '../../mapping/text';

--- a/packages/nimble-components/src/table-column/enum-text/models/table-column-enum-text-validator.ts
+++ b/packages/nimble-components/src/table-column/enum-text/models/table-column-enum-text-validator.ts
@@ -1,6 +1,5 @@
 import type { Mapping } from '../../../mapping/base';
 import { MappingText } from '../../../mapping/text';
-import type { ColumnInternals } from '../../base/models/column-internals';
 import {
     TableColumnEnumBaseValidator,
     enumBaseValidityFlagNames
@@ -19,8 +18,8 @@ const enumTextValidityFlagNames = [
 export class TableColumnEnumTextValidator extends TableColumnEnumBaseValidator<
     typeof enumTextValidityFlagNames
 > {
-    public constructor(columnInternals: ColumnInternals<unknown>) {
-        super(columnInternals, enumTextValidityFlagNames);
+    public constructor() {
+        super(enumTextValidityFlagNames);
     }
 
     private static isSupportedMappingElement(

--- a/packages/nimble-components/src/table-column/icon/index.ts
+++ b/packages/nimble-components/src/table-column/icon/index.ts
@@ -37,21 +37,14 @@ export class TableColumnIcon extends mixinGroupableColumnAPI(
         >
     )
 ) {
-    public override createValidator(): TableColumnIconValidator {
-        return new TableColumnIconValidator(this.columnInternals);
-    }
-
-    public override get validity(): TableColumnValidity {
-        return this.validator.getValidity();
-    }
-
-    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions<TableColumnIconValidator> {
         return {
             cellRecordFieldNames: ['value'],
             cellViewTag: tableColumnIconCellViewTag,
             groupHeaderViewTag: tableColumnIconGroupHeaderViewTag,
             delegatedEvents: [],
-            sortOperation: TableColumnSortOperation.basic
+            sortOperation: TableColumnSortOperation.basic,
+            validator: new TableColumnIconValidator()
         };
     }
 

--- a/packages/nimble-components/src/table-column/icon/index.ts
+++ b/packages/nimble-components/src/table-column/icon/index.ts
@@ -6,7 +6,7 @@ import {
 } from '../enum-base';
 import { styles } from '../enum-base/styles';
 import { template } from '../enum-base/template';
-import { TableColumnSortOperation, TableColumnValidity } from '../base/types';
+import { TableColumnSortOperation } from '../base/types';
 import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
 import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
 import { MappingSpinner } from '../../mapping/spinner';

--- a/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
+++ b/packages/nimble-components/src/table-column/icon/models/table-column-icon-validator.ts
@@ -1,7 +1,6 @@
 import type { Mapping } from '../../../mapping/base';
 import { MappingIcon } from '../../../mapping/icon';
 import { MappingSpinner } from '../../../mapping/spinner';
-import type { ColumnInternals } from '../../base/models/column-internals';
 import {
     TableColumnEnumBaseValidator,
     enumBaseValidityFlagNames
@@ -21,8 +20,8 @@ const iconValidityFlagNames = [
 export class TableColumnIconValidator extends TableColumnEnumBaseValidator<
     typeof iconValidityFlagNames
 > {
-    public constructor(columnInternals: ColumnInternals<unknown>) {
-        super(columnInternals, iconValidityFlagNames);
+    public constructor() {
+        super(iconValidityFlagNames);
     }
 
     private static isIconMappingElement(

--- a/packages/nimble-components/src/table-column/mixins/tests/fractional-width-column.spec.ts
+++ b/packages/nimble-components/src/table-column/mixins/tests/fractional-width-column.spec.ts
@@ -12,6 +12,7 @@ import {
     tableColumnEmptyGroupHeaderViewTag
 } from '../../base/tests/table-column.fixtures';
 import type { ColumnInternalsOptions } from '../../base/models/column-internals';
+import { ColumnValidator } from '../../base/models/column-validator';
 
 const columnName = uniqueElementName();
 @customElement({
@@ -23,7 +24,8 @@ class TestTableColumn extends mixinFractionalWidthColumnAPI(TableColumn) {
             cellRecordFieldNames: [],
             cellViewTag: tableColumnEmptyCellViewTag,
             groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-            delegatedEvents: []
+            delegatedEvents: [],
+            validator: new ColumnValidator<[]>([])
         };
     }
 }

--- a/packages/nimble-components/src/table-column/mixins/tests/groupable-column.spec.ts
+++ b/packages/nimble-components/src/table-column/mixins/tests/groupable-column.spec.ts
@@ -12,6 +12,7 @@ import {
     tableColumnEmptyGroupHeaderViewTag
 } from '../../base/tests/table-column.fixtures';
 import type { ColumnInternalsOptions } from '../../base/models/column-internals';
+import { ColumnValidator } from '../../base/models/column-validator';
 
 const columnName = uniqueElementName();
 @customElement({
@@ -23,7 +24,8 @@ class TestTableColumn extends mixinGroupableColumnAPI(TableColumn) {
             cellRecordFieldNames: [],
             cellViewTag: tableColumnEmptyCellViewTag,
             groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-            delegatedEvents: []
+            delegatedEvents: [],
+            validator: new ColumnValidator<[]>([])
         };
     }
 }

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -14,7 +14,7 @@ import { styles } from '../base/styles';
 import { template } from './template';
 import type { TableNumberField } from '../../table/types';
 import { mixinTextBase } from '../text-base';
-import { TableColumnSortOperation, TableColumnValidity } from '../base/types';
+import { TableColumnSortOperation } from '../base/types';
 import { tableColumnNumberTextGroupHeaderTag } from './group-header-view';
 import { tableColumnNumberTextCellViewTag } from './cell-view';
 import type { ColumnInternalsOptions } from '../base/models/column-internals';
@@ -44,10 +44,7 @@ declare global {
 /**
  * The table column for displaying numbers as text.
  */
-export class TableColumnNumberText extends mixinTextBase<TableColumnNumberTextColumnConfig>() {
-    /** @internal */
-    public validator = new TableColumnNumberTextValidator(this.columnInternals);
-
+export class TableColumnNumberText extends mixinTextBase<TableColumnNumberTextColumnConfig, TableColumnNumberTextValidator>() {
     @attr
     public format: NumberTextFormat;
 
@@ -95,21 +92,18 @@ export class TableColumnNumberText extends mixinTextBase<TableColumnNumberTextCo
         lang.unsubscribe(this.langSubscriber, this);
     }
 
-    public override get validity(): TableColumnValidity {
-        return this.validator.getValidity();
-    }
-
     public placeholderChanged(): void {
         this.updateColumnConfig();
     }
 
-    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions<TableColumnNumberTextValidator> {
         return {
             cellRecordFieldNames: ['value'],
             cellViewTag: tableColumnNumberTextCellViewTag,
             groupHeaderViewTag: tableColumnNumberTextGroupHeaderTag,
             delegatedEvents: [],
-            sortOperation: TableColumnSortOperation.basic
+            sortOperation: TableColumnSortOperation.basic,
+            validator: new TableColumnNumberTextValidator()
         };
     }
 
@@ -162,19 +156,20 @@ export class TableColumnNumberText extends mixinTextBase<TableColumnNumberTextCo
     }
 
     private updateColumnConfig(): void {
-        this.validator.validateDecimalDigits(this.format, this.decimalDigits);
-        this.validator.validateDecimalMaximumDigits(
+        const validator = this.columnInternals.validator!;
+        validator.validateDecimalDigits(this.format, this.decimalDigits);
+        validator.validateDecimalMaximumDigits(
             this.format,
             this.decimalMaximumDigits
         );
-        this.validator.validateNoMutuallyExclusiveProperties(
+        validator.validateNoMutuallyExclusiveProperties(
             this.format,
             this.decimalDigits,
             this.decimalMaximumDigits
         );
-        this.validator.validateAtMostOneUnit(this.unitElements ?? []);
+        validator.validateAtMostOneUnit(this.unitElements ?? []);
 
-        if (this.validator.isValid()) {
+        if (validator.isValid()) {
             const columnConfig: TableColumnNumberTextColumnConfig = {
                 formatter: this.createFormatter(),
                 alignment: this.determineCellContentAlignment(),

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -45,7 +45,10 @@ declare global {
  * The table column for displaying numbers as text.
  */
 export class TableColumnNumberText extends mixinTextBase(
-    TableColumnTextBase<TableColumnNumberTextColumnConfig, TableColumnNumberTextValidator>
+    TableColumnTextBase<
+    TableColumnNumberTextColumnConfig,
+    TableColumnNumberTextValidator
+    >
 ) {
     @attr
     public format: NumberTextFormat;

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -156,7 +156,7 @@ export class TableColumnNumberText extends mixinTextBase<TableColumnNumberTextCo
     }
 
     private updateColumnConfig(): void {
-        const validator = this.columnInternals.validator!;
+        const validator = this.columnInternals.validator;
         validator.validateDecimalDigits(this.format, this.decimalDigits);
         validator.validateDecimalMaximumDigits(
             this.format,

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -44,7 +44,10 @@ declare global {
 /**
  * The table column for displaying numbers as text.
  */
-export class TableColumnNumberText extends mixinTextBase<TableColumnNumberTextColumnConfig, TableColumnNumberTextValidator>() {
+export class TableColumnNumberText extends mixinTextBase<
+TableColumnNumberTextColumnConfig,
+TableColumnNumberTextValidator
+>() {
     @attr
     public format: NumberTextFormat;
 

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -13,7 +13,7 @@ import {
 import { styles } from '../base/styles';
 import { template } from './template';
 import type { TableNumberField } from '../../table/types';
-import { TableColumnTextBase } from '../text-base';
+import { mixinTextBase } from '../text-base';
 import { TableColumnSortOperation, TableColumnValidity } from '../base/types';
 import { tableColumnNumberTextGroupHeaderTag } from './group-header-view';
 import { tableColumnNumberTextCellViewTag } from './cell-view';
@@ -27,9 +27,6 @@ import { lang } from '../../theme-provider';
 import { Unit } from '../../unit/base/unit';
 import { waitUntilCustomElementsDefinedAsync } from '../../utilities/wait-until-custom-elements-defined-async';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
-import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
-import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
-import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 export type TableColumnNumberTextCellRecord = TableNumberField<'value'>;
 export interface TableColumnNumberTextColumnConfig
@@ -47,13 +44,7 @@ declare global {
 /**
  * The table column for displaying numbers as text.
  */
-export class TableColumnNumberText extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(
-        mixinColumnWithPlaceholderAPI(
-            TableColumnTextBase<TableColumnNumberTextColumnConfig>
-        )
-    )
-) {
+export class TableColumnNumberText extends mixinTextBase<TableColumnNumberTextColumnConfig>() {
     /** @internal */
     public validator = new TableColumnNumberTextValidator(this.columnInternals);
 

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -48,7 +48,11 @@ declare global {
  * The table column for displaying numbers as text.
  */
 export class TableColumnNumberText extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumnTextBase<TableColumnNumberTextColumnConfig>))
+    mixinFractionalWidthColumnAPI(
+        mixinColumnWithPlaceholderAPI(
+            TableColumnTextBase<TableColumnNumberTextColumnConfig>
+        )
+    )
 ) {
     /** @internal */
     public validator = new TableColumnNumberTextValidator(this.columnInternals);

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -27,6 +27,9 @@ import { lang } from '../../theme-provider';
 import { Unit } from '../../unit/base/unit';
 import { waitUntilCustomElementsDefinedAsync } from '../../utilities/wait-until-custom-elements-defined-async';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
+import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
+import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
+import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 export type TableColumnNumberTextCellRecord = TableNumberField<'value'>;
 export interface TableColumnNumberTextColumnConfig
@@ -44,7 +47,9 @@ declare global {
 /**
  * The table column for displaying numbers as text.
  */
-export class TableColumnNumberText extends TableColumnTextBase {
+export class TableColumnNumberText extends mixinGroupableColumnAPI(
+    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumnTextBase<TableColumnNumberTextColumnConfig>))
+) {
     /** @internal */
     public validator = new TableColumnNumberTextValidator(this.columnInternals);
 

--- a/packages/nimble-components/src/table-column/number-text/models/table-column-number-text-validator.ts
+++ b/packages/nimble-components/src/table-column/number-text/models/table-column-number-text-validator.ts
@@ -1,4 +1,3 @@
-import type { ColumnInternals } from '../../base/models/column-internals';
 import { ColumnValidator } from '../../base/models/column-validator';
 import { NumberTextFormat } from '../types';
 
@@ -20,8 +19,8 @@ const maximumValidDecimalDigits = 20;
 export class TableColumnNumberTextValidator extends ColumnValidator<
     typeof numberTextValidityFlagNames
 > {
-    public constructor(columnInternals: ColumnInternals<unknown>) {
-        super(columnInternals, numberTextValidityFlagNames);
+    public constructor() {
+        super(numberTextValidityFlagNames);
     }
 
     public validateDecimalDigits(

--- a/packages/nimble-components/src/table-column/number-text/models/tests/table-column-number-text-validator.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/models/tests/table-column-number-text-validator.spec.ts
@@ -1,24 +1,12 @@
-import { ColumnInternals } from '../../../base/models/column-internals';
 import { TableColumnNumberTextValidator } from '../table-column-number-text-validator';
-import { TableColumnSortOperation } from '../../../base/types';
 import { NumberTextFormat } from '../../types';
-import { tableColumnNumberTextCellViewTag } from '../../cell-view';
-import { tableColumnNumberTextGroupHeaderTag } from '../../group-header-view';
 import { unitByteTag } from '../../../../unit/byte';
 
 describe('TableColumnNumberTextValidator', () => {
     let validator: TableColumnNumberTextValidator;
 
     beforeEach(() => {
-        const fakeColumnInternals = new ColumnInternals({
-            cellRecordFieldNames: ['value'],
-            cellViewTag: tableColumnNumberTextCellViewTag,
-            groupHeaderViewTag: tableColumnNumberTextGroupHeaderTag,
-            delegatedEvents: [],
-            sortOperation: TableColumnSortOperation.basic
-        });
-
-        validator = new TableColumnNumberTextValidator(fakeColumnInternals);
+        validator = new TableColumnNumberTextValidator();
     });
 
     it('is valid with valid "decimal-digits" and "decimal" format', () => {

--- a/packages/nimble-components/src/table-column/text-base/index.ts
+++ b/packages/nimble-components/src/table-column/text-base/index.ts
@@ -1,5 +1,8 @@
 import { attr } from '@microsoft/fast-element';
 import { TableColumn } from '../base';
+import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
+import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
+import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 /**
  * The base class for table columns that display fields of any type as text.
@@ -14,4 +17,13 @@ export abstract class TableColumnTextBase<
         this.columnInternals.dataRecordFieldNames = [this.fieldName];
         this.columnInternals.operandDataRecordFieldName = this.fieldName;
     }
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type
+export function mixinTextBase<TColumnConfig>() {
+    return mixinGroupableColumnAPI(
+        mixinFractionalWidthColumnAPI(
+            mixinColumnWithPlaceholderAPI(TableColumnTextBase<TColumnConfig>)
+        )
+    );
 }

--- a/packages/nimble-components/src/table-column/text-base/index.ts
+++ b/packages/nimble-components/src/table-column/text-base/index.ts
@@ -9,7 +9,8 @@ import type { ColumnValidator } from '../base/models/column-validator';
  * The base class for table columns that display fields of any type as text.
  */
 export abstract class TableColumnTextBase<
-    TColumnConfig, TColumnValidator extends ColumnValidator<[]>
+    TColumnConfig,
+    TColumnValidator extends ColumnValidator<[]>
 > extends TableColumn<TColumnConfig, TColumnValidator> {
     @attr({ attribute: 'field-name' })
     public fieldName?: string;
@@ -21,10 +22,15 @@ export abstract class TableColumnTextBase<
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type
-export function mixinTextBase<TColumnConfig, TColumnValidator extends ColumnValidator<[]> = ColumnValidator<[]>>() {
+export function mixinTextBase<
+    TColumnConfig,
+    TColumnValidator extends ColumnValidator<[]> = ColumnValidator<[]>
+>() {
     return mixinGroupableColumnAPI(
         mixinFractionalWidthColumnAPI(
-            mixinColumnWithPlaceholderAPI(TableColumnTextBase<TColumnConfig, TColumnValidator>)
+            mixinColumnWithPlaceholderAPI(
+                TableColumnTextBase<TColumnConfig, TColumnValidator>
+            )
         )
     );
 }

--- a/packages/nimble-components/src/table-column/text-base/index.ts
+++ b/packages/nimble-components/src/table-column/text-base/index.ts
@@ -4,7 +4,9 @@ import { TableColumn } from '../base';
 /**
  * The base class for table columns that display fields of any type as text.
  */
-export abstract class TableColumnTextBase<TColumnConfig> extends TableColumn<TColumnConfig> {
+export abstract class TableColumnTextBase<
+    TColumnConfig
+> extends TableColumn<TColumnConfig> {
     @attr({ attribute: 'field-name' })
     public fieldName?: string;
 

--- a/packages/nimble-components/src/table-column/text-base/index.ts
+++ b/packages/nimble-components/src/table-column/text-base/index.ts
@@ -21,7 +21,10 @@ export abstract class TableColumnTextBase<
     }
 }
 
-type TableColumnBaseConstructor<TColumnConfig, TColumnValidator extends ColumnValidator<[]>> = abstract new (
+type TableColumnBaseConstructor<
+    TColumnConfig,
+    TColumnValidator extends ColumnValidator<[]>
+> = abstract new (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ...args: any[]
 ) => TableColumnTextBase<TColumnConfig, TColumnValidator>;

--- a/packages/nimble-components/src/table-column/text-base/index.ts
+++ b/packages/nimble-components/src/table-column/text-base/index.ts
@@ -3,13 +3,14 @@ import { TableColumn } from '../base';
 import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
 import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
 import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
+import type { ColumnValidator } from '../base/models/column-validator';
 
 /**
  * The base class for table columns that display fields of any type as text.
  */
 export abstract class TableColumnTextBase<
-    TColumnConfig
-> extends TableColumn<TColumnConfig> {
+    TColumnConfig, TColumnValidator extends ColumnValidator<[]>
+> extends TableColumn<TColumnConfig, TColumnValidator> {
     @attr({ attribute: 'field-name' })
     public fieldName?: string;
 
@@ -20,10 +21,10 @@ export abstract class TableColumnTextBase<
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type
-export function mixinTextBase<TColumnConfig>() {
+export function mixinTextBase<TColumnConfig, TColumnValidator extends ColumnValidator<[]> = ColumnValidator<[]>>() {
     return mixinGroupableColumnAPI(
         mixinFractionalWidthColumnAPI(
-            mixinColumnWithPlaceholderAPI(TableColumnTextBase<TColumnConfig>)
+            mixinColumnWithPlaceholderAPI(TableColumnTextBase<TColumnConfig, TColumnValidator>)
         )
     );
 }

--- a/packages/nimble-components/src/table-column/text-base/index.ts
+++ b/packages/nimble-components/src/table-column/text-base/index.ts
@@ -1,15 +1,10 @@
 import { attr } from '@microsoft/fast-element';
-import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
 import { TableColumn } from '../base';
-import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
-import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 /**
  * The base class for table columns that display fields of any type as text.
  */
-export abstract class TableColumnTextBase extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumn))
-) {
+export abstract class TableColumnTextBase<TColumnConfig> extends TableColumn<TColumnConfig> {
     @attr({ attribute: 'field-name' })
     public fieldName?: string;
 

--- a/packages/nimble-components/src/table-column/text/index.ts
+++ b/packages/nimble-components/src/table-column/text/index.ts
@@ -28,7 +28,11 @@ declare global {
  * The table column for displaying string fields as text.
  */
 export class TableColumnText extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumnTextBase<TableColumnTextColumnConfig>))
+    mixinFractionalWidthColumnAPI(
+        mixinColumnWithPlaceholderAPI(
+            TableColumnTextBase<TableColumnTextColumnConfig>
+        )
+    )
 ) {
     public placeholderChanged(): void {
         this.columnInternals.columnConfig = {

--- a/packages/nimble-components/src/table-column/text/index.ts
+++ b/packages/nimble-components/src/table-column/text/index.ts
@@ -8,6 +8,7 @@ import { tableColumnTextGroupHeaderViewTag } from './group-header-view';
 import { tableColumnTextCellViewTag } from './cell-view';
 import type { ColumnInternalsOptions } from '../base/models/column-internals';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
+import { ColumnValidator } from '../base/models/column-validator';
 
 export type TableColumnTextCellRecord = TableStringField<'value'>;
 
@@ -37,7 +38,8 @@ export class TableColumnText extends mixinTextBase<TableColumnTextColumnConfig>(
             cellViewTag: tableColumnTextCellViewTag,
             groupHeaderViewTag: tableColumnTextGroupHeaderViewTag,
             delegatedEvents: [],
-            sortOperation: TableColumnSortOperation.localeAwareCaseSensitive
+            sortOperation: TableColumnSortOperation.localeAwareCaseSensitive,
+            validator: new ColumnValidator<[]>([])
         };
     }
 }

--- a/packages/nimble-components/src/table-column/text/index.ts
+++ b/packages/nimble-components/src/table-column/text/index.ts
@@ -2,15 +2,12 @@ import { DesignSystem } from '@microsoft/fast-foundation';
 import { styles } from '../base/styles';
 import { template } from '../base/template';
 import type { TableStringField } from '../../table/types';
-import { TableColumnTextBase } from '../text-base';
+import { mixinTextBase } from '../text-base';
 import { TableColumnSortOperation } from '../base/types';
 import { tableColumnTextGroupHeaderViewTag } from './group-header-view';
 import { tableColumnTextCellViewTag } from './cell-view';
 import type { ColumnInternalsOptions } from '../base/models/column-internals';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
-import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
-import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
-import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 export type TableColumnTextCellRecord = TableStringField<'value'>;
 
@@ -27,13 +24,7 @@ declare global {
 /**
  * The table column for displaying string fields as text.
  */
-export class TableColumnText extends mixinGroupableColumnAPI(
-    mixinFractionalWidthColumnAPI(
-        mixinColumnWithPlaceholderAPI(
-            TableColumnTextBase<TableColumnTextColumnConfig>
-        )
-    )
-) {
+export class TableColumnText extends mixinTextBase<TableColumnTextColumnConfig>() {
     public placeholderChanged(): void {
         this.columnInternals.columnConfig = {
             placeholder: this.placeholder

--- a/packages/nimble-components/src/table-column/text/index.ts
+++ b/packages/nimble-components/src/table-column/text/index.ts
@@ -8,6 +8,9 @@ import { tableColumnTextGroupHeaderViewTag } from './group-header-view';
 import { tableColumnTextCellViewTag } from './cell-view';
 import type { ColumnInternalsOptions } from '../base/models/column-internals';
 import type { TableColumnTextBaseColumnConfig } from '../text-base/cell-view';
+import { mixinFractionalWidthColumnAPI } from '../mixins/fractional-width-column';
+import { mixinGroupableColumnAPI } from '../mixins/groupable-column';
+import { mixinColumnWithPlaceholderAPI } from '../mixins/placeholder';
 
 export type TableColumnTextCellRecord = TableStringField<'value'>;
 
@@ -24,7 +27,9 @@ declare global {
 /**
  * The table column for displaying string fields as text.
  */
-export class TableColumnText extends TableColumnTextBase {
+export class TableColumnText extends mixinGroupableColumnAPI(
+    mixinFractionalWidthColumnAPI(mixinColumnWithPlaceholderAPI(TableColumnTextBase<TableColumnTextColumnConfig>))
+) {
     public placeholderChanged(): void {
         this.columnInternals.columnConfig = {
             placeholder: this.placeholder

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -350,7 +350,10 @@ export class Table<
             && typeof args === 'string'
         ) {
             this.tableUpdateTracker.trackColumnPropertyChanged(args);
-        } else if (source instanceof ColumnValidator && args === 'isColumnValid') {
+        } else if (
+            source instanceof ColumnValidator
+            && args === 'isColumnValid'
+        ) {
             this.tableValidator.validateColumnConfigurations(this.columns);
         } else if (
             source instanceof TableLayoutManager

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -58,6 +58,7 @@ import { InteractiveSelectionManager } from './models/interactive-selection-mana
 import { DataHierarchyManager } from './models/data-hierarchy-manager';
 import { ExpansionManager } from './models/expansion-manager';
 import { waitUntilCustomElementsDefinedAsync } from '../utilities/wait-until-custom-elements-defined-async';
+import { ColumnValidator } from '../table-column/base/models/column-validator';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -348,11 +349,9 @@ export class Table<
                 || source instanceof ColumnInternals)
             && typeof args === 'string'
         ) {
-            if (args === 'validConfiguration') {
-                this.tableValidator.validateColumnConfigurations(this.columns);
-            } else {
-                this.tableUpdateTracker.trackColumnPropertyChanged(args);
-            }
+            this.tableUpdateTracker.trackColumnPropertyChanged(args);
+        } else if (source instanceof ColumnValidator && args === 'isColumnValid') {
+            this.tableValidator.validateColumnConfigurations(this.columns);
         } else if (
             source instanceof TableLayoutManager
             && args === 'isColumnBeingSized'
@@ -746,6 +745,11 @@ export class Table<
             );
             notifierInternals.subscribe(this);
             this.columnNotifiers.push(notifierInternals);
+            const validatorNotifier = Observable.getNotifier(
+                column.columnInternals.validator
+            );
+            validatorNotifier.subscribe(this);
+            this.columnNotifiers.push(validatorNotifier);
         }
     }
 

--- a/packages/nimble-components/src/table/models/table-validator.ts
+++ b/packages/nimble-components/src/table/models/table-validator.ts
@@ -150,7 +150,7 @@ export class TableValidator<TData extends TableRecord> {
         columns: readonly TableColumn[]
     ): boolean {
         this.invalidColumnConfiguration = columns.some(
-            x => !x.columnInternals.validConfiguration
+            x => !x.columnInternals.validator.isColumnValid
         );
         return !this.invalidColumnConfiguration;
     }

--- a/packages/nimble-components/src/table/tests/table-delegated-events.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-delegated-events.spec.ts
@@ -13,6 +13,7 @@ import {
 import type { TableRecord } from '../types';
 import { TablePageObject } from '../testing/table.pageobject';
 import type { ColumnInternalsOptions } from '../../table-column/base/models/column-internals';
+import { ColumnValidator } from '../../table-column/base/models/column-validator';
 
 interface SimpleTableRecord extends TableRecord {
     foo: string;
@@ -29,7 +30,8 @@ class TestTableColumn extends TableColumn {
             cellRecordFieldNames: ['value'],
             cellViewTag: tableColumnTextCellViewTag,
             groupHeaderViewTag: tableColumnTextGroupHeaderViewTag,
-            delegatedEvents: ['click', 'keydown']
+            delegatedEvents: ['click', 'keydown'],
+            validator: new ColumnValidator<[]>([])
         };
     }
 }

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -26,6 +26,7 @@ import {
     tableColumnValidationTestTag
 } from '../../table-column/base/tests/table-column.fixtures';
 import type { ColumnInternalsOptions } from '../../table-column/base/models/column-internals';
+import { ColumnValidator } from '../../table-column/base/models/column-validator';
 
 interface SimpleTableRecord extends TableRecord {
     stringData: string;
@@ -640,7 +641,8 @@ describe('Table', () => {
                         cellViewTag: focusableCellViewName,
                         cellRecordFieldNames: ['value'],
                         groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-                        delegatedEvents: []
+                        delegatedEvents: [],
+                        validator: new ColumnValidator<[]>([])
                     };
                 }
             }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #1389

## 👩‍💻 Implementation

- Updated `TableColumn`, `ColumnInternals`, and `ColumnInternalsOptions` to be generic with `TColumnValidator extends ColumnValidator<[]>`
- Updated `ColumnInternals` to have a `validator` property whose type is enforced by the type of `TColumnValidator`
- Made `validator` a required input on `ColumnInternalsOptions`, so now every column has to specify a validator. In some cases this is a "default" validator with no validity keys, but making this required simplified a few different code paths. This included keeping columns with validators from having to use the `!` operator to assert that they knew that a validator had been set within their options.
- Updated columns to specify a validator and to use that validator through `ColumnInternals` rather than a class member on the column.

## 🧪 Testing

Existing tests still pass

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
