### PR TITLE
Improve Storybook API docs for menu component

### DIFF
--- a/packages/storybook/src/nimble/anchor-button/anchor-button.stories.ts
+++ b/packages/storybook/src/nimble/anchor-button/anchor-button.stories.ts
@@ -52,7 +52,7 @@ const metadata: Meta<AnchorButtonArgs> = {
     `),
     argTypes: {
         href: {
-            description: hrefDescription('anchor button', false)
+            description: hrefDescription({ componentName: 'anchor button', includeDisable: false })
         },
         appearance: {
             options: Object.keys(ButtonAppearance),

--- a/packages/storybook/src/nimble/anchor-button/anchor-button.stories.ts
+++ b/packages/storybook/src/nimble/anchor-button/anchor-button.stories.ts
@@ -14,10 +14,7 @@ import {
     iconDescription
 } from '../patterns/button/doc-strings';
 import { createUserSelectedThemeStory } from '../../utilities/storybook';
-
-const hrefDescription = `
-In addition to \`href\`, all other attributes of \`<a>\` are also supported, e.g. \`ping\`, \`target\`, \`type\`, etc.
-`;
+import { hrefDescription } from '../patterns/anchor/anchor-docs';
 
 interface AnchorButtonArgs {
     label: string;
@@ -55,7 +52,7 @@ const metadata: Meta<AnchorButtonArgs> = {
     `),
     argTypes: {
         href: {
-            description: hrefDescription
+            description: hrefDescription('anchor button', false)
         },
         appearance: {
             options: Object.keys(ButtonAppearance),

--- a/packages/storybook/src/nimble/anchor/anchor.stories.ts
+++ b/packages/storybook/src/nimble/anchor/anchor.stories.ts
@@ -36,7 +36,7 @@ const metadata: Meta<AnchorArgs> = {
     `),
     argTypes: {
         href: {
-            description: hrefDescription('anchor', true)
+            description: hrefDescription({ componentName: 'anchor', includeDisable: true })
         },
         underlineHidden: {
             name: 'underline-hidden',

--- a/packages/storybook/src/nimble/anchor/anchor.stories.ts
+++ b/packages/storybook/src/nimble/anchor/anchor.stories.ts
@@ -4,12 +4,7 @@ import { bodyFont } from '@ni/nimble-components/dist/esm/theme-provider/design-t
 import { anchorTag } from '@ni/nimble-components/dist/esm/anchor';
 import { AnchorAppearance } from '@ni/nimble-components/dist/esm/anchor/types';
 import { createUserSelectedThemeStory } from '../../utilities/storybook';
-
-const hrefDescription = `
-To disable the control, remove the \`href\` attribute.
-
-In addition to \`href\`, all other attributes of \`<a>\` are also supported, e.g. \`ping\`, \`target\`, \`type\`, etc.
-`;
+import { hrefDescription } from '../patterns/anchor/anchor-docs';
 
 interface AnchorArgs {
     label: string;
@@ -41,7 +36,7 @@ const metadata: Meta<AnchorArgs> = {
     `),
     argTypes: {
         href: {
-            description: hrefDescription
+            description: hrefDescription('anchor', true)
         },
         underlineHidden: {
             name: 'underline-hidden',

--- a/packages/storybook/src/nimble/menu/menu.mdx
+++ b/packages/storybook/src/nimble/menu/menu.mdx
@@ -1,5 +1,6 @@
 import { Controls, Canvas, Meta, Title } from '@storybook/blocks';
 import TargetDocs from '../patterns/anchor/target-docs.mdx';
+import ComponentApisLink from '../patterns/docs/component-apis-link.mdx';
 import * as menuStories from './menu.stories';
 import { menuTag } from '@ni/nimble-components/dist/esm/menu';
 import { menuItemTag } from '@ni/nimble-components/dist/esm/menu-item';
@@ -14,27 +15,53 @@ menubars commonly found at the top of many desktop application windows. A menu i
 choosing an item in a menu that opens a sub menu, or by invoking a command, such as Shift + F10 in Windows, that opens a context specific menu.
 When a user activates a choice in a menu, the menu usually closes unless the choice opened a submenu.
 
-The <Tag name={menuTag}/> supports several child elements including `<header>`, `<hr>`, <Tag name={menuItemTag} open/> and <Tag name={anchorMenuItemTag} open/>.
-
 <Canvas of={menuStories.menu} />
+
+## API
+
 <Controls of={menuStories.menu} />
+<ComponentApisLink />
 
-## Child Elements
+### Menu Item
 
--   <Tag name={menuItemTag} /> - Use this child element to execute a function when
-    the item is activated or to include a sub-menu. To include a sub-menu, place
-    a <Tag name={menuTag} /> as a child of a <Tag name={menuItemTag} />.
--   <Tag name={anchorMenuItemTag} /> - Use this child element to navigate to a URL
-    when the item is activated.
+Use the <Tag name={menuItemTag} /> child element to execute a function when
+    the item is activated or to include a sub-menu.
 
-### Anchor Menu Item Target Configuration
+<Canvas of={menuStories.menuItem} />
+<Controls of={menuStories.menuItem} />
+
+
+### Anchor Menu Item
+
+Use the <Tag name={anchorMenuItemTag} /> child element to navigate to a URL when the item is activated.
+
+<Canvas of={menuStories.anchorMenuItem} />
+<Controls of={menuStories.anchorMenuItem} />
+
+#### Anchor Menu Item Target Configuration
 
 <TargetDocs />
 
-## Custom Header
+{/* ## Usage */}
+
+## Examples
+
+### Nested Menu
+
+To include a sub-menu, place a <Tag name={menuTag} /> as a child of a <Tag name={menuItemTag} />.
+
+For example:
+
+<Canvas of={menuStories.nestedMenu} />
+
+### Custom Header
 
 The menu can be configured to display a custom header with arbitrary content. This could include other nimble components, or even custom elements.
 
 For example:
 
 <Canvas of={menuStories.customMenu} />
+
+{/* ## Accessibility */}
+
+{/* ## Resources */}

--- a/packages/storybook/src/nimble/menu/menu.stories.ts
+++ b/packages/storybook/src/nimble/menu/menu.stories.ts
@@ -20,13 +20,13 @@ interface MenuArgs {
     itemOptions: ItemArgs[];
 }
 
-interface MenuItemArgs {
+interface MenuItemArgsBase {
     text: string;
     disabled: boolean;
     icon: boolean;
 }
 
-interface MenuItemDocsArgs extends MenuItemArgs {
+interface MenuItemArgs extends MenuItemArgsBase {
     change: () => void;
 }
 
@@ -37,7 +37,7 @@ interface AnchorMenuItemArgs {
     icon: boolean;
 }
 
-interface ItemArgs extends MenuItemArgs {
+interface ItemArgs extends MenuItemArgsBase {
     type: 'nimble-menu-item' | 'header' | 'hr';
 }
 
@@ -143,7 +143,7 @@ export const menu: StoryObj<MenuArgs> = {
     }
 };
 
-export const menuItem: StoryObj<MenuItemDocsArgs> = {
+export const menuItem: StoryObj<MenuItemArgs> = {
     // prettier-ignore
     render: createUserSelectedThemeStory(html`
         <${menuTag}>

--- a/packages/storybook/src/nimble/menu/menu.stories.ts
+++ b/packages/storybook/src/nimble/menu/menu.stories.ts
@@ -13,7 +13,8 @@ import {
     bodyFontColor
 } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { menuTag } from '@ni/nimble-components/dist/esm/menu';
-import { createUserSelectedThemeStory } from '../../utilities/storybook';
+import { apiCategory, createUserSelectedThemeStory, disabledDescription, iconDescription, textContentDescription } from '../../utilities/storybook';
+import { hrefDescription } from '../patterns/anchor/anchor-docs';
 
 interface MenuArgs {
     itemOptions: ItemArgs[];
@@ -23,6 +24,10 @@ interface MenuItemArgs {
     text: string;
     disabled: boolean;
     icon: boolean;
+}
+
+interface MenuItemDocsArgs extends MenuItemArgs {
+    change: () => void;
 }
 
 interface AnchorMenuItemArgs {
@@ -127,10 +132,18 @@ export const menu: StoryObj<MenuArgs> = {
                 type: 'nimble-menu-item'
             }
         ]
+    },
+    argTypes: {
+        itemOptions: {
+            name: 'default',
+            description: `The \`${menuTag}\` supports several child elements including \`<header>\`, \`<hr>\`, \`<${menuItemTag}>\`, and \`<${anchorMenuItemTag}>\``,
+            control: false,
+            table: { category: apiCategory.slots }
+        }
     }
 };
 
-export const menuItem: StoryObj<MenuItemArgs> = {
+export const menuItem: StoryObj<MenuItemDocsArgs> = {
     // prettier-ignore
     render: createUserSelectedThemeStory(html`
         <${menuTag}>
@@ -143,12 +156,28 @@ export const menuItem: StoryObj<MenuItemArgs> = {
     args: {
         text: 'Menu Item',
         disabled: false,
-        icon: true
+        icon: true,
+        change: undefined
     },
     argTypes: {
+        text: {
+            name: 'default',
+            description: textContentDescription('menu item'),
+            table: { category: apiCategory.slots }
+        },
         icon: {
-            description:
-                'When including an icon, set `slot="start"` on the icon to ensure proper styling.'
+            name: 'start',
+            description: iconDescription,
+            table: { category: apiCategory.slots }
+        },
+        disabled: {
+            description: disabledDescription('menu item'),
+            table: { category: apiCategory.attributes }
+        },
+        change: {
+            description: 'Fires after the menu item is selected.',
+            table: { category: apiCategory.events },
+            control: false
         }
     }
 };
@@ -164,15 +193,30 @@ export const anchorMenuItem: StoryObj<AnchorMenuItemArgs> = {
         </${menuTag}>
         `),
     args: {
-        text: 'Menu Item',
+        text: 'Anchor Menu Item',
         href: 'https://nimble.ni.dev',
         disabled: false,
         icon: true
     },
     argTypes: {
+        text: {
+            name: 'default',
+            description: textContentDescription('anchor menu item'),
+            table: { category: apiCategory.slots }
+        },
+        href: {
+            name: 'href',
+            description: hrefDescription('anchor menu item', false),
+            table: { category: apiCategory.attributes }
+        },
         icon: {
-            description:
-                'When including an icon, set `slot="start"` on the icon to ensure proper styling.'
+            name: 'start',
+            description: iconDescription,
+            table: { category: apiCategory.slots }
+        },
+        disabled: {
+            description: disabledDescription('anchor menu item'),
+            table: { category: apiCategory.attributes }
         }
     }
 };

--- a/packages/storybook/src/nimble/menu/menu.stories.ts
+++ b/packages/storybook/src/nimble/menu/menu.stories.ts
@@ -171,7 +171,7 @@ export const menuItem: StoryObj<MenuItemArgs> = {
             table: { category: apiCategory.slots }
         },
         disabled: {
-            description: disabledDescription('menu item'),
+            description: disabledDescription({ componentName: 'menu item' }),
             table: { category: apiCategory.attributes }
         },
         change: {
@@ -215,7 +215,7 @@ export const anchorMenuItem: StoryObj<AnchorMenuItemArgs> = {
             table: { category: apiCategory.slots }
         },
         disabled: {
-            description: disabledDescription('anchor menu item'),
+            description: disabledDescription({ componentName: 'anchor menu item' }),
             table: { category: apiCategory.attributes }
         }
     }

--- a/packages/storybook/src/nimble/menu/menu.stories.ts
+++ b/packages/storybook/src/nimble/menu/menu.stories.ts
@@ -206,7 +206,7 @@ export const anchorMenuItem: StoryObj<AnchorMenuItemArgs> = {
         },
         href: {
             name: 'href',
-            description: hrefDescription('anchor menu item', false),
+            description: hrefDescription({ componentName: 'anchor menu item', includeDisable: false }),
             table: { category: apiCategory.attributes }
         },
         icon: {

--- a/packages/storybook/src/nimble/menu/menu.stories.ts
+++ b/packages/storybook/src/nimble/menu/menu.stories.ts
@@ -162,7 +162,7 @@ export const menuItem: StoryObj<MenuItemArgs> = {
     argTypes: {
         text: {
             name: 'default',
-            description: textContentDescription('menu item'),
+            description: textContentDescription({ componentName: 'menu item' }),
             table: { category: apiCategory.slots }
         },
         icon: {
@@ -201,7 +201,7 @@ export const anchorMenuItem: StoryObj<AnchorMenuItemArgs> = {
     argTypes: {
         text: {
             name: 'default',
-            description: textContentDescription('anchor menu item'),
+            description: textContentDescription({ componentName: 'anchor menu item' }),
             table: { category: apiCategory.slots }
         },
         href: {

--- a/packages/storybook/src/nimble/patterns/anchor/anchor-docs.ts
+++ b/packages/storybook/src/nimble/patterns/anchor/anchor-docs.ts
@@ -1,5 +1,5 @@
-export const hrefDescription = (componentName: string, includeDisable: boolean): string => `The URL that the ${componentName} points to. 
-${includeDisable ? 'To disable the control, remove the `href` attribute.' : ''}
+export const hrefDescription = (options: { componentName: string, includeDisable: boolean }): string => `The URL that the ${options.componentName} points to. 
+${options.includeDisable ? 'To disable the control, remove the `href` attribute.' : ''}
 
 In addition to \`href\`, all other attributes of \`<a>\` are also supported, e.g. \`ping\`, \`target\`, \`type\`, etc.
 `;

--- a/packages/storybook/src/nimble/patterns/anchor/anchor-docs.ts
+++ b/packages/storybook/src/nimble/patterns/anchor/anchor-docs.ts
@@ -1,0 +1,5 @@
+export const hrefDescription = (componentName: string, includeDisable: boolean): string => `The URL that the ${componentName} points to. 
+${includeDisable ? 'To disable the control, remove the `href` attribute.' : ''}
+
+In addition to \`href\`, all other attributes of \`<a>\` are also supported, e.g. \`ping\`, \`target\`, \`type\`, etc.
+`;

--- a/packages/storybook/src/nimble/patterns/button/doc-strings.ts
+++ b/packages/storybook/src/nimble/patterns/button/doc-strings.ts
@@ -1,10 +1,12 @@
+import { iconDescription as baseIconDescription } from '../../../utilities/storybook';
+
 export const appearanceDescription = 'This attribute affects the appearance of the button.';
 
 export const appearanceVariantDescription = 'This attribute has no effect on buttons with a `ghost` appearance. There is no `accent` appearance-variant for the `color` UI.';
 
 export const contentHiddenDescription = 'When set, this attribute hides the text and end icon, leaving only the start icon visible.';
 
-export const iconDescription = `Set \`slot="start"\` to include an icon before the text content (or instead of the content when \`content-hidden\` is set).
+export const iconDescription = `${baseIconDescription} When \`content-hidden\` is set the icon will be displayed instead of the text content.
 
 <details>
     <summary>Icon Usage</summary>

--- a/packages/storybook/src/nimble/tree-view/tree-view.stories.ts
+++ b/packages/storybook/src/nimble/tree-view/tree-view.stories.ts
@@ -8,6 +8,7 @@ import { anchorTreeItemTag } from '@ni/nimble-components/dist/esm/anchor-tree-it
 import { treeViewTag } from '@ni/nimble-components/dist/esm/tree-view';
 import { TreeViewSelectionMode } from '@ni/nimble-components/dist/esm/tree-view/types';
 import { createUserSelectedThemeStory } from '../../utilities/storybook';
+import { hrefDescription } from '../patterns/anchor/anchor-docs';
 
 interface TreeArgs {
     selectionMode: TreeViewSelectionMode;
@@ -37,10 +38,6 @@ const selectionModeDescription = `
 <li>None: no items in the tree are selectable through user interaction</li>
 <br>
 Note: Changing the selection mode does not affect which items can be selected programmatically.
-`;
-
-const hrefDescription = `
-In addition to \`href\`, all other attributes of \`<a>\` are also supported, e.g. \`ping\`, \`target\`, \`type\`, etc.
 `;
 
 const metadata: Meta<TreeArgs> = {
@@ -114,7 +111,7 @@ export const anchorTreeItem: StoryObj<AnchorItemArgs> = {
                 'Cannot be selected interactively, as click/Enter causes navigation.'
         },
         href: {
-            description: hrefDescription
+            description: hrefDescription('anchor tree item', false)
         }
     },
     // prettier-ignore

--- a/packages/storybook/src/nimble/tree-view/tree-view.stories.ts
+++ b/packages/storybook/src/nimble/tree-view/tree-view.stories.ts
@@ -111,7 +111,7 @@ export const anchorTreeItem: StoryObj<AnchorItemArgs> = {
                 'Cannot be selected interactively, as click/Enter causes navigation.'
         },
         href: {
-            description: hrefDescription('anchor tree item', false)
+            description: hrefDescription({ componentName: 'anchor tree item', includeDisable: false })
         }
     },
     // prettier-ignore

--- a/packages/storybook/src/utilities/storybook.ts
+++ b/packages/storybook/src/utilities/storybook.ts
@@ -170,5 +170,5 @@ export const apiCategory = {
 } as const;
 
 export const iconDescription = 'Set `slot="start"` to include an icon before the text content.';
-export const disabledDescription = (componentName: string): string => `Disables the ${componentName}.`;
-export const textContentDescription = (componentName: string): string => `The text content of the ${componentName}.`;
+export const disabledDescription = (options: { componentName: string }): string => `Disables the ${options.componentName}.`;
+export const textContentDescription = (options: { componentName: string }): string => `The text content of the ${options.componentName}.`;

--- a/packages/storybook/src/utilities/storybook.ts
+++ b/packages/storybook/src/utilities/storybook.ts
@@ -168,3 +168,7 @@ export const apiCategory = {
     methods: 'Methods',
     slots: 'Slots'
 } as const;
+
+export const iconDescription = 'Set `slot="start"` to include an icon before the text content.';
+export const disabledDescription = (componentName: string): string => `Disables the ${componentName}.`;
+export const textContentDescription = (componentName: string): string => `The text content of the ${componentName}.`;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Continuing the work done in #2027 in service of #824. This PR covers the menu component.

Example of why this is needed: after documenting the `nimble-menu-item` `change` event I searched for usages in SLE and found dozens of instances where apps were using the keyboard inaccessible `click` event instead. I'm fixing them [in this PR](https://dev.azure.com/ni/DevCentral/_git/Skyline/pullrequest/708606).

## 👩‍💻 Implementation

1. Refactored menu MDX and story files to follow patterns from previous PRs. I made some judgement calls about where to document child components vs examples; open to feedback on how it turned out!
1. Added more shared documentation strings and used them in several existing stories.


## 🧪 Testing

Manual storybook inspection

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
