### PR TITLE
Avoid phantom diffs from prettier-eslint

### DIFF
--- a/change/@ni-nimble-components-39a467b0-d65b-41f9-970d-fec80df68bd3.json
+++ b/change/@ni-nimble-components-39a467b0-d65b-41f9-970d-fec80df68bd3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Avoid phantom diffs from prettier-eslint",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-spright-components-3c0bcea9-31fe-4d45-a1fd-6cbd9b45b73e.json
+++ b/change/@ni-spright-components-3c0bcea9-31fe-4d45-a1fd-6cbd9b45b73e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Format command shouldn't run redundant eslint -fix",
+  "packageName": "@ni/spright-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/angular-workspace/example-client-app/src/app/app.module.ts
+++ b/packages/angular-workspace/example-client-app/src/app/app.module.ts
@@ -2,8 +2,7 @@ import { NgModule } from '@angular/core';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
-import {
-    NimbleTextAreaModule, NimbleTextFieldModule, NimbleNumberFieldModule, NimbleSelectModule, NimbleListOptionModule,
+import { NimbleTextAreaModule, NimbleTextFieldModule, NimbleNumberFieldModule, NimbleSelectModule, NimbleListOptionModule,
     NimbleButtonModule, NimbleTreeViewModule, NimbleTreeItemModule, NimbleDrawerModule, NimbleThemeProviderModule,
     NimbleTabModule, NimbleTabPanelModule, NimbleTabsModule, NimbleTabsToolbarModule, NimbleMenuModule,
     NimbleMenuItemModule, NimbleCheckboxModule, NimbleToggleButtonModule, NimbleBreadcrumbModule, NimbleBreadcrumbItemModule,
@@ -11,8 +10,7 @@ import {
     NimbleCardButtonModule, NimbleDialogModule, NimbleRadioGroupModule, NimbleRadioModule, NimbleSpinnerModule,
     NimbleAnchorModule, NimbleAnchorButtonModule, NimbleAnchorTabModule, NimbleAnchorTabsModule,
     NimbleIconCheckModule, NimbleBannerModule, NimbleAnchorMenuItemModule, NimbleAnchorTreeItemModule, NimbleIconXmarkCheckModule,
-    NimbleListOptionGroupModule
-} from '@ni/nimble-angular';
+    NimbleListOptionGroupModule } from '@ni/nimble-angular';
 import { NimbleCardModule } from '@ni/nimble-angular/card';
 import { NimbleLabelProviderCoreModule } from '@ni/nimble-angular/label-provider/core';
 import { NimbleLabelProviderRichTextModule } from '@ni/nimble-angular/label-provider/rich-text';

--- a/packages/angular-workspace/example-client-app/src/app/app.module.ts
+++ b/packages/angular-workspace/example-client-app/src/app/app.module.ts
@@ -2,7 +2,8 @@ import { NgModule } from '@angular/core';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
-import { NimbleTextAreaModule, NimbleTextFieldModule, NimbleNumberFieldModule, NimbleSelectModule, NimbleListOptionModule,
+import {
+    NimbleTextAreaModule, NimbleTextFieldModule, NimbleNumberFieldModule, NimbleSelectModule, NimbleListOptionModule,
     NimbleButtonModule, NimbleTreeViewModule, NimbleTreeItemModule, NimbleDrawerModule, NimbleThemeProviderModule,
     NimbleTabModule, NimbleTabPanelModule, NimbleTabsModule, NimbleTabsToolbarModule, NimbleMenuModule,
     NimbleMenuItemModule, NimbleCheckboxModule, NimbleToggleButtonModule, NimbleBreadcrumbModule, NimbleBreadcrumbItemModule,
@@ -10,7 +11,8 @@ import { NimbleTextAreaModule, NimbleTextFieldModule, NimbleNumberFieldModule, N
     NimbleCardButtonModule, NimbleDialogModule, NimbleRadioGroupModule, NimbleRadioModule, NimbleSpinnerModule,
     NimbleAnchorModule, NimbleAnchorButtonModule, NimbleAnchorTabModule, NimbleAnchorTabsModule,
     NimbleIconCheckModule, NimbleBannerModule, NimbleAnchorMenuItemModule, NimbleAnchorTreeItemModule, NimbleIconXmarkCheckModule,
-    NimbleListOptionGroupModule } from '@ni/nimble-angular';
+    NimbleListOptionGroupModule
+} from '@ni/nimble-angular';
 import { NimbleCardModule } from '@ni/nimble-angular/card';
 import { NimbleLabelProviderCoreModule } from '@ni/nimble-angular/label-provider/core';
 import { NimbleLabelProviderRichTextModule } from '@ni/nimble-angular/label-provider/rich-text';

--- a/packages/eslint-config-nimble/javascript.js
+++ b/packages/eslint-config-nimble/javascript.js
@@ -6,6 +6,18 @@ module.exports = {
     rules: {
         // Enabled to prevent accidental usage of async-await
         'require-await': 'error',
-        'no-return-await': 'off'
+        'no-return-await': 'off',
+
+        // This rule's configuration is based on the NI javascript styleguide:
+        // https://github.com/ni/javascript-styleguide/blob/a1a6abd7adca7d9acd002705101b351d695b2442/packages/eslint-config-javascript/index.js
+        // The only difference is that we're increasing the value of minProperties (from 6) so
+        // that eslint doesn't introduce line breaks where prettier doesn't. If eslint introduces
+        // line breaks, they will be unix-style, which will cause pointless diffs in git.
+        'object-curly-newline': ['error', {
+            ObjectExpression: { minProperties: 1000, multiline: true, consistent: true },
+            ObjectPattern: { minProperties: 1000, multiline: true, consistent: true },
+            ImportDeclaration: { consistent: true },
+            ExportDeclaration: { consistent: true }
+        }],
     },
 };

--- a/packages/eslint-config-nimble/typescript.js
+++ b/packages/eslint-config-nimble/typescript.js
@@ -34,14 +34,17 @@ module.exports = {
         'no-return-await': 'off',
         '@typescript-eslint/return-await': 'error',
 
-        // Increasing the value of minProperties (default is 6?) so that eslint doesn't
-        // introduce line breaks where prettier doesn't. If eslint introduces line breaks,
-        // they will be unix-style, which will cause pointless diffs in git.
+        // This rule's configuration is based on the NI javascript styleguide:
+        // https://github.com/ni/javascript-styleguide/blob/a1a6abd7adca7d9acd002705101b351d695b2442/packages/eslint-config-javascript/index.js
+        // The only difference is that we're increasing the value of minProperties (from 6) so
+        // that eslint doesn't introduce line breaks where prettier doesn't. If eslint introduces
+        // line breaks, they will be unix-style, which will cause pointless diffs in git.
         'object-curly-newline': ['error', {
-            multiline: true,
-            consistent: true,
-            minProperties: 1000
-        }]
+            ObjectExpression: { minProperties: 1000, multiline: true, consistent: true },
+            ObjectPattern: { minProperties: 1000, multiline: true, consistent: true },
+            ImportDeclaration: { consistent: true },
+            ExportDeclaration: { consistent: true }
+        }],
     },
     overrides: [
         {

--- a/packages/eslint-config-nimble/typescript.js
+++ b/packages/eslint-config-nimble/typescript.js
@@ -32,7 +32,16 @@ module.exports = {
         'require-await': 'off',
         '@typescript-eslint/require-await': 'error',
         'no-return-await': 'off',
-        '@typescript-eslint/return-await': 'error'
+        '@typescript-eslint/return-await': 'error',
+
+        // Increasing the value of minProperties (default is 5?) so that eslint doesn't
+        // introduce line breaks where prettier doesn't. If eslint introduces line breaks,
+        // they will be unix-style, which will cause pointless diffs in git.
+        'object-curly-newline': ['error', {
+            multiline: true,
+            consistent: true,
+            minProperties: 1000
+        }]
     },
     overrides: [
         {

--- a/packages/eslint-config-nimble/typescript.js
+++ b/packages/eslint-config-nimble/typescript.js
@@ -34,7 +34,7 @@ module.exports = {
         'no-return-await': 'off',
         '@typescript-eslint/return-await': 'error',
 
-        // Increasing the value of minProperties (default is 5?) so that eslint doesn't
+        // Increasing the value of minProperties (default is 6?) so that eslint doesn't
         // introduce line breaks where prettier doesn't. If eslint introduces line breaks,
         // they will be unix-style, which will cause pointless diffs in git.
         'object-curly-newline': ['error', {

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "npm run generate-icons && npm run generate-workers && npm run build-components && npm run bundle-components && npm run generate-scss",
     "lint-concurrent": "concurrently --timings --group \"npm:eslint\" \"npm:prettier\"",
-    "format": "npm run eslint-fix && npm run prettier-fix",
+    "format": "npm run prettier-fix",
     "eslint": "eslint .",
     "eslint-fix": "eslint . --fix",
     "prettier": "prettier-eslint \"**/*.*\" --list-different --prettier-ignore",

--- a/packages/nimble-components/src/combobox/tests/combobox.foundation.spec.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox.foundation.spec.ts
@@ -454,9 +454,7 @@ describe('Combobox', () => {
     });
 
     it("should set the control's `aria-activedescendant` property to the ID of the currently selected option while open", async () => {
-        const {
-            connect, disconnect, element, option1, option2, option3
-        } = await setup();
+        const { connect, disconnect, element, option1, option2, option3 } = await setup();
 
         await connect();
 

--- a/packages/nimble-components/src/select/tests/select.foundation.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.foundation.spec.ts
@@ -142,9 +142,7 @@ describe('Select', () => {
     });
 
     it('should set its value to the first enabled option', async () => {
-        const {
-            element, connect, disconnect, option1, option2, option3
-        } = await setup();
+        const { element, connect, disconnect, option1, option2, option3 } = await setup();
 
         await connect();
 
@@ -159,9 +157,7 @@ describe('Select', () => {
     });
 
     it('should set its value to the first enabled option when disabled', async () => {
-        const {
-            element, connect, disconnect, option1, option2, option3
-        } = await setup();
+        const { element, connect, disconnect, option1, option2, option3 } = await setup();
         element.disabled = true;
 
         await connect();
@@ -177,9 +173,7 @@ describe('Select', () => {
     });
 
     it('should select the first option with a `selected` attribute', async () => {
-        const {
-            element, connect, disconnect, option1, option2, option3
-        } = await setup();
+        const { element, connect, disconnect, option1, option2, option3 } = await setup();
 
         option2.setAttribute('selected', '');
 
@@ -196,9 +190,7 @@ describe('Select', () => {
     });
 
     it('should select the first option with a `selected` attribute when disabled', async () => {
-        const {
-            element, connect, disconnect, option1, option2, option3
-        } = await setup();
+        const { element, connect, disconnect, option1, option2, option3 } = await setup();
         element.disabled = true;
 
         option2.setAttribute('selected', '');
@@ -914,9 +906,7 @@ describe('Select', () => {
     });
 
     it('should set the `aria-activedescendant` attribute to the ID of the currently selected option', async () => {
-        const {
-            connect, disconnect, element, option1, option2, option3
-        } = await setup();
+        const { connect, disconnect, element, option1, option2, option3 } = await setup();
 
         await connect();
 

--- a/packages/spright-components/package.json
+++ b/packages/spright-components/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "npm run build-components && npm run bundle-components",
     "lint": "npm run eslint && npm run prettier",
-    "format": "npm run eslint-fix && npm run prettier-fix",
+    "format": "npm run prettier-fix",
     "eslint": "eslint .",
     "eslint-fix": "eslint . --fix",
     "prettier": "prettier-eslint \"**/*.*\" --list-different --prettier-ignore",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -10,7 +10,7 @@
     "generate-icons:run": "node build/generate-icons/dist/index.js",
     "start": "storybook dev --quiet -p 6006",
     "lint": "npm run eslint && npm run prettier",
-    "format": "npm run eslint-fix && npm run prettier-fix",
+    "format": "npm run prettier-fix",
     "eslint": "eslint .",
     "eslint-fix": "eslint . --fix",
     "prettier": "prettier-eslint \"**/*.*\" --list-different --prettier-ignore",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Running `npm run format` would result in git detecting that `combobox/select.foundation.spec.ts` had been modified, but the diffs would show no changes.

## 👩‍💻 Implementation

The problem was that formatting was replacing some CRLF line endings with LF line endings.

`prettier-eslint` runs `prettier` followed by `eslint` to fix any formatting issues. The `xxx.foundation.spec.ts` files each had some lines like this:

```ts
const {
    element, connect, disconnect, option1, option2, option3
} = await setup();
```

`prettier` would reformat those lines like this, because they could fit on a single line without exceeding the line length limit:
```ts
const { element, connect, disconnect, option1, option2, option3 } = await setup();
```

Then `eslint` would run, and because these objects have more than five properties (the limit configured by the NI styleguide), it inserts newlines next to the curly braces, so it looks like the original file, except that the inserted newlines are Unix-style (LF) rather than Window-style (CRLF). This causes Git to detect a diff, but it's invisible. Even if you would submit the change, Git normalizes all the line endings to Unix-style upon check-in anyway, so there's no actual, commitable change.

### Solution

Ideally, we could configure `eslint` to use whatever line ending type is used in the rest of the file, but it seems to [only let you specify Unix or Windows](https://eslint.org/docs/latest/rules/linebreak-style). Instead, I am now reconfiguring the `object-curly-newline` rule to use an arbitrarily large `minProperties` value, so that `eslint` does not introduce newlines just because there are a certain number of properties in an object. `prettier` will still introduce newlines as needed, based on line length.

I also updated the npm `format` scripts to stop calling `eslint-fix` before `prettier-fix`. The latter already [does both a `prettier -fix` and `eslint -fix`](https://github.com/prettier/prettier-eslint?tab=readme-ov-file#this-solution), so the separate `eslint-fix` is redundant.

## 🧪 Testing

Ran `npm run format` on the whole repo, and only the two problem files were changed.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
