### PR TITLE
Control Minimum Width token applied to Select and Combobox

### DIFF
--- a/change/@ni-nimble-components-a5b4c275-28d7-4509-af45-748fdd2f69fb.json
+++ b/change/@ni-nimble-components-a5b4c275-28d7-4509-af45-748fdd2f69fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added controlMinWidth token and set Select and Combobox controls to this new value (176px)",
+  "packageName": "@ni/nimble-components",
+  "email": "1458528+fredvisser@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -9,6 +9,7 @@ import {
     borderHoverColor,
     borderWidth,
     controlHeight,
+    controlMinWidth,
     iconSize,
     popupBorderColor,
     smallDelay,
@@ -37,7 +38,7 @@ export const styles = css`
         position: relative;
         justify-content: center;
         ${userSelectNone}
-        min-width: 250px;
+        min-width: ${controlMinWidth};
         outline: none;
         vertical-align: top;
         --ni-private-hover-indicator-width: calc(${borderWidth} + 1px);

--- a/packages/nimble-components/src/theme-provider/design-token-comments.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-comments.ts
@@ -48,6 +48,7 @@ export const comments: { readonly [key in TokenName]: string } = {
     tagFillColor: 'Background fill color for tags, chips, or pills',
     controlHeight:
         'Standard layout height for all controls. Add "labelHeight" for labels on top.',
+    controlMinWidth: 'Standard minimum width for all controls',
     controlSlimHeight:
         'Height of controls that are somewhat shorter than standard height.',
     smallPadding: 'Fixed 4px size ramp token for component layout',

--- a/packages/nimble-components/src/theme-provider/design-token-names.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-names.ts
@@ -38,6 +38,7 @@ export const tokenNames: { readonly [key in TokenName]: string } = {
     cardBorderColor: 'card-border-color',
     tagFillColor: 'tag-fill-color',
     controlHeight: 'control-height',
+    controlMinWidth: 'control-min-width',
     controlSlimHeight: 'control-slim-height',
     smallPadding: 'small-padding',
     mediumPadding: 'medium-padding',

--- a/packages/nimble-components/src/theme-provider/design-tokens.ts
+++ b/packages/nimble-components/src/theme-provider/design-tokens.ts
@@ -259,6 +259,9 @@ export const buttonBorderAccentOutlineColor = DesignToken.create<string>(
 export const controlHeight = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.controlHeight)
 ).withDefault('32px');
+export const controlMinWidth = DesignToken.create<string>(
+    styleNameFromTokenName(tokenNames.controlMinWidth)
+).withDefault('176px');
 export const controlSlimHeight = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.controlSlimHeight)
 ).withDefault('24px');

--- a/packages/storybook/src/nimble/combobox/combobox.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox.stories.ts
@@ -3,7 +3,6 @@ import { html, repeat } from '@microsoft/fast-element';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { HtmlRenderer, Meta, StoryObj } from '@storybook/html';
 import { listOptionTag } from '@ni/nimble-components/dist/esm/list-option';
-import { menuMinWidth } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { comboboxTag } from '@ni/nimble-components/dist/esm/combobox';
 import { ExampleOptionsType } from '@ni/nimble-components/dist/esm/combobox/tests/types';
 import {

--- a/packages/storybook/src/nimble/combobox/combobox.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox.stories.ts
@@ -104,7 +104,7 @@ const metadata: Meta<ComboboxArgs> = {
             appearance="${x => x.appearance}"
             value="${x => x.currentValue}"
             placeholder="${x => x.placeholder}"
-            style="width: var(${menuMinWidth.cssCustomProperty});"
+            style="width: 250px;"
         >
             ${repeat(x => optionSets[x.optionsType], html<OptionArgs>`
                 <${listOptionTag} ?disabled="${x => x.disabled}">${x => x.label}</${listOptionTag}>

--- a/packages/storybook/src/nimble/select/select.stories.ts
+++ b/packages/storybook/src/nimble/select/select.stories.ts
@@ -2,7 +2,6 @@ import { html, repeat, when } from '@microsoft/fast-element';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { HtmlRenderer, Meta, StoryObj } from '@storybook/html';
 import { listOptionTag } from '@ni/nimble-components/dist/esm/list-option';
-import { menuMinWidth } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { selectTag } from '@ni/nimble-components/dist/esm/select';
 import { FilterMode } from '@ni/nimble-components/dist/esm/select/types';
 import { ExampleOptionsType } from '@ni/nimble-components/dist/esm/select/tests/types';

--- a/packages/storybook/src/nimble/select/select.stories.ts
+++ b/packages/storybook/src/nimble/select/select.stories.ts
@@ -100,7 +100,7 @@ const metadata: Meta<SelectArgs> = {
             position="${x => x.dropDownPosition}"
             appearance="${x => x.appearance}"
             filter-mode="${x => (x.filterMode === 'none' ? undefined : x.filterMode)}"
-            style="width: var(${menuMinWidth.cssCustomProperty});"
+            style="width: 250px;"
         >
             ${when(x => x.placeholder, html`
                 <${listOptionTag}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The `sl-details-panel` restyling recently went in, and some apps use `nimble-select` and `nimble-combobox` controls in their details-panels. These dropdown controls were set with `min-width:250px`, and couldn't resize correctly down to 176px.

Before:
![image](https://github.com/ni/nimble/assets/1458528/bbfe44de-761e-4641-bf96-800fb15a1f1f)

After:
![image](https://github.com/ni/nimble/assets/1458528/89b2af79-547e-4ad0-8b6f-cff3a89d0a85)


## 👩‍💻 Implementation

- Added a new `controlMinWidth` token, set to 176px;
- Set the dropdown min-width to this value
- Updated Select and Combobox stories, so those instances didn't change sizes

## 🧪 Testing

- Manual testing of CSS changes with Work Orders app
- Storybook review
- Relying on Chromatic

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
