### PR TITLE
Disable intermittent nimble-select test in webkit

### DIFF
--- a/change/@ni-nimble-components-7d08d3c7-bd27-480e-9219-e0e698d0e55e.json
+++ b/change/@ni-nimble-components-7d08d3c7-bd27-480e-9219-e0e698d0e55e.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "none",
   "comment": "Disable intermittent nimble-select test in webkit",
   "packageName": "@ni/nimble-components",
   "email": "20542556+mollykreis@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@ni-nimble-components-7d08d3c7-bd27-480e-9219-e0e698d0e55e.json
+++ b/change/@ni-nimble-components-7d08d3c7-bd27-480e-9219-e0e698d0e55e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Disable intermittent nimble-select test in webkit",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -709,7 +709,8 @@ describe('Select', () => {
             return fixture<Select>(viewTemplate);
         }
 
-        it('should not confine dropdown to div with "overflow: auto"', async () => {
+        // Intermittent, see: https://github.com/ni/nimble/issues/2272
+        it('should not confine dropdown to div with "overflow: auto" #SkipWebkit', async () => {
             const { element, connect, disconnect } = await setupInDiv();
             const select: Select = element.querySelector(selectTag)!;
             await connect();


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Disabling intermittent test, which is tracked in #2272

## 👩‍💻 Implementation

Disable test

## 🧪 Testing

N/A

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
