### PR TITLE
Disable intermittent markdown serializer test

### DIFF
--- a/change/@ni-nimble-components-b7e0f118-9649-40a9-b14b-241e688a2d42.json
+++ b/change/@ni-nimble-components-b7e0f118-9649-40a9-b14b-241e688a2d42.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Disable intermittent markdown serializer test",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/rich-text/models/tests/markdown-serializer.spec.ts
+++ b/packages/nimble-components/src/rich-text/models/tests/markdown-serializer.spec.ts
@@ -337,7 +337,8 @@ Plain text 3`);
 <user:1> `);
         });
 
-        it('Mention node', async () => {
+        // Intermittent, see https://github.com/ni/nimble/issues/2219
+        xit('Mention node', async () => {
             await appendUserMentionConfiguration(element, [
                 { key: 'user:1', displayName: 'username1' }
             ]);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
Test failed in [this PR build](https://github.com/ni/nimble/actions/runs/9897035682/job/27340606528?pr=2242). Following intermittent test protocol.

```
[test-concurrent:nimble-components] [test-firefox:verbose]   Markdown serializer
[test-concurrent:nimble-components] [test-firefox:verbose]     Serialize rich text editor content to its respective markdown
[test-concurrent:nimble-components] [test-firefox:verbose]       ✗ Mention node (336ms)
[test-concurrent:nimble-components] [test-firefox:verbose] 	InvalidStateError: Selection.collapseToEnd: No selection range exists thrown
```

## 👩‍💻 Implementation

Disabled test and linked to existing issue #2219

## 🧪 Testing

N/A

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
