### PR TITLE
Support arbitrary units in the number-text column

### DIFF
--- a/change/@ni-nimble-components-0747444f-2664-4db0-84c8-37920989a469.json
+++ b/change/@ni-nimble-components-0747444f-2664-4db0-84c8-37920989a469.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Support arbitrary units in the number-text column",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -65,6 +65,9 @@ export class TableColumnNumberText extends mixinTextBase(
     })
     public decimalMaximumDigits?: number;
 
+    @attr({ attribute: 'display-suffix' })
+    public displaySuffix?: string;
+
     /** @internal */
     @observable
     public unitElements?: Element[];
@@ -141,6 +144,10 @@ export class TableColumnNumberText extends mixinTextBase(
         this.updateColumnConfig();
     }
 
+    private displaySuffixChanged(): void {
+        this.updateColumnConfig();
+    }
+
     private unitElementsChanged(): void {
         void this.updateUnit();
     }
@@ -194,6 +201,7 @@ export class TableColumnNumberText extends mixinTextBase(
             numberTextFormat: this.format ?? undefined,
             decimalDigits: this.decimalDigits ?? undefined,
             decimalMaximumDigits: this.decimalMaximumDigits ?? undefined,
+            displaySuffix: this.displaySuffix,
             unitScale
         });
     }

--- a/packages/nimble-components/src/table-column/number-text/models/number-text-unit-format.ts
+++ b/packages/nimble-components/src/table-column/number-text/models/number-text-unit-format.ts
@@ -11,6 +11,7 @@ export interface NumberTextUnitFormatOptions extends UnitFormatOptions {
     numberTextFormat?: NumberTextFormat;
     decimalDigits?: number;
     decimalMaximumDigits?: number;
+    displaySuffix?: string;
 }
 type ResolvedNumberTextUnitFormatOptions = NumberTextUnitFormatOptions &
 Required<UnitFormatOptions>;
@@ -45,12 +46,18 @@ export class NumberTextUnitFormat extends UnitFormat {
                 === targetResolvedOptions.decimalMaximumDigits
             && this._resolvedOptions.numberTextFormat
                 === targetResolvedOptions.numberTextFormat
-            && this._resolvedOptions.unitScale === targetResolvedOptions.unitScale
+            && this._resolvedOptions.unitScale
+                === targetResolvedOptions.unitScale
+            && this._resolvedOptions.displaySuffix
+                === targetResolvedOptions.displaySuffix
         );
     }
 
     protected override tryFormat(number: number): string {
-        return this.resolvedUnitFormat.format(number);
+        const formatted = this.resolvedUnitFormat.format(number);
+        return this._resolvedOptions.displaySuffix
+            ? `${formatted}${this._resolvedOptions.displaySuffix}`
+            : formatted;
     }
 
     private resolveUnitFormat(
@@ -91,7 +98,10 @@ export class NumberTextUnitFormat extends UnitFormat {
                 numberTextFormat: NumberTextFormat.default,
                 decimalDigits: undefined,
                 decimalMaximumDigits: undefined,
-                unitScale: options?.unitScale ?? passthroughUnitScale
+                unitScale: options?.unitScale ?? passthroughUnitScale,
+                displaySuffix: options?.unitScale
+                    ? undefined
+                    : options?.displaySuffix
             };
         }
         const hasDecimalDigits = typeof options.decimalDigits === 'number';
@@ -106,14 +116,20 @@ export class NumberTextUnitFormat extends UnitFormat {
                 numberTextFormat: NumberTextFormat.decimal,
                 decimalDigits: NumberTextUnitFormat.defaultDecimalDigits,
                 decimalMaximumDigits: undefined,
-                unitScale: options.unitScale ?? passthroughUnitScale
+                unitScale: options.unitScale ?? passthroughUnitScale,
+                displaySuffix: options?.unitScale
+                    ? undefined
+                    : options?.displaySuffix
             };
         }
         return {
             numberTextFormat: NumberTextFormat.decimal,
             decimalDigits: options.decimalDigits,
             decimalMaximumDigits: options.decimalMaximumDigits,
-            unitScale: options.unitScale ?? passthroughUnitScale
+            unitScale: options.unitScale ?? passthroughUnitScale,
+            displaySuffix: options?.unitScale
+                ? undefined
+                : options?.displaySuffix
         };
     }
 }

--- a/packages/nimble-components/src/table-column/number-text/models/number-text-unit-format.ts
+++ b/packages/nimble-components/src/table-column/number-text/models/number-text-unit-format.ts
@@ -99,9 +99,7 @@ export class NumberTextUnitFormat extends UnitFormat {
                 decimalDigits: undefined,
                 decimalMaximumDigits: undefined,
                 unitScale: options?.unitScale ?? passthroughUnitScale,
-                displaySuffix: options?.unitScale
-                    ? undefined
-                    : options?.displaySuffix
+                displaySuffix: options?.displaySuffix
             };
         }
         const hasDecimalDigits = typeof options.decimalDigits === 'number';
@@ -117,9 +115,7 @@ export class NumberTextUnitFormat extends UnitFormat {
                 decimalDigits: NumberTextUnitFormat.defaultDecimalDigits,
                 decimalMaximumDigits: undefined,
                 unitScale: options.unitScale ?? passthroughUnitScale,
-                displaySuffix: options?.unitScale
-                    ? undefined
-                    : options?.displaySuffix
+                displaySuffix: options?.displaySuffix
             };
         }
         return {
@@ -127,9 +123,7 @@ export class NumberTextUnitFormat extends UnitFormat {
             decimalDigits: options.decimalDigits,
             decimalMaximumDigits: options.decimalMaximumDigits,
             unitScale: options.unitScale ?? passthroughUnitScale,
-            displaySuffix: options?.unitScale
-                ? undefined
-                : options?.displaySuffix
+            displaySuffix: options?.displaySuffix
         };
     }
 }

--- a/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.spec.ts
@@ -558,6 +558,41 @@ describe('TableColumnNumberText', () => {
                 '11 bytes'
             );
         });
+
+        it('updates format when display-suffix is changed', async () => {
+            await table.setData([{ number1: 100 }]);
+            await waitForUpdatesAsync();
+
+            expect(pageObject.getRenderedCellTextContent(0, 0)).toBe('100.00');
+            expect(pageObject.getRenderedGroupHeaderTextContent(0)).toBe(
+                '100.00'
+            );
+
+            elementReferences.column1.displaySuffix = ' mL/sec';
+            await waitForUpdatesAsync();
+
+            expect(pageObject.getRenderedCellTextContent(0, 0)).toBe(
+                '100.00 mL/sec'
+            );
+            expect(pageObject.getRenderedGroupHeaderTextContent(0)).toBe(
+                '100.00 mL/sec'
+            );
+        });
+
+        it('appends suffix after unit', async () => {
+            elementReferences.column1.appendChild(
+                document.createElement(unitByteTag)
+            );
+            elementReferences.column1.displaySuffix = '/sec';
+            await waitForUpdatesAsync();
+
+            expect(pageObject.getRenderedCellTextContent(0, 0)).toBe(
+                '11 bytes/sec'
+            );
+            expect(pageObject.getRenderedGroupHeaderTextContent(0)).toBe(
+                '11 bytes/sec'
+            );
+        });
     });
 
     const alignmentTestCases = [

--- a/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.stories.ts
+++ b/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.stories.ts
@@ -219,7 +219,7 @@ export const numberTextColumn: StoryObj<NumberTextColumnTableArgs> = {
         displaySuffix: {
             name: 'display-suffix',
             description:
-                'A string to append to the formatted value. This can be used to provide an arbitrary, static unit label when the desired unit is not supported by a `nimble-unit-<name>` element. This value is ignored when the column is configured with a unit element. If a space is desired between the formatted value and the suffix, it should be included in the string.'
+                'A string to append to the formatted value. This can be used to provide an arbitrary, static unit label when the desired unit is not supported by a `nimble-unit-<name>` element. If a space is desired between the formatted value and the suffix, it should be included in the string.'
         },
         checkValidity: {
             name: 'checkValidity()',
@@ -238,6 +238,6 @@ export const numberTextColumn: StoryObj<NumberTextColumnTableArgs> = {
         decimalMaximumDigits: undefined,
         unit: 'volt',
         displaySuffix: '° C',
-        placeholder: 'Unknown voltage'
+        placeholder: 'Unknown temperature'
     }
 };

--- a/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.stories.ts
+++ b/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.stories.ts
@@ -85,6 +85,7 @@ interface NumberTextColumnTableArgs extends SharedTableArgs {
     decimalDigits: number;
     decimalMaximumDigits: number;
     unit: string;
+    displaySuffix: string;
     checkValidity: () => void;
     validity: () => void;
 }
@@ -130,6 +131,8 @@ To improve the ability for users to visually scan values, applications should se
 
 const unitDescription = `A unit for the column may be configured by providing a \`nimble-unit-<name>\` element as content (in addition to the column label). Unit elements represent a set of related, scaled units, e.g. \`nimble-unit-byte\` represents bytes, KB, MB, etc. Values are converted from a source unit (e.g. bytes) to the largest scaled unit (e.g. KB, MB, etc.) that can represent that value with magnitude >= 1. The source data for the column is expected to be given in the base unit specified in the tag name, e.g. for \`nimble-unit-byte\`, a source value should be a number of bytes.
 
+If an element does not exist for the desired unit, \`display-suffix\` may be used instead to append a static string to the formatted value.
+
 <details>
     <summary>Unit Elements</summary>
 
@@ -165,7 +168,7 @@ export const numberTextColumn: StoryObj<NumberTextColumnTableArgs> = {
             <${tableColumnNumberTextTag} field-name="favoriteNumber" format="${x => NumberTextFormat[x.format]}" alignment="${x => NumberTextAlignment[x.alignment]}" decimal-digits="${x => x.decimalDigits}" decimal-maximum-digits="${x => x.decimalMaximumDigits}" placeholder="${x => x.placeholder}">
                 Favorite Number
             </${tableColumnNumberTextTag}>
-            <${tableColumnNumberTextTag} field-name="measurement" format="${x => NumberTextFormat[x.format]}" alignment="${x => NumberTextAlignment[x.alignment]}" decimal-digits="${x => x.decimalDigits}" decimal-maximum-digits="${x => x.decimalMaximumDigits}" placeholder="${x => x.placeholder}">
+            <${tableColumnNumberTextTag} field-name="measurement" format="${x => NumberTextFormat[x.format]}" alignment="${x => NumberTextAlignment[x.alignment]}" decimal-digits="${x => x.decimalDigits}" decimal-maximum-digits="${x => x.decimalMaximumDigits}" display-suffix="${x => x.displaySuffix}" placeholder="${x => x.placeholder}">
                 Measurement
                 ${when(x => x.unit === 'byte', html`<${unitByteTag}></${unitByteTag}>`)}
                 ${when(x => x.unit === 'byte (1024)', html`<${unitByteTag} binary></${unitByteTag}>`)}
@@ -213,6 +216,11 @@ export const numberTextColumn: StoryObj<NumberTextColumnTableArgs> = {
             options: ['default', 'byte', 'byte (1024)', 'volt'],
             control: { type: 'radio' }
         },
+        displaySuffix: {
+            name: 'display-suffix',
+            description:
+                'A string to append to the formatted value. This can be used to provide an arbitrary, static unit label when the desired unit is not supported by a `nimble-unit-<name>` element. This value is ignored when the column is configured with a unit element. If a space is desired between the formatted value and the suffix, it should be included in the string.'
+        },
         checkValidity: {
             name: 'checkValidity()',
             description:
@@ -229,6 +237,7 @@ export const numberTextColumn: StoryObj<NumberTextColumnTableArgs> = {
         decimalDigits: 2,
         decimalMaximumDigits: undefined,
         unit: 'volt',
+        displaySuffix: '° C',
         placeholder: 'Unknown voltage'
     }
 };


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #2016

## 👩‍💻 Implementation

- introduced new number-text column attribute `display-suffix`, which is appended to the formatted value by `NumberTextUnitFormat`

TODO: Angular and Blazor support

## 🧪 Testing

Added a couple new test cases.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
