### PR TITLE
Angular reduce test verbosity

### DIFF
--- a/change/@ni-nimble-angular-51664bbb-8d98-4796-991a-23f64c154a16.json
+++ b/change/@ni-nimble-angular-51664bbb-8d98-4796-991a-23f64c154a16.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Switch to low verbosity spec reporter",
+  "packageName": "@ni/nimble-angular",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-spright-angular-a290383d-e0f8-45b5-9131-4b40694c2c18.json
+++ b/change/@ni-spright-angular-a290383d-e0f8-45b5-9131-4b40694c2c18.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Switch to low verbosity spec reporter",
+  "packageName": "@ni/spright-angular",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33415,6 +33415,7 @@
         "karma-coverage": "^2.0.3",
         "karma-jasmine": "^5.1.0",
         "karma-jasmine-html-reporter": "^2.0.0",
+        "karma-spec-reporter": "^0.0.36",
         "ng-packagr": "^16.2.3",
         "playwright": "1.42.0",
         "rollup": "^4.12.0",

--- a/packages/angular-workspace/example-client-app/karma.conf.js
+++ b/packages/angular-workspace/example-client-app/karma.conf.js
@@ -11,6 +11,7 @@ module.exports = function (config) {
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
+      require('karma-spec-reporter'),
       require('karma-coverage'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
@@ -35,7 +36,12 @@ module.exports = function (config) {
         { type: 'text-summary' }
       ]
     },
-    reporters: ['progress', 'kjhtml'],
+    reporters: ['kjhtml', 'spec'],
+    specReporter: {
+      suppressPassed: true,
+      suppressSkipped: false,
+      showSpecTiming: true
+    },
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,

--- a/packages/angular-workspace/nimble-angular/karma.conf.js
+++ b/packages/angular-workspace/nimble-angular/karma.conf.js
@@ -5,6 +5,7 @@ process.env.CHROME_BIN = require('playwright').chromium.executablePath();
 const karmaJasmine = require('karma-jasmine');
 const karmaChromeLauncher = require('karma-chrome-launcher');
 const karmaJasmineHtmlReporter = require('karma-jasmine-html-reporter');
+const karmaSpecReporter = require('karma-spec-reporter');
 const karmaCoverage = require('karma-coverage');
 const karmaAngular = require('@angular-devkit/build-angular/plugins/karma');
 const path = require('path');
@@ -17,6 +18,7 @@ module.exports = config => {
             karmaJasmine,
             karmaChromeLauncher,
             karmaJasmineHtmlReporter,
+            karmaSpecReporter,
             karmaCoverage,
             karmaAngular
         ],
@@ -41,7 +43,12 @@ module.exports = config => {
                 { type: 'text-summary' }
             ]
         },
-        reporters: ['progress', 'kjhtml'],
+        reporters: ['kjhtml', 'spec'],
+        specReporter: {
+            suppressPassed: true,
+            suppressSkipped: false,
+            showSpecTiming: true
+        },
         port: 9876,
         colors: true,
         logLevel: config.LOG_INFO,

--- a/packages/angular-workspace/package.json
+++ b/packages/angular-workspace/package.json
@@ -61,6 +61,7 @@
     "karma-coverage": "^2.0.3",
     "karma-jasmine": "^5.1.0",
     "karma-jasmine-html-reporter": "^2.0.0",
+    "karma-spec-reporter": "^0.0.36",
     "ng-packagr": "^16.2.3",
     "playwright": "1.42.0",
     "rollup": "^4.12.0",

--- a/packages/angular-workspace/spright-angular/karma.conf.js
+++ b/packages/angular-workspace/spright-angular/karma.conf.js
@@ -5,6 +5,7 @@ process.env.CHROME_BIN = require('playwright').chromium.executablePath();
 const karmaJasmine = require('karma-jasmine');
 const karmaChromeLauncher = require('karma-chrome-launcher');
 const karmaJasmineHtmlReporter = require('karma-jasmine-html-reporter');
+const karmaSpecReporter = require('karma-spec-reporter');
 const karmaCoverage = require('karma-coverage');
 const karmaAngular = require('@angular-devkit/build-angular/plugins/karma');
 const path = require('path');
@@ -17,6 +18,7 @@ module.exports = config => {
             karmaJasmine,
             karmaChromeLauncher,
             karmaJasmineHtmlReporter,
+            karmaSpecReporter,
             karmaCoverage,
             karmaAngular
         ],
@@ -41,7 +43,12 @@ module.exports = config => {
                 { type: 'text-summary' }
             ]
         },
-        reporters: ['progress', 'kjhtml'],
+        reporters: ['kjhtml', 'spec'],
+        specReporter: {
+            suppressPassed: true,
+            suppressSkipped: false,
+            showSpecTiming: true
+        },
         port: 9876,
         colors: true,
         logLevel: config.LOG_INFO,


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

With a single validate command running all validation the verbosity of the angular karma logs makes it difficult to scan logs and identify test failures vs lint failures etc.

## 👩‍💻 Implementation

Switched angular to use `karma-spec-reporter` with low verbosity settings like nimble-components has been.

## 🧪 Testing

Ran locally and rely on CI.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
