### PR TITLE
Fix and re-enable intermittent mention-listbox test

### DIFF
--- a/change/@ni-nimble-components-bb8ab8b7-633d-4a78-9d87-e9ec1263eaff.json
+++ b/change/@ni-nimble-components-bb8ab8b7-633d-4a78-9d87-e9ec1263eaff.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "none",
   "comment": "Fix and re-enable intermittent mention-listbox test",
   "packageName": "@ni/nimble-components",
   "email": "20542556+mollykreis@users.noreply.github.com",

--- a/change/@ni-nimble-components-bb8ab8b7-633d-4a78-9d87-e9ec1263eaff.json
+++ b/change/@ni-nimble-components-bb8ab8b7-633d-4a78-9d87-e9ec1263eaff.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix and re-enable intermittent mention-listbox test",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/rich-text/mention-listbox/tests/mention-listbox.spec.ts
+++ b/packages/nimble-components/src/rich-text/mention-listbox/tests/mention-listbox.spec.ts
@@ -42,7 +42,7 @@ describe('RichTextMentionListbox', () => {
 
     async function waitForSelectionUpdateAsync(): Promise<void> {
         await waitForUpdatesAsync();
-        await waitAnimationFrame();
+        await waitAnimationFrame(); // necessary because scrolling is queued with requestAnimationFrame
     }
 
     it('should scroll the selected option into view when opened', async () => {

--- a/packages/nimble-components/src/rich-text/mention-listbox/tests/mention-listbox.spec.ts
+++ b/packages/nimble-components/src/rich-text/mention-listbox/tests/mention-listbox.spec.ts
@@ -3,6 +3,7 @@ import { RichTextMentionListbox, richTextMentionListboxTag } from '..';
 import { waitForUpdatesAsync } from '../../../testing/async-helpers';
 import { type Fixture, fixture } from '../../../utilities/tests/fixture';
 import { listOptionTag } from '../../../list-option';
+import { waitAnimationFrame } from '../../../utilities/tests/component';
 
 describe('RichTextMentionListbox', () => {
     it('should export its tag', () => {
@@ -41,11 +42,10 @@ describe('RichTextMentionListbox', () => {
 
     async function waitForSelectionUpdateAsync(): Promise<void> {
         await waitForUpdatesAsync();
-        await waitForUpdatesAsync();
+        await waitAnimationFrame();
     }
 
-    // Intermittent test tracked by https://github.com/ni/nimble/issues/1891
-    xit('should scroll the selected option into view when opened', async () => {
+    it('should scroll the selected option into view when opened', async () => {
         const model = new Model();
         const { connect, disconnect } = await setup500Options(model);
         await connect();


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #1891 

It's not clear why, but the mention-listbox test was awaiting `waitForUpdatesAsync` twice before asserting that the scroll position was correct. Other similar tests await `waitForUpdatesAsync` followed by `waitAnimationFrame`. The call to `waitAnimationFrame` is necessary because the scroll is queued with `requestAnimationFrame`.

## 👩‍💻 Implementation

Update the second call to `waitForUpdatesAsync` to a call to `waitAnimationFrame`.

## 🧪 Testing

Ran the test a number of times locally, though I'm not if this verifies much since I was never able to get the test to fail locally before this fix

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
