### PR TITLE
Use display helper consistently for all components

### DIFF
--- a/change/@ni-nimble-components-83fac5bb-4bc6-4067-951d-def8c7404d0c.json
+++ b/change/@ni-nimble-components-83fac5bb-4bc6-4067-951d-def8c7404d0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Switch to custom display helper",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-spright-components-ba62118f-2f23-45ac-aa65-e24740d4b5d7.json
+++ b/change/@ni-spright-components-ba62118f-2f23-45ac-aa65-e24740d4b5d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Switch to custom display helper",
+  "packageName": "@ni/spright-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-nimble/typescript.js
+++ b/packages/eslint-config-nimble/typescript.js
@@ -6,6 +6,12 @@ const restrictedImportsPaths = () => [
             'Please use focusVisible from src/utilities/style/focus instead.'
     },
     {
+        name: '@microsoft/fast-foundation',
+        importNames: ['display'],
+        message:
+            'Please use display from src/utilities/style/display instead.'
+    },
+    {
         name: '@microsoft/fast-components',
         message:
             'It is not expected to leverage @microsoft/fast-components directly as they are coupled to FAST design tokens.'

--- a/packages/nimble-components/docs/css-guidelines.md
+++ b/packages/nimble-components/docs/css-guidelines.md
@@ -198,13 +198,13 @@ When styling the invalid state of a form component, it may seem natural to use `
 
 Instead of styling based on `:invalid`, style the `[error-visible]` attribute. Then the client can create a binding to apply the `invalid` class based on the associated `FormControl`'s status properties, like `invalid`, `dirty`, and `touched`.
 
-## Use FAST's display utility for styling host element
+## Use the display utility for styling host element
 
-For consistent styling, use FAST's `display` utility when setting a `display` style on the host element.
+For consistent styling, use the `display` utility when setting a `display` style on the host element.
 
 ```ts
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 
 export const styles = css`
     ${display('flex')}

--- a/packages/nimble-components/src/anchor-menu-item/styles.ts
+++ b/packages/nimble-components/src/anchor-menu-item/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 
 import {
     bodyDisabledFontColor,

--- a/packages/nimble-components/src/anchor-tab/styles.ts
+++ b/packages/nimble-components/src/anchor-tab/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import { focusVisible } from '../utilities/style/focus';
 import {
     bodyDisabledFontColor,

--- a/packages/nimble-components/src/anchor-tabs/styles.ts
+++ b/packages/nimble-components/src/anchor-tabs/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 
 export const styles = css`
     ${display('grid')}

--- a/packages/nimble-components/src/anchor-tree-item/styles.ts
+++ b/packages/nimble-components/src/anchor-tree-item/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import {
     bodyFontFamily,
     bodyFontWeight,

--- a/packages/nimble-components/src/anchor/styles.ts
+++ b/packages/nimble-components/src/anchor/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import { focusVisible } from '../utilities/style/focus';
 import {
     linkActiveFontColor,

--- a/packages/nimble-components/src/anchored-region/styles.ts
+++ b/packages/nimble-components/src/anchored-region/styles.ts
@@ -1,15 +1,18 @@
 import { css } from '@microsoft/fast-element';
 import { ZIndexLevels } from '../utilities/style/types';
+import { display } from '../utilities/style/display';
 
 export const styles = css`
+    ${display('block')}
+
     :host {
-        /* Avoid using the 'display' helper to customize hidden behavior */
-        display: block;
         contain: layout;
         z-index: ${ZIndexLevels.zIndex1000};
     }
 
+    ${'' /* Override 'display' helper hidden behavior */}
     :host([hidden]) {
+        display: block;
         visibility: hidden;
     }
 `;

--- a/packages/nimble-components/src/banner/styles.ts
+++ b/packages/nimble-components/src/banner/styles.ts
@@ -1,5 +1,4 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
 import {
     BannerFail100DarkUi,
     Black75,
@@ -10,6 +9,7 @@ import {
     Warning100LightUi,
     White
 } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
+import { display } from '../utilities/style/display';
 
 import {
     actionRgbPartialColor,

--- a/packages/nimble-components/src/breadcrumb-item/styles.ts
+++ b/packages/nimble-components/src/breadcrumb-item/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import {
     bodyFontColor,
     borderHoverColor,

--- a/packages/nimble-components/src/breadcrumb/styles.ts
+++ b/packages/nimble-components/src/breadcrumb/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import {
     bodyEmphasizedFont,
     linkActiveFontColor,

--- a/packages/nimble-components/src/card-button/styles.ts
+++ b/packages/nimble-components/src/card-button/styles.ts
@@ -5,7 +5,7 @@ import {
     Black91,
     White
 } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import { focusVisible } from '../utilities/style/focus';
 
 import {

--- a/packages/nimble-components/src/card/styles.ts
+++ b/packages/nimble-components/src/card/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import {
     bodyEmphasizedFontWeight,
     bodyFont,

--- a/packages/nimble-components/src/checkbox/styles.ts
+++ b/packages/nimble-components/src/checkbox/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import { focusVisible } from '../utilities/style/focus';
 
 import {

--- a/packages/nimble-components/src/dialog/styles.ts
+++ b/packages/nimble-components/src/dialog/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 
 import {
     applicationBackgroundColor,

--- a/packages/nimble-components/src/drawer/styles.ts
+++ b/packages/nimble-components/src/drawer/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import {
     applicationBackgroundColor,
     bodyFont,

--- a/packages/nimble-components/src/icon-base/index.ts
+++ b/packages/nimble-components/src/icon-base/index.ts
@@ -28,8 +28,7 @@ export const registerIcon = (baseName: string, iconClass: IconClass): void => {
     const composedIcon = iconClass.compose({
         baseName,
         template,
-        styles,
-        baseClass: iconClass
+        styles
     });
 
     DesignSystem.getOrCreate().withPrefix('nimble').register(composedIcon());

--- a/packages/nimble-components/src/icon-base/styles.ts
+++ b/packages/nimble-components/src/icon-base/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import {
     iconSize,
     warningColor,

--- a/packages/nimble-components/src/label-provider/base/styles.ts
+++ b/packages/nimble-components/src/label-provider/base/styles.ts
@@ -1,0 +1,6 @@
+import { css } from '@microsoft/fast-element';
+import { display } from '../../utilities/style/display';
+
+export const styles = css`
+    ${display('none')}
+`;

--- a/packages/nimble-components/src/label-provider/core/index.ts
+++ b/packages/nimble-components/src/label-provider/core/index.ts
@@ -11,6 +11,7 @@ import {
     filterSearchLabel,
     filterNoResultsLabel
 } from './label-tokens';
+import { styles } from '../base/styles';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -63,7 +64,8 @@ export class LabelProviderCore
 }
 
 const nimbleLabelProviderCore = LabelProviderCore.compose({
-    baseName: 'label-provider-core'
+    baseName: 'label-provider-core',
+    styles
 });
 
 DesignSystem.getOrCreate()

--- a/packages/nimble-components/src/label-provider/rich-text/index.ts
+++ b/packages/nimble-components/src/label-provider/rich-text/index.ts
@@ -7,6 +7,7 @@ import {
     richTextToggleBulletedListLabel,
     richTextToggleNumberedListLabel
 } from './label-tokens';
+import { styles } from '../base/styles';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -43,7 +44,8 @@ export class LabelProviderRichText
 }
 
 const nimbleLabelProviderRichText = LabelProviderRichText.compose({
-    baseName: 'label-provider-rich-text'
+    baseName: 'label-provider-rich-text',
+    styles
 });
 
 DesignSystem.getOrCreate()

--- a/packages/nimble-components/src/label-provider/table/index.ts
+++ b/packages/nimble-components/src/label-provider/table/index.ts
@@ -19,6 +19,7 @@ import {
     tableGroupRowPlaceholderEmptyLabel,
     tableGroupRowPlaceholderNoValueLabel
 } from './label-tokens';
+import { styles } from '../base/styles';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -103,7 +104,8 @@ export class LabelProviderTable
 }
 
 const nimbleLabelProviderTable = LabelProviderTable.compose({
-    baseName: 'label-provider-table'
+    baseName: 'label-provider-table',
+    styles
 });
 
 DesignSystem.getOrCreate()

--- a/packages/nimble-components/src/list-option/styles.ts
+++ b/packages/nimble-components/src/list-option/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import { focusVisible } from '../utilities/style/focus';
 
 import {

--- a/packages/nimble-components/src/listbox/styles.ts
+++ b/packages/nimble-components/src/listbox/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 
 import {
     applicationBackgroundColor,

--- a/packages/nimble-components/src/mapping/base/styles.ts
+++ b/packages/nimble-components/src/mapping/base/styles.ts
@@ -1,0 +1,6 @@
+import { css } from '@microsoft/fast-element';
+import { display } from '../../utilities/style/display';
+
+export const styles = css`
+    ${display('none')}
+`;

--- a/packages/nimble-components/src/mapping/empty/index.ts
+++ b/packages/nimble-components/src/mapping/empty/index.ts
@@ -3,6 +3,7 @@ import { attr } from '@microsoft/fast-element';
 import { Mapping } from '../base';
 import { template } from '../base/template';
 import type { MappingKey } from '../base/types';
+import { styles } from '../base/styles';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -22,7 +23,8 @@ export class MappingEmpty extends Mapping<MappingKey> {
 
 const emptyMapping = MappingEmpty.compose({
     baseName: 'mapping-empty',
-    template
+    template,
+    styles
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(emptyMapping());
 export const mappingEmptyTag = 'nimble-mapping-empty';

--- a/packages/nimble-components/src/mapping/icon/index.ts
+++ b/packages/nimble-components/src/mapping/icon/index.ts
@@ -5,6 +5,7 @@ import { template } from '../base/template';
 import type { IconSeverity } from '../../icon-base/types';
 import { Icon } from '../../icon-base';
 import type { MappingKey } from '../base/types';
+import { styles } from '../base/styles';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -83,7 +84,8 @@ export class MappingIcon extends Mapping<MappingKey> {
 
 const iconMapping = MappingIcon.compose({
     baseName: 'mapping-icon',
-    template
+    template,
+    styles
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(iconMapping());
 export const mappingIconTag = 'nimble-mapping-icon';

--- a/packages/nimble-components/src/mapping/spinner/index.ts
+++ b/packages/nimble-components/src/mapping/spinner/index.ts
@@ -3,6 +3,7 @@ import { attr } from '@microsoft/fast-element';
 import { Mapping } from '../base';
 import { template } from '../base/template';
 import type { MappingKey } from '../base/types';
+import { styles } from '../base/styles';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -25,7 +26,8 @@ export class MappingSpinner extends Mapping<MappingKey> {
 
 const spinnerMapping = MappingSpinner.compose({
     baseName: 'mapping-spinner',
-    template
+    template,
+    styles
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(spinnerMapping());
 export const mappingSpinnerTag = 'nimble-mapping-spinner';

--- a/packages/nimble-components/src/mapping/text/index.ts
+++ b/packages/nimble-components/src/mapping/text/index.ts
@@ -3,6 +3,7 @@ import { attr } from '@microsoft/fast-element';
 import { Mapping } from '../base';
 import { template } from '../base/template';
 import type { MappingKey } from '../base/types';
+import { styles } from '../base/styles';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -22,7 +23,8 @@ export class MappingText extends Mapping<MappingKey> {
 
 const textMapping = MappingText.compose({
     baseName: 'mapping-text',
-    template
+    template,
+    styles
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(textMapping());
 export const mappingTextTag = 'nimble-mapping-text';

--- a/packages/nimble-components/src/mapping/user/index.ts
+++ b/packages/nimble-components/src/mapping/user/index.ts
@@ -3,6 +3,7 @@ import { DesignSystem } from '@microsoft/fast-foundation';
 import { Mapping } from '../base';
 import type { MappingUserKey } from '../base/types';
 import { template } from '../base/template';
+import { styles } from '../base/styles';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -19,7 +20,8 @@ export class MappingUser extends Mapping<MappingUserKey> {
 }
 const mappingUser = MappingUser.compose({
     baseName: 'mapping-user',
-    template
+    template,
+    styles
 });
 DesignSystem.getOrCreate().withPrefix('nimble').register(mappingUser());
 export const mappingUserTag = 'nimble-mapping-user';

--- a/packages/nimble-components/src/menu-button/styles.ts
+++ b/packages/nimble-components/src/menu-button/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import { controlHeight, smallPadding } from '../theme-provider/design-tokens';
 
 export const styles = css`

--- a/packages/nimble-components/src/menu-item/styles.ts
+++ b/packages/nimble-components/src/menu-item/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import { focusVisible } from '../utilities/style/focus';
 
 import {

--- a/packages/nimble-components/src/menu/styles.ts
+++ b/packages/nimble-components/src/menu/styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
 import { White } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
+import { display } from '../utilities/style/display';
 
 import {
     applicationBackgroundColor,

--- a/packages/nimble-components/src/number-field/styles.ts
+++ b/packages/nimble-components/src/number-field/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import {
     borderRgbPartialColor,
     borderHoverColor,

--- a/packages/nimble-components/src/patterns/button/styles.ts
+++ b/packages/nimble-components/src/patterns/button/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../../utilities/style/display';
 import { focusVisible } from '../../utilities/style/focus';
 import {
     actionRgbPartialColor,

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
 import { White } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
+import { display } from '../../utilities/style/display';
 import {
     applicationBackgroundColor,
     bodyFont,

--- a/packages/nimble-components/src/radio-group/styles.ts
+++ b/packages/nimble-components/src/radio-group/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import {
     controlLabelDisabledFontColor,
     controlLabelFont,

--- a/packages/nimble-components/src/radio/styles.ts
+++ b/packages/nimble-components/src/radio/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import {
     bodyDisabledFontColor,
     bodyFont,

--- a/packages/nimble-components/src/rich-text-mention/base/styles.ts
+++ b/packages/nimble-components/src/rich-text-mention/base/styles.ts
@@ -1,0 +1,6 @@
+import { css } from '@microsoft/fast-element';
+import { display } from '../../utilities/style/display';
+
+export const styles = css`
+    ${display('none')}
+`;

--- a/packages/nimble-components/src/rich-text-mention/users/index.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/index.ts
@@ -10,6 +10,7 @@ import type { Mapping } from '../../mapping/base';
 import type { MappingUserKey } from '../../mapping/base/types';
 import { RichTextMentionUsersValidator } from './models/rich-text-mention-users-validator';
 import { richTextMentionUsersViewTag } from './view';
+import { styles } from '../base/styles';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -47,7 +48,8 @@ export class RichTextMentionUsers extends RichTextMention<RichTextMentionUsersVa
 }
 const nimbleRichTextMentionUsers = RichTextMentionUsers.compose({
     baseName: 'rich-text-mention-users',
-    template
+    template,
+    styles
 });
 
 DesignSystem.getOrCreate()

--- a/packages/nimble-components/src/rich-text-mention/users/view/styles.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/view/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../../../utilities/style/display';
 import {
     mentionFont,
     mentionFontColor,

--- a/packages/nimble-components/src/rich-text/editor/styles.ts
+++ b/packages/nimble-components/src/rich-text/editor/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../../utilities/style/display';
 import {
     bodyDisabledFontColor,
     bodyFont,

--- a/packages/nimble-components/src/rich-text/viewer/styles.ts
+++ b/packages/nimble-components/src/rich-text/viewer/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../../utilities/style/display';
 import {
     bodyFont,
     bodyFontColor,

--- a/packages/nimble-components/src/spinner/styles.ts
+++ b/packages/nimble-components/src/spinner/styles.ts
@@ -1,5 +1,4 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
 import {
     Black15,
     Black91,
@@ -7,6 +6,7 @@ import {
     PowerGreen,
     White
 } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
+import { display } from '../utilities/style/display';
 import { spinnerSmallHeight } from '../theme-provider/design-tokens';
 import { Theme } from '../theme-provider/types';
 import { themeBehavior } from '../utilities/style/theme';

--- a/packages/nimble-components/src/switch/styles.ts
+++ b/packages/nimble-components/src/switch/styles.ts
@@ -1,11 +1,11 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
 import {
     Black15,
     Black7,
     Black91,
     White
 } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
+import { display } from '../utilities/style/display';
 import {
     bodyFont,
     borderHoverColor,

--- a/packages/nimble-components/src/tab-panel/styles.ts
+++ b/packages/nimble-components/src/tab-panel/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import {
     bodyFont,
     bodyFontColor,

--- a/packages/nimble-components/src/tab/styles.ts
+++ b/packages/nimble-components/src/tab/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import {
     borderHoverColor,
     borderWidth,

--- a/packages/nimble-components/src/table-column/anchor/cell-view/styles.ts
+++ b/packages/nimble-components/src/table-column/anchor/cell-view/styles.ts
@@ -5,13 +5,17 @@ import {
     placeholderFont,
     placeholderFontColor
 } from '../../../theme-provider/design-tokens';
+import { display } from '../../../utilities/style/display';
 
 export const styles = css`
+    ${display('flex')}
+
     :host {
         width: fit-content;
         max-width: 100%;
         height: fit-content;
         align-self: center;
+        align-items: center;
     }
 
     nimble-anchor {

--- a/packages/nimble-components/src/table-column/base/styles.ts
+++ b/packages/nimble-components/src/table-column/base/styles.ts
@@ -1,9 +1,8 @@
 import { css } from '@microsoft/fast-element';
+import { display } from '../../utilities/style/display';
 
 export const styles = css`
-    :host {
-        display: contents;
-    }
+    ${display('contents')}
 
     .header-content {
         white-space: nowrap;

--- a/packages/nimble-components/src/table-column/mapping/cell-view/styles.ts
+++ b/packages/nimble-components/src/table-column/mapping/cell-view/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../../../utilities/style/display';
 import {
     bodyFont,
     bodyFontColor,

--- a/packages/nimble-components/src/table-column/mapping/group-header-view/styles.ts
+++ b/packages/nimble-components/src/table-column/mapping/group-header-view/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../../../utilities/style/display';
 import {
     bodyFont,
     bodyFontColor,

--- a/packages/nimble-components/src/table-column/text-base/cell-view/styles.ts
+++ b/packages/nimble-components/src/table-column/text-base/cell-view/styles.ts
@@ -5,8 +5,15 @@ import {
     placeholderFont,
     placeholderFontColor
 } from '../../../theme-provider/design-tokens';
+import { display } from '../../../utilities/style/display';
 
 export const styles = css`
+    ${display('flex')}
+
+    :host {
+        align-items: center;
+    }
+
     :host(.right-align) {
         margin-left: auto;
     }

--- a/packages/nimble-components/src/table-column/text-base/group-header-view/styles.ts
+++ b/packages/nimble-components/src/table-column/text-base/group-header-view/styles.ts
@@ -1,7 +1,10 @@
 import { css } from '@microsoft/fast-element';
 import { bodyFont, bodyFontColor } from '../../../theme-provider/design-tokens';
+import { display } from '../../../utilities/style/display';
 
 export const styles = css`
+    ${display('flex')}
+
     span {
         font: ${bodyFont};
         color: ${bodyFontColor};

--- a/packages/nimble-components/src/table/components/cell/styles.ts
+++ b/packages/nimble-components/src/table/components/cell/styles.ts
@@ -24,8 +24,6 @@ export const styles = css`
 
     .cell-view {
         overflow: hidden;
-        display: flex;
-        align-items: center;
     }
 
     .action-menu {

--- a/packages/nimble-components/src/table/components/cell/styles.ts
+++ b/packages/nimble-components/src/table/components/cell/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../../../utilities/style/display';
 import {
     controlHeight,
     controlSlimHeight,

--- a/packages/nimble-components/src/table/components/group-row/styles.ts
+++ b/packages/nimble-components/src/table/components/group-row/styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
 import { White } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
+import { display } from '../../../utilities/style/display';
 import {
     applicationBackgroundColor,
     borderWidth,

--- a/packages/nimble-components/src/table/components/group-row/styles.ts
+++ b/packages/nimble-components/src/table/components/group-row/styles.ts
@@ -71,7 +71,6 @@ export const styles = css`
         padding-left: ${mediumPadding};
         ${userSelectNone}
         overflow: hidden;
-        display: flex;
     }
 
     .group-row-child-count {

--- a/packages/nimble-components/src/table/components/header/styles.ts
+++ b/packages/nimble-components/src/table/components/header/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../../../utilities/style/display';
 import {
     controlHeight,
     iconColor,

--- a/packages/nimble-components/src/table/components/row/styles.ts
+++ b/packages/nimble-components/src/table/components/row/styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
 import { White } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
+import { display } from '../../../utilities/style/display';
 import {
     applicationBackgroundColor,
     borderWidth,

--- a/packages/nimble-components/src/table/components/row/styles.ts
+++ b/packages/nimble-components/src/table/components/row/styles.ts
@@ -18,8 +18,8 @@ import { themeBehavior } from '../../../utilities/style/theme';
 import { styles as expandCollapseStyles } from '../../../patterns/expand-collapse/styles';
 
 export const styles = css`
-    ${expandCollapseStyles}
     ${display('flex')}
+    ${expandCollapseStyles}
 
     :host {
         width: fit-content;

--- a/packages/nimble-components/src/table/styles.ts
+++ b/packages/nimble-components/src/table/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import { White } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
 import {
     applicationBackgroundColor,

--- a/packages/nimble-components/src/table/styles.ts
+++ b/packages/nimble-components/src/table/styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utilities/style/display';
 import { White } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
+import { display } from '../utilities/style/display';
 import {
     applicationBackgroundColor,
     bodyFont,

--- a/packages/nimble-components/src/tabs-toolbar/styles.ts
+++ b/packages/nimble-components/src/tabs-toolbar/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import {
     bodyFont,
     bodyFontColor,

--- a/packages/nimble-components/src/tabs/styles.ts
+++ b/packages/nimble-components/src/tabs/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 
 export const styles = css`
     ${display('grid')}

--- a/packages/nimble-components/src/text-area/styles.ts
+++ b/packages/nimble-components/src/text-area/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import {
     borderRgbPartialColor,
     borderHoverColor,

--- a/packages/nimble-components/src/text-field/styles.ts
+++ b/packages/nimble-components/src/text-field/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 
 import {
     borderRgbPartialColor,

--- a/packages/nimble-components/src/theme-provider/styles.ts
+++ b/packages/nimble-components/src/theme-provider/styles.ts
@@ -1,7 +1,6 @@
 import { css } from '@microsoft/fast-element';
+import { display } from '../utilities/style/display';
 
 export const styles = css`
-    :host {
-        display: contents;
-    }
+    ${display('contents')}
 `;

--- a/packages/nimble-components/src/toolbar/styles.ts
+++ b/packages/nimble-components/src/toolbar/styles.ts
@@ -4,8 +4,11 @@ import {
     smallPadding,
     standardPadding
 } from '../theme-provider/design-tokens';
+import { display } from '../utilities/style/display';
 
 export const styles = css`
+    ${display('inline')}
+
     .positioning-region {
         display: flex;
         padding: ${smallPadding} ${standardPadding};

--- a/packages/nimble-components/src/tooltip/styles.ts
+++ b/packages/nimble-components/src/tooltip/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import {
     BannerFail100DarkUi,
     Black15,

--- a/packages/nimble-components/src/tooltip/styles.ts
+++ b/packages/nimble-components/src/tooltip/styles.ts
@@ -1,5 +1,4 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '../utilities/style/display';
 import {
     BannerFail100DarkUi,
     Black15,
@@ -10,6 +9,7 @@ import {
     Information100LightUi,
     White
 } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
+import { display } from '../utilities/style/display';
 import {
     tooltipCaptionFont,
     tooltipCaptionFontColor,

--- a/packages/nimble-components/src/tree-item/styles.ts
+++ b/packages/nimble-components/src/tree-item/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import { focusVisible } from '../utilities/style/focus';
 import {
     bodyFontColor,

--- a/packages/nimble-components/src/tree-view/styles.ts
+++ b/packages/nimble-components/src/tree-view/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
+import { display } from '../utilities/style/display';
 import { focusVisible } from '../utilities/style/focus';
 
 export const styles = css`

--- a/packages/nimble-components/src/unit/base/styles.ts
+++ b/packages/nimble-components/src/unit/base/styles.ts
@@ -1,0 +1,6 @@
+import { css } from '@microsoft/fast-element';
+import { display } from '../../utilities/style/display';
+
+export const styles = css`
+    ${display('none')}
+`;

--- a/packages/nimble-components/src/unit/byte/index.ts
+++ b/packages/nimble-components/src/unit/byte/index.ts
@@ -4,6 +4,7 @@ import { template } from '../base/template';
 import { byte1024UnitScale } from '../../utilities/unit-format/unit-scale/byte-1024-unit-scale';
 import { byteUnitScale } from '../../utilities/unit-format/unit-scale/byte-unit-scale';
 import { Unit } from '../base/unit';
+import { styles } from '../base/styles';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -36,7 +37,8 @@ export class UnitByte extends Unit {
 
 const nimbleUnitByte = UnitByte.compose({
     baseName: 'unit-byte',
-    template
+    template,
+    styles
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleUnitByte());

--- a/packages/nimble-components/src/unit/celsius/index.ts
+++ b/packages/nimble-components/src/unit/celsius/index.ts
@@ -2,6 +2,7 @@ import { DesignSystem } from '@microsoft/fast-foundation';
 import { template } from '../base/template';
 import { Unit } from '../base/unit';
 import { celsiusUnitScale } from '../../utilities/unit-format/unit-scale/celsius-unit-scale';
+import { styles } from '../base/styles';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -21,7 +22,8 @@ export class UnitCelsius extends Unit {
 
 const nimbleUnitCelsius = UnitCelsius.compose({
     baseName: 'unit-celsius',
-    template
+    template,
+    styles
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleUnitCelsius());

--- a/packages/nimble-components/src/unit/fahrenheit/index.ts
+++ b/packages/nimble-components/src/unit/fahrenheit/index.ts
@@ -2,6 +2,7 @@ import { DesignSystem } from '@microsoft/fast-foundation';
 import { template } from '../base/template';
 import { Unit } from '../base/unit';
 import { fahrenheitUnitScale } from '../../utilities/unit-format/unit-scale/fahrenheit-unit-scale';
+import { styles } from '../base/styles';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -21,7 +22,8 @@ export class UnitFahrenheit extends Unit {
 
 const nimbleUnitFahrenheit = UnitFahrenheit.compose({
     baseName: 'unit-fahrenheit',
-    template
+    template,
+    styles
 });
 
 DesignSystem.getOrCreate()

--- a/packages/nimble-components/src/unit/volt/index.ts
+++ b/packages/nimble-components/src/unit/volt/index.ts
@@ -2,6 +2,7 @@ import { DesignSystem } from '@microsoft/fast-foundation';
 import { template } from '../base/template';
 import { Unit } from '../base/unit';
 import { voltUnitScale } from '../../utilities/unit-format/unit-scale/volt-unit-scale';
+import { styles } from '../base/styles';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -21,7 +22,8 @@ export class UnitVolt extends Unit {
 
 const nimbleUnitVolt = UnitVolt.compose({
     baseName: 'unit-volt',
-    template
+    template,
+    styles
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleUnitVolt());

--- a/packages/nimble-components/src/utilities/style/display.ts
+++ b/packages/nimble-components/src/utilities/style/display.ts
@@ -1,0 +1,9 @@
+import {
+    type CSSDisplayPropertyValue,
+    // eslint-disable-next-line no-restricted-imports
+    display as foundationDisplay
+} from '@microsoft/fast-foundation';
+
+export const display: typeof foundationDisplay = (
+    displayValue: CSSDisplayPropertyValue
+) => `${foundationDisplay(displayValue)}`;

--- a/packages/nimble-components/src/wafer-map/styles.ts
+++ b/packages/nimble-components/src/wafer-map/styles.ts
@@ -1,10 +1,12 @@
 import { css } from '@microsoft/fast-element';
 import { DigitalGreenLight } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
 import { borderColor, borderWidth } from '../theme-provider/design-tokens';
+import { display } from '../utilities/style/display';
 
 export const styles = css`
+    ${display('inline-block')}
+
     :host {
-        display: inline-block;
         width: 500px;
         height: 500px;
     }

--- a/packages/spright-components/src/rectangle/styles.ts
+++ b/packages/spright-components/src/rectangle/styles.ts
@@ -1,5 +1,4 @@
 import { css } from '@microsoft/fast-element';
-import { display } from '@microsoft/fast-foundation';
 import {
     bodyDisabledFontColor,
     bodyFont,
@@ -7,6 +6,7 @@ import {
     borderHoverColor,
     borderRgbPartialColor
 } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
+import { display } from '../utilities/style/display';
 
 export const styles = css`
     ${display('inline-block')}

--- a/packages/spright-components/src/utilities/style/display.ts
+++ b/packages/spright-components/src/utilities/style/display.ts
@@ -1,0 +1,9 @@
+import {
+    type CSSDisplayPropertyValue,
+    // eslint-disable-next-line no-restricted-imports
+    display as foundationDisplay
+} from '@microsoft/fast-foundation';
+
+export const display: typeof foundationDisplay = (
+    displayValue: CSSDisplayPropertyValue
+) => `${foundationDisplay(displayValue)}`;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This PR updates all defined components to use a custom version of the `display` helper. The goal of this PR is to be a refactor to use the same helper but should be effectively a no-op.

## 👩‍💻 Implementation

- Added a custom display helper
- Updated all elements to use it
- Updates elements that were missing it to have one with a value that reflects what shows up in storybook todaay as the computed display value
  - Utility elements that should never be visible / have visible content were set to `display: none;`

## 🧪 Testing

Rely on storybook to verify nothing changed.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed. Updated the `display` doc topic.
