### PR TITLE
Angular export mapping key type

### DIFF
--- a/angular-workspace/projects/ni/nimble-angular/table-column/icon/nimble-table-column-icon.directive.ts
+++ b/angular-workspace/projects/ni/nimble-angular/table-column/icon/nimble-table-column-icon.directive.ts
@@ -2,8 +2,9 @@ import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
 import { type TableColumnIcon, tableColumnIconTag } from '@ni/nimble-components/dist/esm/table-column/icon';
 import { BooleanValueOrAttribute, NumberValueOrAttribute, toBooleanProperty, toNullableNumberProperty } from '@ni/nimble-angular/internal-utilities';
 import { NimbleTableColumnBaseDirective } from '@ni/nimble-angular/table-column';
-import type { MappingKeyType } from '@ni/nimble-components/dist/esm/table-column/enum-base/types';
+import { MappingKeyType } from '@ni/nimble-components/dist/esm/table-column/enum-base/types';
 
+export { MappingKeyType };
 export type { TableColumnIcon };
 export { tableColumnIconTag };
 

--- a/change/@ni-nimble-angular-a1577ef5-7463-420d-aefc-68727634382f.json
+++ b/change/@ni-nimble-angular-a1577ef5-7463-420d-aefc-68727634382f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Export `MappingKeyType` from `NimbleTableColumnIconModule`",
+  "packageName": "@ni/nimble-angular",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

In #2026, the `enum-text` column was removed from nimble. However, I hadn't realized that in Angular, `NimbleTableColumnEnumTextModule` was the only module that exported `MappingKeyType`, which was expected to be used by both the `enum-text` column and the `icon` column. Therefore, the `icon` column is now unusable in Angular because `MappingKeyType` isn't exported.

Therefore, this PR exports `MappingKeyType` from `NimbleTableColumnIconModule`.

## 👩‍💻 Implementation

Export `MappingKeyType` from `NimbleTableColumnIconModule`

## 🧪 Testing

N/A

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
