### PR TITLE
Angular i18n enable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5917,9 +5917,9 @@
       "link": true
     },
     "node_modules/@ni/eslint-config-angular": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@ni/eslint-config-angular/-/eslint-config-angular-7.0.0.tgz",
-      "integrity": "sha512-VXWhigyI+DtJfAkgVwHUOIswSaQS31j9b0/lYi3obWsraXcoP+NKOwZDW23IbOodrnovXY1On+Z9oDRo6a0XHw==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@ni/eslint-config-angular/-/eslint-config-angular-7.0.5.tgz",
+      "integrity": "sha512-wWVCriua+ZaGCBrRYv92fWl+Jk+nPeyQgzVgK/Ap+lmnPZoJR8/ud81Beu5OCSt3m0GqUvbIzt/oyNS4VEPQUw==",
       "dev": true,
       "peerDependencies": {
         "@angular-eslint/builder": "^16.3.1",
@@ -32624,7 +32624,7 @@
         "@angular/localize": "^16.2.12",
         "@lhci/cli": "^0.13.0",
         "@microsoft/fast-web-utilities": "^6.0.0",
-        "@ni/eslint-config-angular": "^7.0.0",
+        "@ni/eslint-config-angular": "^7.0.5",
         "@ni/eslint-config-javascript": "^4.2.0",
         "@ni/eslint-config-typescript": "^4.2.0",
         "@ni/jasmine-parameterized": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5917,9 +5917,9 @@
       "link": true
     },
     "node_modules/@ni/eslint-config-angular": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@ni/eslint-config-angular/-/eslint-config-angular-7.0.5.tgz",
-      "integrity": "sha512-wWVCriua+ZaGCBrRYv92fWl+Jk+nPeyQgzVgK/Ap+lmnPZoJR8/ud81Beu5OCSt3m0GqUvbIzt/oyNS4VEPQUw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@ni/eslint-config-angular/-/eslint-config-angular-7.0.6.tgz",
+      "integrity": "sha512-t0ytVl64IJK+Erzj6IMZImi3mAKXvNp4gfoQQdrbF6CEfehFcm7dQ4dygTNoyNMJhKSd5h39WEZGmDjoI0h0+w==",
       "dev": true,
       "peerDependencies": {
         "@angular-eslint/builder": "^16.3.1",
@@ -32624,7 +32624,7 @@
         "@angular/localize": "^16.2.12",
         "@lhci/cli": "^0.13.0",
         "@microsoft/fast-web-utilities": "^6.0.0",
-        "@ni/eslint-config-angular": "^7.0.5",
+        "@ni/eslint-config-angular": "^7.0.6",
         "@ni/eslint-config-javascript": "^4.2.0",
         "@ni/eslint-config-typescript": "^4.2.0",
         "@ni/jasmine-parameterized": "*",

--- a/packages/angular-workspace/.eslintrc.js
+++ b/packages/angular-workspace/.eslintrc.js
@@ -1,3 +1,5 @@
+const { ignoreAttributes } = require('@ni/eslint-config-angular/template/options');
+
 module.exports = {
     root: true,
     ignorePatterns: [
@@ -104,9 +106,27 @@ module.exports = {
             '@ni/eslint-config-angular/template'
         ],
         rules: {
-            // nimble-angular shouldn't provide user-visible strings so doesn't need i18n
-            // example-client-app is just for demo purposes and isn't anticipated to be localized
-            '@angular-eslint/template/i18n': 'off'
+            // Enable i18n template checking for the purpose of making sure to capture updates for the lint rules
+            // New entries should be added to the ignoreAttributeSets:
+            // See: https://github.com/ni/javascript-styleguide/blob/main/packages/eslint-config-angular/template/options.js
+            '@angular-eslint/template/i18n': [
+                'error',
+                {
+                    checkText: false,
+                    checkId: false,
+                    ignoreAttributes: [
+                        ...ignoreAttributes.all,
+                        // The following attributes should be marked i18n in production applications but
+                        // are ignored here as they do not actually need to be marked for tests / example apps
+                        'action-menu-label',
+                        'aria-label',
+                        'button-label',
+                        'placeholder',
+                        'text',
+                        'title'
+                    ]
+                }
+            ],
         }
     }, {
         files: ['*.js'],

--- a/packages/angular-workspace/package.json
+++ b/packages/angular-workspace/package.json
@@ -46,7 +46,7 @@
     "@angular/localize": "^16.2.12",
     "@lhci/cli": "^0.13.0",
     "@microsoft/fast-web-utilities": "^6.0.0",
-    "@ni/eslint-config-angular": "^7.0.5",
+    "@ni/eslint-config-angular": "^7.0.6",
     "@ni/eslint-config-javascript": "^4.2.0",
     "@ni/eslint-config-typescript": "^4.2.0",
     "@ni/jasmine-parameterized": "*",

--- a/packages/angular-workspace/package.json
+++ b/packages/angular-workspace/package.json
@@ -46,7 +46,7 @@
     "@angular/localize": "^16.2.12",
     "@lhci/cli": "^0.13.0",
     "@microsoft/fast-web-utilities": "^6.0.0",
-    "@ni/eslint-config-angular": "^7.0.0",
+    "@ni/eslint-config-angular": "^7.0.5",
     "@ni/eslint-config-javascript": "^4.2.0",
     "@ni/eslint-config-typescript": "^4.2.0",
     "@ni/jasmine-parameterized": "*",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Enables the i18n attribute lint rule for the angular-workspace. The goal is to have some level of automation in detecting attributes that should not be marked i18n early to add to the javascript style guide angular eslint configuration.

## 👩‍💻 Implementation

- Enabled the rule with a local list of exceptions.
- Found that even though the i18n attributes rule is enabled for all files, it does not seem to run for our tests. Seems to be because our inline templates in tests are not defined at the top-level of the file. Created angular-eslint issue: https://github.com/angular-eslint/angular-eslint/issues/1825

## 🧪 Testing

Rely on CI.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed. Comments are in the eslint config, didn't seem like additional were neecessary.
