### PR TITLE
Blazor and Spright invoke publish fix

### DIFF
--- a/change/@ni-nimble-blazor-0e03174a-6e07-468e-9cbd-c0532f11f040.json
+++ b/change/@ni-nimble-blazor-0e03174a-6e07-468e-9cbd-c0532f11f040.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Invoke publish fix",
+  "packageName": "@ni/nimble-blazor",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-spright-blazor-e0f06838-76e7-40ad-bac2-82922622a7e5.json
+++ b/change/@ni-spright-blazor-e0f06838-76e7-40ad-bac2-82922622a7e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Invoke publish fix",
+  "packageName": "@ni/spright-blazor",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-blazor/NimbleBlazor/package.json
+++ b/packages/nimble-blazor/NimbleBlazor/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "pack": "cross-env-shell dotnet pack -c Release -p:PackageVersion=$npm_package_version --output ../dist",
     "invoke-publish": "npm run invoke-publish:setup && npm run invoke-publish:nuget && npm run invoke-publish:noop -- ",
-    "invoke-publish:setup": "rimraf --glob \"dist/NimbleBlazor.*.nupkg\" && npm run pack",
-    "invoke-publish:nuget": "cross-env-shell dotnet nuget push \"dist/NimbleBlazor.*.nupkg\" -k $NUGET_SECRET_TOKEN -s \"https://api.nuget.org/v3/index.json\"",
+    "invoke-publish:setup": "rimraf --glob \"../dist/NimbleBlazor.*.nupkg\" && npm run pack",
+    "invoke-publish:nuget": "cross-env-shell dotnet nuget push \"../dist/NimbleBlazor.*.nupkg\" -k $NUGET_SECRET_TOKEN -s \"https://api.nuget.org/v3/index.json\"",
     "invoke-publish:noop": "echo \"noop command to swallow npm args\""
   },
   "repository": {

--- a/packages/nimble-blazor/SprightBlazor/package.json
+++ b/packages/nimble-blazor/SprightBlazor/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "pack": "cross-env-shell dotnet pack -c Release -p:PackageVersion=$npm_package_version --output ../dist",
     "invoke-publish": "npm run invoke-publish:setup && npm run invoke-publish:nuget && npm run invoke-publish:noop -- ",
-    "invoke-publish:setup": "rimraf --glob \"dist/SprightBlazor.*.nupkg\" && npm run pack",
-    "invoke-publish:nuget": "cross-env-shell dotnet nuget push \"dist/SprightBlazor.*.nupkg\" -k $NUGET_SECRET_TOKEN -s \"https://api.nuget.org/v3/index.json\"",
+    "invoke-publish:setup": "rimraf --glob \"../dist/SprightBlazor.*.nupkg\" && npm run pack",
+    "invoke-publish:nuget": "cross-env-shell dotnet nuget push \"../dist/SprightBlazor.*.nupkg\" -k $NUGET_SECRET_TOKEN -s \"https://api.nuget.org/v3/index.json\"",
     "invoke-publish:noop": "echo \"noop command to swallow npm args\""
   },
   "repository": {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Ran the `invoke-publish:setup` command locally and found that it was not behaving as expected. Old packages were not removed. Realized the commands were running in the wrong directory.

## 👩‍💻 Implementation

Update the `invoke-publish:setup` and `invoke-publish:nuget` commands for Nimble and Spright to point to the correct directory.

## 🧪 Testing

Validated `invoke-publish:setup` locally and relying on publish in CI for the package publish 🤞

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
