### PR TITLE
Collapse breadcrumbs to avoid overflow

### DIFF
--- a/packages/nimble-components/src/breadcrumb-item/styles.ts
+++ b/packages/nimble-components/src/breadcrumb-item/styles.ts
@@ -32,6 +32,8 @@ export const styles = css`
 
         .listitem {
             display: flex;
+            overflow: hidden;
+            text-wrap: nowrap;
             align-items: center;
         }
 
@@ -39,7 +41,6 @@ export const styles = css`
             color: ${linkFontColor};
             display: flex;
             align-items: center;
-            justify-content: center;
             text-decoration: none;
         }
 
@@ -49,6 +50,12 @@ export const styles = css`
 
         .content {
             pointer-events: none;
+        }
+
+        slot {
+            display: block;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
 
         [part='end'] {

--- a/packages/nimble-components/src/breadcrumb/index.ts
+++ b/packages/nimble-components/src/breadcrumb/index.ts
@@ -1,11 +1,16 @@
-import { attr } from '@microsoft/fast-element';
+import { DOM, attr, observable } from '@microsoft/fast-element';
 import {
     DesignSystem,
-    Breadcrumb as FoundationBreadcrumb,
-    breadcrumbTemplate as template
+    Breadcrumb as FoundationBreadcrumb
 } from '@microsoft/fast-foundation';
 import { styles } from './styles';
-import type { BreadcrumbAppearance } from './types';
+import { BreadcrumbAppearance, CollapseState } from './types';
+import { template } from './template';
+import {
+    controlSlimHeight,
+    iconSize,
+    mediumPadding
+} from '../theme-provider/design-tokens';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -19,6 +24,100 @@ declare global {
 export class Breadcrumb extends FoundationBreadcrumb {
     @attr
     public appearance: BreadcrumbAppearance;
+
+    /** @internal */
+    @observable
+    public collapseState: CollapseState = CollapseState.none;
+
+    /** @internal */
+    @observable
+    public list?: HTMLElement;
+
+    /** @internal */
+    @observable
+    public collapsedItems: HTMLElement[] = [];
+
+    // Unfortunately, after being slotted, the breadcrumb items' widths can change (possibly font loading?),
+    // so we need to update the item widths and collapse state whenever the total width changes.
+    private readonly observer = new ResizeObserver(() => {
+        this.queueUpdateCollapseState();
+    });
+
+    private itemWidths: number[] = [];
+    private updateCollapseStateQueued = false;
+
+    public override connectedCallback(): void {
+        super.connectedCallback();
+        this.observer.observe(this.list!);
+        window.addEventListener('resize', this.queueUpdateCollapseState);
+    }
+
+    public override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this.observer.disconnect();
+        window.removeEventListener('resize', this.queueUpdateCollapseState);
+    }
+
+    public override slottedBreadcrumbItemsChanged(): void {
+        super.slottedBreadcrumbItemsChanged();
+        this.queueUpdateCollapseState();
+    }
+
+    private readonly queueUpdateCollapseState: () => void = () => {
+        if (
+            this.$fastController.isConnected
+            && !this.updateCollapseStateQueued
+        ) {
+            this.updateCollapseStateQueued = true;
+            DOM.queueUpdate(() => this.updateCollapseState());
+        }
+    };
+
+    private updateCollapseState(): void {
+        this.updateCollapseStateQueued = false;
+
+        this.updateItemWidths();
+        const fullWidth = this.itemWidths.reduce((sum, width) => sum + width);
+        const firstAndLastItemWidth = (this.itemWidths[0] ?? 0)
+            + (this.itemWidths.length > 1 ? this.itemWidths.at(-1)! : 0);
+        const partiallyCollapsedWidth = this.collapsedItemWidth + firstAndLastItemWidth;
+
+        if (this.list!.offsetWidth < partiallyCollapsedWidth) {
+            this.collapseState = CollapseState.collapseExceptCurrent;
+            this.collapsedItems = this.slottedBreadcrumbItems.slice(0, -1);
+        } else if (this.list!.offsetWidth < fullWidth) {
+            this.collapseState = CollapseState.collapseMiddle;
+            this.collapsedItems = this.slottedBreadcrumbItems.slice(1, -1);
+        } else {
+            this.collapseState = CollapseState.none;
+            this.collapsedItems = [];
+        }
+    }
+
+    private updateItemWidths(): void {
+        if (this.itemWidths.length !== this.slottedBreadcrumbItems.length) {
+            this.itemWidths = this.slottedBreadcrumbItems.map(
+                item => item.scrollWidth
+            );
+            return;
+        }
+        for (let i = 0; i < this.slottedBreadcrumbItems.length; i++) {
+            const itemWidth = this.slottedBreadcrumbItems[i]!.scrollWidth;
+            // Ignore bogus widths for collapsed items
+            if (itemWidth !== 0) {
+                this.itemWidths[i] = itemWidth;
+            }
+        }
+    }
+
+    private get collapsedItemWidth(): number {
+        // We need the width before it is added to the DOM, so we hardcode knowledge about the tokens involved
+        return (
+            parseFloat(controlSlimHeight.getValueFor(this))
+            + 2 * parseFloat(mediumPadding.getValueFor(this))
+            + parseFloat(iconSize.getValueFor(this))
+        );
+    }
 }
 
 const nimbleBreadcrumb = Breadcrumb.compose({

--- a/packages/nimble-components/src/breadcrumb/styles.ts
+++ b/packages/nimble-components/src/breadcrumb/styles.ts
@@ -2,24 +2,44 @@ import { css } from '@microsoft/fast-element';
 import { display } from '../utilities/style/display';
 import {
     bodyEmphasizedFont,
+    controlSlimHeight,
     linkFontColor,
-    linkProminentFontColor
+    linkProminentFontColor,
+    menuMinWidth
 } from '../theme-provider/design-tokens';
+import { CollapseState } from './types';
 
 export const styles = css`
     ${display('inline-block')}
 
+    :host {
+        width: 100%;
+    }
+
     .list {
         display: flex;
-        flex-wrap: wrap;
+    }
+
+    .${CollapseState.collapseMiddle} ::slotted(:not(:first-child, :last-child)),
+    .${CollapseState.collapseExceptCurrent} ::slotted(:not(:last-child)) {
+        display: none;
+    }
+
+    .${CollapseState.collapseExceptCurrent} ::slotted(:last-child) {
+        min-width: ${menuMinWidth};
     }
 
     ::slotted(:last-child) {
+        order: 1000;
         font: ${bodyEmphasizedFont};
         color: ${linkFontColor};
     }
 
     :host([appearance='prominent']) ::slotted(:last-child) {
         color: ${linkProminentFontColor};
+    }
+
+    .collapsed-items-button {
+        height: ${controlSlimHeight};
     }
 `;

--- a/packages/nimble-components/src/breadcrumb/template.ts
+++ b/packages/nimble-components/src/breadcrumb/template.ts
@@ -1,0 +1,50 @@
+import {
+    elements,
+    html,
+    ref,
+    repeat,
+    slotted,
+    when,
+    type ViewTemplate
+} from '@microsoft/fast-element';
+import type { FoundationElementTemplate } from '@microsoft/fast-foundation';
+import type { Breadcrumb } from '.';
+import { breadcrumbItemTag, type BreadcrumbItem } from '../breadcrumb-item';
+import { menuButtonTag } from '../menu-button';
+import { menuTag } from '../menu';
+import { anchorMenuItemTag } from '../anchor-menu-item';
+import { iconThreeDotsLineTag } from '../icons/three-dots-line';
+import { CollapseState } from './types';
+
+// prettier-ignore
+export const template: FoundationElementTemplate<
+ViewTemplate<Breadcrumb>
+> = () => html<Breadcrumb>`
+    <template role="navigation">
+        <div ${ref('list')} role="list" part="list"
+            class="list ${x => x.collapseState}"
+        >
+            <slot
+                ${slotted({ property: 'slottedBreadcrumbItems', filter: elements() })}
+            ></slot>
+            ${when(x => x.collapseState !== CollapseState.none, html<Breadcrumb>`
+                <${breadcrumbItemTag}>
+                    <${menuButtonTag}
+                        appearance="ghost"
+                        content-hidden
+                        class="collapsed-items-button"
+                    >
+                        <${iconThreeDotsLineTag} slot="start"></${iconThreeDotsLineTag}>
+                        <${menuTag} slot="menu">
+                            ${repeat(x => x.collapsedItems, html<BreadcrumbItem>`
+                                <${anchorMenuItemTag} href="${x => x.href}">
+                                    ${x => x.textContent}
+                                </${anchorMenuItemTag}>
+                            `)}
+                        </${menuTag}>
+                    </${menuButtonTag}>
+                </${breadcrumbItemTag}>
+            `)}
+        </div>
+    </template>
+`;

--- a/packages/nimble-components/src/breadcrumb/types.ts
+++ b/packages/nimble-components/src/breadcrumb/types.ts
@@ -8,3 +8,13 @@ export const BreadcrumbAppearance = {
 } as const;
 export type BreadcrumbAppearance =
     (typeof BreadcrumbAppearance)[keyof typeof BreadcrumbAppearance];
+
+/**
+ * @internal
+ */
+export const CollapseState = {
+    none: 'collapse-none',
+    collapseMiddle: 'collapse-middle',
+    collapseExceptCurrent: 'collapse-except-current'
+} as const;
+export type CollapseState = (typeof CollapseState)[keyof typeof CollapseState];

--- a/packages/storybook/src/nimble/breadcrumb/breadcrumb.stories.ts
+++ b/packages/storybook/src/nimble/breadcrumb/breadcrumb.stories.ts
@@ -46,6 +46,7 @@ const itemHrefDescription = `${defaultHrefDescription} If the last breadcrumb it
 export const _standardBreadcrumb: StoryObj<BreadcrumbArgs> = {
     // prettier-ignore
     render: createUserSelectedThemeStory(html`
+        <nimble-button>Before</nimble-button>
         <${breadcrumbTag}
             appearance="${x => BreadcrumbAppearance[x.appearance]}"
         >
@@ -57,6 +58,7 @@ export const _standardBreadcrumb: StoryObj<BreadcrumbArgs> = {
                 </${breadcrumbItemTag}>
             `)}
         </${breadcrumbTag}>
+        <nimble-button>After</nimble-button>
 `),
     // eslint-disable-next-line storybook/no-redundant-story-name
     name: 'Standard Breadcrumb',
@@ -79,14 +81,18 @@ With a standard breadcrumb containing multiple items, the last breadcrumb repres
         options: [
             {
                 href: '#',
-                label: 'Page 1'
+                label: 'Page 1111111111111111111111111111111111111111111111111111'
             },
             {
                 href: '#',
-                label: 'Page 2'
+                label: 'Page 222222222222222222222222222222222222222222222222222222222222222222222222'
             },
             {
-                label: 'Current (No Link)'
+                href: '#',
+                label: 'Page 33333333333333'
+            },
+            {
+                label: 'Current (No Link)99999999999999999999999999999999999999999999999999999999999999999999999999'
             }
         ],
         appearance: 'default'


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes: #2213

## 👩‍💻 Implementation

TODO

Tooltip with full text of current/last breadcrumb item needs to be added when the text is ellipsized.

## 🧪 Testing

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
