### PR TITLE
Align column header based on cell content alignment

### DIFF
--- a/change/@ni-nimble-components-48e9cade-64e1-47a5-a616-c2e2a930a2b1.json
+++ b/change/@ni-nimble-components-48e9cade-64e1-47a5-a616-c2e2a930a2b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Align column header based on cell content alignment",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table-column/base/models/column-internals.ts
+++ b/packages/nimble-components/src/table-column/base/models/column-internals.ts
@@ -1,6 +1,10 @@
 import { uniqueId } from '@microsoft/fast-web-utilities';
 import { ViewTemplate, observable } from '@microsoft/fast-element';
-import { TableColumnSortDirection, TableFieldName } from '../../../table/types';
+import {
+    type TableColumnHeaderAlignment,
+    TableColumnSortDirection,
+    TableFieldName
+} from '../../../table/types';
 import type { TableCell } from '../../../table/components/cell';
 import {
     TableColumnSortOperation,
@@ -152,6 +156,12 @@ export class ColumnInternals<
      */
     @observable
     public hideHeaderIndicators = false;
+
+    /**
+     * How to align the header content.
+     */
+    @observable
+    public headerAlignment?: TableColumnHeaderAlignment;
 
     /**
      * @internal Do not write to this value directly. It is used by the Table in order to store

--- a/packages/nimble-components/src/table-column/base/models/column-internals.ts
+++ b/packages/nimble-components/src/table-column/base/models/column-internals.ts
@@ -1,7 +1,7 @@
 import { uniqueId } from '@microsoft/fast-web-utilities';
 import { ViewTemplate, observable } from '@microsoft/fast-element';
 import {
-    type TableColumnAlignment,
+    TableColumnAlignment,
     TableColumnSortDirection,
     TableFieldName
 } from '../../../table/types';
@@ -161,7 +161,7 @@ export class ColumnInternals<
      * How to align the header content.
      */
     @observable
-    public headerAlignment?: TableColumnAlignment;
+    public headerAlignment: TableColumnAlignment = TableColumnAlignment.left;
 
     /**
      * @internal Do not write to this value directly. It is used by the Table in order to store

--- a/packages/nimble-components/src/table-column/base/models/column-internals.ts
+++ b/packages/nimble-components/src/table-column/base/models/column-internals.ts
@@ -1,7 +1,7 @@
 import { uniqueId } from '@microsoft/fast-web-utilities';
 import { ViewTemplate, observable } from '@microsoft/fast-element';
 import {
-    type TableColumnHeaderAlignment,
+    type TableColumnAlignment,
     TableColumnSortDirection,
     TableFieldName
 } from '../../../table/types';
@@ -161,7 +161,7 @@ export class ColumnInternals<
      * How to align the header content.
      */
     @observable
-    public headerAlignment?: TableColumnHeaderAlignment;
+    public headerAlignment?: TableColumnAlignment;
 
     /**
      * @internal Do not write to this value directly. It is used by the Table in order to store

--- a/packages/nimble-components/src/table-column/number-text/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/cell-view/index.ts
@@ -6,7 +6,7 @@ import type {
 } from '..';
 import { styles } from '../../text-base/cell-view/styles';
 import { TableColumnTextCellViewBase } from '../../text-base/cell-view';
-import { TextCellViewBaseAlignment } from '../../text-base/cell-view/types';
+import { TableColumnAlignment } from '../../../table/types';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -23,7 +23,7 @@ TableColumnNumberTextColumnConfig
 > {
     protected override columnConfigChanged(): void {
         super.columnConfigChanged();
-        this.alignment = this.columnConfig?.alignment ?? TextCellViewBaseAlignment.left;
+        this.alignment = this.columnConfig?.alignment ?? TableColumnAlignment.left;
     }
 
     protected updateText(): void {

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -12,7 +12,10 @@ import {
 } from '@microsoft/fast-element';
 import { styles } from '../base/styles';
 import { template } from './template';
-import type { TableNumberField } from '../../table/types';
+import {
+    TableColumnHeaderAlignment,
+    type TableNumberField
+} from '../../table/types';
 import { TableColumnTextBase, mixinTextBase } from '../text-base';
 import { TableColumnSortOperation } from '../base/types';
 import { tableColumnNumberTextGroupHeaderTag } from './group-header-view';
@@ -180,6 +183,9 @@ export class TableColumnNumberText extends mixinTextBase(
                 alignment: this.determineCellContentAlignment(),
                 placeholder: this.placeholder
             };
+            this.columnInternals.headerAlignment = columnConfig.alignment === TextCellViewBaseAlignment.right
+                ? TableColumnHeaderAlignment.right
+                : TableColumnHeaderAlignment.left;
             this.columnInternals.columnConfig = columnConfig;
         } else {
             this.columnInternals.columnConfig = undefined;

--- a/packages/nimble-components/src/table-column/number-text/index.ts
+++ b/packages/nimble-components/src/table-column/number-text/index.ts
@@ -12,10 +12,7 @@ import {
 } from '@microsoft/fast-element';
 import { styles } from '../base/styles';
 import { template } from './template';
-import {
-    TableColumnHeaderAlignment,
-    type TableNumberField
-} from '../../table/types';
+import { TableColumnAlignment, type TableNumberField } from '../../table/types';
 import { TableColumnTextBase, mixinTextBase } from '../text-base';
 import { TableColumnSortOperation } from '../base/types';
 import { tableColumnNumberTextGroupHeaderTag } from './group-header-view';
@@ -25,7 +22,6 @@ import { NumberTextAlignment, NumberTextFormat } from './types';
 import type { UnitFormat } from '../../utilities/unit-format/unit-format';
 import { NumberTextUnitFormat } from './models/number-text-unit-format';
 import { TableColumnNumberTextValidator } from './models/table-column-number-text-validator';
-import { TextCellViewBaseAlignment } from '../text-base/cell-view/types';
 import { lang } from '../../theme-provider';
 import { Unit } from '../../unit/base/unit';
 import { waitUntilCustomElementsDefinedAsync } from '../../utilities/wait-until-custom-elements-defined-async';
@@ -35,7 +31,7 @@ export type TableColumnNumberTextCellRecord = TableNumberField<'value'>;
 export interface TableColumnNumberTextColumnConfig
     extends TableColumnTextBaseColumnConfig {
     formatter: UnitFormat;
-    alignment: TextCellViewBaseAlignment;
+    alignment: TableColumnAlignment;
 }
 
 declare global {
@@ -183,9 +179,7 @@ export class TableColumnNumberText extends mixinTextBase(
                 alignment: this.determineCellContentAlignment(),
                 placeholder: this.placeholder
             };
-            this.columnInternals.headerAlignment = columnConfig.alignment === TextCellViewBaseAlignment.right
-                ? TableColumnHeaderAlignment.right
-                : TableColumnHeaderAlignment.left;
+            this.columnInternals.headerAlignment = columnConfig.alignment;
             this.columnInternals.columnConfig = columnConfig;
         } else {
             this.columnInternals.columnConfig = undefined;
@@ -204,13 +198,13 @@ export class TableColumnNumberText extends mixinTextBase(
         });
     }
 
-    private determineCellContentAlignment(): TextCellViewBaseAlignment {
+    private determineCellContentAlignment(): TableColumnAlignment {
         if (this.alignment === NumberTextAlignment.left) {
-            return TextCellViewBaseAlignment.left;
+            return TableColumnAlignment.left;
         }
 
         if (this.alignment === NumberTextAlignment.right) {
-            return TextCellViewBaseAlignment.right;
+            return TableColumnAlignment.right;
         }
 
         // Look at format and decimal max digits and unit to determine the default alignment
@@ -219,9 +213,9 @@ export class TableColumnNumberText extends mixinTextBase(
             && typeof this.decimalMaximumDigits !== 'number'
             && !this.unit
         ) {
-            return TextCellViewBaseAlignment.right;
+            return TableColumnAlignment.right;
         }
-        return TextCellViewBaseAlignment.left;
+        return TableColumnAlignment.left;
     }
 }
 

--- a/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.spec.ts
@@ -4,7 +4,10 @@ import { tableTag, type Table } from '../../../table';
 import { TableColumnNumberText, tableColumnNumberTextTag } from '..';
 import { waitForUpdatesAsync } from '../../../testing/async-helpers';
 import { type Fixture, fixture } from '../../../utilities/tests/fixture';
-import type { TableRecord } from '../../../table/types';
+import {
+    TableColumnHeaderAlignment,
+    type TableRecord
+} from '../../../table/types';
 import { TablePageObject } from '../../../table/testing/table.pageobject';
 import { NumberTextAlignment, NumberTextFormat } from '../types';
 import type { TableColumnNumberTextCellView } from '../cell-view';
@@ -713,6 +716,29 @@ describe('TableColumnNumberText', () => {
             await waitForUpdatesAsync();
             expect(cellView.alignment).toEqual(TextCellViewBaseAlignment.left);
         });
+    });
+
+    it('configures header alignment based on cell alignment', async () => {
+        const column = elementReferences.column1;
+        await table.setData([{ number1: 10 }]);
+        column.alignment = NumberTextAlignment.right;
+        await connect();
+        await waitForUpdatesAsync();
+        expect(column.columnInternals.headerAlignment).toEqual(
+            TableColumnHeaderAlignment.right
+        );
+
+        elementReferences.column1.alignment = NumberTextAlignment.left;
+        await waitForUpdatesAsync();
+        expect(column.columnInternals.headerAlignment).toEqual(
+            TableColumnHeaderAlignment.left
+        );
+
+        elementReferences.column1.alignment = NumberTextAlignment.right;
+        await waitForUpdatesAsync();
+        expect(column.columnInternals.headerAlignment).toEqual(
+            TableColumnHeaderAlignment.right
+        );
     });
 
     describe('placeholder', () => {

--- a/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.spec.ts
@@ -4,14 +4,10 @@ import { tableTag, type Table } from '../../../table';
 import { TableColumnNumberText, tableColumnNumberTextTag } from '..';
 import { waitForUpdatesAsync } from '../../../testing/async-helpers';
 import { type Fixture, fixture } from '../../../utilities/tests/fixture';
-import {
-    TableColumnHeaderAlignment,
-    type TableRecord
-} from '../../../table/types';
+import { TableColumnAlignment, type TableRecord } from '../../../table/types';
 import { TablePageObject } from '../../../table/testing/table.pageobject';
 import { NumberTextAlignment, NumberTextFormat } from '../types';
 import type { TableColumnNumberTextCellView } from '../cell-view';
-import { TextCellViewBaseAlignment } from '../../text-base/cell-view/types';
 import { lang, themeProviderTag } from '../../../theme-provider';
 import { unitByteTag } from '../../../unit/byte';
 
@@ -570,7 +566,7 @@ describe('TableColumnNumberText', () => {
             decimalMaximumDigits: undefined,
             unit: false,
             configuredColumnAlignment: NumberTextAlignment.default,
-            expectedCellViewAlignment: TextCellViewBaseAlignment.left
+            expectedCellViewAlignment: TableColumnAlignment.left
         },
         {
             name: 'with default format and left alignment',
@@ -578,7 +574,7 @@ describe('TableColumnNumberText', () => {
             decimalMaximumDigits: undefined,
             unit: false,
             configuredColumnAlignment: NumberTextAlignment.left,
-            expectedCellViewAlignment: TextCellViewBaseAlignment.left
+            expectedCellViewAlignment: TableColumnAlignment.left
         },
         {
             name: 'with default format and right alignment',
@@ -586,7 +582,7 @@ describe('TableColumnNumberText', () => {
             decimalMaximumDigits: undefined,
             unit: false,
             configuredColumnAlignment: NumberTextAlignment.right,
-            expectedCellViewAlignment: TextCellViewBaseAlignment.right
+            expectedCellViewAlignment: TableColumnAlignment.right
         },
         {
             name: 'with default format, default alignment, and unit',
@@ -594,7 +590,7 @@ describe('TableColumnNumberText', () => {
             decimalMaximumDigits: undefined,
             unit: true,
             configuredColumnAlignment: NumberTextAlignment.default,
-            expectedCellViewAlignment: TextCellViewBaseAlignment.left
+            expectedCellViewAlignment: TableColumnAlignment.left
         },
         {
             name: 'with decimal format and default alignment',
@@ -602,7 +598,7 @@ describe('TableColumnNumberText', () => {
             decimalMaximumDigits: undefined,
             unit: false,
             configuredColumnAlignment: NumberTextAlignment.default,
-            expectedCellViewAlignment: TextCellViewBaseAlignment.right
+            expectedCellViewAlignment: TableColumnAlignment.right
         },
         {
             name: 'with decimal format and left alignment',
@@ -610,7 +606,7 @@ describe('TableColumnNumberText', () => {
             decimalMaximumDigits: undefined,
             unit: false,
             configuredColumnAlignment: NumberTextAlignment.left,
-            expectedCellViewAlignment: TextCellViewBaseAlignment.left
+            expectedCellViewAlignment: TableColumnAlignment.left
         },
         {
             name: 'with decimal format and right alignment',
@@ -618,7 +614,7 @@ describe('TableColumnNumberText', () => {
             decimalMaximumDigits: undefined,
             unit: false,
             configuredColumnAlignment: NumberTextAlignment.right,
-            expectedCellViewAlignment: TextCellViewBaseAlignment.right
+            expectedCellViewAlignment: TableColumnAlignment.right
         },
         {
             name: 'with decimal format, default alignment, and decimalMaximumDigits',
@@ -626,7 +622,7 @@ describe('TableColumnNumberText', () => {
             decimalMaximumDigits: 1,
             unit: false,
             configuredColumnAlignment: NumberTextAlignment.default,
-            expectedCellViewAlignment: TextCellViewBaseAlignment.left
+            expectedCellViewAlignment: TableColumnAlignment.left
         },
         {
             name: 'with decimal format, right alignment, and decimalMaximumDigits',
@@ -634,7 +630,7 @@ describe('TableColumnNumberText', () => {
             decimalMaximumDigits: 1,
             unit: false,
             configuredColumnAlignment: NumberTextAlignment.right,
-            expectedCellViewAlignment: TextCellViewBaseAlignment.right
+            expectedCellViewAlignment: TableColumnAlignment.right
         },
         {
             name: 'with decimal format, default alignment, and unit',
@@ -642,7 +638,7 @@ describe('TableColumnNumberText', () => {
             decimalMaximumDigits: undefined,
             unit: true,
             configuredColumnAlignment: NumberTextAlignment.default,
-            expectedCellViewAlignment: TextCellViewBaseAlignment.left
+            expectedCellViewAlignment: TableColumnAlignment.left
         }
     ] as const;
     describe('sets the correct initial alignment on the cell', () => {
@@ -684,19 +680,19 @@ describe('TableColumnNumberText', () => {
                 0,
                 0
             ) as TableColumnNumberTextCellView;
-            expect(cellView.alignment).toEqual(TextCellViewBaseAlignment.left);
+            expect(cellView.alignment).toEqual(TableColumnAlignment.left);
         });
 
         it('when alignment changes', async () => {
             elementReferences.column1.alignment = NumberTextAlignment.right;
             await waitForUpdatesAsync();
-            expect(cellView.alignment).toEqual(TextCellViewBaseAlignment.right);
+            expect(cellView.alignment).toEqual(TableColumnAlignment.right);
         });
 
         it('when format changes and alignment is set to "default"', async () => {
             elementReferences.column1.format = NumberTextFormat.decimal;
             await waitForUpdatesAsync();
-            expect(cellView.alignment).toEqual(TextCellViewBaseAlignment.right);
+            expect(cellView.alignment).toEqual(TableColumnAlignment.right);
         });
 
         it('when format is decimal, alignment is set to "default", and decimalMaximumDigits becomes set', async () => {
@@ -704,7 +700,7 @@ describe('TableColumnNumberText', () => {
             await waitForUpdatesAsync();
             elementReferences.column1.decimalMaximumDigits = 1;
             await waitForUpdatesAsync();
-            expect(cellView.alignment).toEqual(TextCellViewBaseAlignment.left);
+            expect(cellView.alignment).toEqual(TableColumnAlignment.left);
         });
 
         it('when format is decimal, alignment is set to "default", and unit element is appended', async () => {
@@ -714,7 +710,7 @@ describe('TableColumnNumberText', () => {
                 document.createElement(unitByteTag)
             );
             await waitForUpdatesAsync();
-            expect(cellView.alignment).toEqual(TextCellViewBaseAlignment.left);
+            expect(cellView.alignment).toEqual(TableColumnAlignment.left);
         });
     });
 
@@ -725,19 +721,19 @@ describe('TableColumnNumberText', () => {
         await connect();
         await waitForUpdatesAsync();
         expect(column.columnInternals.headerAlignment).toEqual(
-            TableColumnHeaderAlignment.right
+            TableColumnAlignment.right
         );
 
         elementReferences.column1.alignment = NumberTextAlignment.left;
         await waitForUpdatesAsync();
         expect(column.columnInternals.headerAlignment).toEqual(
-            TableColumnHeaderAlignment.left
+            TableColumnAlignment.left
         );
 
         elementReferences.column1.alignment = NumberTextAlignment.right;
         await waitForUpdatesAsync();
         expect(column.columnInternals.headerAlignment).toEqual(
-            TableColumnHeaderAlignment.right
+            TableColumnAlignment.right
         );
     });
 

--- a/packages/nimble-components/src/table-column/text-base/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/text-base/cell-view/index.ts
@@ -1,8 +1,7 @@
 import { observable } from '@microsoft/fast-element';
 import { TableCellView } from '../../base/cell-view';
 import type { TableCellRecord } from '../../base/types';
-import { TextCellViewBaseAlignment } from './types';
-import type { TableFieldValue } from '../../../table/types';
+import { TableColumnAlignment, TableFieldValue } from '../../../table/types';
 
 export interface TableColumnTextBaseCellRecord extends TableCellRecord {
     value: TableFieldValue;
@@ -35,7 +34,7 @@ export abstract class TableColumnTextCellViewBase<
      * The alignment of the text within the cell.
      */
     @observable
-    public alignment: TextCellViewBaseAlignment = TextCellViewBaseAlignment.left;
+    public alignment: TableColumnAlignment = TableColumnAlignment.left;
 
     /**
      * Whether or not the text being displayed in the cell view is a placeholder.

--- a/packages/nimble-components/src/table-column/text-base/cell-view/template.ts
+++ b/packages/nimble-components/src/table-column/text-base/cell-view/template.ts
@@ -2,13 +2,13 @@ import { html } from '@microsoft/fast-element';
 
 import type { TableColumnTextCellViewBase } from '.';
 import { overflow } from '../../../utilities/directive/overflow';
-import { TextCellViewBaseAlignment } from './types';
+import { TableColumnAlignment } from '../../../table/types';
 
 // prettier-ignore
 export const template = html<TableColumnTextCellViewBase>`
     <template
         class="
-            ${x => (x.alignment === TextCellViewBaseAlignment.right ? 'right-align' : '')}
+            ${x => (x.alignment === TableColumnAlignment.right ? 'right-align' : '')}
             ${x => (x.isPlaceholder ? 'placeholder' : '')}
         "
     >

--- a/packages/nimble-components/src/table-column/text-base/cell-view/tests/table-column-text-base-cell-view.spec.ts
+++ b/packages/nimble-components/src/table-column/text-base/cell-view/tests/table-column-text-base-cell-view.spec.ts
@@ -8,7 +8,7 @@ import {
 import { waitForUpdatesAsync } from '../../../../testing/async-helpers';
 import { template as textBaseCellViewTemplate } from '../template';
 import { styles as textBaseCellViewStyles } from '../styles';
-import { TextCellViewBaseAlignment } from '../types';
+import { TableColumnAlignment } from '../../../../table/types';
 
 describe('TableColumnTextCellViewBase', () => {
     let element: TableColumnTextCellViewBase;
@@ -48,17 +48,17 @@ describe('TableColumnTextCellViewBase', () => {
     });
 
     it('defaults to left alignment', () => {
-        expect(element.alignment).toBe(TextCellViewBaseAlignment.left);
+        expect(element.alignment).toBe(TableColumnAlignment.left);
     });
 
     it('styles cell correctly with left alignment', async () => {
-        element.alignment = TextCellViewBaseAlignment.left;
+        element.alignment = TableColumnAlignment.left;
         await waitForUpdatesAsync();
         expect(getComputedStyle(element).marginLeft).toEqual('0px');
     });
 
     it('styles cell correctly with right alignment', async () => {
-        element.alignment = TextCellViewBaseAlignment.right;
+        element.alignment = TableColumnAlignment.right;
         await waitForUpdatesAsync();
         expect(getComputedStyle(element).marginLeft).not.toEqual('0px');
     });

--- a/packages/nimble-components/src/table-column/text-base/cell-view/tests/types.spec.ts
+++ b/packages/nimble-components/src/table-column/text-base/cell-view/tests/types.spec.ts
@@ -1,9 +1,0 @@
-import type { TextCellViewBaseAlignment } from '../types';
-
-describe('TableColumnTextCellViewBase types', () => {
-    it('TextCellViewBaseAlignment fails compile if assigning arbitrary string values', () => {
-        // @ts-expect-error This expect will fail if the enum-like type is missing "as const"
-        const alignment: TextCellViewBaseAlignment = 'hello';
-        expect(alignment).toEqual('hello');
-    });
-});

--- a/packages/nimble-components/src/table-column/text-base/cell-view/types.ts
+++ b/packages/nimble-components/src/table-column/text-base/cell-view/types.ts
@@ -1,9 +1,0 @@
-/**
- * The aligment of the value in a TableColumnTextCellViewBase instance.
- */
-export const TextCellViewBaseAlignment = {
-    left: 'left',
-    right: 'right'
-} as const;
-export type TextCellViewBaseAlignment =
-    (typeof TextCellViewBaseAlignment)[keyof typeof TextCellViewBaseAlignment];

--- a/packages/nimble-components/src/table/components/header/index.ts
+++ b/packages/nimble-components/src/table/components/header/index.ts
@@ -1,6 +1,9 @@
 import { attr, observable } from '@microsoft/fast-element';
 import { DesignSystem, FoundationElement } from '@microsoft/fast-foundation';
-import { TableColumnSortDirection } from '../../types';
+import {
+    TableColumnHeaderAlignment,
+    TableColumnSortDirection
+} from '../../types';
 import { styles } from './styles';
 import { template } from './template';
 
@@ -23,6 +26,9 @@ export class TableHeader extends FoundationElement {
 
     @attr({ attribute: 'indicators-hidden', mode: 'boolean' })
     public indicatorsHidden = false;
+
+    @observable
+    public alignment: TableColumnHeaderAlignment = TableColumnHeaderAlignment.left;
 
     @observable
     public isGrouped = false;

--- a/packages/nimble-components/src/table/components/header/index.ts
+++ b/packages/nimble-components/src/table/components/header/index.ts
@@ -1,9 +1,6 @@
 import { attr, observable } from '@microsoft/fast-element';
 import { DesignSystem, FoundationElement } from '@microsoft/fast-foundation';
-import {
-    TableColumnHeaderAlignment,
-    TableColumnSortDirection
-} from '../../types';
+import { TableColumnAlignment, TableColumnSortDirection } from '../../types';
 import { styles } from './styles';
 import { template } from './template';
 
@@ -28,7 +25,7 @@ export class TableHeader extends FoundationElement {
     public indicatorsHidden = false;
 
     @observable
-    public alignment: TableColumnHeaderAlignment = TableColumnHeaderAlignment.left;
+    public alignment: TableColumnAlignment = TableColumnAlignment.left;
 
     @observable
     public isGrouped = false;

--- a/packages/nimble-components/src/table/components/header/styles.ts
+++ b/packages/nimble-components/src/table/components/header/styles.ts
@@ -27,7 +27,7 @@ export const styles = css`
     }
 
     :host(.right-align) {
-        justify-content: flex-end;
+        flex-direction: row-reverse;
     }
 
     :host(${focusVisible}) {

--- a/packages/nimble-components/src/table/components/header/styles.ts
+++ b/packages/nimble-components/src/table/components/header/styles.ts
@@ -6,6 +6,7 @@ import {
     controlHeight,
     iconColor,
     mediumPadding,
+    smallPadding,
     tableHeaderFont,
     tableHeaderFontColor
 } from '../../../theme-provider/design-tokens';
@@ -17,17 +18,20 @@ export const styles = css`
     :host {
         height: ${controlHeight};
         align-items: center;
-        padding: 0px ${mediumPadding};
+        padding-left: ${mediumPadding};
+        padding-right: ${smallPadding};
         font: ${tableHeaderFont};
         color: ${tableHeaderFontColor};
         ${iconColor.cssCustomProperty}: ${tableHeaderFontColor};
         text-transform: uppercase;
-        gap: ${mediumPadding};
+        gap: ${smallPadding};
         cursor: default;
     }
 
     :host(.right-align) {
         flex-direction: row-reverse;
+        padding-left: ${smallPadding};
+        padding-right: ${mediumPadding};
     }
 
     :host(${focusVisible}) {

--- a/packages/nimble-components/src/table/components/header/styles.ts
+++ b/packages/nimble-components/src/table/components/header/styles.ts
@@ -26,6 +26,10 @@ export const styles = css`
         cursor: default;
     }
 
+    :host(.right-align) {
+        justify-content: flex-end;
+    }
+
     :host(${focusVisible}) {
         outline: calc(2 * ${borderWidth}) solid ${borderHoverColor};
         outline-offset: calc(-2 * ${borderWidth});

--- a/packages/nimble-components/src/table/components/header/template.ts
+++ b/packages/nimble-components/src/table/components/header/template.ts
@@ -3,7 +3,10 @@ import type { TableHeader } from '.';
 import { iconArrowDownTag } from '../../../icons/arrow-down';
 import { iconArrowUpTag } from '../../../icons/arrow-up';
 import { iconTwoSquaresInBracketsTag } from '../../../icons/two-squares-in-brackets';
-import { TableColumnSortDirection } from '../../types';
+import {
+    TableColumnHeaderAlignment,
+    TableColumnSortDirection
+} from '../../types';
 import {
     tableColumnHeaderGroupedLabel,
     tableColumnHeaderSortedAscendingLabel,
@@ -13,11 +16,14 @@ import {
 // prettier-ignore
 export const template = html<TableHeader>`
     <template role="columnheader"
+        class="${x => (x.alignment === TableColumnHeaderAlignment.right ? 'right-align' : '')}"
         aria-sort="${x => x.ariaSort}"
         ${'' /* Prevent header double clicks from selecting text */}
         @mousedown="${(_x, c) => !((c.event as MouseEvent).detail > 1)}"
     >
-        <slot></slot>
+        ${when(x => x.alignment === TableColumnHeaderAlignment.left, html`
+            <slot></slot>
+        `)}
 
         ${when(x => !x.indicatorsHidden, html<TableHeader>`
             ${'' /* Set aria-hidden="true" on sort indicators because aria-sort is set on the 1st sorted column */}
@@ -43,6 +49,10 @@ export const template = html<TableHeader>`
                     aria-label="${x => tableColumnHeaderGroupedLabel.getValueFor(x)}"
                 ></${iconTwoSquaresInBracketsTag}>
             `)}
+        `)}
+
+        ${when(x => x.alignment === TableColumnHeaderAlignment.right, html`
+            <slot></slot>
         `)}
     </template>
 `;

--- a/packages/nimble-components/src/table/components/header/template.ts
+++ b/packages/nimble-components/src/table/components/header/template.ts
@@ -18,9 +18,7 @@ export const template = html<TableHeader>`
         ${'' /* Prevent header double clicks from selecting text */}
         @mousedown="${(_x, c) => !((c.event as MouseEvent).detail > 1)}"
     >
-        ${when(x => x.alignment === TableColumnAlignment.left, html`
-            <slot></slot>
-        `)}
+        <slot></slot>
 
         ${when(x => !x.indicatorsHidden, html<TableHeader>`
             ${'' /* Set aria-hidden="true" on sort indicators because aria-sort is set on the 1st sorted column */}
@@ -46,10 +44,6 @@ export const template = html<TableHeader>`
                     aria-label="${x => tableColumnHeaderGroupedLabel.getValueFor(x)}"
                 ></${iconTwoSquaresInBracketsTag}>
             `)}
-        `)}
-
-        ${when(x => x.alignment === TableColumnAlignment.right, html`
-            <slot></slot>
         `)}
     </template>
 `;

--- a/packages/nimble-components/src/table/components/header/template.ts
+++ b/packages/nimble-components/src/table/components/header/template.ts
@@ -3,10 +3,7 @@ import type { TableHeader } from '.';
 import { iconArrowDownTag } from '../../../icons/arrow-down';
 import { iconArrowUpTag } from '../../../icons/arrow-up';
 import { iconTwoSquaresInBracketsTag } from '../../../icons/two-squares-in-brackets';
-import {
-    TableColumnHeaderAlignment,
-    TableColumnSortDirection
-} from '../../types';
+import { TableColumnAlignment, TableColumnSortDirection } from '../../types';
 import {
     tableColumnHeaderGroupedLabel,
     tableColumnHeaderSortedAscendingLabel,
@@ -16,12 +13,12 @@ import {
 // prettier-ignore
 export const template = html<TableHeader>`
     <template role="columnheader"
-        class="${x => (x.alignment === TableColumnHeaderAlignment.right ? 'right-align' : '')}"
+        class="${x => (x.alignment === TableColumnAlignment.right ? 'right-align' : '')}"
         aria-sort="${x => x.ariaSort}"
         ${'' /* Prevent header double clicks from selecting text */}
         @mousedown="${(_x, c) => !((c.event as MouseEvent).detail > 1)}"
     >
-        ${when(x => x.alignment === TableColumnHeaderAlignment.left, html`
+        ${when(x => x.alignment === TableColumnAlignment.left, html`
             <slot></slot>
         `)}
 
@@ -51,7 +48,7 @@ export const template = html<TableHeader>`
             `)}
         `)}
 
-        ${when(x => x.alignment === TableColumnHeaderAlignment.right, html`
+        ${when(x => x.alignment === TableColumnAlignment.right, html`
             <slot></slot>
         `)}
     </template>

--- a/packages/nimble-components/src/table/components/header/tests/table-header.spec.ts
+++ b/packages/nimble-components/src/table/components/header/tests/table-header.spec.ts
@@ -2,10 +2,7 @@ import { html } from '@microsoft/fast-element';
 import { TableHeader } from '..';
 import { waitForUpdatesAsync } from '../../../../testing/async-helpers';
 import { type Fixture, fixture } from '../../../../utilities/tests/fixture';
-import {
-    TableColumnHeaderAlignment,
-    TableColumnSortDirection
-} from '../../../types';
+import { TableColumnAlignment, TableColumnSortDirection } from '../../../types';
 import { TableHeaderPageObject } from './table-header-pageobject';
 
 async function setup(): Promise<Fixture<TableHeader>> {
@@ -152,6 +149,6 @@ describe('TableHeader', () => {
     });
 
     it('defaults to left-aligned', () => {
-        expect(element.alignment).toBe(TableColumnHeaderAlignment.left);
+        expect(element.alignment).toBe(TableColumnAlignment.left);
     });
 });

--- a/packages/nimble-components/src/table/components/header/tests/table-header.spec.ts
+++ b/packages/nimble-components/src/table/components/header/tests/table-header.spec.ts
@@ -2,7 +2,10 @@ import { html } from '@microsoft/fast-element';
 import { TableHeader } from '..';
 import { waitForUpdatesAsync } from '../../../../testing/async-helpers';
 import { type Fixture, fixture } from '../../../../utilities/tests/fixture';
-import { TableColumnSortDirection } from '../../../types';
+import {
+    TableColumnHeaderAlignment,
+    TableColumnSortDirection
+} from '../../../types';
 import { TableHeaderPageObject } from './table-header-pageobject';
 
 async function setup(): Promise<Fixture<TableHeader>> {
@@ -146,5 +149,9 @@ describe('TableHeader', () => {
         expect(element.getAttribute('aria-sort')).toEqual('descending');
         expect(pageObject.isSortAscendingIconVisible()).toBeFalse();
         expect(pageObject.isSortDescendingIconVisible()).toBeFalse();
+    });
+
+    it('defaults to left-aligned', () => {
+        expect(element.alignment).toBe(TableColumnHeaderAlignment.left);
     });
 });

--- a/packages/nimble-components/src/table/template.ts
+++ b/packages/nimble-components/src/table/template.ts
@@ -13,7 +13,6 @@ import { tableRowTag } from './components/row';
 import type { TableColumn } from '../table-column/base';
 import {
     TableActionMenuToggleEventDetail,
-    TableColumnAlignment,
     TableColumnSortDirection,
     TableRowSelectionMode,
     TableRowSelectionState,

--- a/packages/nimble-components/src/table/template.ts
+++ b/packages/nimble-components/src/table/template.ts
@@ -13,6 +13,7 @@ import { tableRowTag } from './components/row';
 import type { TableColumn } from '../table-column/base';
 import {
     TableActionMenuToggleEventDetail,
+    TableColumnHeaderAlignment,
     TableColumnSortDirection,
     TableRowSelectionMode,
     TableRowSelectionState,
@@ -109,6 +110,7 @@ export const template = html<Table>`
                                             ?indicators-hidden="${x => x.columnInternals.hideHeaderIndicators}"
                                             @keydown="${(x, c) => c.parent.onHeaderKeyDown(x, c.event as KeyboardEvent)}"
                                             @click="${(x, c) => c.parent.toggleColumnSort(x, (c.event as MouseEvent).shiftKey)}"
+                                            :alignment="${x => (typeof x.columnInternals.headerAlignment === 'string' ? x.columnInternals.headerAlignment : TableColumnHeaderAlignment.left)}"
                                             :isGrouped=${x => (typeof x.columnInternals.groupIndex === 'number' && !x.columnInternals.groupingDisabled)}
                                         >
                                             <slot name="${x => x.slot}"></slot>

--- a/packages/nimble-components/src/table/template.ts
+++ b/packages/nimble-components/src/table/template.ts
@@ -13,7 +13,7 @@ import { tableRowTag } from './components/row';
 import type { TableColumn } from '../table-column/base';
 import {
     TableActionMenuToggleEventDetail,
-    TableColumnHeaderAlignment,
+    TableColumnAlignment,
     TableColumnSortDirection,
     TableRowSelectionMode,
     TableRowSelectionState,
@@ -110,7 +110,7 @@ export const template = html<Table>`
                                             ?indicators-hidden="${x => x.columnInternals.hideHeaderIndicators}"
                                             @keydown="${(x, c) => c.parent.onHeaderKeyDown(x, c.event as KeyboardEvent)}"
                                             @click="${(x, c) => c.parent.toggleColumnSort(x, (c.event as MouseEvent).shiftKey)}"
-                                            :alignment="${x => (typeof x.columnInternals.headerAlignment === 'string' ? x.columnInternals.headerAlignment : TableColumnHeaderAlignment.left)}"
+                                            :alignment="${x => (typeof x.columnInternals.headerAlignment === 'string' ? x.columnInternals.headerAlignment : TableColumnAlignment.left)}"
                                             :isGrouped=${x => (typeof x.columnInternals.groupIndex === 'number' && !x.columnInternals.groupingDisabled)}
                                         >
                                             <slot name="${x => x.slot}"></slot>

--- a/packages/nimble-components/src/table/template.ts
+++ b/packages/nimble-components/src/table/template.ts
@@ -110,7 +110,7 @@ export const template = html<Table>`
                                             ?indicators-hidden="${x => x.columnInternals.hideHeaderIndicators}"
                                             @keydown="${(x, c) => c.parent.onHeaderKeyDown(x, c.event as KeyboardEvent)}"
                                             @click="${(x, c) => c.parent.toggleColumnSort(x, (c.event as MouseEvent).shiftKey)}"
-                                            :alignment="${x => (typeof x.columnInternals.headerAlignment === 'string' ? x.columnInternals.headerAlignment : TableColumnAlignment.left)}"
+                                            :alignment="${x => x.columnInternals.headerAlignment}"
                                             :isGrouped=${x => (typeof x.columnInternals.groupIndex === 'number' && !x.columnInternals.groupingDisabled)}
                                         >
                                             <slot name="${x => x.slot}"></slot>

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -13,6 +13,7 @@ import {
     uniqueElementName
 } from '../../utilities/tests/fixture';
 import {
+    TableColumnHeaderAlignment,
     TableColumnSortDirection,
     TableRecord,
     TableRecordDelayedHierarchyState,
@@ -270,6 +271,25 @@ describe('Table', () => {
 
             const header = pageObject.getHeaderElement(0);
             expect(header.indicatorsHidden).toBeTrue();
+        });
+
+        it('sets column header alignment to left by default', async () => {
+            await connect();
+            await waitForUpdatesAsync();
+
+            const header = pageObject.getHeaderElement(0);
+            expect(header.alignment).toEqual(TableColumnHeaderAlignment.left);
+        });
+
+        it('sets column header alignment to right when configured as right in columnInternals', async () => {
+            await connect();
+            await waitForUpdatesAsync();
+
+            element.columns[0]!.columnInternals.headerAlignment = TableColumnHeaderAlignment.right;
+            await waitForUpdatesAsync();
+
+            const header = pageObject.getHeaderElement(0);
+            expect(header.alignment).toEqual(TableColumnHeaderAlignment.right);
         });
 
         it('can set data before the element is connected', async () => {

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -13,7 +13,7 @@ import {
     uniqueElementName
 } from '../../utilities/tests/fixture';
 import {
-    TableColumnHeaderAlignment,
+    TableColumnAlignment,
     TableColumnSortDirection,
     TableRecord,
     TableRecordDelayedHierarchyState,
@@ -278,18 +278,18 @@ describe('Table', () => {
             await waitForUpdatesAsync();
 
             const header = pageObject.getHeaderElement(0);
-            expect(header.alignment).toEqual(TableColumnHeaderAlignment.left);
+            expect(header.alignment).toEqual(TableColumnAlignment.left);
         });
 
         it('sets column header alignment to right when configured as right in columnInternals', async () => {
             await connect();
             await waitForUpdatesAsync();
 
-            element.columns[0]!.columnInternals.headerAlignment = TableColumnHeaderAlignment.right;
+            element.columns[0]!.columnInternals.headerAlignment = TableColumnAlignment.right;
             await waitForUpdatesAsync();
 
             const header = pageObject.getHeaderElement(0);
-            expect(header.alignment).toEqual(TableColumnHeaderAlignment.right);
+            expect(header.alignment).toEqual(TableColumnAlignment.right);
         });
 
         it('can set data before the element is connected', async () => {

--- a/packages/nimble-components/src/table/tests/types.spec.ts
+++ b/packages/nimble-components/src/table/tests/types.spec.ts
@@ -36,9 +36,9 @@ describe('Table type', () => {
         expect(focusType).toEqual('hello');
     });
 
-    it('TableColumnHeaderAlignment fails compile if assigning arbitrary string values', () => {
+    it('TableColumnAlignment fails compile if assigning arbitrary string values', () => {
         // @ts-expect-error This expect will fail if the enum-like type is missing "as const"
-        const alignment: TableColumnHeaderAlignment = 'hello';
+        const alignment: TableColumnAlignment = 'hello';
         expect(alignment).toEqual('hello');
     });
 });

--- a/packages/nimble-components/src/table/tests/types.spec.ts
+++ b/packages/nimble-components/src/table/tests/types.spec.ts
@@ -35,4 +35,10 @@ describe('Table type', () => {
         const focusType: TableFocusType = 'hello';
         expect(focusType).toEqual('hello');
     });
+
+    it('TableColumnHeaderAlignment fails compile if assigning arbitrary string values', () => {
+        // @ts-expect-error This expect will fail if the enum-like type is missing "as const"
+        const alignment: TableColumnHeaderAlignment = 'hello';
+        expect(alignment).toEqual('hello');
+    });
 });

--- a/packages/nimble-components/src/table/types.ts
+++ b/packages/nimble-components/src/table/types.ts
@@ -219,6 +219,18 @@ export interface TableRowState<TData extends TableRecord = TableRecord> {
 
 /**
  * @internal
+ *
+ * Alignment of column header content
+ */
+export const TableColumnHeaderAlignment = {
+    left: 'left',
+    right: 'right'
+} as const;
+export type TableColumnHeaderAlignment =
+    (typeof TableColumnHeaderAlignment)[keyof typeof TableColumnHeaderAlignment];
+
+/**
+ * @internal
  * Table keyboard focus types
  */
 export const TableFocusType = {
@@ -236,6 +248,7 @@ export type TableFocusType =
 
 /**
  * @internal
+ *
  * Focusable elements of a table row
  */
 export interface TableRowFocusableElements {
@@ -248,6 +261,7 @@ export interface TableRowFocusableElements {
 
 /**
  * @internal
+ *
  * Focusable elements of a table's header
  */
 export interface TableHeaderFocusableElements {

--- a/packages/nimble-components/src/table/types.ts
+++ b/packages/nimble-components/src/table/types.ts
@@ -220,14 +220,14 @@ export interface TableRowState<TData extends TableRecord = TableRecord> {
 /**
  * @internal
  *
- * Alignment of column header content
+ * Alignment of column content
  */
-export const TableColumnHeaderAlignment = {
+export const TableColumnAlignment = {
     left: 'left',
     right: 'right'
 } as const;
-export type TableColumnHeaderAlignment =
-    (typeof TableColumnHeaderAlignment)[keyof typeof TableColumnHeaderAlignment];
+export type TableColumnAlignment =
+    (typeof TableColumnAlignment)[keyof typeof TableColumnAlignment];
 
 /**
  * @internal

--- a/packages/storybook/src/nimble/table-column/number-text/table-column-number-text-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/number-text/table-column-number-text-matrix.stories.ts
@@ -59,6 +59,8 @@ const component = (
         <${tableColumnNumberTextTag}
             field-name="number"
             group-index="0"
+            sort-index="0"
+            sort-direction="descending"
             alignment="${() => alignment}"
             placeholder="${() => placeholder}"
         >
@@ -69,6 +71,8 @@ const component = (
             decimal-digits="3"
             field-name="number"
             group-index="2"
+            sort-index="1"
+            sort-direction="ascending"
             alignment="${() => alignment}"
             placeholder="${() => placeholder}"
         >


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #1750 

## 👩‍💻 Implementation

`TableHeader` now has an `alignment` property that it uses to organize/align the header contents. This property gets bound to a new `headerAlignment` property on `ColumnInternals`. Its type is a new enum, `TableColumnHeaderAlignment`, which has values `left` and `right`. There is already an alignment enum for the cell contents (`TextCellViewBaseAlignment`), but I don't think we should directly couple cell and header alignment. 

Currently the only column that can have right-aligned cell content is the number-text column. It now updates `columnInternals.headerAlignment` whenever its cell content alignment might have changed.

The referenced bug doesn't really answer the question of where sort/grouping indicators (and future menu dropdown) should go when right-aligning the header. For now, I have assumed we should shift them to the left side of the column label.

## 🧪 Testing

Created new unit test cases.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
