### PR TITLE
Require an icon to be specified on icon mappings

### DIFF
--- a/change/@ni-nimble-components-4d64effc-fc76-4e79-895f-8d61e2d7b02f.json
+++ b/change/@ni-nimble-components-4d64effc-fc76-4e79-895f-8d61e2d7b02f.json
@@ -1,6 +1,6 @@
 {
   "type": "major",
-  "comment": "Require an icon to be specified on icon mappings",
+  "comment": "[Breaking change]: Having an `undefined` icon on `nimble-mapping-icon` results in an invalid mapping column; Use `nimble-mapping-empty` or `nimble-mapping-text` instead.",
   "packageName": "@ni/nimble-components",
   "email": "20542556+mollykreis@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@ni-nimble-components-4d64effc-fc76-4e79-895f-8d61e2d7b02f.json
+++ b/change/@ni-nimble-components-4d64effc-fc76-4e79-895f-8d61e2d7b02f.json
@@ -1,6 +1,6 @@
 {
   "type": "major",
-  "comment": "[Breaking change]: Having an `undefined` icon on `nimble-mapping-icon` results in an invalid mapping column; Use `nimble-mapping-empty` or `nimble-mapping-text` instead.",
+  "comment": "Breaking change: Having an `undefined` icon on `nimble-mapping-icon` results in an invalid mapping column; Use `nimble-mapping-empty` or `nimble-mapping-text` instead.",
   "packageName": "@ni/nimble-components",
   "email": "20542556+mollykreis@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@ni-nimble-components-4d64effc-fc76-4e79-895f-8d61e2d7b02f.json
+++ b/change/@ni-nimble-components-4d64effc-fc76-4e79-895f-8d61e2d7b02f.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Require an icon to be specified on icon mappings",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table-column/enum-base/models/mapping-icon-config.ts
+++ b/packages/nimble-components/src/table-column/enum-base/models/mapping-icon-config.ts
@@ -8,9 +8,7 @@ export interface IconView {
     textHidden: boolean;
 }
 
-const createIconTemplate = (
-    icon: string
-): ViewTemplate<IconView> => {
+const createIconTemplate = (icon: string): ViewTemplate<IconView> => {
     return html`
         <${icon}
             title="${x => (x.textHidden ? x.text : '')}"

--- a/packages/nimble-components/src/table-column/enum-base/models/mapping-icon-config.ts
+++ b/packages/nimble-components/src/table-column/enum-base/models/mapping-icon-config.ts
@@ -8,18 +8,9 @@ export interface IconView {
     textHidden: boolean;
 }
 
-// Create an empty template containing only a space because creating a ViewTemplate
-// with an empty string throws an exception at runtime.
-// prettier-ignore
-const emptyTemplate = html<IconView>` `;
-
 const createIconTemplate = (
-    icon: string | undefined
+    icon: string
 ): ViewTemplate<IconView> => {
-    if (icon === undefined) {
-        return emptyTemplate;
-    }
-
     return html`
         <${icon}
             title="${x => (x.textHidden ? x.text : '')}"
@@ -39,7 +30,7 @@ export class MappingIconConfig extends MappingConfig {
     public readonly iconTemplate: ViewTemplate<IconView>;
 
     public constructor(
-        resolvedIcon: string | undefined,
+        resolvedIcon: string,
         public readonly severity: IconSeverity,
         text: string | undefined,
         public readonly textHidden: boolean

--- a/packages/nimble-components/src/table-column/mapping/index.ts
+++ b/packages/nimble-components/src/table-column/mapping/index.ts
@@ -78,6 +78,10 @@ export class TableColumnMapping extends mixinGroupableColumnAPI(
 
     protected createMappingConfig(mapping: Mapping<unknown>): MappingConfig {
         if (mapping instanceof MappingIcon) {
+            if (!mapping.resolvedIcon) {
+                throw Error('Unresolved icon');
+            }
+
             return new MappingIconConfig(
                 mapping.resolvedIcon,
                 mapping.severity,

--- a/packages/nimble-components/src/table-column/mapping/models/table-column-mapping-validator.ts
+++ b/packages/nimble-components/src/table-column/mapping/models/table-column-mapping-validator.ts
@@ -43,13 +43,6 @@ export class TableColumnMappingValidator extends TableColumnEnumBaseValidator<
         );
     }
 
-    private static hasUnresolvedIcon(mappingIcon: MappingIcon): boolean {
-        return (
-            typeof mappingIcon.icon === 'string'
-            && mappingIcon.resolvedIcon === undefined
-        );
-    }
-
     public override validate(
         mappings: Mapping<unknown>[],
         keyType: MappingKeyType
@@ -63,7 +56,7 @@ export class TableColumnMappingValidator extends TableColumnEnumBaseValidator<
     private validateIconNames(mappings: Mapping<unknown>[]): void {
         const invalid = mappings
             .filter(TableColumnMappingValidator.isIconMappingElement)
-            .some(TableColumnMappingValidator.hasUnresolvedIcon);
+            .some(mappingIcon => mappingIcon.resolvedIcon === undefined);
         this.setConditionValue('invalidIconName', invalid);
     }
 

--- a/packages/nimble-components/src/table-column/mapping/tests/table-column-mapping.spec.ts
+++ b/packages/nimble-components/src/table-column/mapping/tests/table-column-mapping.spec.ts
@@ -186,20 +186,6 @@ describe('TableColumnMapping', () => {
         expect(() => pageObject.getRenderedMappingColumnCellIconTagName(0, 0)).toThrowError();
     });
 
-    it('displays blank when no icon specified for mapping', async () => {
-        ({ connect, disconnect, model } = await setup({
-            keyType: MappingKeyType.string,
-            iconMappings: [{ key: 'a', text: 'alpha', icon: undefined }]
-        }));
-        pageObject = new TablePageObject<SimpleTableRecord>(model.table);
-        columnPageObject = new TableColumnMappingPageObject(pageObject);
-        await model.table.setData([{ field1: 'a' }]);
-        await connect();
-        await waitForUpdatesAsync();
-
-        expect(() => pageObject.getRenderedMappingColumnCellIconTagName(0, 0)).toThrowError();
-    });
-
     it('changing fieldName updates display', async () => {
         ({ connect, disconnect, model } = await setup({
             keyType: MappingKeyType.string,
@@ -310,23 +296,6 @@ describe('TableColumnMapping', () => {
                 ).toContain(name);
             });
         });
-    });
-
-    it('sets group header text label and no icon when icon is undefined', async () => {
-        ({ connect, disconnect, model } = await setup({
-            keyType: MappingKeyType.string,
-            iconMappings: [{ key: 'b', text: 'bravo', icon: undefined }]
-        }));
-        pageObject = new TablePageObject<SimpleTableRecord>(model.table);
-        columnPageObject = new TableColumnMappingPageObject(pageObject);
-        await model.table.setData([{ field1: 'b' }]);
-        await connect();
-        await waitForUpdatesAsync();
-        model.col1.groupIndex = 0;
-        await waitForUpdatesAsync();
-
-        expect(() => columnPageObject.getRenderedGroupHeaderIconTagName(0)).toThrowError();
-        expect(pageObject.getRenderedGroupHeaderTextContent(0)).toBe('bravo');
     });
 
     it('clears cell when mappings removed', async () => {
@@ -563,6 +532,17 @@ describe('TableColumnMapping', () => {
             ({ connect, disconnect, model } = await setup({
                 keyType: MappingKeyType.string,
                 iconMappings: [{ key: 'a', text: 'alpha', icon: 'foo' }]
+            }));
+            await connect();
+            await waitForUpdatesAsync();
+            expect(model.col1.checkValidity()).toBeFalse();
+            expect(model.col1.validity.invalidIconName).toBeTrue();
+        });
+
+        it('is invalid with undefined icon value', async () => {
+            ({ connect, disconnect, model } = await setup({
+                keyType: MappingKeyType.string,
+                iconMappings: [{ key: 'a', text: 'alpha', icon: undefined }]
             }));
             await connect();
             await waitForUpdatesAsync();

--- a/packages/storybook/src/nimble/mapping/icon/mapping-icon.stories.ts
+++ b/packages/storybook/src/nimble/mapping/icon/mapping-icon.stories.ts
@@ -27,9 +27,7 @@ export const iconMapping: StoryObj = {
         },
         icon: {
             control: false,
-            description: `The tag name of the Nimble icon to render, e.g. \`nimble-icon-check\`. Alternatively, set \`icon\` to \`undefined\` to render
-                no icon for the mapping while still providing a label to be used when grouping. Space will always be reserved for the icon so
-                that the text in cells and group rows associated with icon mappings will always be aligned.`
+            description: 'The tag name of the Nimble icon to render, e.g. `nimble-icon-check`.'
         },
         severity: {
             control: false,

--- a/packages/storybook/src/nimble/table-column/mapping/table-column-mapping-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/mapping/table-column-mapping-matrix.stories.ts
@@ -18,6 +18,10 @@ import {
 
 const data = [
     {
+        id: '-1',
+        code: -1
+    },
+    {
         id: '0',
         code: 0
     },
@@ -36,18 +40,6 @@ const data = [
     {
         id: '4',
         code: 4
-    },
-    {
-        id: '5',
-        code: 5
-    },
-    {
-        id: '6',
-        code: 6
-    },
-    {
-        id: '7',
-        code: 7
     }
 ] as const;
 
@@ -69,21 +61,19 @@ const component = (): ViewTemplate => html`
             group-index="0"
         >
             Column 1
-            <${mappingIconTag} key="0" text="Icon" icon="${iconCheckTag}" severity="success"></${mappingIconTag}>
-            <${mappingIconTag} key="1" text="Icon, text-hidden" icon="${iconXmarkTag}" text-hidden></${mappingIconTag}>
-            <${mappingSpinnerTag} key="2" text="Spinner"></${mappingSpinnerTag}>
-            <${mappingSpinnerTag} key="3" text="Spinner, text-hidden" text-hidden></${mappingSpinnerTag}>
-            <${mappingIconTag} key="4" text="Undefined icon, text-hidden" text-hidden></${mappingIconTag}>
-            <${mappingIconTag} key="5" text="Undefined icon"></${mappingIconTag}>
-            <${mappingTextTag} key="6" text="Text"></${mappingTextTag}>
-            <${mappingEmptyTag} key="7" text="Empty mapping"></${mappingEmptyTag}>
+            <${mappingIconTag} key="-1" text="Icon" icon="${iconCheckTag}" severity="success"></${mappingIconTag}>
+            <${mappingIconTag} key="0" text="Icon, text-hidden" icon="${iconXmarkTag}" text-hidden></${mappingIconTag}>
+            <${mappingSpinnerTag} key="1" text="Spinner"></${mappingSpinnerTag}>
+            <${mappingSpinnerTag} key="2" text="Spinner, text-hidden" text-hidden></${mappingSpinnerTag}>
+            <${mappingTextTag} key="3" text="Text"></${mappingTextTag}>
+            <${mappingEmptyTag} key="4" text="Empty mapping"></${mappingEmptyTag}>
         </${tableColumnMappingTag}>
         <${tableColumnMappingTag}
             field-name="code"
             key-type="number"
         >
             Column 2
-            <${mappingIconTag} key="-1" text="Unknown value"></${mappingIconTag}>
+            <${mappingTextTag} key="-1" text="Unknown value"></${mappingTextTag}>
             <${mappingIconTag} key="0" text="Zero" icon="${iconCheckTag}" severity="success"></${mappingIconTag}>
             <${mappingIconTag} key="1" text="One" icon="${iconCheckTag}" severity="warning"></${mappingIconTag}>
             <${mappingIconTag} key="2" text="Two" icon="${iconCheckTag}" severity="error"></${mappingIconTag}>
@@ -94,7 +84,7 @@ const component = (): ViewTemplate => html`
             width-mode="${TableColumnMappingWidthMode.iconSize}"
         >
             <${iconQuestionTag} title="Icon-only column"></${iconQuestionTag}>
-            <${mappingIconTag} key="-1" text="Unknown value"></${mappingIconTag}>
+            <${mappingEmptyTag} key="-1" text="Unknown value"></${mappingEmptyTag}>
             <${mappingIconTag} key="0" text="Zero" icon="${iconCheckTag}" severity="success" text-hidden></${mappingIconTag}>
             <${mappingIconTag} key="1" text="One" icon="${iconCheckTag}" severity="warning" text-hidden></${mappingIconTag}>
             <${mappingIconTag} key="2" text="Two" icon="${iconCheckTag}" severity="error" text-hidden></${mappingIconTag}>
@@ -106,7 +96,7 @@ const component = (): ViewTemplate => html`
             key-type="number"
         >
             Column 3
-            <${mappingIconTag} key="-1" text="Unknown value"></${mappingIconTag}>
+            <${mappingTextTag} key="-1" text="Unknown value"></${mappingTextTag}>
             <${mappingIconTag} key="0" text="Zero" icon="${iconCheckTag}" severity="information"></${mappingIconTag}>
         </${tableColumnMappingTag}>
     </${tableTag}>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

In #1874, we introduced the ability to have icon mappings with an `undefined` icon to support use cases where the cell should be empty with non-empty group rows and where the cell should have only text. These use cases are now covered by usages of `nimble-mapping-empty` and `nimble-mapping-text`, both of which are supported by the mapping column. Therefore, we no longer need to support icon mappings without an icon.

## 👩‍💻 Implementation

Mostly reverting #1874, with a few minor updates to account for updates made in the source since the change was put it.

## 🧪 Testing

- Added new unit test that verifies setting an `undefined` icon on an icon mapping in the mapping column results in a validation error
- Updated matrix tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
