### PR TITLE
Remove extra whitespace from mapping docs

### DIFF
--- a/packages/storybook/src/nimble/table-column/mapping/table-column-mapping.mdx
+++ b/packages/storybook/src/nimble/table-column/mapping/table-column-mapping.mdx
@@ -8,7 +8,6 @@ import * as textMappingStories from '../../mapping/text/mapping-text.stories';
 import ComponentApisLink from '../../../docs/component-apis-link.mdx';
 import { tableColumnMappingTag } from '../../../../../nimble-components/src/table-column/mapping';
 import { mappingEmptyTag } from '../../../../../nimble-components/src/mapping/empty';
-import { tableTag } from '../../../../../nimble-components/src/table';
 import { spinnerTag } from '../../../../../nimble-components/src/spinner';
 import iconOnlyIconHeader from './images/icon-only-icon-header.png';
 import iconOnlyTextHeader from './images/icon-only-text-header.png';

--- a/packages/storybook/src/nimble/table-column/mapping/table-column-mapping.mdx
+++ b/packages/storybook/src/nimble/table-column/mapping/table-column-mapping.mdx
@@ -22,7 +22,6 @@ import { NimbleSpinner } from '../../spinner/spinner.react';
 
 The <Tag name={tableColumnMappingTag}/> renders specific number, boolean, or
 string values as an icon, a spinner, text, or an icon/spinner with text in the
-
 <Tag name={tableTag} />.
 
 <p>{columnOperationBehavior}</p>

--- a/packages/storybook/src/nimble/table-column/mapping/table-column-mapping.mdx
+++ b/packages/storybook/src/nimble/table-column/mapping/table-column-mapping.mdx
@@ -22,7 +22,7 @@ import { NimbleSpinner } from '../../spinner/spinner.react';
 
 The <Tag name={tableColumnMappingTag}/> renders specific number, boolean, or
 string values as an icon, a spinner, text, or an icon/spinner with text in the
-<Tag name={tableTag} />.
+table.
 
 <p>{columnOperationBehavior}</p>
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

https://nimble.ni.dev/storybook/?path=/docs/components-table-column-mapping--docs

![image](https://github.com/ni/nimble/assets/10500124/f9582e56-e779-434a-b96b-9440d59b0f6e)


## 👩‍💻 Implementation

Change to use the table element's name instead of its tag. We use plain text element names and code-formatted element tags pretty interchangeably throughout our docs.

I would mildly prefer to keep using the`<Tag>` but Prettier is insisting on putting an extra newline before it if it's the first thing on a line. I played with some [configuration options](https://prettier.io/docs/en/options.html) and couldn't find one to change that behavior.

Other options include moving this string to the `.stories.ts` file, adding inline prettier ignores, or debugging further. I went with something simple for a relatively minor bug that I didn't want to spend much time on unless it bothers us in more places, but if this makes you go "ick" I can reconsider.

## 🧪 Testing

In a local build the whitespace is gone

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
