### PR TITLE
Update `SelectPageObject` `clickOption` to only deal with visible options.

### DIFF
--- a/change/@ni-nimble-components-6184ec15-e807-4933-bafe-5cb321d1ae16.json
+++ b/change/@ni-nimble-components-6184ec15-e807-4933-bafe-5cb321d1ae16.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make SelectPageObject clickOption reference only visible options.",
+  "packageName": "@ni/nimble-components",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/select/testing/select.pageobject.ts
+++ b/packages/nimble-components/src/select/testing/select.pageobject.ts
@@ -119,7 +119,8 @@ export class SelectPageObject {
         if (!selectedOption) {
             throw new Error('No option is selected to click');
         }
-        this.clickOption(this.selectElement.options.indexOf(selectedOption));
+        const visibleOptions = this.getVisibleOptions();
+        this.clickOption(visibleOptions.indexOf(selectedOption));
     }
 
     public async clickFilterInput(): Promise<void> {
@@ -131,13 +132,14 @@ export class SelectPageObject {
     }
 
     public clickOption(index: number): void {
-        if (index >= this.selectElement.options.length) {
+        const visibleOptions = this.getVisibleOptions();
+        if (index >= visibleOptions.length) {
             throw new Error(
                 '"index" greater than number of current displayed options'
             );
         }
 
-        const option = this.selectElement.options[index]!;
+        const option = visibleOptions[index]!;
         option.scrollIntoView();
         option.click();
     }
@@ -321,6 +323,12 @@ export class SelectPageObject {
 
     public getFilterInputText(): string {
         return this.selectElement.filterInput?.value ?? '';
+    }
+
+    private getVisibleOptions(): ListOption[] {
+        return this.selectElement.options.filter(
+            o => !((o as ListOption).hidden || (o as ListOption).visuallyHidden)
+        ) as ListOption[];
     }
 
     private getFilterInput(): HTMLInputElement | null | undefined {

--- a/packages/nimble-components/src/select/testing/select.pageobject.ts
+++ b/packages/nimble-components/src/select/testing/select.pageobject.ts
@@ -155,6 +155,9 @@ export class SelectPageObject {
     /**
      * Click the option with the text provided by the 'displayText' parameter.
      * @param value The text of the option to be selected
+     * @remarks This method is useful when the display text is unique. If the
+     * display text is not unique, the first option with the matching text will
+     * be selected.
      */
     public clickOptionWithDisplayText(displayText: string): void {
         if (!this.selectElement.open) {

--- a/packages/nimble-components/src/select/testing/select.pageobject.ts
+++ b/packages/nimble-components/src/select/testing/select.pageobject.ts
@@ -131,6 +131,14 @@ export class SelectPageObject {
         await waitForUpdatesAsync();
     }
 
+    /**
+     * Selects an option using an index value into the list of visible options.
+     * Options that have the `hidden` or `visuallyHidden` attribute set to true
+     * are not considered visible.
+     * @param index The index of the option in the visible set to be selected
+     * @remarks Prefer clickOptionWithDisplayText where possible. This method is
+     * useful when the display text is not unique and the index is known.
+     */
     public clickOption(index: number): void {
         const visibleOptions = this.getVisibleOptions();
         if (index >= visibleOptions.length) {
@@ -152,7 +160,7 @@ export class SelectPageObject {
         if (!this.selectElement.open) {
             this.clickSelect();
         }
-        const optionIndex = this.selectElement.options.findIndex(
+        const optionIndex = this.getVisibleOptions().findIndex(
             o => o.text === displayText
         );
         if (optionIndex === -1) {

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -994,7 +994,7 @@ describe('Select', () => {
                 expect(element.value).toBe('one');
 
                 await pageObject.openAndSetFilterText('T'); // Matches 'Two' and 'Three'
-                pageObject.clickOption(2); // index 2 matches option with 'Three' text
+                pageObject.clickOption(1); // index 1 matches option with 'Three' text
                 expect(element.value).toBe('three');
                 expect(element.open).toBeFalse();
             });
@@ -1051,7 +1051,7 @@ describe('Select', () => {
             it('clicking disabled option does not cause select to change state', async () => {
                 await pageObject.openAndSetFilterText('T');
                 const currentFilteredOptions = pageObject.getFilteredOptions();
-                pageObject.clickOption(3); // click disabled option
+                pageObject.clickOption(2); // click disabled option
 
                 expect(pageObject.getFilteredOptions()).toEqual(
                     currentFilteredOptions
@@ -1370,7 +1370,7 @@ describe('Select', () => {
         it('selecting option will replace placeholder text with selected option text', async () => {
             expect(pageObject.getDisplayText()).toBe('One');
             await clickAndWaitForOpen(element);
-            pageObject.clickOption(1);
+            pageObject.clickOption(0);
             await waitForUpdatesAsync();
 
             expect(pageObject.getDisplayText()).toBe('Two');

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -994,7 +994,7 @@ describe('Select', () => {
                 expect(element.value).toBe('one');
 
                 await pageObject.openAndSetFilterText('T'); // Matches 'Two' and 'Three'
-                pageObject.clickOption(1); // index 1 matches option with 'Three' text
+                pageObject.clickOptionWithDisplayText('Three');
                 expect(element.value).toBe('three');
                 expect(element.open).toBeFalse();
             });
@@ -1370,7 +1370,7 @@ describe('Select', () => {
         it('selecting option will replace placeholder text with selected option text', async () => {
             expect(pageObject.getDisplayText()).toBe('One');
             await clickAndWaitForOpen(element);
-            pageObject.clickOption(0);
+            pageObject.clickOptionWithDisplayText('Two');
             await waitForUpdatesAsync();
 
             expect(pageObject.getDisplayText()).toBe('Two');
@@ -1403,7 +1403,7 @@ describe('Select', () => {
 
         it('programmatically setting selected of current selected option to false results in placeholder being displayed', async () => {
             await clickAndWaitForOpen(element);
-            pageObject.clickOption(1);
+            pageObject.clickOptionWithDisplayText('Two');
             const selectedOption = pageObject.getSelectedOption();
             selectedOption!.selected = false;
             await waitForUpdatesAsync();
@@ -1460,7 +1460,7 @@ describe('Select', () => {
             await waitForUpdatesAsync();
             expect(pageObject.isClearButtonVisible()).toBeFalse();
             await clickAndWaitForOpen(element);
-            pageObject.clickOption(1);
+            pageObject.clickOptionWithDisplayText('Two');
             await waitForUpdatesAsync();
 
             expect(pageObject.isClearButtonVisible()).toBeTrue();
@@ -1514,7 +1514,7 @@ describe('Select', () => {
             it('after clicking clear button and then selecting an option, clear button is visible again', async () => {
                 pageObject.clickClearButton();
                 await clickAndWaitForOpen(element);
-                pageObject.clickOption(1);
+                pageObject.clickOptionWithDisplayText('Two');
                 await waitForUpdatesAsync();
                 expect(pageObject.isClearButtonVisible()).toBeTrue();
             });
@@ -1534,7 +1534,7 @@ describe('Select', () => {
 
             it('after clicking clear button, placeholder is visible', async () => {
                 await clickAndWaitForOpen(element);
-                pageObject.clickOption(1);
+                pageObject.clickOptionWithDisplayText('Two');
                 await waitForUpdatesAsync();
                 pageObject.clickClearButton();
                 await waitForUpdatesAsync();
@@ -1590,7 +1590,7 @@ describe('Select', () => {
 
         it('can select an option within a group', async () => {
             await clickAndWaitForOpen(element);
-            pageObject.clickOption(1);
+            pageObject.clickOptionWithDisplayText('Two');
             expect(element.value).toBe('two');
             expect(element.selectedIndex).toBe(1);
         });
@@ -2015,6 +2015,31 @@ describe('Select', () => {
             pageObject.clickOptionWithDisplayText('Two');
             expect(element.value).toBe('two');
             expect(element.selectedIndex).toBe(1);
+        });
+
+        it('exercise clickOptionWithDisplayText with a hidden option', () => {
+            const option = element.options[0] as ListOption;
+            option.hidden = true;
+            pageObject.clickSelect();
+            pageObject.clickOptionWithDisplayText('Two');
+            expect(element.value).toBe('two');
+            expect(element.selectedIndex).toBe(1);
+        });
+
+        it('exercise clickOption', () => {
+            pageObject.clickSelect();
+            pageObject.clickOption(1);
+            expect(element.value).toBe('two');
+            expect(element.selectedIndex).toBe(1);
+        });
+
+        it('exercise clickOption with a hidden option', () => {
+            const option = element.options[0] as ListOption;
+            option.hidden = true;
+            pageObject.clickSelect();
+            pageObject.clickOption(1);
+            expect(element.value).toBe('three');
+            expect(element.selectedIndex).toBe(2);
         });
 
         it('exercise getGroupLabels', async () => {

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -2038,7 +2038,7 @@ describe('Select', () => {
             option.hidden = true;
             pageObject.clickSelect();
             pageObject.clickOption(1);
-            expect(element.value).toBe('three');
+            expect(element.value).toBe('edge');
             expect(element.selectedIndex).toBe(2);
         });
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

While doing the integration work to begin leveraging a select with grouping in SLE, I recognized that an existing page object had an API for selecting options by index, where the index was related to only the visible options in the dropdown. I feel this is more intuitive for a pageObject API than what we currently had in our own, so I'm updating our pageObject implementation to follow this.

## 👩‍💻 Implementation

Simply finding the visible options with which to relate the provided `index` parameter to `clickOption` against.

## 🧪 Testing

Updated tests that had to adjust the index they were using to align with only the visible options.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
