### PR TITLE
Storybook CONTRIBUTING doc improvements

### DIFF
--- a/change/@ni-nimble-components-76187332-e94b-49f3-8357-9af0f0cb7061.json
+++ b/change/@ni-nimble-components-76187332-e94b-49f3-8357-9af0f0cb7061.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Storybook CONTRIBUTING doc improvements",
+  "packageName": "@ni/nimble-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/CONTRIBUTING.md
+++ b/packages/nimble-components/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Before building a new component, 3 specification documents need to be created:
 
 2. Create Storybook documentation and tests for the component as described in [`@ni-private/storybook` CONTRIBUTING](/packages/storybook/CONTRIBUTING.md).
 
-3. Run the Storybook command from the repo root:  `npm run storybook`.
+3. Run the Storybook command from the repo root: `npm run storybook`.
 
     This command also causes `nimble-components` (and `spright-components`) to rebuild whenever a source file is changed so that Storybook can reflect the current state.
 

--- a/packages/nimble-components/CONTRIBUTING.md
+++ b/packages/nimble-components/CONTRIBUTING.md
@@ -24,7 +24,7 @@ From the repo root directory:
 2. Run `npm run build`
 3. Run the different Nimble Components test configurations:
 
-    - To view the components and manually test behaviors in Storybook: `npm run start -w @ni-private/storybook`
+    - To view the components and manually test behaviors in Storybook: `npm run storybook`
 
         **Note**: You will need to refresh your browser window to see style changes made in source.
 
@@ -41,7 +41,8 @@ Before building a new component, 3 specification documents need to be created:
 ## Development workflow
 
 1. When creating new components, create the folder structure and decide how to implement the component as described in [Develop new components](#develop-new-components).
-2. Run the Storybook build and start commands from the `storybook` package directory:
+2. Create Storybook documentation and tests for the component as described in [`@ni-private/storybook` CONTRIBUTING](/packages/storybook/CONTRIBUTING.md).
+3. Run the Storybook build and start commands from the `storybook` package directory:
 
     `npm run build`
 
@@ -49,11 +50,11 @@ Before building a new component, 3 specification documents need to be created:
 
     Storybook will build its own copy of the component in a temporary folder which is separate from the normal build.
 
-3. Make functional and style changes to the component.
+4. Make functional and style changes to the component.
 
     The storybook will hot reload when you save changes, but the styles will not. On each save that changes `index.ts` or `styles.ts`, **you will need to refresh your browser window to see style changes**.
 
-4. Create or update tests.
+5. Create or update tests.
 
     To build and run the tests once, from the `nimble` directory run:
 
@@ -65,17 +66,17 @@ Before building a new component, 3 specification documents need to be created:
 
     See [Unit tests](#unit-tests) for additional available commands.
 
-5. Test out the component in each of the 3 major browsers: Chrome, Firefox, and Safari (WebKit).
+6. Test out the component in each of the 3 major browsers: Chrome, Firefox, and Safari (WebKit).
    For developers on non-Mac platforms, Safari/WebKit can be tested via the Playwright package:
 
     - To open Storybook with WebKit, after running the Storybook command, run the command `npm run storybook-open-webkit -w @ni/nimble-components` from the `nimble` directory.
     - To run the unit tests with WebKit, use the command `npm run test-webkit -w @ni/nimble-components` from the `nimble` directory.
 
-6. Create change files for your work by running the following from the `nimble` directory:
+7. Create change files for your work by running the following from the `nimble` directory:
 
     `npm run change`
 
-7. Update the [Component Status table](./src/tests/component-status.stories.ts) to reflect the new component state.
+8. Update the [Component Status table](./src/tests/component-status.stories.ts) to reflect the new component state.
 
 ## Develop new components
 

--- a/packages/nimble-components/CONTRIBUTING.md
+++ b/packages/nimble-components/CONTRIBUTING.md
@@ -41,14 +41,12 @@ Before building a new component, 3 specification documents need to be created:
 ## Development workflow
 
 1. When creating new components, create the folder structure and decide how to implement the component as described in [Develop new components](#develop-new-components).
+
 2. Create Storybook documentation and tests for the component as described in [`@ni-private/storybook` CONTRIBUTING](/packages/storybook/CONTRIBUTING.md).
-3. Run the Storybook build and start commands from the `storybook` package directory:
 
-    `npm run build`
+3. Run the Storybook command from the repo root:  `npm run storybook`.
 
-    `npm run start`
-
-    Storybook will build its own copy of the component in a temporary folder which is separate from the normal build.
+    This command also causes `nimble-components` (and `spright-components`) to rebuild whenever a source file is changed so that Storybook can reflect the current state.
 
 4. Make functional and style changes to the component.
 

--- a/packages/nimble-components/CONTRIBUTING.md
+++ b/packages/nimble-components/CONTRIBUTING.md
@@ -67,7 +67,6 @@ Before building a new component, 3 specification documents need to be created:
 6. Test out the component in each of the 3 major browsers: Chrome, Firefox, and Safari (WebKit).
    For developers on non-Mac platforms, Safari/WebKit can be tested via the Playwright package:
 
-    - To open Storybook with WebKit, after running the Storybook command, run the command `npm run storybook-open-webkit -w @ni/nimble-components` from the `nimble` directory.
     - To run the unit tests with WebKit, use the command `npm run test-webkit -w @ni/nimble-components` from the `nimble` directory.
 
 7. Create change files for your work by running the following from the `nimble` directory:

--- a/packages/storybook/CONTRIBUTING.md
+++ b/packages/storybook/CONTRIBUTING.md
@@ -1,4 +1,8 @@
-# Creating Storybook Component Documentation
+# Creating Storybook Files for a Component
+
+This package contains Storybook files for each component which accomplish two things:
+1. provide user facing documentation in the [public Nimble and Spright Storybook](https://nimble.ni.dev/storybook).
+2. comprehensively test visual states of the component in [Chromatic](https://www.chromatic.com/builds?appId=60e89457a987cf003efc0a5b).
 
 ## Getting Started
 
@@ -6,7 +10,20 @@ From the Nimble repo root directory:
 
 1. Run `npm install`
 2. Run `npm run build`
-3. To view the component documentation in Storybook: `npm run start -w @ni-private/storybook`
+3. To view the component documentation in Storybook: `npm run storybook`
+
+## Folder Structure
+
+Create a folder for each component under `src/nimble` or `src/spright`. The folder should match the name of the component in the corresponding `@ni/nimble-components` or `@ni/spright-components` package.
+
+Each folder should include the following files:
+
+| File                             | Description                          |
+| -------------------------------- | ------------------------------------ |
+| component-name.stories.ts        | Contains the component hosted in Storybook. This provides a live component view for development and testing along with API documentation.  |
+| component-name-matrix.stories.ts | Contains a story that shows all component states for all themes hosted in Storybook. This is used by Chromatic visual tests to verify styling changes across all themes and states.   |
+| component-name.mdx               | Contains the Storybook documentation for this component. This should provide design guidance and usage information. See below for more information about the structure of this file. |
+| component-name.react.tsx         | Simple React wrapper for the component to be used in Storybook MDX documentation.   |
 
 ## Documentation Workflow
 
@@ -23,7 +40,11 @@ import * as componentNameStories from './component-name.stories';
 *Component description*
 
 <Canvas of={componentNameStories.firstStoryName} />
+
+## API
+
 <Controls of={componentNameStories.firstStoryName} />
+<ComponentApisLink />
 
 ## Appearances
 

--- a/packages/storybook/README.md
+++ b/packages/storybook/README.md
@@ -2,6 +2,7 @@
 
 Private package containing the Storybook for the Nimble repo.
 
-## Developer Workflows
+## Contributing
 
-When running Storybook locally with `npm run start`, changes to `nimble-components` or `spright-components` will not be reflected in the stories until the modified package is rebuilt and the page is refreshed. To avoid having to manually run `npm run build-components` any time you make a change, you can instead run `npm run build-components:watch` to have the package automatically rebuild whenever it is modified.
+See `Getting Started` in [`CONTRIBUTING.md`](/CONTRIBUTING.md#getting-started) to get started with building
+and running storybook.


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

#2044 removed instructions for contributors about what Storybook files need to be created for each component. I think that info is valuable for external contributors so I want to revive it in an appropriate place.

## 👩‍💻 Implementation

1. Revived the docs that existed before in nimble-components/CONTRIBUTING.md and put them in storybook/CONTRIBUTING.md and added additonal context
2. Linked to those docs from nimble-components/CONTRIBUTING.md
3. Updated storybook README contributing section
4. Other minor tweaks to reflect new patterns and commands

## 🧪 Testing

N/A

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [X] I have updated the project documentation to reflect my changes or determined no changes are needed.
