### PR TITLE
Make nimble component lint and test run concurrently

### DIFF
--- a/change/@ni-nimble-components-5ec786bd-2a49-43a5-a397-4dcc3d8eaed3.json
+++ b/change/@ni-nimble-components-5ec786bd-2a49-43a5-a397-4dcc3d8eaed3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Tests make more parallel",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32730,6 +32730,7 @@
         "@types/jasmine": "^5.1.4",
         "@types/offscreencanvas": "^2019.7.3",
         "@types/webpack-env": "^1.15.2",
+        "concurrently": "^8.2.2",
         "css-loader": "^6.7.3",
         "eslint-plugin-jsdoc": "^48.2.0",
         "jasmine-core": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "change": "beachball change",
     "check": "beachball check --changehint \"Run 'npm run change' to generate a change file\"",
     "invoke-publish": "cross-env-shell beachball publish --yes --access public --message \\\"applying package updates [skip ci]\\\" -n $NPM_SECRET_TOKEN",
-    "validate": "npm run build && npm run lint && npm run test",
     "performance": "npm run performance --workspaces --if-present",
     "beachball-sync": "beachball sync",
     "lint-sequential": "npm run lint --workspaces --if-present",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "validate": "npm run build && npm run lint && npm run test",
     "performance": "npm run performance --workspaces --if-present",
     "beachball-sync": "beachball sync",
-    "concurrently-lint-test": "concurrently --group \"npm run lint\" \"npm run test\""
+    "lint-concurrently": "npm run lint-concurrently --workspaces --if-present",
+    "test-concurrently": "npm run test-concurrently --workspaces --if-present",
+    "concurrently-lint-test": "concurrently --timings --group \"npm:lint\" \"npm:test\" \"npm:lint-concurrently\" \"npm:test-concurrently\""
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
     "postinstall": "patch-package && npm run playwright:setup",
     "playwright:setup": "playwright install --with-deps",
     "build": "npm run build --workspaces --if-present",
-    "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present",
-    "test": "npm test --workspaces --if-present",
     "pack": "npm run pack --workspaces --if-present",
     "change": "beachball change",
     "check": "beachball check --changehint \"Run 'npm run change' to generate a change file\"",
@@ -17,9 +15,11 @@
     "validate": "npm run build && npm run lint && npm run test",
     "performance": "npm run performance --workspaces --if-present",
     "beachball-sync": "beachball sync",
-    "lint-concurrently": "npm run lint-concurrently --workspaces --if-present",
-    "test-concurrently": "npm run test-concurrently --workspaces --if-present",
-    "concurrently-lint-test": "concurrently --timings --group \"npm:lint\" \"npm:test\" \"npm:lint-concurrently\" \"npm:test-concurrently\""
+    "lint-sequential": "npm run lint --workspaces --if-present",
+    "test-sequential": "npm run test --workspaces --if-present",
+    "lint-concurrently": "npm run lint-concurrently -w packages/nimble-components",
+    "test-concurrently": "npm run test-concurrently -w packages/nimble-components",
+    "concurrently-lint-test": "concurrently --timings --group \"npm:lint-sequential\" \"npm:test-sequential\" \"npm:lint-concurrently\" \"npm:test-concurrently\""
   },
   "repository": {
     "type": "git",

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -4,7 +4,7 @@
   "description": "Styled web components for the NI Nimble Design System",
   "scripts": {
     "build": "npm run generate-icons && npm run generate-workers && npm run build-components && npm run bundle-components && npm run generate-scss",
-    "lint": "npm run eslint && npm run prettier",
+    "lint-concurrently": "concurrently --timings --group \"npm:eslint\" \"npm:prettier\"",
     "format": "npm run eslint-fix && npm run prettier-fix",
     "eslint": "eslint .",
     "eslint-fix": "eslint src --fix",
@@ -44,7 +44,7 @@
     "test-webkit:verbose": "karma start karma.conf.verbose.js --browsers=WebkitHeadless --single-run --skip-tags SkipWebkit",
     "test-webkit:watch": "karma start karma.conf.js --browsers=WebkitHeadless --skip-tags SkipWebkit --watch-extensions js",
     "test-webkit": "karma start karma.conf.js --browsers=WebkitHeadless --single-run --skip-tags SkipWebkit",
-    "test": "npm run test-chrome:verbose && npm run test-firefox:verbose"
+    "test-concurrently": "concurrently --timings --group \"npm:test-chrome:verbose\" \"npm:test-firefox:verbose\""
   },
   "repository": {
     "type": "git",
@@ -104,8 +104,8 @@
     "apache-arrow": "^15.0.0"
   },
   "devDependencies": {
-    "@ni/jasmine-parameterized": "^0.3.0",
     "@ni-private/eslint-config-nimble": "^1.0.0",
+    "@ni/jasmine-parameterized": "^0.3.0",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.0.1",
@@ -114,6 +114,7 @@
     "@types/jasmine": "^5.1.4",
     "@types/offscreencanvas": "^2019.7.3",
     "@types/webpack-env": "^1.15.2",
+    "concurrently": "^8.2.2",
     "css-loader": "^6.7.3",
     "eslint-plugin-jsdoc": "^48.2.0",
     "jasmine-core": "^5.1.2",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Investigating locally I found that by far the nimble-components lint steps (both eslint and prettier) as well as the karma runs (chrome and firefox) are the slowest to run. Updated the concurrent run so that the component commands run in parallel from the start along with synchronous test and lint runs of every other package.

With this change the following commands all start at the same time:

```
npm run lint (runs lint sequentially one by one for each package in workspace order)
npm run test (runs test sequentially one by one for each package in workspace order)
npm run -w packages/nimble-components prettier (as part of npm run lint-concurrently)
npm run -w packages/nimble-components lint (as part of npm run lint-concurrently)
npm run -w packages/nimble-components test-firefox:verbose (as part of npm run test-concurrently)
npm run -w packages/nimble-components test-chrome:verbose (as part of npm run test-concurrently)
```

And can see in the following table that the last to finish are the components commands:

```
--> ┌───────────────────┬──────────┬───────────┬────────┬───────────────────────────┐
--> │ name              │ duration │ exit code │ killed │ command                   │
--> ├───────────────────┼──────────┼───────────┼────────┼───────────────────────────┤
--> │ lint-concurrently │ 317,863  │ 0         │ false  │ npm run lint-concurrently │
--> │ test-concurrently │ 311,984  │ 0         │ false  │ npm run test-concurrently │
--> │ test              │ 292,637  │ 0         │ false  │ npm run test              │
--> │ lint              │ 269,971  │ 0         │ false  │ npm run lint              │
--> └───────────────────┴──────────┴───────────┴────────┴───────────────────────────┘

[lint-concurrently] --> ┌──────────┬──────────┬───────────┬────────┬──────────────────┐
[lint-concurrently] --> │ name     │ duration │ exit code │ killed │ command          │
[lint-concurrently] --> ├──────────┼──────────┼───────────┼────────┼──────────────────┤
[lint-concurrently] --> │ prettier │ 316,767  │ 0         │ false  │ npm run prettier │
[lint-concurrently] --> │ eslint   │ 93,986   │ 0         │ false  │ npm run eslint   │
[lint-concurrently] --> └──────────┴──────────┴───────────┴────────┴──────────────────┘

[test-concurrently] --> ┌──────────────────────┬──────────┬───────────┬────────┬──────────────────────────────┐
[test-concurrently] --> │ name                 │ duration │ exit code │ killed │ command                      │
[test-concurrently] --> ├──────────────────────┼──────────┼───────────┼────────┼──────────────────────────────┤
[test-concurrently] --> │ test-firefox:verbose │ 310,925  │ 0         │ false  │ npm run test-firefox:verbose │
[test-concurrently] --> │ test-chrome:verbose  │ 303,807  │ 0         │ false  │ npm run test-chrome:verbose  │
[test-concurrently] --> └──────────────────────┴──────────┴───────────┴────────┴──────────────────────────────┘
```

In the end this ends up shaving off only about 2-3 minutes from the CI. I suspect we are probably at the point of diminishing returns for concurrent execution.

## 👩‍💻 Implementation

- Renamed the lint and test commands for nimble components so they do not run in the normal lint and test execution for the workspace
- Made the components lint and test commands run their substeps concurrently
- Included the new concurrent component lint and test commands in the top level `npm run concurrently-lint-test`

## 🧪 Testing

Tested locally and CI.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
