### PR TITLE
Configure karma/jasmine to fail tests with no expectations

### DIFF
--- a/change/@ni-jasmine-parameterized-3ada924d-4814-4609-a50c-1c1f93b7ed4a.json
+++ b/change/@ni-jasmine-parameterized-3ada924d-4814-4609-a50c-1c1f93b7ed4a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update test configuration to fail if no expectations",
+  "packageName": "@ni/jasmine-parameterized",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-nimble-angular-24785877-fa91-4af1-a40c-7aae97d3b6ad.json
+++ b/change/@ni-nimble-angular-24785877-fa91-4af1-a40c-7aae97d3b6ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update test configuration to fail if no expectations",
+  "packageName": "@ni/nimble-angular",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-nimble-components-3450c920-5103-42d6-9e8d-20b0355d954e.json
+++ b/change/@ni-nimble-components-3450c920-5103-42d6-9e8d-20b0355d954e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update test configuration to fail if no expectations",
+  "packageName": "@ni/nimble-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-spright-angular-25930686-8239-4d62-a666-bf0dee7148a4.json
+++ b/change/@ni-spright-angular-25930686-8239-4d62-a666-bf0dee7148a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update test configuration to fail if no expectations",
+  "packageName": "@ni/spright-angular",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-spright-components-7f1912ca-942e-4e16-9ad4-27c3524f1d6f.json
+++ b/change/@ni-spright-components-7f1912ca-942e-4e16-9ad4-27c3524f1d6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update test configuration to fail if no expectations",
+  "packageName": "@ni/spright-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/angular-workspace/example-client-app/karma.conf.js
+++ b/packages/angular-workspace/example-client-app/karma.conf.js
@@ -24,10 +24,7 @@ module.exports = config => {
         ],
         client: {
             jasmine: {
-                // you can add configuration options for Jasmine here
-                // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
-                // for example, you can disable the random execution with `random: false`
-                // or set a specific seed with `seed: 4321`
+                failSpecWithNoExpectations: true,
                 stopSpecOnExpectationFailure: false
             },
             clearContext: false // leave Jasmine Spec Runner output visible in browser

--- a/packages/angular-workspace/nimble-angular/karma.conf.js
+++ b/packages/angular-workspace/nimble-angular/karma.conf.js
@@ -24,10 +24,7 @@ module.exports = config => {
         ],
         client: {
             jasmine: {
-                // you can add configuration options for Jasmine here
-                // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
-                // for example, you can disable the random execution with `random: false`
-                // or set a specific seed with `seed: 4321`
+                failSpecWithNoExpectations: true,
                 stopSpecOnExpectationFailure: false
             },
             clearContext: false // leave Jasmine Spec Runner output visible in browser

--- a/packages/angular-workspace/spright-angular/karma.conf.js
+++ b/packages/angular-workspace/spright-angular/karma.conf.js
@@ -24,10 +24,7 @@ module.exports = config => {
         ],
         client: {
             jasmine: {
-                // you can add configuration options for Jasmine here
-                // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
-                // for example, you can disable the random execution with `random: false`
-                // or set a specific seed with `seed: 4321`
+                failSpecWithNoExpectations: true,
                 stopSpecOnExpectationFailure: false
             },
             clearContext: false // leave Jasmine Spec Runner output visible in browser

--- a/packages/jasmine-parameterized/karma.conf.cjs
+++ b/packages/jasmine-parameterized/karma.conf.cjs
@@ -55,7 +55,11 @@ module.exports = config => {
             }
         },
         client: {
-            captureConsole: true
+            captureConsole: true,
+            jasmine: {
+                failSpecWithNoExpectations: true,
+                stopSpecOnExpectationFailure: false
+            },
         },
         // to disable the WARN 404 for image requests
         logLevel: config.LOG_ERROR,

--- a/packages/nimble-components/karma.conf.js
+++ b/packages/nimble-components/karma.conf.js
@@ -144,6 +144,7 @@ module.exports = config => {
         },
         client: {
             jasmine: {
+                failSpecWithNoExpectations: true,
                 stopSpecOnExpectationFailure: false
             },
             captureConsole: true

--- a/packages/spright-components/karma.conf.js
+++ b/packages/spright-components/karma.conf.js
@@ -131,6 +131,7 @@ module.exports = config => {
         },
         client: {
             jasmine: {
+                failSpecWithNoExpectations: true,
                 stopSpecOnExpectationFailure: false
             },
             captureConsole: true


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

A test with no expectations typically indicates a problem with the test. We'd like to detect this situation automatically.

See [similar PR for SystemLinkShared](https://dev.azure.com/ni/DevCentral/_git/Skyline/pullrequest/750756)

## 👩‍💻 Implementation

Set [`client.jasmine.failSpecWithNoExpectations: true`](https://jasmine.github.io/api/5.1/Configuration) in each package's `karma.conf.js`

## 🧪 Testing

Locally verified that a test with no expectations would pass before but fails now.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
