### PR TITLE
Update select page object

### DIFF
--- a/change/@ni-nimble-components-1d7d08c5-fc96-4796-bce3-650510487895.json
+++ b/change/@ni-nimble-components-1d7d08c5-fc96-4796-bce3-650510487895.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adding new SelectPageObject API.",
+  "packageName": "@ni/nimble-components",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/select/testing/select.pageobject.ts
+++ b/packages/nimble-components/src/select/testing/select.pageobject.ts
@@ -81,12 +81,23 @@ export class SelectPageObject {
         ).map(group => group.labelContent);
     }
 
-    public getGroupOptionLabels(groupIndex: number): string[] {
+    public getGroupOptionLabelsByIndex(groupIndex: number): string[] {
         const group = Array.from(
             this.selectElement.querySelectorAll<ListOptionGroup>(
                 '[role="group"]'
             ) ?? []
         )[groupIndex];
+        return Array.from(
+            group?.querySelectorAll<ListOption>('[role="option"]') ?? []
+        ).map(option => option.textContent?.trim() ?? '');
+    }
+
+    public getGroupOptionLabelsByLabel(groupLabel: string): string[] {
+        const group = Array.from(
+            this.selectElement.querySelectorAll<ListOptionGroup>(
+                '[role="group"]'
+            ) ?? []
+        ).find(g => g.labelContent === groupLabel);
         return Array.from(
             group?.querySelectorAll<ListOption>('[role="option"]') ?? []
         ).map(option => option.textContent?.trim() ?? '');

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -2000,10 +2000,16 @@ describe('Select', () => {
             ]);
         });
 
-        it('exercise getOptionLabels', async () => {
+        it('exercise getGroupOptionLabelsByIndex', async () => {
             await clickAndWaitForOpen(element);
-            const optionLabels = pageObject.getGroupOptionLabels(0);
+            const optionLabels = pageObject.getGroupOptionLabelsByIndex(0);
             expect(optionLabels).toEqual(['One', 'Two', 'Edge']);
+        });
+
+        it('exercise getGroupOptionLabelsByLabel', async () => {
+            await clickAndWaitForOpen(element);
+            const optionLabels = pageObject.getGroupOptionLabelsByLabel('Group Two');
+            expect(optionLabels).toEqual(['Three', 'Four']);
         });
     });
 });


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Recognized that as part of attempting to migrate an SLE component to the `Select` to use the grouping feature that there was a useful pageObject API for retrieving the options for a group by providing the group's label. This PR adds that functionality to the `SelectPageObject`.

## 👩‍💻 Implementation

Simple implementation mirroring a similar existing one.

## 🧪 Testing

Added test for the new pageObject method.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
