### PR TITLE
Update TanStack and fix a row indentation issue

### DIFF
--- a/change/@ni-nimble-components-cf8992cf-ac3f-4511-b84e-aa287edb1fa6.json
+++ b/change/@ni-nimble-components-cf8992cf-ac3f-4511-b84e-aa287edb1fa6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update TanStack and fix bug with row indentation in the table",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8223,9 +8223,9 @@
       }
     },
     "node_modules/@tanstack/table-core": {
-      "version": "8.19.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.19.2.tgz",
-      "integrity": "sha512-KpRjhgehIhbfH78ARm/GJDXGnpdw4bCg3qas6yjWSi7czJhI/J6pWln7NHtmBkGE9ZbohiiNtLqwGzKmBfixig==",
+      "version": "8.19.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.19.3.tgz",
+      "integrity": "sha512-IqREj9ADoml9zCAouIG/5kCGoyIxPFdqdyoxis9FisXFi5vT+iYfEfLosq4xkU/iDbMcEuAj+X8dWRLvKYDNoQ==",
       "engines": {
         "node": ">=12"
       },
@@ -28819,7 +28819,7 @@
         "@microsoft/fast-foundation": "^2.49.6",
         "@microsoft/fast-web-utilities": "^6.0.0",
         "@ni/nimble-tokens": "^7.0.1",
-        "@tanstack/table-core": "8.19.2",
+        "@tanstack/table-core": "^8.19.3",
         "@tanstack/virtual-core": "^3.8.3",
         "@tiptap/core": "^2.2.2",
         "@tiptap/extension-bold": "^2.2.2",

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -67,7 +67,7 @@
     "@microsoft/fast-foundation": "^2.49.6",
     "@microsoft/fast-web-utilities": "^6.0.0",
     "@ni/nimble-tokens": "^7.0.1",
-    "@tanstack/table-core": "8.19.2",
+    "@tanstack/table-core": "^8.19.3",
     "@tanstack/virtual-core": "^3.8.3",
     "@tiptap/core": "^2.2.2",
     "@tiptap/extension-bold": "^2.2.2",

--- a/packages/nimble-components/src/table/index.ts
+++ b/packages/nimble-components/src/table/index.ts
@@ -1081,13 +1081,10 @@ export class Table<
         const slotsByRecordId = this.getRequestedSlotsByRecordId();
         this.tableData = rows.map(row => {
             const isGroupRow = row.getIsGrouped();
-            const hasParentRow = isGroupRow ? false : row.getParentRow();
             const isParent = !isGroupRow && this.getRowCanExpand(row);
-            const isChildOfGroupRowWithNoHierarchy = !isGroupRow
-                && !isParent
-                && !hasParentRow
-                && row.depth > 0
-                && !this.parentIdFieldName;
+            const isDataChildOfGroupRowWithNoHierarchy = !isGroupRow // is a data row (not a group row)
+                && !this.parentIdFieldName // table does not have hierarchy enabled
+                && row.getParentRow()?.getIsGrouped(); // row has a parent that is a group row
             const rowState: TableRowState<TData> = {
                 record: row.original.clientRecord,
                 id: row.id,
@@ -1097,7 +1094,7 @@ export class Table<
                 groupRowValue: isGroupRow
                     ? row.getValue(row.groupingColumnId!)
                     : undefined,
-                nestingLevel: isChildOfGroupRowWithNoHierarchy
+                nestingLevel: isDataChildOfGroupRowWithNoHierarchy
                     ? row.depth - 1
                     : row.depth,
                 isParentRow: isParent,


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #2289 
Fixes #2284

## 👩‍💻 Implementation

TanStack fixed the bug that was causing #2284, so updating TanStack resolved that issue. However, some of the TanStack code changed slightly, so I had to update our check for determining if a row was the direct child of a group row in a table without hierarchy enabled.

## 🧪 Testing

- Ensured there were no chromatic diffs
- Manually tested that grouping and ungrouping a column with hierarchy results in the correct indentation of rows

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
