### PR TITLE
Color visited links distinctly

### DIFF
--- a/change/@ni-nimble-components-0c029825-498d-4f88-944e-2388a1ba0983.json
+++ b/change/@ni-nimble-components-0c029825-498d-4f88-944e-2388a1ba0983.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Color visited links distinctly",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/anchor/styles.ts
+++ b/packages/nimble-components/src/anchor/styles.ts
@@ -7,7 +7,9 @@ import {
     linkDisabledFontColor,
     linkFont,
     linkFontColor,
-    linkProminentFontColor
+    linkProminentFontColor,
+    linkActiveVisitedColor,
+    linkVisitedColor
 } from '../theme-provider/design-tokens';
 
 export const styles = css`
@@ -36,6 +38,10 @@ export const styles = css`
 
         :host([appearance='prominent']) .control {
             color: ${linkProminentFontColor};
+        }
+
+        .control:visited {
+            color: ${linkVisitedColor};
         }
 
         [part='start'] {
@@ -69,11 +75,14 @@ export const styles = css`
         .control:active {
             color: ${linkActiveFontColor};
             text-decoration: underline;
-            box-shadow: none;
         }
 
         :host([appearance='prominent']) .control:active {
             color: ${linkActiveProminentFontColor};
+        }
+
+        .control:active:visited {
+            color: ${linkActiveVisitedColor};
         }
 
         :host([underline-hidden]) .control:active {

--- a/packages/nimble-components/src/theme-provider/design-token-comments.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-comments.ts
@@ -46,6 +46,8 @@ export const comments: { readonly [key in TokenName]: string } = {
     popupBorderColor: 'Border color for menus and dialog boxes',
     cardBorderColor: 'Border color for cards',
     tagFillColor: 'Background fill color for tags, chips, or pills',
+    linkVisitedColor: 'Text color for visited links',
+    linkActiveVisitedColor: 'Text color for active visited links',
     controlHeight:
         'Standard layout height for all controls. Add "labelHeight" for labels on top.',
     controlSlimHeight:

--- a/packages/nimble-components/src/theme-provider/design-token-names.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-names.ts
@@ -37,6 +37,8 @@ export const tokenNames: { readonly [key in TokenName]: string } = {
     popupBorderColor: 'popup-border-color',
     cardBorderColor: 'card-border-color',
     tagFillColor: 'tag-fill-color',
+    linkVisitedColor: 'link-visited-color',
+    linkActiveVisitedColor: 'link-active-visited-color',
     controlHeight: 'control-height',
     controlSlimHeight: 'control-slim-height',
     smallPadding: 'small-padding',

--- a/packages/nimble-components/src/theme-provider/design-tokens.ts
+++ b/packages/nimble-components/src/theme-provider/design-tokens.ts
@@ -98,7 +98,9 @@ import {
     GridHeaderFamily,
     GridHeaderWeight,
     GridHeaderSize,
-    DigitalGreenDark105
+    DigitalGreenDark105,
+    NiIndigo,
+    IndigoDark1
 } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
 import {
     modalBackdropColorThemeColorStatic,
@@ -253,6 +255,24 @@ export const buttonBorderAccentOutlineColor = DesignToken.create<string>(
     DigitalGreenLight,
     PowerGreen,
     hexToRgbaCssColor(White, 0.3)
+));
+
+export const linkVisitedColor = DesignToken.create<string>(
+    styleNameFromTokenName(tokenNames.linkVisitedColor)
+).withDefault((element: HTMLElement) => getColorForTheme(
+    element,
+    Information100LightUi,
+    Information100DarkUi,
+    hexToRgbaCssColor(White, 0.6)
+));
+
+export const linkActiveVisitedColor = DesignToken.create<string>(
+    styleNameFromTokenName(tokenNames.linkActiveVisitedColor)
+).withDefault((element: HTMLElement) => getColorForTheme(
+    element,
+    IndigoDark1,
+    NiIndigo,
+    hexToRgbaCssColor(White, 0.75)
 ));
 
 // Component Sizing Tokens

--- a/packages/storybook/src/nimble/anchor/anchor-matrix.stories.ts
+++ b/packages/storybook/src/nimble/anchor/anchor-matrix.stories.ts
@@ -62,7 +62,7 @@ export const anchorThemeMatrix: StoryFn = createMatrixThemeStory(
     ])
 );
 
-const interactionStatesHover = cartesianProduct([
+const interactionStatesIncludingDisabled = cartesianProduct([
     disabledStates,
     underlineHiddenStates,
     appearanceStates
@@ -76,10 +76,15 @@ const interactionStates = cartesianProduct([
 
 export const anchorInteractionsThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrixInteractionsFromStates(component, {
-        hover: interactionStatesHover,
+        hover: interactionStatesIncludingDisabled,
         hoverActive: interactionStates,
         active: interactionStates,
-        focus: interactionStates
+        focus: interactionStates,
+        visited: {
+            plain: interactionStatesIncludingDisabled,
+            active: interactionStates,
+            focus: interactionStates
+        }
     })
 );
 

--- a/packages/storybook/src/utilities/matrix.ts
+++ b/packages/storybook/src/utilities/matrix.ts
@@ -110,16 +110,23 @@ export function createMatrixInteractionsFromStates<
     THover extends readonly unknown[],
     THoverActive extends readonly unknown[],
     TActive extends readonly unknown[],
-    TFocus extends readonly unknown[]
+    TFocus extends readonly unknown[],
+    TVisited extends readonly unknown[],
+    TVisitedCombinations extends {
+        plain: TVisited[],
+        active: TActive[],
+        focus: TFocus[]
+    }
 >(
     component: (
-        ...states: THover | TActive | THoverActive | TFocus
+        ...states: THover | TActive | THoverActive | TFocus | TVisited
     ) => ViewTemplate,
     states: {
         hover: THover[],
         hoverActive: THoverActive[],
         active: TActive[],
-        focus: TFocus[]
+        focus: TFocus[],
+        visited?: TVisitedCombinations
     }
 ): ViewTemplate {
     // prettier-ignore
@@ -144,6 +151,20 @@ export function createMatrixInteractionsFromStates<
             <p>Focus</p>
             ${createMatrixFromStates(component, states.focus)}
         </div>
+        ${states.visited ? html`
+            <div class="pseudo-visited-all">
+                <p>Visited</p>
+                ${createMatrixFromStates(component, states.visited.plain)}
+            </div>
+            <div class="pseudo-visited-all pseudo-active-all">
+                <p>Visited and active</p>
+                ${createMatrixFromStates(component, states.visited.active)}
+            </div>
+            <div class="pseudo-visited-all pseudo-focus-visible-all pseudo-focus-within-all">
+                <p>Visited and focus</p>
+                ${createMatrixFromStates(component, states.visited.focus)}
+            </div>
+        ` : ''}
     </div>
 `;
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Part of #2011

## 👩‍💻 Implementation

- Changed color of visited anchors per the [design in Figma](https://www.figma.com/design/PO9mFOu5BCl8aJvFchEeuN/Nimble_Components?node-id=8729-84171&t=ZWhzibWRmDT2XoD7-0).
- Created two new theme-aware tokens for this
- Added interesting "visited" cases to the anchor's interaction matrix story. This required updates to the `createMatrixInteractionsFromStates` utility function.

## 🧪 Testing

Added visual tests, and manually tested in Storybook.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.