### PR TITLE
Update version of FAST and remove bug workaround

### DIFF
--- a/change/@ni-nimble-components-078b375d-daec-46bc-8525-995725df1168.json
+++ b/change/@ni-nimble-components-078b375d-daec-46bc-8525-995725df1168.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update version of FAST",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6232,16 +6232,16 @@
       "integrity": "sha512-72RZXVfCbwQzvo5sXXkuLXLT7rMeYaSf5r/6ewQiv/trBtqpWRm4DEH2EilHw/iWTBKOXs1qZNQndgUMa5n4LA=="
     },
     "node_modules/@microsoft/fast-element": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.12.0.tgz",
-      "integrity": "sha512-gQutuDHPKNxUEcQ4pypZT4Wmrbapus+P9s3bR/SEOLsMbNqNoXigGImITygI5zhb+aA5rzflM6O8YWkmRbGkPA=="
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.13.0.tgz",
+      "integrity": "sha512-iFhzKbbD0cFRo9cEzLS3Tdo9BYuatdxmCEKCpZs1Cro/93zNMpZ/Y9/Z7SknmW6fhDZbpBvtO8lLh9TFEcNVAQ=="
     },
     "node_modules/@microsoft/fast-foundation": {
-      "version": "2.49.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.49.4.tgz",
-      "integrity": "sha512-5I2tSPo6bnOfVAIX7XzX+LhilahwvD7h+yzl3jW0t5IYmMX9Lci9VUVyx5f8hHdb1O9a8Y9Atb7Asw7yFO/u+w==",
+      "version": "2.49.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.49.6.tgz",
+      "integrity": "sha512-DZVr+J/NIoskFC1Y6xnAowrMkdbf2d5o7UyWK6gW5AiQ6S386Ql8dw4KcC4kHaeE1yL2CKvweE79cj6ZhJhTvA==",
       "dependencies": {
-        "@microsoft/fast-element": "^1.12.0",
+        "@microsoft/fast-element": "^1.13.0",
         "@microsoft/fast-web-utilities": "^5.4.1",
         "tabbable": "^5.2.0",
         "tslib": "^1.13.0"
@@ -33205,7 +33205,7 @@
       "dependencies": {
         "@microsoft/fast-colors": "^5.3.1",
         "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "2.49.4",
+        "@microsoft/fast-foundation": "2.49.6",
         "@microsoft/fast-web-utilities": "^6.0.0",
         "@ni/nimble-tokens": "^6.13.1",
         "@tanstack/table-core": "^8.10.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33205,7 +33205,7 @@
       "dependencies": {
         "@microsoft/fast-colors": "^5.3.1",
         "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "2.49.6",
+        "@microsoft/fast-foundation": "^2.49.6",
         "@microsoft/fast-web-utilities": "^6.0.0",
         "@ni/nimble-tokens": "^6.13.1",
         "@tanstack/table-core": "^8.10.7",
@@ -33245,7 +33245,7 @@
         "@babel/cli": "^7.13.16",
         "@babel/core": "^7.20.12",
         "@chromatic-com/storybook": "^1.2.25",
-        "@microsoft/fast-react-wrapper": "0.3.22",
+        "@microsoft/fast-react-wrapper": "^0.3.22",
         "@ni/eslint-config-javascript": "^4.2.0",
         "@ni/eslint-config-typescript": "^4.2.0",
         "@ni/jasmine-parameterized": "^0.2.3",

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@microsoft/fast-colors": "^5.3.1",
     "@microsoft/fast-element": "^1.12.0",
-    "@microsoft/fast-foundation": "2.49.4",
+    "@microsoft/fast-foundation": "2.49.6",
     "@microsoft/fast-web-utilities": "^6.0.0",
     "@ni/nimble-tokens": "^6.13.1",
     "@tanstack/table-core": "^8.10.7",

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@microsoft/fast-colors": "^5.3.1",
     "@microsoft/fast-element": "^1.12.0",
-    "@microsoft/fast-foundation": "2.49.6",
+    "@microsoft/fast-foundation": "^2.49.6",
     "@microsoft/fast-web-utilities": "^6.0.0",
     "@ni/nimble-tokens": "^6.13.1",
     "@tanstack/table-core": "^8.10.7",
@@ -109,7 +109,7 @@
     "@babel/cli": "^7.13.16",
     "@babel/core": "^7.20.12",
     "@chromatic-com/storybook": "^1.2.25",
-    "@microsoft/fast-react-wrapper": "0.3.22",
+    "@microsoft/fast-react-wrapper": "^0.3.22",
     "@ni/eslint-config-javascript": "^4.2.0",
     "@ni/eslint-config-typescript": "^4.2.0",
     "@ni/jasmine-parameterized": "^0.2.3",

--- a/packages/nimble-components/src/anchor-menu-item/index.ts
+++ b/packages/nimble-components/src/anchor-menu-item/index.ts
@@ -2,7 +2,6 @@ import { attr, observable } from '@microsoft/fast-element';
 import {
     DesignSystem,
     AnchorOptions,
-    MenuItem as FoundationMenuItem,
     MenuItemColumnCount
 } from '@microsoft/fast-foundation';
 import { keyEnter } from '@microsoft/fast-web-utilities';
@@ -103,20 +102,3 @@ DesignSystem.getOrCreate()
     .withPrefix('nimble')
     .register(nimbleAnchorMenuItem());
 export const anchorMenuItemTag = 'nimble-anchor-menu-item';
-
-// This is a workaround for the fact that FAST's menu uses `instanceof MenuItem`
-// in their logic for indenting menu items. Since our AnchorMenuItem derives from
-// AnchorBase and not FAST's MenuItem, we need to change their MenuItem's definition
-// of `hasInstance` so that it includes our AnchorMenuItem, too.
-//
-// If/when we change FAST to test for the presence of `startColumnCount` instead
-// of using `instanceof MenuItem`, we can remove this workaround. Here is the
-// PR into FAST: https://github.com/microsoft/fast/pull/6667
-const originalInstanceOf = FoundationMenuItem[Symbol.hasInstance].bind(FoundationMenuItem);
-Object.defineProperty(FoundationMenuItem, Symbol.hasInstance, {
-    value(instance: unknown) {
-        return (
-            originalInstanceOf(instance) || instance instanceof AnchorMenuItem
-        );
-    }
-});

--- a/packages/nimble-components/src/anchor-menu-item/tests/anchor-menu-item.spec.ts
+++ b/packages/nimble-components/src/anchor-menu-item/tests/anchor-menu-item.spec.ts
@@ -2,13 +2,10 @@
 import { customElement, html, ref } from '@microsoft/fast-element';
 import { MenuItem as FoundationMenuItem } from '@microsoft/fast-foundation';
 import { parameterizeSpec } from '@ni/jasmine-parameterized';
-import { AnchorMenuItem, anchorMenuItemTag } from '..';
-import { anchorTag } from '../../anchor';
-import { buttonTag } from '../../button';
+import { AnchorMenuItem } from '..';
 import type { IconCheck } from '../../icons/check';
 import type { IconXmark } from '../../icons/xmark';
-import { Menu, menuTag } from '../../menu';
-import { menuItemTag } from '../../menu-item';
+import type { Menu } from '../../menu';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 
@@ -172,45 +169,6 @@ describe('Anchor Menu Item', () => {
             expect(model.item2.startColumnCount).toBe(1);
             expect(model.item3.startColumnCount).toBe(1);
             expect(model.item4dot2.startColumnCount).toBe(0);
-        });
-    });
-
-    describe('FoundationMenuItem instanceof override', () => {
-        it('returns true for FoundationMenuItem', () => {
-            const foundationMenuItem = document.createElement(
-                'foundation-menu-item'
-            );
-            expect(foundationMenuItem instanceof FoundationMenuItem).toBeTrue();
-        });
-
-        it('returns true for AnchorMenuItem', () => {
-            const anchorMenuItem = document.createElement(anchorMenuItemTag);
-            expect(anchorMenuItem instanceof FoundationMenuItem).toBeTrue();
-        });
-
-        it('returns true for MenuItem', () => {
-            const menuItem = document.createElement(menuItemTag);
-            expect(menuItem instanceof FoundationMenuItem).toBeTrue();
-        });
-
-        it('returns false for Menu', () => {
-            const menu = document.createElement(menuTag);
-            expect(menu instanceof FoundationMenuItem).toBeFalse();
-        });
-
-        it('returns false for Anchor', () => {
-            const anchor = document.createElement(anchorTag);
-            expect(anchor instanceof FoundationMenuItem).toBeFalse();
-        });
-
-        it('returns false for Button', () => {
-            const button = document.createElement(buttonTag);
-            expect(button instanceof FoundationMenuItem).toBeFalse();
-        });
-
-        it('returns false for div', () => {
-            const div = document.createElement('div');
-            expect(div instanceof FoundationMenuItem).toBeFalse();
         });
     });
 });


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #1661

## 👩‍💻 Implementation

- Updated `fast-foundation` to 2.49.6 (and unpinned version for it and `fast-react-wrapper`)
- Removed bug workaround from anchor menu item (as well as tests for workaround)

## 🧪 Testing

Verified in Storybook that theme can be changed without crashing, and indentation of anchor menu item is correct.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
