### PR TITLE
Improve API docs for buttons and improve overall doc consistency

### DIFF
--- a/packages/storybook/CONTRIBUTING.md
+++ b/packages/storybook/CONTRIBUTING.md
@@ -83,6 +83,8 @@ Note: if linking in a story via a native or Nimble anchor component, use the fol
 <a href="./?path=/docs/some--id" target="_top">Link</a>
 ```
 
+Linking to headings within a document doesn't work very well; avoid using links and refer to the section using **Bold** instead.
+
 All other Markdown formatting is supported. See any [Markdown Cheatsheet](https://www.markdownguide.org/cheat-sheet/) for more information.
 
 ### Testing 

--- a/packages/storybook/CONTRIBUTING.md
+++ b/packages/storybook/CONTRIBUTING.md
@@ -83,7 +83,7 @@ Note: if linking in a story via a native or Nimble anchor component, use the fol
 <a href="./?path=/docs/some--id" target="_top">Link</a>
 ```
 
-Linking to headings within a document doesn't work very well; avoid using links and refer to the section using **Bold** instead.
+Linking to headings within a document doesn't work very well, i.e. `./page#some-heading`; avoid using links to specific headings and instead link to the page and refer to the section using **Bold**, i.e. `See **Some Heading** on [Page](./page)`.
 
 All other Markdown formatting is supported. See any [Markdown Cheatsheet](https://www.markdownguide.org/cheat-sheet/) for more information.
 

--- a/packages/storybook/CONTRIBUTING.md
+++ b/packages/storybook/CONTRIBUTING.md
@@ -54,6 +54,8 @@ import * as componentNameStories from './component-name.stories';
 
 ### Appearance Variants
 
+### Sizing
+
 ## Examples
 
 ## Accessibility

--- a/packages/storybook/CONTRIBUTING.md
+++ b/packages/storybook/CONTRIBUTING.md
@@ -46,11 +46,13 @@ import * as componentNameStories from './component-name.stories';
 <Controls of={componentNameStories.firstStoryName} />
 <ComponentApisLink />
 
-## Appearances
+## Usage
 
-## Appearance Variants
+## Styling
 
-## Usage 
+### Appearances
+
+### Appearance Variants
 
 ## Examples
 

--- a/packages/storybook/src/nimble/anchor-button/anchor-button.mdx
+++ b/packages/storybook/src/nimble/anchor-button/anchor-button.mdx
@@ -20,6 +20,8 @@ An anchor button is a component with the visual appearance of a button, but it n
 <Canvas of={anchorButtonStories.outlineAnchorButton} />
 <Controls of={anchorButtonStories.outlineAnchorButton} />
 
+## Styling
+
 <StylingDocs components={{ Button: anchorButtonTag }} />
 
 {/* ## Usage */}

--- a/packages/storybook/src/nimble/anchor-button/anchor-button.stories.ts
+++ b/packages/storybook/src/nimble/anchor-button/anchor-button.stories.ts
@@ -8,6 +8,7 @@ import {
     ButtonAppearanceVariant
 } from '@ni/nimble-components/dist/esm/patterns/button/types';
 import {
+    appearanceDescription,
     appearanceVariantDescription,
     contentHiddenDescription,
     endIconDescription,
@@ -56,7 +57,8 @@ const metadata: Meta<AnchorButtonArgs> = {
         },
         appearance: {
             options: Object.keys(ButtonAppearance),
-            control: { type: 'radio' }
+            control: { type: 'radio' },
+            description: appearanceDescription
         },
         appearanceVariant: {
             name: 'appearance-variant',

--- a/packages/storybook/src/nimble/anchor-tabs/anchor-tabs.mdx
+++ b/packages/storybook/src/nimble/anchor-tabs/anchor-tabs.mdx
@@ -14,9 +14,11 @@ tab panels hosted on the same page.
 <Canvas of={anchorTabsStories.anchorTabs} />
 <Controls of={anchorTabsStories.anchorTabs} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/anchor-tabs/anchor-tabs.mdx
+++ b/packages/storybook/src/nimble/anchor-tabs/anchor-tabs.mdx
@@ -16,10 +16,6 @@ tab panels hosted on the same page.
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/anchor/anchor.mdx
+++ b/packages/storybook/src/nimble/anchor/anchor.mdx
@@ -12,10 +12,6 @@ Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/link/), an anchor/link widget
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/anchor/anchor.mdx
+++ b/packages/storybook/src/nimble/anchor/anchor.mdx
@@ -10,9 +10,11 @@ Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/link/), an anchor/link widget
 <Canvas of={anchorStories.anchor} />
 <Controls of={anchorStories.anchor} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/anchored-region/anchored-region.mdx
+++ b/packages/storybook/src/nimble/anchored-region/anchored-region.mdx
@@ -19,10 +19,6 @@ available space, or even resize itself based on that space.
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/anchored-region/anchored-region.mdx
+++ b/packages/storybook/src/nimble/anchored-region/anchored-region.mdx
@@ -17,9 +17,11 @@ available space, or even resize itself based on that space.
 <Canvas of={anchoredRegionStories.anchoredRegion} />
 <Controls of={anchoredRegionStories.anchoredRegion} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/banner/banner.mdx
+++ b/packages/storybook/src/nimble/banner/banner.mdx
@@ -16,9 +16,11 @@ should be spaced apart using the <code>{bannerGapSize.cssCustomProperty}</code> 
 <Canvas of={bannerStories._banner} />
 <Controls of={bannerStories._banner} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/banner/banner.mdx
+++ b/packages/storybook/src/nimble/banner/banner.mdx
@@ -18,10 +18,6 @@ should be spaced apart using the <code>{bannerGapSize.cssCustomProperty}</code> 
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/breadcrumb/breadcrumb.mdx
+++ b/packages/storybook/src/nimble/breadcrumb/breadcrumb.mdx
@@ -15,9 +15,11 @@ for information on using this component in Angular with RouterLink directives.
 <Controls of={breadcrumbStories._standardBreadcrumb} />
 <Stories of={breadcrumbStories} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/breadcrumb/breadcrumb.mdx
+++ b/packages/storybook/src/nimble/breadcrumb/breadcrumb.mdx
@@ -17,10 +17,6 @@ for information on using this component in Angular with RouterLink directives.
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/button/button.mdx
+++ b/packages/storybook/src/nimble/button/button.mdx
@@ -1,6 +1,7 @@
 import { Canvas, Meta, Controls, Title } from '@storybook/blocks';
 import ContentHiddenDocs from '../patterns/button/content-hidden-docs.mdx';
 import StylingDocs from '../patterns/button/styling-docs.mdx';
+import ComponentApisLink from '../../docs/component-apis-link.mdx';
 import { buttonTag } from '@ni/nimble-components/dist/esm/button';
 import { anchorButtonTag } from '@ni/nimble-components/dist/esm/anchor-button';
 import * as buttonStories from './button.stories';
@@ -15,17 +16,27 @@ action, or performing a delete operation.
 If you want a button that triggers navigation to a URL, use the <Tag name={anchorButtonTag}/> instead.
 
 <Canvas of={buttonStories.outlineButton} />
+
+## API
+
 <Controls of={buttonStories.outlineButton} />
+
+<ComponentApisLink />
+
+## Styling
 
 <StylingDocs components={{ Button: buttonTag }} />
 
-## Sizing
+### Sizing
 
 Nimble Buttons are currently always 32px tall. Designs exist for other sizes; if you need these in an application, please comment on [Configurable height for nimble controls (#610)](https://github.com/ni/nimble/issues/610).
 
+{/* ## Usage */}
+
+{/* ## Examples */}
+
 ## Accessibility
 
-Please work with your designer and ensure you have a 4.5:1
-contrast ratio text to background.
-
 <ContentHiddenDocs buttonElement="nimble-button" />
+
+{/* ## Resources */}

--- a/packages/storybook/src/nimble/button/button.stories.ts
+++ b/packages/storybook/src/nimble/button/button.stories.ts
@@ -10,9 +10,10 @@ import {
     appearanceVariantDescription,
     contentHiddenDescription,
     endIconDescription,
-    iconDescription
+    iconDescription,
+    textContentDescription
 } from '../patterns/button/doc-strings';
-import { createUserSelectedThemeStory } from '../../utilities/storybook';
+import { apiCategory, createUserSelectedThemeStory, disabledDescription } from '../../utilities/storybook';
 
 interface ButtonArgs {
     label: string;
@@ -22,6 +23,7 @@ interface ButtonArgs {
     icon: boolean;
     contentHidden: boolean;
     endIcon: boolean;
+    click: () => void;
 }
 
 const metadata: Meta<ButtonArgs> = {
@@ -36,22 +38,45 @@ const metadata: Meta<ButtonArgs> = {
         appearance: {
             options: Object.keys(ButtonAppearance),
             control: { type: 'radio' },
-            description: appearanceDescription
+            description: appearanceDescription,
+            table: { category: apiCategory.attributes }
         },
         appearanceVariant: {
             name: 'appearance-variant',
             options: Object.keys(ButtonAppearanceVariant),
             control: { type: 'radio' },
-            description: appearanceVariantDescription
+            description: appearanceVariantDescription,
+            table: { category: apiCategory.attributes }
         },
         contentHidden: {
-            description: contentHiddenDescription
+            name: 'content-hidden',
+            description: contentHiddenDescription,
+            table: { category: apiCategory.attributes }
+        },
+        disabled: {
+            description: disabledDescription({ componentName: 'button' }),
+            table: { category: apiCategory.attributes }
+        },
+        label: {
+            name: 'default',
+            description: textContentDescription({ componentName: 'button' }),
+            table: { category: apiCategory.slots }
         },
         icon: {
-            description: iconDescription
+            name: 'start',
+            description: iconDescription,
+            table: { category: apiCategory.slots }
         },
         endIcon: {
-            description: endIconDescription
+            name: 'end',
+            description: endIconDescription,
+            table: { category: apiCategory.slots }
+        },
+        click: {
+            description:
+                'Fires when the button is activated by either keyboard or mouse.',
+            table: { category: apiCategory.events },
+            control: false
         }
     },
     // prettier-ignore

--- a/packages/storybook/src/nimble/button/button.stories.ts
+++ b/packages/storybook/src/nimble/button/button.stories.ts
@@ -23,7 +23,7 @@ interface ButtonArgs {
     icon: boolean;
     contentHidden: boolean;
     endIcon: boolean;
-    click: () => void;
+    click: undefined;
 }
 
 const metadata: Meta<ButtonArgs> = {

--- a/packages/storybook/src/nimble/card-button/card-button.mdx
+++ b/packages/storybook/src/nimble/card-button/card-button.mdx
@@ -13,11 +13,12 @@ application. The <Tag name={cardButtonTag}/> is intended to be larger and more p
 Note: The styling for the "Color" theme is not complete.
 
 <Canvas of={cardButtonStories.cardButton} />
+
+## API
+
 <Controls of={cardButtonStories.cardButton} />
 
-{/* ## Appearances */}
-
-{/* ## Appearance Variants */}
+{/* ## Styling */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/card-button/card-button.mdx
+++ b/packages/storybook/src/nimble/card-button/card-button.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Controls, Title } from '@storybook/blocks';
 import { NimbleCardButton } from './card-button.react';
+import { anchorButtonTag } from '@ni/nimble-components/dist/esm/anchor-button';
 import { cardButtonTag } from '@ni/nimble-components/dist/esm/card-button';
 import { buttonTag } from '@ni/nimble-components/dist/esm/button';
 import * as cardButtonStories from './card-button.stories';
@@ -9,6 +10,8 @@ import * as cardButtonStories from './card-button.stories';
 
 The <Tag name={cardButtonTag}/> is a button that is designed to contain arbitrary content that is specified by a client
 application. The <Tag name={cardButtonTag}/> is intended to be larger and more prominent on a page than the standard <Tag name={buttonTag}/>.
+
+If you want a button that triggers navigation to a URL, use the <Tag name={anchorButtonTag}/> instead.
 
 Note: The styling for the "Color" theme is not complete.
 

--- a/packages/storybook/src/nimble/card-button/card-button.stories.ts
+++ b/packages/storybook/src/nimble/card-button/card-button.stories.ts
@@ -3,11 +3,13 @@ import { withActions } from '@storybook/addon-actions/decorator';
 import type { HtmlRenderer, Meta, StoryObj } from '@storybook/html';
 import { bodyFont } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { cardButtonTag } from '@ni/nimble-components/dist/esm/card-button';
-import { createUserSelectedThemeStory } from '../../utilities/storybook';
+import { apiCategory, createUserSelectedThemeStory, disabledDescription } from '../../utilities/storybook';
 
 interface CardButtonArgs {
     disabled: boolean;
     selected: boolean;
+    content: string;
+    click: () => void;
 }
 
 const metadata: Meta<CardButtonArgs> = {
@@ -52,6 +54,28 @@ const metadata: Meta<CardButtonArgs> = {
     args: {
         disabled: false,
         selected: false
+    },
+    argTypes: {
+        disabled: {
+            description: disabledDescription({ componentName: 'card button' }),
+            table: { category: apiCategory.attributes }
+        },
+        selected: {
+            description: 'Styles the card button to indicate it is selected.',
+            table: { category: apiCategory.attributes }
+        },
+        content: {
+            name: 'default',
+            description: 'The card button allows arbitrary HTML child content in its default slot.',
+            table: { category: apiCategory.slots },
+            control: false
+        },
+        click: {
+            description:
+                'Fires when the card button is activated by either keyboard or mouse.',
+            table: { category: apiCategory.events },
+            control: false
+        }
     }
 };
 

--- a/packages/storybook/src/nimble/card-button/card-button.stories.ts
+++ b/packages/storybook/src/nimble/card-button/card-button.stories.ts
@@ -9,7 +9,7 @@ interface CardButtonArgs {
     disabled: boolean;
     selected: boolean;
     content: string;
-    click: () => void;
+    click: undefined;
 }
 
 const metadata: Meta<CardButtonArgs> = {

--- a/packages/storybook/src/nimble/card/card.mdx
+++ b/packages/storybook/src/nimble/card/card.mdx
@@ -14,10 +14,6 @@ application. The <Tag name={cardTag} /> is intended for grouping related content
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/card/card.mdx
+++ b/packages/storybook/src/nimble/card/card.mdx
@@ -12,9 +12,11 @@ application. The <Tag name={cardTag} /> is intended for grouping related content
 <Canvas of={cardStories.card} />
 <Controls of={cardStories.card} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/checkbox/checkbox.mdx
+++ b/packages/storybook/src/nimble/checkbox/checkbox.mdx
@@ -12,10 +12,6 @@ Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/) - The dual-state c
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/checkbox/checkbox.mdx
+++ b/packages/storybook/src/nimble/checkbox/checkbox.mdx
@@ -10,9 +10,11 @@ Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/) - The dual-state c
 <Canvas of={checkboxStories.checkbox} />
 <Controls of={checkboxStories.checkbox} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/combobox/combobox.mdx
+++ b/packages/storybook/src/nimble/combobox/combobox.mdx
@@ -11,10 +11,6 @@ import { listOptionTag } from '@ni/nimble-components/dist/esm/list-option/';
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/combobox/combobox.mdx
+++ b/packages/storybook/src/nimble/combobox/combobox.mdx
@@ -9,9 +9,11 @@ import { listOptionTag } from '@ni/nimble-components/dist/esm/list-option/';
 <Canvas of={comboboxStories.underlineCombobox} />
 <Controls of={comboboxStories.underlineCombobox} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/dialog/dialog.mdx
+++ b/packages/storybook/src/nimble/dialog/dialog.mdx
@@ -11,13 +11,13 @@ By default, the first focusable control gets focus when the dialog is opened. To
 <Canvas of={dialogStories.dialog} />
 <Controls of={dialogStories.dialog} />
 
-{/* ## Styling */}
+## Styling
 
 {/* ### Appearances */}
 
 {/* ### Appearance Variants */}
 
-## Sizing
+### Sizing
 
 The dialog size can be customized by modyfing the width, height and max-height properties of `nimble-dialog::part(control)`.
 

--- a/packages/storybook/src/nimble/dialog/dialog.mdx
+++ b/packages/storybook/src/nimble/dialog/dialog.mdx
@@ -13,10 +13,6 @@ By default, the first focusable control gets focus when the dialog is opened. To
 
 ## Styling
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 ### Sizing
 
 The dialog size can be customized by modyfing the width, height and max-height properties of `nimble-dialog::part(control)`.

--- a/packages/storybook/src/nimble/dialog/dialog.mdx
+++ b/packages/storybook/src/nimble/dialog/dialog.mdx
@@ -11,9 +11,11 @@ By default, the first focusable control gets focus when the dialog is opened. To
 <Canvas of={dialogStories.dialog} />
 <Controls of={dialogStories.dialog} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 ## Sizing
 

--- a/packages/storybook/src/nimble/dialog/dialog.stories.ts
+++ b/packages/storybook/src/nimble/dialog/dialog.stories.ts
@@ -61,7 +61,7 @@ const content = {
 const sizeDescription = `
 Size of a nimble dialog.
 
-See the Sizing section of the Usage Docs for information on controlling the size of the dialog.
+See the **Sizing** section for information on controlling the size of the dialog.
 `;
 
 const widths = {

--- a/packages/storybook/src/nimble/drawer/drawer.mdx
+++ b/packages/storybook/src/nimble/drawer/drawer.mdx
@@ -9,9 +9,11 @@ Specialized dialog designed to slide in from either side of the page. Typically 
 <Canvas of={drawerStories.drawer} />
 <Controls of={drawerStories.drawer} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/drawer/drawer.mdx
+++ b/packages/storybook/src/nimble/drawer/drawer.mdx
@@ -11,10 +11,6 @@ Specialized dialog designed to slide in from either side of the page. Typically 
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/icon-base/icons.mdx
+++ b/packages/storybook/src/nimble/icon-base/icons.mdx
@@ -10,9 +10,11 @@ Nimble icons can be slotted into other components or used independently. Each ic
 <Canvas of={iconsStories.icons} />
 <Controls of={iconsStories.icons} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/icon-base/icons.mdx
+++ b/packages/storybook/src/nimble/icon-base/icons.mdx
@@ -12,10 +12,6 @@ Nimble icons can be slotted into other components or used independently. Each ic
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/menu-button/menu-button.mdx
+++ b/packages/storybook/src/nimble/menu-button/menu-button.mdx
@@ -19,6 +19,8 @@ often styled as a typical push button with a downward pointing arrow or triangle
 
 <ComponentApisLink />
 
+## Styling
+
 <StylingDocs components={{ Button: menuButtonTag }} />
 
 {/* ## Usage */}

--- a/packages/storybook/src/nimble/menu-button/menu-button.stories.ts
+++ b/packages/storybook/src/nimble/menu-button/menu-button.stories.ts
@@ -55,7 +55,7 @@ const metadata: Meta<MenuButtonArgs> = {
         label: {
             name: 'default',
             description:
-                'The text content of the button. This will be hidden when `content-hidden` is set but should always be provided; see the `Accessibility` section for more info.',
+                'The text content of the button. This will be hidden when `content-hidden` is set but should always be provided; see the **Accessibility** section for more info.',
             table: { category: apiCategory.slots }
         },
         icon: {

--- a/packages/storybook/src/nimble/menu-button/menu-button.stories.ts
+++ b/packages/storybook/src/nimble/menu-button/menu-button.stories.ts
@@ -17,12 +17,14 @@ import {
     appearanceVariantDescription,
     contentHiddenDescription,
     endIconDescription,
-    iconDescription
+    iconDescription,
+    textContentDescription
 } from '../patterns/button/doc-strings';
 import {
     apiCategory,
     createUserSelectedThemeStory,
-    disableStorybookZoomTransform
+    disableStorybookZoomTransform,
+    disabledDescription
 } from '../../utilities/storybook';
 
 interface MenuButtonArgs {
@@ -54,8 +56,7 @@ const metadata: Meta<MenuButtonArgs> = {
     argTypes: {
         label: {
             name: 'default',
-            description:
-                'The text content of the button. This will be hidden when `content-hidden` is set but should always be provided; see the **Accessibility** section for more info.',
+            description: textContentDescription({ componentName: 'menu button' }),
             table: { category: apiCategory.slots }
         },
         icon: {
@@ -94,7 +95,7 @@ const metadata: Meta<MenuButtonArgs> = {
         },
         disabled: {
             control: { type: 'boolean' },
-            description: 'Disables the button.',
+            description: disabledDescription({ componentName: 'menu button' }),
             table: { category: apiCategory.attributes }
         },
         contentHidden: {

--- a/packages/storybook/src/nimble/menu-button/menu-button.stories.ts
+++ b/packages/storybook/src/nimble/menu-button/menu-button.stories.ts
@@ -38,8 +38,8 @@ interface MenuButtonArgs {
     disabled: boolean;
     contentHidden: boolean;
     menuPosition: string;
-    toggle: () => void;
-    beforetoggle: () => void;
+    toggle: undefined;
+    beforetoggle: undefined;
 }
 
 const metadata: Meta<MenuButtonArgs> = {

--- a/packages/storybook/src/nimble/menu/menu.stories.ts
+++ b/packages/storybook/src/nimble/menu/menu.stories.ts
@@ -27,7 +27,7 @@ interface MenuItemArgsBase {
 }
 
 interface MenuItemArgs extends MenuItemArgsBase {
-    change: () => void;
+    change: undefined;
 }
 
 interface AnchorMenuItemArgs {

--- a/packages/storybook/src/nimble/number-field/number-field.mdx
+++ b/packages/storybook/src/nimble/number-field/number-field.mdx
@@ -12,10 +12,6 @@ Similar to a single line text box but only used for numeric data. The controls a
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/number-field/number-field.mdx
+++ b/packages/storybook/src/nimble/number-field/number-field.mdx
@@ -10,9 +10,11 @@ Similar to a single line text box but only used for numeric data. The controls a
 <Canvas of={numberFieldStories.underlineNumberField} />
 <Controls of={numberFieldStories.underlineNumberField} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/patterns/button/doc-strings.ts
+++ b/packages/storybook/src/nimble/patterns/button/doc-strings.ts
@@ -1,8 +1,8 @@
 import { iconDescription as baseIconDescription } from '../../../utilities/storybook';
 
-export const appearanceDescription = 'This attribute affects the appearance of the button.';
+export const appearanceDescription = 'This attribute affects the appearance of the button. See the **Styling** section for more information.';
 
-export const appearanceVariantDescription = 'This attribute has no effect on buttons with a `ghost` appearance. There is no `accent` appearance-variant for the `color` UI.';
+export const appearanceVariantDescription = 'This attribute configures additional variations of the button appearance. It has no effect on buttons with a `ghost` appearance. There is no `accent` appearance-variant for the `color` UI.  See the **Styling** section for more information.';
 
 export const contentHiddenDescription = 'When set, this attribute hides the text and end icon, leaving only the start icon visible.';
 

--- a/packages/storybook/src/nimble/patterns/button/doc-strings.ts
+++ b/packages/storybook/src/nimble/patterns/button/doc-strings.ts
@@ -1,4 +1,6 @@
-import { iconDescription as baseIconDescription } from '../../../utilities/storybook';
+import { textContentDescription as baseTextContentDescription, iconDescription as baseIconDescription } from '../../../utilities/storybook';
+
+export const textContentDescription = (options: { componentName: string }): string => `${baseTextContentDescription(options)} This will be hidden when \`content-hidden\` is set but should always be provided; see the **Accessibility** section for more info.`;
 
 export const appearanceDescription = 'This attribute affects the appearance of the button. See the **Styling** section for more information.';
 

--- a/packages/storybook/src/nimble/patterns/button/styling-docs.mdx
+++ b/packages/storybook/src/nimble/patterns/button/styling-docs.mdx
@@ -1,7 +1,5 @@
 import { NimbleIconKey } from '../../icons/key.react';
 
-## Styling
-
 ### Appearances
 
 These are the standard styling options for the button. Each should be considered for use before employing an appearance variant.

--- a/packages/storybook/src/nimble/radio-group/radio-group.mdx
+++ b/packages/storybook/src/nimble/radio-group/radio-group.mdx
@@ -9,9 +9,11 @@ Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/radio/) - A radio group is a 
 <Canvas of={radioGroupStories.radioGroup} />
 <Controls of={radioGroupStories.radioGroup} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/radio-group/radio-group.mdx
+++ b/packages/storybook/src/nimble/radio-group/radio-group.mdx
@@ -11,10 +11,6 @@ Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/radio/) - A radio group is a 
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/select/select.mdx
+++ b/packages/storybook/src/nimble/select/select.mdx
@@ -11,9 +11,11 @@ Select is a control for selecting amongst a set of options. Its value comes from
 <Canvas of={selectStories.underlineSelect} />
 <Controls of={selectStories.underlineSelect} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/select/select.mdx
+++ b/packages/storybook/src/nimble/select/select.mdx
@@ -13,10 +13,6 @@ Select is a control for selecting amongst a set of options. Its value comes from
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/switch/switch.mdx
+++ b/packages/storybook/src/nimble/switch/switch.mdx
@@ -15,9 +15,11 @@ pressed or not pressed and can optionally allow for a partially pressed state.
 <Canvas of={switchStories.switchStory} />
 <Controls of={switchStories.switchStory} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/switch/switch.mdx
+++ b/packages/storybook/src/nimble/switch/switch.mdx
@@ -17,10 +17,6 @@ pressed or not pressed and can optionally allow for a partially pressed state.
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/table-column/date-text/table-column-date-text.mdx
+++ b/packages/storybook/src/nimble/table-column/date-text/table-column-date-text.mdx
@@ -13,9 +13,11 @@ The <Tag name={tableColumnDateTextTag}/> column is used to display date-time fie
 <Canvas of={tableColumnDateTextStories.dateTextColumn} />
 <Controls of={tableColumnDateTextStories.dateTextColumn} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 ## Usage
 

--- a/packages/storybook/src/nimble/table-column/date-text/table-column-date-text.mdx
+++ b/packages/storybook/src/nimble/table-column/date-text/table-column-date-text.mdx
@@ -15,10 +15,6 @@ The <Tag name={tableColumnDateTextTag}/> column is used to display date-time fie
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 ## Usage
 
 ### Best Practices

--- a/packages/storybook/src/nimble/table-column/number-text/table-column-number-text.mdx
+++ b/packages/storybook/src/nimble/table-column/number-text/table-column-number-text.mdx
@@ -20,9 +20,11 @@ based on the value of the `lang` token, which can be set via the [nimble-theme-p
 <Canvas of={tableColumnNumberTextStories.numberTextColumn} />
 <Controls of={tableColumnNumberTextStories.numberTextColumn} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 ## Usage
 

--- a/packages/storybook/src/nimble/table-column/number-text/table-column-number-text.mdx
+++ b/packages/storybook/src/nimble/table-column/number-text/table-column-number-text.mdx
@@ -22,10 +22,6 @@ based on the value of the `lang` token, which can be set via the [nimble-theme-p
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 ## Usage
 
 ### Best Practices

--- a/packages/storybook/src/nimble/table-column/text/table-column-text.mdx
+++ b/packages/storybook/src/nimble/table-column/text/table-column-text.mdx
@@ -15,10 +15,6 @@ The <Tag name={tableColumnTextTag}/> column is used to display string fields as 
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 ## Usage
 
 ### Best Practices

--- a/packages/storybook/src/nimble/table-column/text/table-column-text.mdx
+++ b/packages/storybook/src/nimble/table-column/text/table-column-text.mdx
@@ -13,9 +13,11 @@ The <Tag name={tableColumnTextTag}/> column is used to display string fields as 
 <Canvas of={tableColumnTextStories.textColumn} />
 <Controls of={tableColumnTextStories.textColumn} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 ## Usage
 

--- a/packages/storybook/src/nimble/table/table.mdx
+++ b/packages/storybook/src/nimble/table/table.mdx
@@ -55,6 +55,8 @@ The expected usage of the dynamically loaded hierarchy is as follows:
 
 {/* ### Appearance Variants */}
 
+### Sizing
+
 The <Tag name={tableTag}/> should be sized explicitly or sized to fill the space of a parent container. The <Tag name={tableTag}/> does not currently support being styled with `height: auto`. The ability to auto size the table is tracked with [issue 1624](https://github.com/ni/nimble/issues/1624).
 
 {/* ## Usage */}

--- a/packages/storybook/src/nimble/table/table.mdx
+++ b/packages/storybook/src/nimble/table/table.mdx
@@ -51,10 +51,6 @@ The expected usage of the dynamically loaded hierarchy is as follows:
 
 ## Styling
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 ### Sizing
 
 The <Tag name={tableTag}/> should be sized explicitly or sized to fill the space of a parent container. The <Tag name={tableTag}/> does not currently support being styled with `height: auto`. The ability to auto size the table is tracked with [issue 1624](https://github.com/ni/nimble/issues/1624).

--- a/packages/storybook/src/nimble/table/table.mdx
+++ b/packages/storybook/src/nimble/table/table.mdx
@@ -49,13 +49,11 @@ The expected usage of the dynamically loaded hierarchy is as follows:
 -   the table will not render delayed hierarchy state (loading or expandable) if the table's `parentIdFieldName` is not configured; however, the options will remain cached within the table if the `parentIdFieldName` becomes `undefined`, and that cached configuration will render in the table if the table's `parentIdFieldName` is changed back to a non-`undefined` value
 -   calling `setData` will clear options associated with IDs that are no longer present in the data
 
-{/* ## Styling */}
+## Styling
 
 {/* ### Appearances */}
 
 {/* ### Appearance Variants */}
-
-## Styling
 
 The <Tag name={tableTag}/> should be sized explicitly or sized to fill the space of a parent container. The <Tag name={tableTag}/> does not currently support being styled with `height: auto`. The ability to auto size the table is tracked with [issue 1624](https://github.com/ni/nimble/issues/1624).
 

--- a/packages/storybook/src/nimble/table/table.mdx
+++ b/packages/storybook/src/nimble/table/table.mdx
@@ -49,9 +49,11 @@ The expected usage of the dynamically loaded hierarchy is as follows:
 -   the table will not render delayed hierarchy state (loading or expandable) if the table's `parentIdFieldName` is not configured; however, the options will remain cached within the table if the `parentIdFieldName` becomes `undefined`, and that cached configuration will render in the table if the table's `parentIdFieldName` is changed back to a non-`undefined` value
 -   calling `setData` will clear options associated with IDs that are no longer present in the data
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 ## Styling
 

--- a/packages/storybook/src/nimble/tabs/tabs.mdx
+++ b/packages/storybook/src/nimble/tabs/tabs.mdx
@@ -20,10 +20,6 @@ If you want a sequence of tabs that navigate to different URLs, use the Anchor T
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/tabs/tabs.mdx
+++ b/packages/storybook/src/nimble/tabs/tabs.mdx
@@ -18,9 +18,11 @@ If you want a sequence of tabs that navigate to different URLs, use the Anchor T
 <Canvas of={tabsStories.tabs} />
 <Controls of={tabsStories.tabs} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/text-area/text-area.mdx
+++ b/packages/storybook/src/nimble/text-area/text-area.mdx
@@ -14,10 +14,6 @@ If you configure your text area to be resizable (with the `resize` attribute) in
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/text-area/text-area.mdx
+++ b/packages/storybook/src/nimble/text-area/text-area.mdx
@@ -12,9 +12,11 @@ If you configure your text area to be resizable (with the `resize` attribute) in
 <Canvas of={textAreaStories.outlineTextArea} />
 <Controls of={textAreaStories.outlineTextArea} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/text-field/text-field.mdx
+++ b/packages/storybook/src/nimble/text-field/text-field.mdx
@@ -10,9 +10,11 @@ A single-line text field.
 <Canvas of={textFieldStories.underlineTextField} />
 <Controls of={textFieldStories.underlineTextField} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/text-field/text-field.mdx
+++ b/packages/storybook/src/nimble/text-field/text-field.mdx
@@ -12,10 +12,6 @@ A single-line text field.
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/toggle-button/toggle-button.mdx
+++ b/packages/storybook/src/nimble/toggle-button/toggle-button.mdx
@@ -9,9 +9,7 @@ import * as toggleButtonStories from './toggle-button.stories';
 
 Per [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/button/) - A toggle button is a two-state button
 that can be either off (not pressed) or on (pressed). For example, a button labeled mute in an audio player could
-indicate that sound is muted by setting the pressed state true. Important: it is critical the label on a toggle does
-not change when its state changes. In this example, when the pressed state is true, the label remains "Mute" so a
-screen reader would say something like "Mute toggle button pressed".
+indicate that sound is muted by setting the pressed state true.
 
 <Canvas of={toggleButtonStories.outlineButton} />
 

--- a/packages/storybook/src/nimble/toggle-button/toggle-button.mdx
+++ b/packages/storybook/src/nimble/toggle-button/toggle-button.mdx
@@ -14,7 +14,12 @@ not change when its state changes. In this example, when the pressed state is tr
 screen reader would say something like "Mute toggle button pressed".
 
 <Canvas of={toggleButtonStories.outlineButton} />
+
+## API
+
 <Controls of={toggleButtonStories.outlineButton} />
+
+## Styling
 
 <StylingDocs components={{ Button: toggleButtonTag }} />
 

--- a/packages/storybook/src/nimble/toggle-button/toggle-button.stories.ts
+++ b/packages/storybook/src/nimble/toggle-button/toggle-button.stories.ts
@@ -24,7 +24,7 @@ interface ToggleButtonArgs {
     icon: boolean;
     contentHidden: boolean;
     endIcon: boolean;
-    change: () => void;
+    change: undefined;
 }
 
 const contentDescription = textContentDescription({ componentName: 'toggle button' });

--- a/packages/storybook/src/nimble/toggle-button/toggle-button.stories.ts
+++ b/packages/storybook/src/nimble/toggle-button/toggle-button.stories.ts
@@ -10,9 +10,10 @@ import {
     appearanceVariantDescription,
     contentHiddenDescription,
     endIconDescription,
-    iconDescription
+    iconDescription,
+    textContentDescription
 } from '../patterns/button/doc-strings';
-import { createUserSelectedThemeStory } from '../../utilities/storybook';
+import { apiCategory, createUserSelectedThemeStory, disabledDescription } from '../../utilities/storybook';
 
 interface ToggleButtonArgs {
     label: string;
@@ -23,7 +24,12 @@ interface ToggleButtonArgs {
     icon: boolean;
     contentHidden: boolean;
     endIcon: boolean;
+    change: () => void;
 }
+
+const contentDescription = textContentDescription({ componentName: 'toggle button' });
+
+const defaultSlotDescription = `${contentDescription} The content should remain the same whether the toggle button is pressed or not.`;
 
 const metadata: Meta<ToggleButtonArgs> = {
     title: 'Components/Toggle Button',
@@ -35,24 +41,49 @@ const metadata: Meta<ToggleButtonArgs> = {
     },
     argTypes: {
         appearance: {
-            options: Object.values(ButtonAppearance),
+            options: Object.keys(ButtonAppearance),
             control: { type: 'radio' },
-            description: appearanceDescription
+            description: appearanceDescription,
+            table: { category: apiCategory.attributes }
         },
         appearanceVariant: {
             name: 'appearance-variant',
             options: Object.keys(ButtonAppearanceVariant),
             control: { type: 'radio' },
-            description: appearanceVariantDescription
+            description: appearanceVariantDescription,
+            table: { category: apiCategory.attributes }
         },
         contentHidden: {
-            description: contentHiddenDescription
+            name: 'content-hidden',
+            description: contentHiddenDescription,
+            table: { category: apiCategory.attributes }
+        },
+        disabled: {
+            description: disabledDescription({ componentName: 'toggle button' }),
+            table: { category: apiCategory.attributes }
+        },
+        checked: {
+            description: 'Whether the toggle button is pressed (on) or not pressed (off).',
+            table: { category: apiCategory.attributes }
+        },
+        label: {
+            name: 'default',
+            description: defaultSlotDescription,
+            table: { category: apiCategory.slots }
         },
         icon: {
-            description: iconDescription
+            name: 'start',
+            description: iconDescription,
+            table: { category: apiCategory.slots }
         },
         endIcon: {
-            description: endIconDescription
+            name: 'end',
+            description: endIconDescription,
+            table: { category: apiCategory.slots }
+        },
+        change: {
+            description: 'Fires when the toggle button is pressed via mouse or keyboard.',
+            table: { category: apiCategory.events }
         }
     },
     // prettier-ignore

--- a/packages/storybook/src/nimble/toolbar/toolbar.mdx
+++ b/packages/storybook/src/nimble/toolbar/toolbar.mdx
@@ -24,10 +24,6 @@ nimble-toolbar::part(positioning-region) {
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/toolbar/toolbar.mdx
+++ b/packages/storybook/src/nimble/toolbar/toolbar.mdx
@@ -22,9 +22,11 @@ nimble-toolbar::part(positioning-region) {
 
 <Canvas of={toolbarStories.toolbar} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/tooltip/tooltip.mdx
+++ b/packages/storybook/src/nimble/tooltip/tooltip.mdx
@@ -13,10 +13,6 @@ It is recommended to set up aria-describedby, an accessibility feature that sets
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/tooltip/tooltip.mdx
+++ b/packages/storybook/src/nimble/tooltip/tooltip.mdx
@@ -11,9 +11,11 @@ It is recommended to set up aria-describedby, an accessibility feature that sets
 <Canvas of={tooltipStories.tooltip} />
 <Controls of={tooltipStories.tooltip} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/tree-view/tree-view.mdx
+++ b/packages/storybook/src/nimble/tree-view/tree-view.mdx
@@ -20,9 +20,11 @@ which navigate to a url upon activation. Both types of tree items support icons 
 <Canvas of={treeViewStories.treeItem} />
 <Controls of={treeViewStories.treeItem} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/tree-view/tree-view.mdx
+++ b/packages/storybook/src/nimble/tree-view/tree-view.mdx
@@ -22,10 +22,6 @@ which navigate to a url upon activation. Both types of tree items support icons 
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/wafer-map/wafer-map.mdx
+++ b/packages/storybook/src/nimble/wafer-map/wafer-map.mdx
@@ -12,10 +12,6 @@ A wafer map is a component for visualizing data from the manufacture of semicond
 
 {/* ## Styling */}
 
-{/* ### Appearances */}
-
-{/* ### Appearance Variants */}
-
 {/* ## Usage */}
 
 {/* ## Examples */}

--- a/packages/storybook/src/nimble/wafer-map/wafer-map.mdx
+++ b/packages/storybook/src/nimble/wafer-map/wafer-map.mdx
@@ -10,9 +10,11 @@ A wafer map is a component for visualizing data from the manufacture of semicond
 <Canvas of={waferMapStories.waferMap} />
 <Controls of={waferMapStories.waferMap} />
 
-{/* ## Appearances */}
+{/* ## Styling */}
 
-{/* ## Appearance Variants */}
+{/* ### Appearances */}
+
+{/* ### Appearance Variants */}
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/utilities/storybook.ts
+++ b/packages/storybook/src/utilities/storybook.ts
@@ -170,5 +170,5 @@ export const apiCategory = {
 } as const;
 
 export const iconDescription = 'Set `slot="start"` to include an icon before the text content.';
-export const disabledDescription = (options: { componentName: string }): string => `Disables the ${options.componentName}.`;
+export const disabledDescription = (options: { componentName: string }): string => `Styles the ${options.componentName} as disabled and prevents focus and user interaction.`;
 export const textContentDescription = (options: { componentName: string }): string => `The text content of the ${options.componentName}.`;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As part of #824 we want to improve the accuracy and comprehensiveness of our storybook API documentation.

## 👩‍💻 Implementation

1. Update `button`, `toggle-button`, and `card-button` to follow new API doc pattern. (I'll do `anchor-button` along with other anchors).
2. Add and tweak wording on shared documentation strings and utilities
3. Tweak organization of MDX headings in all stories to put Appearance and Sizing under Styling
4. Add CONTRIBUTING guidance about referring to sections within docs (in previous PRs we gave up on trying to link to sections and started using bolded text instead).

## 🧪 Testing

Local storybook exploration

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
