### PR TITLE
Disable intermittent nimble-select test in webkit

### DIFF
--- a/change/@ni-nimble-components-9d206e17-6484-45b1-9966-d36adfa7764a.json
+++ b/change/@ni-nimble-components-9d206e17-6484-45b1-9966-d36adfa7764a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Disable intermittent test",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -655,7 +655,8 @@ describe('Select', () => {
             return fixture<Select>(viewTemplate);
         }
 
-        it('should limit dropdown height to viewport', async () => {
+        // Intermittent, see: https://github.com/ni/nimble/issues/2269
+        it('should limit dropdown height to viewport #SkipWebkit', async () => {
             const { element, connect, disconnect } = await setup500Options();
             await connect();
             await clickAndWaitForOpen(element);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

I've created https://github.com/ni/nimble/issues/2269 to track that this test is being disabled.

## 👩‍💻 Implementation

Disable the test on webkit & link the issue

## 🧪 Testing

N/A

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
