### PR TITLE
List option in group needs to register with Select

### DIFF
--- a/change/@ni-nimble-angular-c7726be8-75d2-4414-b506-e8a7ed07e478.json
+++ b/change/@ni-nimble-angular-c7726be8-75d2-4414-b506-e8a7ed07e478.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing scenario where list option in a group would not call registerOwner on Select.",
+  "packageName": "@ni/nimble-angular",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-bb580e8a-344f-497f-9512-991103fa1968.json
+++ b/change/@ni-nimble-components-bb580e8a-344f-497f-9512-991103fa1968.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing scenario where list option in a group would not call registerOwner on Select.",
+  "packageName": "@ni/nimble-components",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/angular-workspace/nimble-angular/src/directives/select/tests/nimble-select-control-value-accessor.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/select/tests/nimble-select-control-value-accessor.directive.spec.ts
@@ -4,6 +4,7 @@ import { AbstractControl, FormControl, FormGroup, FormsModule, ReactiveFormsModu
 import { SelectPageObject } from '@ni/nimble-angular/select/testing';
 import { NimbleSelectModule } from '../nimble-select.module';
 import { NimbleListOptionModule } from '../../list-option/nimble-list-option.module';
+import { NimbleListOptionGroupModule } from '../../list-option-group/nimble-list-option-group.module';
 import { processUpdates, waitForUpdatesAsync } from '../../../testing/async-helpers';
 import type { Select } from '../nimble-select.directive';
 
@@ -308,6 +309,160 @@ describe('Nimble select control value accessor', () => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
                 imports: [NimbleSelectModule, NimbleListOptionModule, FormsModule, ReactiveFormsModule]
+            });
+        });
+
+        beforeEach(async () => {
+            fixture = TestBed.createComponent(TestHostComponent);
+            testHostComponent = fixture.componentInstance;
+            select = testHostComponent.select.nativeElement;
+            fixture.detectChanges();
+            // wait for select's 'options' property to be updated from slotted content
+            await waitForUpdatesAsync();
+        });
+
+        afterEach(() => {
+            processUpdates();
+        });
+
+        it('can set value to option that is dynamically added from input', async () => {
+            const oldSelectValue = testHostComponent.selectValue;
+            const newValue = { name: 'Option 4', value: 4 };
+            testHostComponent.selectValue = newValue;
+            // this will result in an option added after the first option in DOM order
+            testHostComponent.ngOnChanges({ selectValue: new SimpleChange(oldSelectValue, testHostComponent.selectValue, false) });
+            fixture.detectChanges();
+            await fixture.whenStable();
+            await waitForUpdatesAsync();
+            expect(select.selectedIndex).toBe(1);
+        });
+    });
+
+    describe('dynamically added options to group on init', () => {
+        @Component({
+            template: `
+                <form [formGroup]='form'>
+                    <nimble-select #select formControlName="selectValue">
+                        <nimble-list-option-group label="Group 1">
+                            <nimble-list-option *ngFor="let option of selectOptions"
+                                [ngValue]="option">
+                                {{ option.name }}
+                            </nimble-list-option>
+                        </nimble-list-option-group>
+                    </nimble-select>
+                </form>
+             `
+        })
+        class TestHostComponent implements OnInit {
+            @ViewChild('select', { static: true }) public select: ElementRef<Select>;
+
+            @Input() public selectValue = '';
+
+            public selectOptions: { name: string, value: number }[] = [
+                { name: 'Option 1', value: 1 },
+                { name: 'Option 2', value: 2 },
+                { name: 'Option 3', value: 3 }
+            ];
+
+            public selectedOption = new FormControl<{ name: string, value: number } | null>(null);
+
+            public form: FormGroup = new FormGroup({
+                selectValue: this.selectedOption
+            });
+
+            public get selectValueField(): AbstractControl {
+                return this.form.get('selectValue')!;
+            }
+
+            public ngOnInit(): void {
+                this.selectOptions.push({ name: 'Option 4', value: 4 });
+                this.selectValueField.setValue(this.selectOptions[3]);
+            }
+        }
+
+        let select: Select;
+        let fixture: ComponentFixture<TestHostComponent>;
+        let testHostComponent: TestHostComponent;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleSelectModule, NimbleListOptionModule, NimbleListOptionGroupModule, FormsModule, ReactiveFormsModule]
+            });
+        });
+
+        beforeEach(async () => {
+            fixture = TestBed.createComponent(TestHostComponent);
+            testHostComponent = fixture.componentInstance;
+            select = testHostComponent.select.nativeElement;
+            fixture.detectChanges();
+            // wait for select's 'options' property to be updated from slotted content
+            await waitForUpdatesAsync();
+        });
+
+        afterEach(() => {
+            processUpdates();
+        });
+
+        it('can set value to option that is dynamically added during init', () => {
+            expect(select.selectedIndex).toBe(3);
+        });
+    });
+
+    describe('dynamically added options to group on update', () => {
+        @Component({
+            template: `
+                <form [formGroup]='form'>
+                    <nimble-select #select formControlName="selectValue">
+                        <nimble-list-option-group label="Group 1">
+                            <nimble-list-option *ngFor="let option of selectOptions"
+                                [ngValue]="option">
+                                {{ option.name }}
+                            </nimble-list-option>
+                        </nimble-list-option-group>
+                    </nimble-select>
+                </form>
+             `
+        })
+        class TestHostComponent implements OnChanges {
+            @ViewChild('select', { static: true }) public select: ElementRef<Select>;
+
+            @Input() public selectValue?: { name: string, value: number };
+
+            public selectOptions: { name: string, value: number }[] = [
+                { name: 'Option 1', value: 1 },
+                { name: 'Option 2', value: 2 },
+                { name: 'Option 3', value: 3 }
+            ];
+
+            public selectedOption = new FormControl<{ name: string, value: number } | null>(null);
+
+            public form: FormGroup = new FormGroup({
+                selectValue: this.selectedOption
+            });
+
+            public get selectValueField(): AbstractControl {
+                return this.form.get('selectValue')!;
+            }
+
+            public ngOnChanges(changes: SimpleChanges): void {
+                if (changes.selectValue.currentValue !== changes.selectValue.previousValue) {
+                    // intentionally adding option after first option for DOM order
+                    const newValue = changes.selectValue.currentValue as { name: string, value: number };
+                    this.selectOptions.splice(1, 0, newValue);
+                    this.selectValueField.setValue(newValue);
+                }
+            }
+        }
+
+        let select: Select;
+        let fixture: ComponentFixture<TestHostComponent>;
+        let testHostComponent: TestHostComponent;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [NimbleSelectModule, NimbleListOptionModule, NimbleListOptionGroupModule, FormsModule, ReactiveFormsModule]
             });
         });
 

--- a/packages/angular-workspace/nimble-angular/src/directives/select/tests/nimble-select-control-value-accessor.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/select/tests/nimble-select-control-value-accessor.directive.spec.ts
@@ -362,7 +362,7 @@ describe('Nimble select control value accessor', () => {
                 { name: 'Option 1', value: 1 },
                 { name: 'Option 2', value: 2 },
                 { name: 'Option 3', value: 3 }
-            ] as const;
+            ];
 
             public selectedOption = new FormControl<{ name: string, value: number } | null>(null);
 

--- a/packages/angular-workspace/nimble-angular/src/directives/select/tests/nimble-select-control-value-accessor.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/select/tests/nimble-select-control-value-accessor.directive.spec.ts
@@ -358,11 +358,11 @@ describe('Nimble select control value accessor', () => {
 
             @Input() public selectValue = '';
 
-            public selectOptions: { name: string, value: number }[] = [
+            public selectOptions = [
                 { name: 'Option 1', value: 1 },
                 { name: 'Option 2', value: 2 },
                 { name: 'Option 3', value: 3 }
-            ];
+            ] as const;
 
             public selectedOption = new FormControl<{ name: string, value: number } | null>(null);
 

--- a/packages/angular-workspace/nimble-angular/src/directives/select/tests/nimble-select-control-value-accessor.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/select/tests/nimble-select-control-value-accessor.directive.spec.ts
@@ -275,7 +275,7 @@ describe('Nimble select control value accessor', () => {
 
             @Input() public selectValue?: { name: string, value: number };
 
-            public selectOptions: { name: string, value: number }[] = [
+            public selectOptions = [
                 { name: 'Option 1', value: 1 },
                 { name: 'Option 2', value: 2 },
                 { name: 'Option 3', value: 3 }
@@ -429,7 +429,7 @@ describe('Nimble select control value accessor', () => {
 
             @Input() public selectValue?: { name: string, value: number };
 
-            public selectOptions: { name: string, value: number }[] = [
+            public selectOptions = [
                 { name: 'Option 1', value: 1 },
                 { name: 'Option 2', value: 2 },
                 { name: 'Option 3', value: 3 }

--- a/packages/nimble-components/src/list-option/index.ts
+++ b/packages/nimble-components/src/list-option/index.ts
@@ -66,9 +66,22 @@ export class ListOption extends FoundationListboxOption {
 
     public override connectedCallback(): void {
         super.connectedCallback();
-        if (this.isListOptionOwner(this.parentElement)) {
-            this.parentElement.registerOption(this);
+        const owner = this.getListOptionOwner();
+        owner?.registerOption(this);
+    }
+
+    private getListOptionOwner(): ListOptionOwner | null {
+        let parent = this.parentElement;
+
+        while (parent) {
+            if (this.isListOptionOwner(parent)) {
+                return parent;
+            }
+
+            parent = parent.parentElement;
         }
+
+        return null;
     }
 
     private isListOptionOwner(

--- a/packages/nimble-components/src/list-option/index.ts
+++ b/packages/nimble-components/src/list-option/index.ts
@@ -70,7 +70,7 @@ export class ListOption extends FoundationListboxOption {
         owner?.registerOption(this);
     }
 
-    private getListOptionOwner(): ListOptionOwner | null {
+    private getListOptionOwner(): ListOptionOwner | undefined {
         let parent = this.parentElement;
 
         while (parent) {
@@ -81,7 +81,7 @@ export class ListOption extends FoundationListboxOption {
             parent = parent.parentElement;
         }
 
-        return null;
+        return undefined;
     }
 
     private isListOptionOwner(

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -511,7 +511,7 @@ describe('Select', () => {
         ).and.callThrough();
         registerOptionSpy.calls.reset();
         const pageObject = new SelectPageObject(element);
-        const group = pageObject.getAllGroups()[0] as ListOptionGroup;
+        const group = pageObject.getAllGroups()[0]!;
         group.insertAdjacentElement('afterbegin', newOption);
 
         expect(registerOptionSpy.calls.count()).toBe(1);

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -482,7 +482,6 @@ describe('Select', () => {
             element,
             'registerOption'
         ).and.callThrough();
-        registerOptionSpy.calls.reset();
         element.insertBefore(newOption, element.options[0]!);
 
         expect(registerOptionSpy.calls.count()).toBe(1);
@@ -509,7 +508,6 @@ describe('Select', () => {
             element,
             'registerOption'
         ).and.callThrough();
-        registerOptionSpy.calls.reset();
         const pageObject = new SelectPageObject(element);
         const group = pageObject.getAllGroups()[0]!;
         group.insertAdjacentElement('afterbegin', newOption);

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -500,6 +500,35 @@ describe('Select', () => {
         await disconnect();
     });
 
+    it('option added directly to DOM under group synchronously registers with Select', async () => {
+        const { element, connect, disconnect } = await setupWithGroups();
+        await connect();
+        await waitForUpdatesAsync();
+        const newOption = new ListOption('foo', 'foo');
+        const registerOptionSpy = spyOn(
+            element,
+            'registerOption'
+        ).and.callThrough();
+        registerOptionSpy.calls.reset();
+        const pageObject = new SelectPageObject(element);
+        const group = pageObject.getAllGroups()[0] as ListOptionGroup;
+        group.insertAdjacentElement('afterbegin', newOption);
+
+        expect(registerOptionSpy.calls.count()).toBe(1);
+        expect(element.options).toContain(newOption);
+
+        // While the option is registered synchronously as shown above,
+        // properties like selectedIndex will only be correct asynchronously
+        // See https://github.com/ni/nimble/issues/1915
+        expect(element.selectedIndex).toBe(0);
+        await waitForUpdatesAsync();
+        expect(element.value).toBe('one');
+        // This assertion shows that after 'slottedOptionsChanged' runs, the
+        // 'selectedIndex' state has been corrected to expected DOM order.
+        expect(element.selectedIndex).toBe(1);
+        await disconnect();
+    });
+
     it('programmatically setting selected of current selected option to false results in blank display', async () => {
         const { element, connect, disconnect } = await setup();
         await connect();


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Had a realization that list options that were in a group would not go through the `registerOption` routine (a fix for SLE Angular apps). While I'm not sure if there is any current use-case that would hit the problem, I went ahead and made the fix and the tests that demonstrate the problem.

## 👩‍💻 Implementation

Just made the private `getListOptionOwner` routine  on `ListOption` a bit more robust.

## 🧪 Testing

Wrote component and Angular tests modeled after existing tests but with a group as the option owner.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
