### PR TITLE
Update `@types/markdown-it` to resolve build issues

### DIFF
--- a/change/@ni-nimble-components-1f069de3-62f6-4562-a64e-5c37fcaedc5f.json
+++ b/change/@ni-nimble-components-1f069de3-62f6-4562-a64e-5c37fcaedc5f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update @types/markdown-it to remove @types/linkify-it peerDependency",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10077,12 +10077,12 @@
       "dev": true
     },
     "node_modules/@types/markdown-it": {
-      "version": "13.0.7",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.7.tgz",
-      "integrity": "sha512-U/CBi2YUUcTHBt5tjO2r5QV/x0Po6nsYwQU4Y04fBS6vfoImaiZ6f8bi3CjTCxBPQSO1LMyUqkByzi8AidyxfA==",
+      "version": "13.0.8",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.8.tgz",
+      "integrity": "sha512-V+KmpgiipS+zoypeUSS9ojesWtY/0k4XfqcK2fnVrX/qInJhX7rsCxZ/rygiPH2zxlPPrhfuW0I6ddMcWTKLsg==",
       "dependencies": {
-        "@types/linkify-it": "*",
-        "@types/mdurl": "*"
+        "@types/linkify-it": "^3",
+        "@types/mdurl": "^1"
       }
     },
     "node_modules/@types/mdast": {
@@ -10095,9 +10095,9 @@
       }
     },
     "node_modules/@types/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
+      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA=="
     },
     "node_modules/@types/mdx": {
       "version": "2.0.13",
@@ -32707,7 +32707,7 @@
         "@types/d3-scale": "^4.0.2",
         "@types/d3-selection": "^3.0.0",
         "@types/d3-zoom": "^3.0.0",
-        "@types/markdown-it": "^13.0.0",
+        "@types/markdown-it": "^13.0.8",
         "comlink": "4.4.1",
         "d3-array": "^3.2.2",
         "d3-random": "^3.0.1",
@@ -32758,7 +32758,6 @@
         "webpack-dev-middleware": "^7.0.0"
       },
       "peerDependencies": {
-        "@types/linkify-it": "^3.0.5",
         "apache-arrow": "^15.0.0"
       }
     },

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -88,7 +88,7 @@
     "@types/d3-scale": "^4.0.2",
     "@types/d3-selection": "^3.0.0",
     "@types/d3-zoom": "^3.0.0",
-    "@types/markdown-it": "^13.0.0",
+    "@types/markdown-it": "^13.0.8",
     "comlink": "4.4.1",
     "d3-array": "^3.2.2",
     "d3-random": "^3.0.1",
@@ -101,8 +101,7 @@
     "tslib": "^2.2.0"
   },
   "peerDependencies": {
-    "apache-arrow": "^15.0.0",
-    "@types/linkify-it": "^3.0.5"
+    "apache-arrow": "^15.0.0"
   },
   "devDependencies": {
     "@ni/jasmine-parameterized": "^0.3.0",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The peer dep `"@types/linkify-it": "^3.0.5"` was added to resolve an issue with how `@types/markdown-it` manages deps. That was resolved in `@types/markdown-it@13.0.8`.

Closes https://github.com/ni/nimble/issues/2061

## 👩‍💻 Implementation

Bump our min version of `@types/markdown-it` and remove the `@types/linkify-it` peer dep.

## 🧪 Testing

Rely on CI

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
