### PR TITLE
Revert previous change as this causes a regression in Angular apps.

### DIFF
--- a/change/@ni-nimble-components-c2b8b01f-bf00-478f-8462-4f3996aaaaa4.json
+++ b/change/@ni-nimble-components-c2b8b01f-bf00-478f-8462-4f3996aaaaa4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert previous change as this causes a regression in Angular apps.",
+  "packageName": "@ni/nimble-components",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/select/index.ts
+++ b/packages/nimble-components/src/select/index.ts
@@ -286,6 +286,7 @@ export class Select
         prev: Element[] | undefined,
         next: Element[] | undefined
     ): void {
+        const value = this.value;
         this.options.forEach(o => {
             const notifier = Observable.getNotifier(o);
             notifier.unsubscribe(this, 'value');
@@ -300,8 +301,6 @@ export class Select
             notifier.unsubscribe(this, 'listOptions');
         });
         const options = this.getSlottedOptions(next);
-        // reset selectedIndex in case the selected option was removed or reordered
-        this.selectedIndex = options.findIndex(o => o.selected);
         super.slottedOptionsChanged(prev, options);
 
         options.forEach(o => {
@@ -322,6 +321,9 @@ export class Select
         // We need to force an update to the filteredOptions observable
         // (by calling 'filterOptions()) so that the template correctly updates.
         this.filterOptions();
+        if (value) {
+            this.value = value;
+        }
     }
 
     /**

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -546,19 +546,6 @@ describe('Select', () => {
         await disconnect();
     });
 
-    it('removing selected option results in first selectable option being selected', async () => {
-        const { element, connect, disconnect } = await setup();
-        await connect();
-        await waitForUpdatesAsync();
-        expect(element.value).toBe('one');
-
-        element.removeChild(element.options[0]!);
-        await waitForUpdatesAsync();
-        expect(element.value).toBe('two');
-
-        await disconnect();
-    });
-
     describe('with all options disabled', () => {
         async function setupAllDisabled(): Promise<Fixture<Select>> {
             const viewTemplate = html`
@@ -1673,13 +1660,6 @@ describe('Select', () => {
             await clickAndWaitForOpen(element);
             pageObject.clickOptionWithDisplayText('New Option');
             expect(element.value).toBe('new option');
-        });
-
-        it('removing selected option from group results in first selectable option being selected', async () => {
-            const group = pageObject.getGroup(0);
-            group.removeChild(group.listOptions[0] as Node);
-            await waitForUpdatesAsync();
-            expect(element.value).toBe('two');
         });
 
         it('removing option from group removes option from options of select', async () => {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

- #2175

## 👩‍💻 Implementation

When putting in the changes to have the `Select` respond to changes to a `ListOptionGroup`s slotted content, I made it so that if the selected option was removed, that the `selectedIndex` would get set to -1, and just have `setDefaultSelectedOption` handle setting the value. So, if a previous value had been set it was essentially forgotten about. This works except for the case where the value is set before _any_ options have been slotted, which happens in an Angular environment commonly.

For now, I'm just removing the logic change and the two tests I wrote to verify the new behavior I was trying to promote. The result of this is that if one removes the selected option from a `Select` that it won't change its value. I don't think this is correct behavior (as the native `select` does not do this), so I will file an issue to track this problem, but will note the Angular case to ensure we don't repeat the same implementation.

## 🧪 Testing

Just removed some tests that were added along with the breaking change.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
