### PR TITLE
Make clear select button match design spec

### DIFF
--- a/change/@ni-nimble-components-85683753-1a07-4b68-bedc-a0b406157f56.json
+++ b/change/@ni-nimble-components-85683753-1a07-4b68-bedc-a0b406157f56.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make clear select button match design spec",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/select/styles.ts
+++ b/packages/nimble-components/src/select/styles.ts
@@ -6,6 +6,7 @@ import {
     borderRgbPartialColor,
     borderWidth,
     controlHeight,
+    controlSlimHeight,
     fillHoverColor,
     fillHoverSelectedColor,
     fillSelectedColor,
@@ -39,8 +40,7 @@ export const styles = css`
 
     .clear-button {
         order: 3;
-        width: auto;
-        height: auto;
+        height: ${controlSlimHeight};
         margin-left: ${smallPadding};
     }
 

--- a/packages/nimble-components/src/select/template.ts
+++ b/packages/nimble-components/src/select/template.ts
@@ -23,7 +23,7 @@ import {
 } from '../label-provider/core/label-tokens';
 import { FilterMode } from './types';
 import { buttonTag } from '../button';
-import { iconXmarkTag } from '../icons/xmark';
+import { iconTimesTag } from '../icons/times';
 
 /* eslint-disable @typescript-eslint/indent */
 // prettier-ignore
@@ -74,7 +74,7 @@ SelectOptions
                             content-hidden
                             appearance="ghost"
                             @click="${(x, c) => x.clearClickHandler(c.event as MouseEvent)}">
-                            <${iconXmarkTag} slot="start"></${iconXmarkTag}>
+                            <${iconTimesTag} slot="start"></${iconTimesTag}>
                         </${buttonTag}>
                     `)}
                     <div aria-hidden="true" class="indicator" part="indicator">


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The clear button in the nimble-select deviated from the design spec in two ways:
- The button was 18px by 18px rather than 24px by 24px
- The icon in the button was `nimble-icon-xmark` rather than `nimble-icon-times`

## 👩‍💻 Implementation

- Update icon and button size

## 🧪 Testing

Manually tested in storybook

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
