### PR TITLE
Move anchored region import from menu to menu item

### DIFF
--- a/change/@ni-nimble-components-f028edbe-bdf4-412d-97f6-8514653f4f59.json
+++ b/change/@ni-nimble-components-f028edbe-bdf4-412d-97f6-8514653f4f59.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Move anchored region import from menu to menu item",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/menu-item/index.ts
+++ b/packages/nimble-components/src/menu-item/index.ts
@@ -7,6 +7,10 @@ import {
 import { arrowExpanderRight16X16 } from '@ni/nimble-tokens/dist/icons/js';
 import { styles } from './styles';
 
+// FAST menu item template requires an anchored region is available using tagFor DI
+// Register anchored region explicitly to make sure it is defined for the template
+import '../anchored-region';
+
 declare global {
     interface HTMLElementTagNameMap {
         'nimble-menu-item': MenuItem;

--- a/packages/nimble-components/src/menu/index.ts
+++ b/packages/nimble-components/src/menu/index.ts
@@ -5,10 +5,6 @@ import {
 } from '@microsoft/fast-foundation';
 import { styles } from './styles';
 
-// FAST menu template requires an anchored region is available using tagFor DI
-// Register anchored region explicitly to make sure it is defined for the template
-import '../anchored-region';
-
 declare global {
     interface HTMLElementTagNameMap {
         'nimble-menu': Menu;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Saw an issue in the menu matrix story where sub-menus looked wrong. Turns out it was because `AnchoredRegion` had not been registered, and FAST's menu item template was using `tagFor(AnchoredRegion)`.

## 👩‍💻 Implementation

We already had an import of `anchored-region` in the menu code, but it really belongs in menu item. Moved it.

## 🧪 Testing

Trusting Chromatic.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
