### PR TITLE
Disable intermittent RichTextEditorMentionListbox test

### DIFF
--- a/change/@ni-nimble-components-555e2d1a-b303-4444-94fc-eba40913c8e5.json
+++ b/change/@ni-nimble-components-555e2d1a-b303-4444-94fc-eba40913c8e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "disable intermittent test",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
@@ -1542,7 +1542,8 @@ describe('RichTextEditorMentionListbox', () => {
             expect(pageObject.isMentionListboxOpened()).toBeTrue();
         });
 
-        it('should show mention popup for multiple mention configuration elements', async () => {
+        // Intermittent, see https://github.com/ni/nimble/issues/2219
+        xit('should show mention popup for multiple mention configuration elements', async () => {
             await appendUserMentionConfiguration(element, [
                 { key: 'user:1', displayName: 'username1' },
                 { key: 'user:2', displayName: 'username2' }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The test `RichTextEditorMentionListbox Dynamically update mention popup items based on configuration changes should show mention popup for multiple mention configuration elements` is intermittent on main and being disabled.

See  https://github.com/ni/nimble/issues/2219

## 👩‍💻 Implementation

Disabled the test.

## 🧪 Testing

Rely on CI.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
