### PR TITLE
Avoid another instance of intermittent test component id collision

### DIFF
--- a/change/@ni-nimble-angular-b713ec30-9161-40eb-b626-06c4da13a667.json
+++ b/change/@ni-nimble-angular-b713ec30-9161-40eb-b626-06c4da13a667.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Avoid another instance of intermittent test component id collision",
+  "packageName": "@ni/nimble-angular",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/angular-workspace/nimble-angular/src/thirdparty/directives/tests/router_integration.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/thirdparty/directives/tests/router_integration.spec.ts
@@ -7146,7 +7146,9 @@ class DummyLinkCmp {
 class AbsoluteSimpleLinkCmp {
 }
 
-@Component({selector: 'link-cmp', template: `<a [routerLink]="['../simple']">link</a>`})
+// [Nimble] add irrelevant :not(body) to selector to force distinct component ID generation
+//  Solution based on suggestion from https://angular.io/errors/NG0912#debugging-the-error
+@Component({selector: 'link-cmp:not(body)', template: `<a [routerLink]="['../simple']">link</a>`})
 class RelativeLinkCmp {
 }
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

I thought I had resolved this in #2087, but I just ran into another case of this Angular ID collision issue in [this build](https://github.com/ni/nimble/actions/runs/9751655260/job/26913710201?pr=2193). This time rather than being a collision for components `AbsoluteSimpleLinkCmp` and `RelativeLinkCmp`, it's a collision between two different definitions of `RelativeLinkCmp`:

```
Failed: NG0912: Component ID generation collision detected. Components 'RelativeLinkCmp' and 'RelativeLinkCmp' with selector 'link-cmp' generated the same component ID. To fix this, you can change the selector of one of those components or add an extra host attribute to force a different ID. Find more at https://angular.io/errors/NG0912
```

## 👩‍💻 Implementation

I'm still not clear on why this is intermittent, but I'm content to just add a uniquifying `:not(body)` to the selector for one of the `RelativeLinkCmp` components that can conflict.

## 🧪 Testing

None

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
