### PR TITLE
Use trace colors on landing page

### DIFF
--- a/packages/site/landing/index.html
+++ b/packages/site/landing/index.html
@@ -62,16 +62,19 @@
                 </div>
             </div>
         </div>
-        <svg class="circle-wrapper" id="circles" viewBox="0 0 1550 1550" width="1300" height="1300" stroke-width="50"
-            fill="transparent" stroke-linecap="round">
-            <circle cx="775" cy="775" r="750" />
-            <circle cx="775" cy="775" r="700" />
-            <circle cx="775" cy="775" r="650" />
-            <circle cx="775" cy="775" r="600" />
-            <circle cx="775" cy="775" r="550" />
-            <circle cx="775" cy="775" r="500" />
-            <circle cx="775" cy="775" r="450" />
-        </svg>
+        <nimble-theme-provider theme="dark">
+            <svg class="circle-wrapper" id="circles" viewBox="0 0 1550 1550" width="1300" height="1300" stroke-width="50"
+                fill="transparent" stroke-linecap="round">
+                <circle cx="775" cy="775" r="750" />
+                <circle cx="775" cy="775" r="700" />
+                <circle cx="775" cy="775" r="650" />
+                <circle cx="775" cy="775" r="600" />
+                <circle cx="775" cy="775" r="550" />
+                <circle cx="775" cy="775" r="500" />
+                <circle cx="775" cy="775" r="450" />
+                <circle cx="775" cy="775" r="400" />
+            </svg>
+        </nimble-theme-provider>
     </div>
 </body>
 

--- a/packages/site/landing/styles.scss
+++ b/packages/site/landing/styles.scss
@@ -2,8 +2,6 @@
 @import "@ni/nimble-components/dist/fonts";
 @import "@ni/nimble-components/dist/tokens";
 
-$rgb-ni-sky-light: #A5DDED;
-$rgb-labview: #FFC60B;
 $card-height: 4.5rem;
 
 

--- a/packages/site/landing/styles.scss
+++ b/packages/site/landing/styles.scss
@@ -61,13 +61,14 @@ circle {
 }
 
 $colors:
-    $ni-nimble-base-power-green,
-    $ni-nimble-base-rgb-ni-green,
-    $ni-nimble-base-forest-green,
-    $ni-nimble-base-ni-scarlet,
-    $rgb-ni-sky-light,
-    $ni-nimble-base-ni-sky,
-    $rgb-labview;
+    $ni-nimble-graph-trace-1-color,
+    $ni-nimble-graph-trace-2-color,
+    $ni-nimble-graph-trace-3-color,
+    $ni-nimble-graph-trace-4-color,
+    $ni-nimble-graph-trace-5-color,
+    $ni-nimble-graph-trace-6-color,
+    $ni-nimble-graph-trace-7-color,
+    $ni-nimble-graph-trace-8-color;
 
 @for $i from 1 through length($colors) {
     circle:nth-of-type(#{length($colors)}n+#{$i}) {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Switched to using the graph trace colors for the circles on the landing page.

## 👩‍💻 Implementation

Switched to the trace tokens. Also put it in dark theme which gives lighter color traces.

## 🧪 Testing

Rely on CI.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
