### PR TITLE
Fix select search icon

### DIFF
--- a/change/@ni-nimble-components-f68155d2-0e7b-40fe-a4b1-6ca75800e45a.json
+++ b/change/@ni-nimble-components-f68155d2-0e7b-40fe-a4b1-6ca75800e45a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Correct the size of the search icon in the select",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/select/styles.ts
+++ b/packages/nimble-components/src/select/styles.ts
@@ -102,7 +102,8 @@ export const styles = css`
     }
 
     .filter-icon {
-        padding-left: ${smallPadding};
+        flex-shrink: 0;
+        margin-left: ${smallPadding};
         ${iconColor.cssCustomProperty}: ${placeholderFontColor};
     }
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #2287 

## 👩‍💻 Implementation

There were two styling issues with the icon:
1. The icon was shrinking because `flex-shrink` wasn't set
2. The space between the icon and the side of the drop-down was set with padding rather than a margin, which messed with the space that the svg had to render within the icon element

## 🧪 Testing

Manually inspected in storybook

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
