### PR TITLE
Table data assignment bug

### DIFF
--- a/change/@ni-nimble-components-10037fe8-2f92-4583-b31d-0df0d2900fc3.json
+++ b/change/@ni-nimble-components-10037fe8-2f92-4583-b31d-0df0d2900fc3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bug in nimble-table to avoid requiring a full copy of the data to be made when hierarchy is enabled",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -321,7 +321,10 @@ export class Table<
 
     public async setData(newData: readonly TData[]): Promise<void> {
         await this.processPendingUpdates();
-        const tanstackUpdates = this.calculateTanStackData(newData);
+        // Make a shallow clone of the record to avoid holding a reference to the client's data object.
+        // This also ensures that a data update will always result in a row's record being a new object.
+        const clonedData = newData.map(record => ({ ...record }));
+        const tanstackUpdates = this.calculateTanStackData(clonedData);
         this.updateTableOptions(tanstackUpdates);
     }
 

--- a/packages/nimble-components/src/table/models/array-to-tree.ts
+++ b/packages/nimble-components/src/table/models/array-to-tree.ts
@@ -55,7 +55,9 @@ export function arrayToTree<TData extends TableRecord>(
             orphanIds.delete(itemId);
         }
 
-        // add the current item's data to the item in the lookup table
+        // Add the current item's data to the item in the lookup table.
+        // Make a shallow clone of the record to avoid holding a reference to the client's data object.
+        // This also ensures that a data update will always result in a row's record being a new object.
         lookup[itemId]!.clientRecord = { ...item };
         const treeItem = lookup[itemId]!;
 

--- a/packages/nimble-components/src/table/models/array-to-tree.ts
+++ b/packages/nimble-components/src/table/models/array-to-tree.ts
@@ -56,7 +56,7 @@ export function arrayToTree<TData extends TableRecord>(
         }
 
         // add the current item's data to the item in the lookup table
-        lookup[itemId]!.clientRecord = item;
+        lookup[itemId]!.clientRecord = { ...item };
         const treeItem = lookup[itemId]!;
 
         // Add the index to the item

--- a/packages/nimble-components/src/table/models/array-to-tree.ts
+++ b/packages/nimble-components/src/table/models/array-to-tree.ts
@@ -55,10 +55,8 @@ export function arrayToTree<TData extends TableRecord>(
             orphanIds.delete(itemId);
         }
 
-        // Add the current item's data to the item in the lookup table.
-        // Make a shallow clone of the record to avoid holding a reference to the client's data object.
-        // This also ensures that a data update will always result in a row's record being a new object.
-        lookup[itemId]!.clientRecord = { ...item };
+        // add the current item's data to the item in the lookup table
+        lookup[itemId]!.clientRecord = item;
         const treeItem = lookup[itemId]!;
 
         // Add the index to the item

--- a/packages/nimble-components/src/table/models/data-hierarchy-manager.ts
+++ b/packages/nimble-components/src/table/models/data-hierarchy-manager.ts
@@ -20,6 +20,7 @@ export class DataHierarchyManager<TData extends TableRecord> {
             && typeof parentIdFieldName === 'string'
         ) {
             try {
+                // The arrayToTree algorithm will make a shallow clone of the records, so it does not need to be done here.
                 this._hierarchicalData = arrayToTree<TData>(records, {
                     id: idFieldName,
                     parentId: parentIdFieldName
@@ -29,6 +30,8 @@ export class DataHierarchyManager<TData extends TableRecord> {
             } catch {
                 this.isDataFlat = true;
                 this._hierarchicalData = records.map((record, index) => ({
+                    // Make a shallow clone of the record to avoid holding a reference to the client's data object.
+                    // This also ensures that a data update will always result in a row's record being a new object.
                     clientRecord: { ...record },
                     originalIndex: index
                 }));
@@ -37,6 +40,8 @@ export class DataHierarchyManager<TData extends TableRecord> {
         } else {
             this.isDataFlat = true;
             this._hierarchicalData = records.map((record, index) => ({
+                // Make a shallow clone of the record to avoid holding a reference to the client's data object.
+                // This also ensures that a data update will always result in a row's record being a new object.
                 clientRecord: { ...record },
                 originalIndex: index
             }));

--- a/packages/nimble-components/src/table/models/data-hierarchy-manager.ts
+++ b/packages/nimble-components/src/table/models/data-hierarchy-manager.ts
@@ -20,7 +20,6 @@ export class DataHierarchyManager<TData extends TableRecord> {
             && typeof parentIdFieldName === 'string'
         ) {
             try {
-                // The arrayToTree algorithm will make a shallow clone of the records, so it does not need to be done here.
                 this._hierarchicalData = arrayToTree<TData>(records, {
                     id: idFieldName,
                     parentId: parentIdFieldName
@@ -30,9 +29,7 @@ export class DataHierarchyManager<TData extends TableRecord> {
             } catch {
                 this.isDataFlat = true;
                 this._hierarchicalData = records.map((record, index) => ({
-                    // Make a shallow clone of the record to avoid holding a reference to the client's data object.
-                    // This also ensures that a data update will always result in a row's record being a new object.
-                    clientRecord: { ...record },
+                    clientRecord: record,
                     originalIndex: index
                 }));
                 this._parentIdConfigurationValid = false;
@@ -40,9 +37,7 @@ export class DataHierarchyManager<TData extends TableRecord> {
         } else {
             this.isDataFlat = true;
             this._hierarchicalData = records.map((record, index) => ({
-                // Make a shallow clone of the record to avoid holding a reference to the client's data object.
-                // This also ensures that a data update will always result in a row's record being a new object.
-                clientRecord: { ...record },
+                clientRecord: record,
                 originalIndex: index
             }));
             this._parentIdConfigurationValid = true;

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -972,17 +972,23 @@ describe('Table', () => {
                 await connect();
                 await waitForUpdatesAsync();
 
-                const data: SimpleTableRecord[] = hierarchicalData.map(x => ({ ...x }));
+                const data: SimpleTableRecord[] = hierarchicalData.map(x => ({
+                    ...x
+                }));
                 await element.setData(data);
                 await waitForUpdatesAsync();
                 const currentFieldValue = data[0]!.stringData;
-                expect(pageObject.getRenderedCellTextContent(0, 0)).toEqual(currentFieldValue);
+                expect(pageObject.getRenderedCellTextContent(0, 0)).toEqual(
+                    currentFieldValue
+                );
 
                 const updatedFieldValue = `${currentFieldValue} - updated value`;
                 data[0]!.stringData = updatedFieldValue;
                 await element.setData(data);
                 await waitForUpdatesAsync();
-                expect(pageObject.getRenderedCellTextContent(0, 0)).toEqual(updatedFieldValue);
+                expect(pageObject.getRenderedCellTextContent(0, 0)).toEqual(
+                    updatedFieldValue
+                );
             });
 
             it('shows collapse all button with hierarchical data', async () => {

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -392,7 +392,7 @@ describe('Table', () => {
             verifyRenderedData(simpleTableData);
         });
 
-        it('can update a record without making a copy of the data', async () => {
+        it('can update a record without making a copy of the data without hierarchy enabled', async () => {
             await connect();
             await waitForUpdatesAsync();
 
@@ -965,6 +965,26 @@ describe('Table', () => {
                     parentId3: 'Parent 2'
                 }
             ];
+
+            it('can update a record without making a copy of the data with hierarchy enabled', async () => {
+                element.idFieldName = 'id';
+                element.parentIdFieldName = 'parentId';
+                await connect();
+                await waitForUpdatesAsync();
+
+                const data: SimpleTableRecord[] = [...hierarchicalData];
+                await element.setData(data);
+                await waitForUpdatesAsync();
+                const currentFieldValue = data[0]!.stringData;
+                expect(pageObject.getRenderedCellTextContent(0, 0)).toEqual(currentFieldValue);
+
+                const updatedFieldValue = `${currentFieldValue} - updated value`;
+                data[0]!.stringData = updatedFieldValue;
+                await element.setData(data);
+                await waitForUpdatesAsync();
+                expect(pageObject.getRenderedCellTextContent(0, 0)).toEqual(updatedFieldValue);
+            });
+
             it('shows collapse all button with hierarchical data', async () => {
                 await connect();
                 element.idFieldName = 'id';

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -972,7 +972,7 @@ describe('Table', () => {
                 await connect();
                 await waitForUpdatesAsync();
 
-                const data: SimpleTableRecord[] = [...hierarchicalData];
+                const data: SimpleTableRecord[] = hierarchicalData.map(x => ({ ...x }));
                 await element.setData(data);
                 await waitForUpdatesAsync();
                 const currentFieldValue = data[0]!.stringData;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #2265 

## 👩‍💻 Implementation

The `arrayToTree` code path for setting data in the table does not make a copy of each record in the same way that the other `setData` code paths do. Therefore, I updated the `arrayToTree` function to copy the record as it turns the array into a tree.

## 🧪 Testing

- Added a new unit test that failed before my change and now passes
    - Note, there already is a similar test for non-hierarchical data, so I only added a new test for hierarchical data.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
