### PR TITLE
Add Spright rectangle component to Blazor example

### DIFF
--- a/change/@ni-nimble-blazor-b9a4025f-2fd1-4b3e-8295-540f02450064.json
+++ b/change/@ni-nimble-blazor-b9a4025f-2fd1-4b3e-8295-540f02450064.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add Spright rectangle component to Blazor example",
+  "packageName": "@ni/nimble-blazor",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-spright-blazor-6664d301-7c3b-4c3a-bb31-86a2c805dfbf.json
+++ b/change/@ni-spright-blazor-6664d301-7c3b-4c3a-bb31-86a2c805dfbf.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add Spright rectangle component to Blazor example",
+  "packageName": "@ni/spright-blazor",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/blazor-workspace/Examples/Demo.Client/packages.lock.json
+++ b/packages/blazor-workspace/Examples/Demo.Client/packages.lock.json
@@ -340,10 +340,17 @@
         "dependencies": {
           "Microsoft.AspNetCore.Components.Web": "[6.*, )",
           "NI.CSharp.Analyzers": "[2.0.21, 2.0.21]",
-          "NimbleBlazor": "[1.0.0, )"
+          "NimbleBlazor": "[1.0.0, )",
+          "SprightBlazor": "[1.0.0, )"
         }
       },
       "nimbleblazor": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.AspNetCore.Components.Web": "[6.0.29, )"
+        }
+      },
+      "sprightblazor": {
         "type": "Project",
         "dependencies": {
           "Microsoft.AspNetCore.Components.Web": "[6.0.29, )"

--- a/packages/blazor-workspace/Examples/Demo.Client/wwwroot/index.html
+++ b/packages/blazor-workspace/Examples/Demo.Client/wwwroot/index.html
@@ -20,7 +20,7 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
-    <script src="_content/NimbleBlazor/nimble-components/all-components-bundle.min.js"></script>
+    <script src="_content/SprightBlazor/spright-components/all-components-bundle.min.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 

--- a/packages/blazor-workspace/Examples/Demo.Hybrid/packages.lock.json
+++ b/packages/blazor-workspace/Examples/Demo.Hybrid/packages.lock.json
@@ -358,10 +358,17 @@
         "dependencies": {
           "Microsoft.AspNetCore.Components.Web": "[6.*, )",
           "NI.CSharp.Analyzers": "[2.0.21, 2.0.21]",
-          "NimbleBlazor": "[1.0.0, )"
+          "NimbleBlazor": "[1.0.0, )",
+          "SprightBlazor": "[1.0.0, )"
         }
       },
       "nimbleblazor": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.AspNetCore.Components.Web": "[6.0.29, )"
+        }
+      },
+      "sprightblazor": {
         "type": "Project",
         "dependencies": {
           "Microsoft.AspNetCore.Components.Web": "[6.0.29, )"

--- a/packages/blazor-workspace/Examples/Demo.Hybrid/wwwroot/index.html
+++ b/packages/blazor-workspace/Examples/Demo.Hybrid/wwwroot/index.html
@@ -21,10 +21,11 @@
         <a class="dismiss">🗙</a>
     </div>
     <script src="_framework/blazor.webview.js"></script>
-    <script src="_content/NimbleBlazor/nimble-components/all-components-bundle.min.js"></script>
+    <script src="_content/SprightBlazor/spright-components/all-components-bundle.min.js"></script>
     <!-- This script is a workaround needed for Nimble Blazor to work in Blazor Hybrid.
          See https://github.com/dotnet/aspnetcore/issues/42349 -->
     <script src="_content/NimbleBlazor/NimbleBlazor.HybridWorkaround.js"></script>
+    <script src="_content/SprightBlazor/SprightBlazor.HybridWorkaround.js"></script>
 </body>
 
 </html>

--- a/packages/blazor-workspace/Examples/Demo.Server/Pages/_Layout.cshtml
+++ b/packages/blazor-workspace/Examples/Demo.Server/Pages/_Layout.cshtml
@@ -28,6 +28,6 @@
     </div>
 
     <script src="_framework/blazor.server.js"></script>
-    <script src="_content/NimbleBlazor/nimble-components/all-components-bundle.min.js"></script>
+    <script src="_content/SprightBlazor/spright-components/all-components-bundle.min.js"></script>
 </body>
 </html>

--- a/packages/blazor-workspace/Examples/Demo.Server/packages.lock.json
+++ b/packages/blazor-workspace/Examples/Demo.Server/packages.lock.json
@@ -204,10 +204,17 @@
         "dependencies": {
           "Microsoft.AspNetCore.Components.Web": "[6.*, )",
           "NI.CSharp.Analyzers": "[2.0.21, 2.0.21]",
-          "NimbleBlazor": "[1.0.0, )"
+          "NimbleBlazor": "[1.0.0, )",
+          "SprightBlazor": "[1.0.0, )"
         }
       },
       "nimbleblazor": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.AspNetCore.Components.Web": "[6.0.29, )"
+        }
+      },
+      "sprightblazor": {
         "type": "Project",
         "dependencies": {
           "Microsoft.AspNetCore.Components.Web": "[6.0.29, )"

--- a/packages/blazor-workspace/Examples/Demo.Shared/Demo.Shared.csproj
+++ b/packages/blazor-workspace/Examples/Demo.Shared/Demo.Shared.csproj
@@ -42,6 +42,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\NimbleBlazor\NimbleBlazor.csproj" />
+    <ProjectReference Include="..\..\SprightBlazor\SprightBlazor.csproj" />
   </ItemGroup>
 
 </Project>

--- a/packages/blazor-workspace/Examples/Demo.Shared/Pages/ComponentsDemo.razor
+++ b/packages/blazor-workspace/Examples/Demo.Shared/Pages/ComponentsDemo.razor
@@ -384,5 +384,9 @@
             <NimbleButton @onclick=@(_ => AddDiesToRadius(10))>Increase Die Count</NimbleButton>
             <NimbleButton @onclick=@(_ => RemoveDiesFromRadius(10))>Decrease Die Count</NimbleButton>
         </div>
+        <div class="sub-container">
+            <div class="container-label">Rectangle (Spright)</div>
+            <SprightRectangle>Spright!</SprightRectangle>
+        </div>
     </div>
 </div>

--- a/packages/blazor-workspace/Examples/Demo.Shared/_Imports.razor
+++ b/packages/blazor-workspace/Examples/Demo.Shared/_Imports.razor
@@ -4,4 +4,5 @@
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
 @using NimbleBlazor
+@using SprightBlazor
 @using Demo.Shared.Pages

--- a/packages/blazor-workspace/Examples/Demo.Shared/packages.lock.json
+++ b/packages/blazor-workspace/Examples/Demo.Shared/packages.lock.json
@@ -205,6 +205,12 @@
         "dependencies": {
           "Microsoft.AspNetCore.Components.Web": "[6.0.29, )"
         }
+      },
+      "sprightblazor": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.AspNetCore.Components.Web": "[6.0.29, )"
+        }
       }
     }
   }

--- a/packages/blazor-workspace/NimbleBlazor/NimbleBlazor.csproj
+++ b/packages/blazor-workspace/NimbleBlazor/NimbleBlazor.csproj
@@ -51,6 +51,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="CHANGELOG.json" />
     <None Include="package.json" />
     <None Include="packages.lock.json" />
   </ItemGroup>

--- a/packages/blazor-workspace/NimbleBlazor/NimbleBlazor.csproj
+++ b/packages/blazor-workspace/NimbleBlazor/NimbleBlazor.csproj
@@ -24,10 +24,13 @@
     <NoWarn>CS8669</NoWarn>
   </PropertyGroup>
 
+  <!-- 
+    Need to explicitly exclude json and config files from Content, or they will get copied to the output directory.
+    See: https://github.com/dotnet/sdk/issues/25587#issuecomment-1134731799
+  -->
   <ItemGroup>
-    <Content Remove="CHANGELOG.json" />
-    <Content Remove="package.json" />
-    <Content Remove="packages.lock.json" />
+    <Content Remove="**\*.json" />
+    <Content Remove="**\*.config" />
   </ItemGroup>
 
   <ItemGroup>

--- a/packages/blazor-workspace/NimbleBlazor/NimbleBlazor.csproj
+++ b/packages/blazor-workspace/NimbleBlazor/NimbleBlazor.csproj
@@ -52,7 +52,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="CHANGELOG.json" />
     <None Include="package.json" />
     <None Include="packages.lock.json" />
   </ItemGroup>

--- a/packages/blazor-workspace/NimbleBlazor/NimbleBlazor.csproj
+++ b/packages/blazor-workspace/NimbleBlazor/NimbleBlazor.csproj
@@ -25,6 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Remove="CHANGELOG.json" />
     <Content Remove="package.json" />
     <Content Remove="packages.lock.json" />
   </ItemGroup>

--- a/packages/blazor-workspace/SprightBlazor/SprightBlazor.csproj
+++ b/packages/blazor-workspace/SprightBlazor/SprightBlazor.csproj
@@ -51,6 +51,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="CHANGELOG.json" />
     <None Include="package.json" />
     <None Include="packages.lock.json" />
   </ItemGroup>

--- a/packages/blazor-workspace/SprightBlazor/SprightBlazor.csproj
+++ b/packages/blazor-workspace/SprightBlazor/SprightBlazor.csproj
@@ -24,10 +24,13 @@
     <NoWarn>CS8669</NoWarn>
   </PropertyGroup>
 
+  <!-- 
+    Need to explicitly exclude json and config files from Content, or they will get copied to the output directory.
+    See: https://github.com/dotnet/sdk/issues/25587#issuecomment-1134731799
+  -->
   <ItemGroup>
-    <Content Remove="CHANGELOG.json" />
-    <Content Remove="package.json" />
-    <Content Remove="packages.lock.json" />
+    <Content Remove="**\*.json" />
+    <Content Remove="**\*.config" />
   </ItemGroup>
 
   <ItemGroup>

--- a/packages/blazor-workspace/SprightBlazor/SprightBlazor.csproj
+++ b/packages/blazor-workspace/SprightBlazor/SprightBlazor.csproj
@@ -52,7 +52,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="CHANGELOG.json" />
     <None Include="package.json" />
     <None Include="packages.lock.json" />
   </ItemGroup>

--- a/packages/blazor-workspace/SprightBlazor/SprightBlazor.csproj
+++ b/packages/blazor-workspace/SprightBlazor/SprightBlazor.csproj
@@ -25,6 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Remove="CHANGELOG.json" />
     <Content Remove="package.json" />
     <Content Remove="packages.lock.json" />
   </ItemGroup>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Part of #1977

## 👩‍💻 Implementation

Added the rectangle element to the bottom of the component in `Demo.Shared`. Nothing really noteworthy to point out.

## 🧪 Testing

Ran all of the example projects and made sure things rendered properly.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
