### PR TITLE
Try SprightBlazor publish again

### DIFF
--- a/change/@ni-nimble-blazor-29e5ca8f-13c3-45af-8fe7-7bbdb471b597.json
+++ b/change/@ni-nimble-blazor-29e5ca8f-13c3-45af-8fe7-7bbdb471b597.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "sync packages",
+  "packageName": "@ni/nimble-blazor",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33820,7 +33820,7 @@
     },
     "packages/nimble-blazor/NimbleBlazor": {
       "name": "@ni/nimble-blazor",
-      "version": "16.0.7",
+      "version": "16.0.8",
       "license": "MIT",
       "peerDependencies": {
         "cross-env": "^7.0.3",

--- a/packages/nimble-blazor/NimbleBlazor/package.json
+++ b/packages/nimble-blazor/NimbleBlazor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ni/nimble-blazor",
-  "version": "16.0.7",
+  "version": "16.0.8",
   "description": "Blazor components for the NI Nimble Design System",
   "scripts": {
     "pack": "cross-env-shell dotnet pack -c Release -p:PackageVersion=$npm_package_version --output ../dist",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The Spright publish failed on main saying the package does not exist.

## 👩‍💻 Implementation

- Manually synced blazor package
- Created the SprightBlazor package locally and manually uploaded: https://www.nuget.org/packages/SprightBlazor/0.0.1
- Updated the api key to include read write on SprightBlazor

## 🧪 Testing

Rely on CI.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
