### PR TITLE
Add and exercise testing fixture in spright-components

### DIFF
--- a/change/@ni-spright-components-36d79c25-cc4c-4e7f-8c5c-f5a627f428f8.json
+++ b/change/@ni-spright-components-36d79c25-cc4c-4e7f-8c5c-f5a627f428f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add and exercise testing fixture in spright-components",
+  "packageName": "@ni/spright-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/spright-components/.prettierignore
+++ b/packages/spright-components/.prettierignore
@@ -18,3 +18,5 @@ dist
 node_modules
 package.json
 CHANGELOG.*
+src/utilities/tests/tests/fixture.spec.ts
+src/utilities/tests/fixture.ts

--- a/packages/spright-components/src/rectangle/tests/rectangle.spec.ts
+++ b/packages/spright-components/src/rectangle/tests/rectangle.spec.ts
@@ -1,6 +1,24 @@
+import { html } from '@microsoft/fast-element';
 import { Rectangle, rectangleTag } from '..';
+import { fixture, Fixture } from '../../utilities/tests/fixture';
+
+async function setup(): Promise<Fixture<Rectangle>> {
+    return fixture<Rectangle>(html`<spright-rectangle></spright-rectangle>`);
+}
 
 describe('Rectangle', () => {
+    let element: Rectangle;
+    let connect: () => Promise<void>;
+    let disconnect: () => Promise<void>;
+
+    beforeEach(async () => {
+        ({ element, connect, disconnect } = await setup());
+    });
+
+    afterEach(async () => {
+        await disconnect();
+    });
+
     it('should export its tag', () => {
         expect(rectangleTag).toBe('spright-rectangle');
     });
@@ -9,5 +27,12 @@ describe('Rectangle', () => {
         expect(document.createElement('spright-rectangle')).toBeInstanceOf(
             Rectangle
         );
+    });
+
+    it('should have a slot element in the shadow DOM', async () => {
+        await connect();
+        expect(
+            (element.shadowRoot?.childNodes.item(0) as HTMLElement).tagName
+        ).toBe('SLOT');
     });
 });

--- a/packages/spright-components/src/utilities/tests/fixture.ts
+++ b/packages/spright-components/src/utilities/tests/fixture.ts
@@ -1,0 +1,222 @@
+/* eslint-disable */
+
+// Sourced from:
+// https://github.com/microsoft/fast/blob/928d73621c62064992189270a920b2c6d6d9e19e/packages/web-components/fast-foundation/src/test-utilities/fixture.ts
+// Pending standalone availability in a package:
+// https://github.com/microsoft/fast/issues/4930
+// With updated imports and the following patches:
+// 1. https://github.com/microsoft/fast/issues/4930#issuecomment-885326451
+// 2. Style the parent to be at the top-left corner of the page to prevent intermittencies related to controls being pushed out of the viewport by the tet runner page content.
+// 3. Remove the option for a custom parent to be specified in the `FixtureOptions` so that the patch mentioned above will never be unintentially bypassed.
+
+import {
+    Constructable,
+    defaultExecutionContext,
+    ExecutionContext,
+    HTMLView,
+    ViewTemplate,
+} from '@microsoft/fast-element';
+import { Container, DesignSystem, DesignSystemRegistrationContext, DI } from '@microsoft/fast-foundation';
+
+import type {
+    FoundationElementDefinition,
+    FoundationElementRegistry,
+} from '@microsoft/fast-foundation';
+
+/**
+ * Options used to customize the creation of the test fixture.
+ */
+export interface FixtureOptions {
+    /**
+     * The document to run the fixture in.
+     * @defaultValue `globalThis.document`
+     */
+    document?: Document;
+
+    /**
+     * The data source to bind the HTML to.
+     * @defaultValue An empty object.
+     */
+    source?: any;
+
+    /**
+     * The execution context to use during binding.
+     * @defaultValue {@link @microsoft/fast-element#defaultExecutionContext}
+     */
+    context?: ExecutionContext;
+
+    /**
+     * A pre-configured design system instance used in setting up the fixture.
+     */
+    designSystem?: DesignSystem;
+}
+
+export interface Fixture<TElement = HTMLElement> {
+    /**
+     * The document the fixture is running in.
+     */
+    document: Document;
+
+    /**
+     * The template the fixture was created from.
+     */
+    template: ViewTemplate;
+
+    /**
+     * The view that was created from the fixture's template.
+     */
+    view: HTMLView;
+
+    /**
+     * The parent element that the view was appended to.
+     * @remarks
+     * This element will be appended to the DOM only
+     * after {@link Fixture.connect} has been called.
+     */
+    parent: HTMLElement;
+
+    /**
+     * The first element in the {@link Fixture.view}.
+     */
+    element: TElement;
+
+    /**
+     * Adds the {@link Fixture.parent} to the DOM, causing the
+     * connect lifecycle to begin.
+     * @remarks
+     * Yields control to the caller one Microtask later, in order to
+     * ensure that the DOM has settled.
+     */
+    connect: () => Promise<void>;
+
+    /**
+     * Removes the {@link Fixture.parent} from the DOM, causing the
+     * disconnect lifecycle to begin.
+     * @remarks
+     * Yields control to the caller one Microtask later, in order to
+     * ensure that the DOM has settled.
+     */
+    disconnect: () => Promise<void>;
+}
+
+function findElement(view: HTMLView): HTMLElement {
+    let current: Node | null = view.firstChild;
+
+    while (current !== null && current.nodeType !== 1) {
+        current = current.nextSibling;
+    }
+
+    return current as any;
+}
+
+/**
+ * Creates a random, unique name suitable for use as a Custom Element name.
+ */
+export function uniqueElementName(): string {
+    return `fast-unique-${Math.random().toString(36).substring(7)}`;
+}
+
+function isElementRegistry<T>(
+    obj: any
+): obj is FoundationElementRegistry<FoundationElementDefinition, any> {
+    return typeof obj.register === "function";
+}
+
+/**
+ * Creates a test fixture suitable for testing custom elements, templates, and bindings.
+ * @param templateNameOrRegistry An HTML template or single element name to create the fixture for.
+ * @param options Enables customizing fixture creation behavior.
+ * @remarks
+ * Yields control to the caller one Microtask later, in order to
+ * ensure that the DOM has settled.
+ */
+export async function fixture<TElement = HTMLElement>(
+    templateNameOrRegistry:
+        | ViewTemplate
+        | string
+        | FoundationElementRegistry<FoundationElementDefinition, Constructable<TElement>>
+        | [
+              FoundationElementRegistry<
+                  FoundationElementDefinition,
+                  Constructable<TElement>
+              >,
+              ...FoundationElementRegistry<FoundationElementDefinition, Constructable>[]
+          ],
+    options: FixtureOptions = {}
+): Promise<Fixture<TElement>> {
+    const document = options.document || globalThis.document;
+    const parent = Object.assign(document.createElement("div"), {
+        // Position the fixture in the top-left corner of the page.
+        // Prevents intermittencies related to controls being pushed out of the
+        // view port by test runner page content, i.e. jasmine reporter content
+        style: 'position: absolute; top: 0; left: 0;'
+    });
+    const source = options.source || {};
+    const context = options.context || defaultExecutionContext;
+
+    if (typeof templateNameOrRegistry === "string") {
+        const html = `<${templateNameOrRegistry}></${templateNameOrRegistry}>`;
+        templateNameOrRegistry = new ViewTemplate(html, []);
+    } else if (isElementRegistry(templateNameOrRegistry)) {
+        templateNameOrRegistry = [templateNameOrRegistry];
+    }
+
+    if (Array.isArray(templateNameOrRegistry)) {
+        const first = templateNameOrRegistry[0];
+        const ds = options.designSystem || DesignSystem.getOrCreate(parent);
+        let prefix = "";
+
+        ds.register(templateNameOrRegistry, {
+            register(container: Container, context: DesignSystemRegistrationContext) {
+                prefix = context.elementPrefix;
+            },
+        });
+
+        const elementName = `${prefix}-${first.definition.baseName}`;
+        const html = `<${elementName}></${elementName}>`;
+        templateNameOrRegistry = new ViewTemplate(html, []);
+    }
+
+    const view = templateNameOrRegistry.create();
+    const element = findElement(view) as any;
+    let isConnected = false;
+
+    view.bind(source, context);
+    view.appendTo(parent);
+
+    customElements.upgrade(parent);
+
+    // Hook into the Microtask Queue to ensure the DOM is settled
+    // before yielding control to the caller.
+    await Promise.resolve();
+
+    const connect = async () => {
+        if (isConnected) {
+            return;
+        }
+
+        isConnected = true;
+        document.body.appendChild(parent);
+        await Promise.resolve();
+    };
+
+    const disconnect = async () => {
+        if (!isConnected) {
+            return;
+        }
+
+        isConnected = false;
+        document.body.removeChild(parent);
+        await Promise.resolve();
+    };
+
+    return {
+        document,
+        template: templateNameOrRegistry,
+        view,
+        parent,
+        element,
+        connect,
+        disconnect,
+    };
+}

--- a/packages/spright-components/src/utilities/tests/tests/fixture.spec.ts
+++ b/packages/spright-components/src/utilities/tests/tests/fixture.spec.ts
@@ -1,0 +1,97 @@
+/* eslint-disable */
+
+// Source from:
+// https://github.com/microsoft/fast/blob/1afe35adf2bf730ac5c09c315b626eec168cd362/packages/web-components/fast-foundation/src/test-utilities/fixture.spec.ts
+// With updates to use jasmine
+
+import {
+    attr,
+    customElement,
+    FASTElement,
+    html,
+    observable
+} from '@microsoft/fast-element';
+import { waitForUpdatesAsync } from '@ni/nimble-components/dist/esm/testing/async-helpers';
+import { uniqueElementName, fixture } from '../fixture';
+
+describe('The fixture helper', () => {
+    const name = uniqueElementName();
+    const template = html<MyElement>`
+        ${x => x.value}
+        <slot></slot>
+    `;
+
+    @customElement({
+        name,
+        template
+    })
+    class MyElement extends FASTElement {
+        @attr value = 'value';
+    }
+
+    class MyModel {
+        @observable value = 'different value';
+    }
+
+    it('can create a fixture for an element by name', async () => {
+        const { element } = await fixture(name);
+        expect(element).toBeInstanceOf(MyElement);
+    });
+
+    it('can create a fixture for an element by template', async () => {
+        const { element } = await fixture(html`
+      <${name}>
+        Some content here.
+      </${name}>
+    `);
+
+        expect(element).toBeInstanceOf(MyElement);
+        expect(element.innerText.trim()).toEqual('Some content here.');
+    });
+
+    it('can connect an element', async () => {
+        const { element, connect } = await fixture(name);
+
+        expect(element.isConnected).toEqual(false);
+
+        await connect();
+
+        expect(element.isConnected).toEqual(true);
+
+        document.body.removeChild(element.parentElement!);
+    });
+
+    it('can disconnect an element', async () => {
+        const { element, connect, disconnect } = await fixture(name);
+
+        expect(element.isConnected).toEqual(false);
+
+        await connect();
+
+        expect(element.isConnected).toEqual(true);
+
+        await disconnect();
+
+        expect(element.isConnected).toEqual(false);
+    });
+
+    it('can bind an element to data', async () => {
+        const source = new MyModel();
+        const { element, disconnect } = await fixture<MyElement>(
+            html<MyModel>`
+      <${name} value=${x => x.value}></${name}>
+    `,
+            { source }
+        );
+
+        expect(element.value).toEqual(source.value);
+
+        source.value = 'something else';
+
+        await waitForUpdatesAsync();
+
+        expect(element.value).toEqual(source.value);
+
+        await disconnect();
+    });
+});


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The test fixture utility was accidentally left out of `spright-components`.

## 👩‍💻 Implementation

Added the fixture utility, its tests, and added a rectangle component test that uses the fixture.

## 🧪 Testing

Tests pass.

## ✅ Checklist


- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
