### PR TITLE
Update menu button column styles

### DIFF
--- a/change/@ni-nimble-components-334dab4c-65a4-4b4a-9a92-56976aee8c66.json
+++ b/change/@ni-nimble-components-334dab4c-65a4-4b4a-9a92-56976aee8c66.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update menu-button column styles",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table-column/menu-button/cell-view/styles.ts
+++ b/packages/nimble-components/src/table-column/menu-button/cell-view/styles.ts
@@ -1,5 +1,4 @@
 import { css } from '@microsoft/fast-element';
-import { controlSlimHeight } from '../../../theme-provider/design-tokens';
 
 export const styles = css`
     :host {
@@ -8,7 +7,6 @@ export const styles = css`
     }
 
     nimble-menu-button {
-        height: ${controlSlimHeight};
         width: 100%;
     }
 

--- a/packages/nimble-components/src/table/components/row/styles.ts
+++ b/packages/nimble-components/src/table/components/row/styles.ts
@@ -55,8 +55,8 @@ export const styles = css`
     }
 
     :host(${focusVisible}) {
-        outline: calc(2 * ${borderWidth}) solid ${borderHoverColor};
-        outline-offset: calc(-2 * ${borderWidth});
+        outline: none;
+        box-shadow: inset calc(2 * ${borderWidth}) calc(2 * ${borderWidth}) ${borderHoverColor}, inset calc(-2 * ${borderWidth}) calc(-2 * ${borderWidth}) ${borderHoverColor};
     }
 
     .expand-collapse-button {

--- a/packages/nimble-components/src/table/components/row/styles.ts
+++ b/packages/nimble-components/src/table/components/row/styles.ts
@@ -56,7 +56,11 @@ export const styles = css`
 
     :host(${focusVisible}) {
         outline: none;
-        box-shadow: inset calc(2 * ${borderWidth}) calc(2 * ${borderWidth}) ${borderHoverColor}, inset calc(-2 * ${borderWidth}) calc(-2 * ${borderWidth}) ${borderHoverColor};
+        box-shadow:
+            inset calc(2 * ${borderWidth}) calc(2 * ${borderWidth})
+                ${borderHoverColor},
+            inset calc(-2 * ${borderWidth}) calc(-2 * ${borderWidth})
+                ${borderHoverColor};
     }
 
     .expand-collapse-button {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #2247

The only item from #2247 that we agreed should be changed is the height of the menu button. It will no longer be styled with a height of `controlSlimHeight` and instead have its default height. Additionally, @fredvisser wanted the row's focus-visible outline to be centered correctly when making this change since the misalignment of the outline is significantly more apparent when there is a 32px control in a cell. Therefore, I've also address that in this PR.

## 👩‍💻 Implementation

- Remove styling of the menu-button's height
- Update the focus-visible styling of a row so that the green outline now symmetrically outlines the row. This now matches the outline height of each cell. Previously the top border of the outline was 2px too high because the row borders aren't symmetrical -- specifically, a row has a 2px top border and a 0px bottom border in order to have the horizontal dividers between rows.

## 🧪 Testing

Manually tested

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
