### PR TITLE
Address issue with select not recognizing when group options are updated.

### DIFF
--- a/change/@ni-nimble-components-74f7e672-53d5-4a77-84db-3f032a350bdb.json
+++ b/change/@ni-nimble-components-74f7e672-53d5-4a77-84db-3f032a350bdb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Address issue with select not recognizing when group options are updated",
+  "packageName": "@ni/nimble-components",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/select/index.ts
+++ b/packages/nimble-components/src/select/index.ts
@@ -298,6 +298,7 @@ export class Select
             const notifier = Observable.getNotifier(el);
             notifier.unsubscribe(this, 'hidden');
             notifier.unsubscribe(this, 'visuallyHidden');
+            notifier.unsubscribe(this, 'listOptions');
         });
         const options = this.getSlottedOptions(next);
         super.slottedOptionsChanged(prev, options);
@@ -313,6 +314,7 @@ export class Select
             const notifier = Observable.getNotifier(el);
             notifier.subscribe(this, 'hidden');
             notifier.subscribe(this, 'visuallyHidden');
+            notifier.subscribe(this, 'listOptions');
         });
         this.setProxyOptions();
         this.updateValue();
@@ -408,6 +410,11 @@ export class Select
             }
             case 'disabled': {
                 this.updateDisplayValue();
+                break;
+            }
+            case 'listOptions': {
+                // force refresh of slotted options for groups
+                this.slottedOptionsChanged(this.slottedOptions, this.slottedOptions);
                 break;
             }
             default:

--- a/packages/nimble-components/src/select/index.ts
+++ b/packages/nimble-components/src/select/index.ts
@@ -286,7 +286,6 @@ export class Select
         prev: Element[] | undefined,
         next: Element[] | undefined
     ): void {
-        const value = this.value;
         this.options.forEach(o => {
             const notifier = Observable.getNotifier(o);
             notifier.unsubscribe(this, 'value');
@@ -301,6 +300,8 @@ export class Select
             notifier.unsubscribe(this, 'listOptions');
         });
         const options = this.getSlottedOptions(next);
+        // reset selectedIndex in case the selected option was removed or reordered
+        this.selectedIndex = options.findIndex(o => o.selected);
         super.slottedOptionsChanged(prev, options);
 
         options.forEach(o => {
@@ -321,9 +322,6 @@ export class Select
         // We need to force an update to the filteredOptions observable
         // (by calling 'filterOptions()) so that the template correctly updates.
         this.filterOptions();
-        if (value) {
-            this.value = value;
-        }
     }
 
     /**

--- a/packages/nimble-components/src/select/index.ts
+++ b/packages/nimble-components/src/select/index.ts
@@ -412,7 +412,10 @@ export class Select
             }
             case 'listOptions': {
                 // force refresh of slotted options for groups
-                this.slottedOptionsChanged(this.slottedOptions, this.slottedOptions);
+                this.slottedOptionsChanged(
+                    this.slottedOptions,
+                    this.slottedOptions
+                );
                 break;
             }
             default:

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -1661,6 +1661,14 @@ describe('Select', () => {
             expect(element.options).toContain(newOption);
         });
 
+        it('removing option from group removes option from options of select', async () => {
+            const group = pageObject.getGroup(0);
+            const option = group.listOptions[0];
+            group.removeChild(option as Node);
+            await waitForUpdatesAsync();
+            expect(element.options).not.toContain(option!);
+        });
+
         it('placeholder can be defined in a group', async () => {
             const group = pageObject.getGroup(0);
             const placeholder = new ListOption('Placeholder', 'placeholder');

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -1653,6 +1653,28 @@ describe('Select', () => {
             expect(group.visuallyHidden).toBeFalse();
         });
 
+        it('adding option to group is added to options of select', async () => {
+            const group = pageObject.getGroup(0);
+            const newOption = new ListOption('New Option', 'new-option');
+            group.appendChild(newOption);
+            await waitForUpdatesAsync();
+            expect(element.options).toContain(newOption);
+        });
+
+        it('placeholder can be defined in a group', async () => {
+            const group = pageObject.getGroup(0);
+            const placeholder = new ListOption('Placeholder', 'placeholder');
+            placeholder.hidden = true;
+            placeholder.disabled = true;
+            placeholder.selected = true;
+            element.selectedIndex = -1;
+            group.insertAdjacentElement('afterbegin', placeholder);
+            await waitForUpdatesAsync();
+            expect(pageObject.getDisplayText()).toBe('Placeholder');
+            await clickAndWaitForOpen(element);
+            expect(pageObject.isOptionVisible(0)).toBeFalse();
+        });
+
         describe('filtering', () => {
             beforeEach(async () => {
                 element.filterMode = FilterMode.standard;

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -180,11 +180,9 @@ describe('Select', () => {
         await waitForUpdatesAsync();
         expect(element.value).toBe('two');
 
-        // Add option zero at the top of the options list
-        // prettier-ignore
-        element.insertAdjacentHTML(
-            'afterbegin',
-            '<nimble-list-option value="zero">Zero</nimble-list-option>'
+        element.insertBefore(
+            new ListOption('zero', 'zero'),
+            element.options[0]!
         );
         await waitForUpdatesAsync();
 
@@ -544,6 +542,19 @@ describe('Select', () => {
 
         expect(element.value).toBe('one');
         expect(changeEvent.calls.count()).toBe(0);
+
+        await disconnect();
+    });
+
+    it('removing selected option results in first selectable option being selected', async () => {
+        const { element, connect, disconnect } = await setup();
+        await connect();
+        await waitForUpdatesAsync();
+        expect(element.value).toBe('one');
+
+        element.removeChild(element.options[0]!);
+        await waitForUpdatesAsync();
+        expect(element.value).toBe('two');
 
         await disconnect();
     });
@@ -1653,12 +1664,21 @@ describe('Select', () => {
             expect(group.visuallyHidden).toBeFalse();
         });
 
-        it('adding option to group is added to options of select', async () => {
+        it('after adding option to a group, it can be selected', async () => {
             const group = pageObject.getGroup(0);
-            const newOption = new ListOption('New Option', 'new-option');
+            const newOption = new ListOption('New Option', 'new option');
             group.appendChild(newOption);
             await waitForUpdatesAsync();
-            expect(element.options).toContain(newOption);
+            await clickAndWaitForOpen(element);
+            pageObject.clickOptionWithDisplayText('New Option');
+            expect(element.value).toBe('new option');
+        });
+
+        it('removing selected option from group results in first selectable option being selected', async () => {
+            const group = pageObject.getGroup(0);
+            group.removeChild(group.listOptions[0] as Node);
+            await waitForUpdatesAsync();
+            expect(element.value).toBe('two');
         });
 
         it('removing option from group removes option from options of select', async () => {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Realized from a conversation that the `Select` wasn't reacting to updates to `ListOptionGroup` slotted content updates.

## 👩‍💻 Implementation

Simply needed to have the `Select` observe the `listOption` property of the `ListOptionGroup` elements it owns, and then call `slottedOptionsChanged` directly. Also required a slight change to how we maintain the currently selected option when the options are changed, particularly for when the selected option is removed.

## 🧪 Testing

Added a few unit tests.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
