### PR TITLE
Select no value change on focusout

### DIFF
--- a/change/@ni-nimble-components-b897b4de-cdc6-4a5c-84f7-e4a2fc2c9c07.json
+++ b/change/@ni-nimble-components-b897b4de-cdc6-4a5c-84f7-e4a2fc2c9c07.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Don't change Select value on focusout.",
+  "packageName": "@ni/nimble-components",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/select/index.ts
+++ b/packages/nimble-components/src/select/index.ts
@@ -503,24 +503,13 @@ export class Select
             return true;
         }
 
+        this.open = false;
         const focusTarget = e.relatedTarget as HTMLElement;
         if (this.isSameNode(focusTarget)) {
             this.focus();
             return true;
         }
 
-        if (!this.options?.includes(focusTarget as ListboxOption)) {
-            let currentActiveIndex = this.openActiveIndex ?? this.selectedIndex;
-            this.open = false;
-            if (currentActiveIndex === -1) {
-                currentActiveIndex = this.selectedIndex;
-            }
-
-            if (this.selectedIndex !== currentActiveIndex) {
-                this.selectedIndex = currentActiveIndex;
-                this.updateValue(true);
-            }
-        }
         return true;
     }
 

--- a/packages/nimble-components/src/select/index.ts
+++ b/packages/nimble-components/src/select/index.ts
@@ -327,20 +327,23 @@ export class Select
             return;
         }
 
+        let optionClicked = false;
         if (this.open) {
             const captured = (e.target as HTMLElement).closest<ListOption>(
                 'option,[role=option]'
             );
+            optionClicked = captured !== null;
 
             if (captured?.disabled) {
                 return;
             }
         }
 
+        const currentIndex = this.openActiveIndex ?? this.selectedIndex;
         super.clickHandler(e);
 
         this.open = this.collapsible && !this.open;
-        if (!this.open && this.selectedIndex !== -1) {
+        if (!this.open && this.selectedIndex !== currentIndex && optionClicked) {
             this.updateValue(true);
         }
     }

--- a/packages/nimble-components/src/select/index.ts
+++ b/packages/nimble-components/src/select/index.ts
@@ -343,7 +343,11 @@ export class Select
         super.clickHandler(e);
 
         this.open = this.collapsible && !this.open;
-        if (!this.open && this.selectedIndex !== currentIndex && optionClicked) {
+        if (
+            !this.open
+            && this.selectedIndex !== currentIndex
+            && optionClicked
+        ) {
             this.updateValue(true);
         }
     }

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -442,6 +442,24 @@ describe('Select', () => {
         await disconnect();
     });
 
+    it('navigating to different option in dropdown and then clicking select (not dropdown) does not change value or emit change event', async () => {
+        const { element, connect, disconnect } = await setup();
+        await connect();
+        await waitForUpdatesAsync();
+        const changeEvent = jasmine.createSpy();
+        element.addEventListener('change', changeEvent);
+        const pageObject = new SelectPageObject(element);
+        await clickAndWaitForOpen(element);
+
+        pageObject.pressArrowDownKey();
+        pageObject.clickSelect();
+
+        expect(element.value).toBe('one');
+        expect(changeEvent.calls.count()).toBe(0);
+
+        await disconnect();
+    });
+
     describe('with 500 options', () => {
         async function setup500Options(): Promise<Fixture<Select>> {
             // prettier-ignore

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -62,7 +62,7 @@ async function clickAndWaitForOpen(select: Select): Promise<void> {
     await regionLoadedListener.promise;
 }
 
-describe('Select', () => {
+fdescribe('Select', () => {
     it('should set classes based on collapsible, open, disabled, and position', async () => {
         const { element, connect, disconnect } = await setup('above', true);
 
@@ -427,19 +427,17 @@ describe('Select', () => {
         await disconnect();
     });
 
-    it('when handling change event, value of select element matches what was selected in dropdown on focusout', async () => {
+    it('navigating to different option in dropdown and then clicking away does not change value', async () => {
         const { element, connect, disconnect } = await setup();
         await connect();
         await waitForUpdatesAsync();
         const pageObject = new SelectPageObject(element);
         await clickAndWaitForOpen(element);
 
-        const changeValuePromise = pageObject.waitForChange();
         pageObject.pressArrowDownKey();
         await pageObject.clickAway();
-        const selectValue = await changeValuePromise;
 
-        expect(selectValue).toBe('two');
+        expect(element.value).toBe('one');
 
         await disconnect();
     });
@@ -756,14 +754,14 @@ describe('Select', () => {
             expect(element.open).toBeFalse();
         });
 
-        it('filtering out current selected item and then pressing <Tab> changes value and closes popup', async () => {
+        it('filtering out current selected item and then pressing <Tab> does not change value and closes popup', async () => {
             const currentSelection = pageObject.getSelectedOption();
             expect(currentSelection?.text).toBe('One');
             expect(element.value).toBe('one');
 
             await pageObject.openAndSetFilterText('T'); // Matches 'Two' and 'Three'
             pageObject.pressTabKey();
-            expect(element.value).toBe('two'); // 'Two' is first option in list so it should be selected now
+            expect(element.value).toBe('one');
             expect(element.open).toBeFalse();
         });
 
@@ -789,14 +787,14 @@ describe('Select', () => {
             expect(element.open).toBeFalse();
         });
 
-        it('filtering out current selected item and then losing focus changes value and closes popup', async () => {
+        it('filtering out current selected item and then losing focus does not change value and closes popup', async () => {
             const currentSelection = pageObject.getSelectedOption();
             expect(currentSelection?.text).toBe('One');
             expect(element.value).toBe('one');
 
             await pageObject.openAndSetFilterText('T'); // Matches 'Two' and 'Three'
             await pageObject.clickAway();
-            expect(element.value).toBe('two'); // 'Two' is first option in list so it should be selected now
+            expect(element.value).toBe('one'); // 'Two' is first option in list so it should be selected now
             expect(element.open).toBeFalse();
         });
 

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -62,7 +62,7 @@ async function clickAndWaitForOpen(select: Select): Promise<void> {
     await regionLoadedListener.promise;
 }
 
-fdescribe('Select', () => {
+describe('Select', () => {
     it('should set classes based on collapsible, open, disabled, and position', async () => {
         const { element, connect, disconnect } = await setup('above', true);
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Consensus was reached that it felt incorrect for the `Select` to update its value to something different after navigating to a new option and then either pressing `<Tab>` or clicking away.

## 👩‍💻 Implementation

Changed it so that the `focusoutHandler` no longer updates the `selectedIndex`.

## 🧪 Testing

Changed the tests that were asserting the improper behavior.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
