### PR TITLE
Link to table colum configuration docs from each column

### DIFF
--- a/packages/storybook/src/docs/table-column-apis-link.mdx
+++ b/packages/storybook/src/docs/table-column-apis-link.mdx
@@ -1,0 +1,7 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Patterns/table-column/table-column-apis-link" />
+
+See
+[Table Column Configuration](?path=/docs/components-table-column-configuration--docs)
+for APIs common across table column types.

--- a/packages/storybook/src/nimble/table-column/anchor/table-column-anchor.mdx
+++ b/packages/storybook/src/nimble/table-column/anchor/table-column-anchor.mdx
@@ -2,6 +2,7 @@ import { Controls, Canvas, Meta, Title } from '@storybook/blocks';
 import TargetDocs from '../../patterns/anchor/target-docs.mdx';
 import * as tableColumnAnchorStories from './table-column-anchor.stories';
 import ComponentApisLink from '../../../docs/component-apis-link.mdx';
+import TableColumnApisLink from '../../../docs/table-column-apis-link.mdx';
 import { tableColumnAnchorTag } from '../../../../../nimble-components/src/table-column/anchor';
 import { tableTag } from '../../../../../nimble-components/src/table';
 
@@ -16,6 +17,7 @@ link, that cell will display a link, otherwise it will display plain text.
 
 ## API
 
+<TableColumnApisLink />
 <Controls of={tableColumnAnchorStories.anchorColumn} />
 <ComponentApisLink />
 

--- a/packages/storybook/src/nimble/table-column/date-text/table-column-date-text.mdx
+++ b/packages/storybook/src/nimble/table-column/date-text/table-column-date-text.mdx
@@ -2,6 +2,7 @@ import { Canvas, Meta, Controls, Title } from '@storybook/blocks';
 import { NimbleTableColumnDateText } from './table-column-date-text.react';
 import * as tableColumnDateTextStories from './table-column-date-text.stories';
 import ComponentApisLink from '../../../docs/component-apis-link.mdx';
+import TableColumnApisLink from '../../../docs/table-column-apis-link.mdx';
 import { tableColumnDateTextTag } from '../../../../../nimble-components/src/table-column/date-text';
 import { tableTag } from '../../../../../nimble-components/src/table';
 import NoNullAndUndefinedBestPractice from '../../patterns/table-column/no-null-and-undefined-best-practice-docs.mdx';
@@ -22,6 +23,7 @@ token, which can be set via the
 
 ## API
 
+<TableColumnApisLink />
 <Controls of={tableColumnDateTextStories.dateTextColumn} />
 <ComponentApisLink />
 

--- a/packages/storybook/src/nimble/table-column/duration-text/table-column-duration-text.mdx
+++ b/packages/storybook/src/nimble/table-column/duration-text/table-column-duration-text.mdx
@@ -1,6 +1,7 @@
 import { Controls, Canvas, Meta, Title } from '@storybook/blocks';
 import * as tableColumnDurationTextStories from './table-column-duration-text.stories';
 import ComponentApisLink from '../../../docs/component-apis-link.mdx';
+import TableColumnApisLink from '../../../docs/table-column-apis-link.mdx';
 import { tableColumnDurationTextTag } from '../../../../../nimble-components/src/table-column/duration-text';
 import { tableTag } from '../../../../../nimble-components/src/table';
 import NoNullAndUndefinedBestPractice from '../../patterns/table-column/no-null-and-undefined-best-practice-docs.mdx';
@@ -25,6 +26,7 @@ the
 
 ## API
 
+<TableColumnApisLink />
 <Controls of={tableColumnDurationTextStories.durationTextColumn} />
 <ComponentApisLink />
 

--- a/packages/storybook/src/nimble/table-column/mapping/table-column-mapping.mdx
+++ b/packages/storybook/src/nimble/table-column/mapping/table-column-mapping.mdx
@@ -6,6 +6,7 @@ import * as iconMappingStories from '../../mapping/icon/mapping-icon.stories';
 import * as spinnerMappingStories from '../../mapping/spinner/mapping-spinner.stories';
 import * as textMappingStories from '../../mapping/text/mapping-text.stories';
 import ComponentApisLink from '../../../docs/component-apis-link.mdx';
+import TableColumnApisLink from '../../../docs/table-column-apis-link.mdx';
 import { tableColumnMappingTag } from '../../../../../nimble-components/src/table-column/mapping';
 import { mappingEmptyTag } from '../../../../../nimble-components/src/mapping/empty';
 import { spinnerTag } from '../../../../../nimble-components/src/spinner';
@@ -29,6 +30,7 @@ table.
 
 ## API
 
+<TableColumnApisLink />
 <Controls of={tableColumnMappingStories.mappingColumn} />
 <ComponentApisLink />
 

--- a/packages/storybook/src/nimble/table-column/number-text/table-column-number-text.mdx
+++ b/packages/storybook/src/nimble/table-column/number-text/table-column-number-text.mdx
@@ -6,6 +6,7 @@ import {
 } from '../base/table-column-stories-utils';
 import * as tableColumnNumberTextStories from './table-column-number-text.stories';
 import ComponentApisLink from '../../../docs/component-apis-link.mdx';
+import TableColumnApisLink from '../../../docs/table-column-apis-link.mdx';
 import { tableColumnNumberTextTag } from '../../../../../nimble-components/src/table-column/number-text';
 import { tableTag } from '../../../../../nimble-components/src/table';
 import NoNullAndUndefinedBestPractice from '../../patterns/table-column/no-null-and-undefined-best-practice-docs.mdx';
@@ -24,6 +25,7 @@ the [nimble-theme-provider](?path=/docs/tokens-theme-provider--docs).
 
 ## API
 
+<TableColumnApisLink />
 <Controls of={tableColumnNumberTextStories.numberTextColumn} />
 <ComponentApisLink />
 

--- a/packages/storybook/src/nimble/table-column/text/table-column-text.mdx
+++ b/packages/storybook/src/nimble/table-column/text/table-column-text.mdx
@@ -2,6 +2,7 @@ import { Canvas, Meta, Controls, Title } from '@storybook/blocks';
 import { NimbleTableColumnText } from './table-column-text.react';
 import * as tableColumnTextStories from './table-column-text.stories';
 import ComponentApisLink from '../../../docs/component-apis-link.mdx';
+import TableColumnApisLink from '../../../docs/table-column-apis-link.mdx';
 import { tableColumnTextTag } from '../../../../../nimble-components/src/table-column/text';
 import { tableTag } from '../../../../../nimble-components/src/table';
 import NoNullAndUndefinedBestPractice from '../../patterns/table-column/no-null-and-undefined-best-practice-docs.mdx';
@@ -16,6 +17,7 @@ text in the <Tag name={tableTag}/>.
 
 ## API
 
+<TableColumnApisLink />
 <Controls of={tableColumnTextStories.textColumn} />
 <ComponentApisLink />
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Molly [pointed out](https://github.com/ni/nimble/pull/2204#discussion_r1659063808) that clients might be missing common table column APIs from the table on each column type. But I don't want to bloat every column's docs with the common APIs.

## 👩‍💻 Implementation

Link to the docs for the common APIs from each column's docs.

## 🧪 Testing

Local storybook inspection.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
