### PR TITLE
Remove unused css-loader dependency

### DIFF
--- a/change/@ni-nimble-components-2801a71d-ad81-4d18-a570-48ddbaa1c0d5.json
+++ b/change/@ni-nimble-components-2801a71d-ad81-4d18-a570-48ddbaa1c0d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "remove unused css-loader dep",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33742,7 +33742,6 @@
         "@types/offscreencanvas": "^2019.7.3",
         "@types/webpack-env": "^1.15.2",
         "concurrently": "^8.2.2",
-        "css-loader": "^6.7.3",
         "jasmine-core": "^5.1.2",
         "karma": "^6.3.0",
         "karma-chrome-launcher": "^3.1.0",

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -114,7 +114,6 @@
     "@types/offscreencanvas": "^2019.7.3",
     "@types/webpack-env": "^1.15.2",
     "concurrently": "^8.2.2",
-    "css-loader": "^6.7.3",
     "jasmine-core": "^5.1.2",
     "karma": "^6.3.0",
     "karma-chrome-launcher": "^3.1.0",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The renovate major update in https://github.com/ni/nimble/pull/2226 attempted to update the css-loader library which is not used by nimble-components.

## 👩‍💻 Implementation

Removed the libary.

## 🧪 Testing

Rely on CI.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
