### PR TITLE
Disable three more intermittent rich text tests

### DIFF
--- a/change/@ni-nimble-components-71a03cfe-7d36-40e8-b31f-425872712553.json
+++ b/change/@ni-nimble-components-71a03cfe-7d36-40e8-b31f-425872712553.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Disable three more intermittent rich text tests",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
@@ -1193,7 +1193,8 @@ describe('RichTextEditorMentionListbox', () => {
             expect(pageObject.isMentionListboxOpened()).toBeFalse();
         });
 
-        it('should commit mention into the editor on Enter', async () => {
+        // Intermittent, see https://github.com/ni/nimble/issues/2150
+        xit('should commit mention into the editor on Enter', async () => {
             await appendUserMentionConfiguration(element, [
                 { key: 'user:1', displayName: 'username1' }
             ]);
@@ -1212,7 +1213,8 @@ describe('RichTextEditorMentionListbox', () => {
             expect(pageObject.isMentionListboxOpened()).toBeFalse();
         });
 
-        it('should commit mention into the editor on Tab', async () => {
+        // Intermittent, see https://github.com/ni/nimble/issues/2150
+        xit('should commit mention into the editor on Tab', async () => {
             await appendUserMentionConfiguration(element, [
                 { key: 'user:1', displayName: 'username1' }
             ]);
@@ -1545,7 +1547,8 @@ describe('RichTextEditorMentionListbox', () => {
             expect(pageObject.isMentionListboxOpened()).toBeTrue();
         });
 
-        it('should show mention popup for multiple mention configuration elements', async () => {
+        // Intermittent, see https://github.com/ni/nimble/issues/2150
+        xit('should show mention popup for multiple mention configuration elements', async () => {
             await appendUserMentionConfiguration(element, [
                 { key: 'user:1', displayName: 'username1' },
                 { key: 'user:2', displayName: 'username2' }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Seems to be the same issue that caused Jesse to recently disable three RichTextEditorMention tests. See #2150. There are probably other tests that are intermittent, but I don't want to pre-emptively disable tests until we see them fail.

## 👩‍💻 Implementation

The usual.

## 🧪 Testing

N/A

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
