### PR TITLE
Fix Select arrow down behavior with hidden selected option

### DIFF
--- a/packages/nimble-components/src/select/index.ts
+++ b/packages/nimble-components/src/select/index.ts
@@ -567,15 +567,33 @@ export class Select
      */
     public override keydownHandler(e: KeyboardEvent): BooleanOrVoid {
         const initialSelectedIndex = this.selectedIndex;
-        super.keydownHandler(e);
         const key = e.key;
         if (e.ctrlKey || e.shiftKey) {
             return true;
         }
 
+        if (key !== keyArrowDown) {
+            super.keydownHandler(e);
+        }
+
         let currentActiveIndex = this.openActiveIndex ?? this.selectedIndex;
         let commitValueThenClose = false;
         switch (key) {
+            case keyArrowDown: {
+                const selectedOption = this.options[this.selectedIndex];
+                if (this.open && isListOption(selectedOption) && !isOptionOrGroupVisible(selectedOption)) {
+                    if (this.openActiveIndex === this.selectedIndex) {
+                        this.selectFirstOption();
+                    } else {
+                        this.selectNextOption();
+                    }
+                } else {
+                    super.keydownHandler(e);
+                }
+
+                currentActiveIndex = this.openActiveIndex ?? this.selectedIndex;
+                break;
+            }
             case keySpace: {
                 // when dropdown is open allow user to enter a space for filter text
                 if (this.open && this.filterMode !== FilterMode.none) {

--- a/packages/nimble-components/src/select/index.ts
+++ b/packages/nimble-components/src/select/index.ts
@@ -591,6 +591,7 @@ export class Select
                     super.keydownHandler(e);
                 }
 
+                // update currentActiveIndex again as dependent state may have changed
                 currentActiveIndex = this.openActiveIndex ?? this.selectedIndex;
                 break;
             }

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -27,6 +27,7 @@ type OptionInitialState =
     | 'disabled hidden'
     | 'disabled selected hidden'
     | 'hidden'
+    | 'hidden selected'
     | 'visually-hidden';
 
 async function setup(
@@ -581,6 +582,43 @@ describe('Select', () => {
         await waitForUpdatesAsync();
 
         expect(pageObject.isLoadingVisualVisible()).toBeTrue();
+
+        await disconnect();
+    });
+
+    it('when second option is selected and hidden, pressing arrow down while dropdown is open selects first option', async () => {
+        const { element, connect, disconnect } = await setup(
+            undefined,
+            false,
+            undefined,
+            'hidden selected'
+        );
+        const pageObject = new SelectPageObject(element);
+        await connect();
+        await waitForUpdatesAsync();
+        pageObject.clickSelect();
+        pageObject.pressArrowDownKey();
+
+        expect(pageObject.getActiveOption()?.value).toBe('one');
+
+        await disconnect();
+    });
+
+    it('when second option is selected and hidden, pressing arrow down twice while dropdown is open selects third option', async () => {
+        const { element, connect, disconnect } = await setup(
+            undefined,
+            false,
+            undefined,
+            'hidden selected'
+        );
+        const pageObject = new SelectPageObject(element);
+        await connect();
+        await waitForUpdatesAsync();
+        pageObject.clickSelect();
+        pageObject.pressArrowDownKey();
+        pageObject.pressArrowDownKey();
+
+        expect(pageObject.getActiveOption()?.value).toBe('three');
 
         await disconnect();
     });


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

While doing the integration work of updating the SLE user selector to use dynamic options, a non-ideal behavior became apparent in the case where a user would provide some filter text, filtering out the current selected user (which as our guidance states, requires the option to be present but hidden), and then press `ArrowDown`, and nothing would get selected. This would happen when the selected option was _below_ the other options in DOM order.

The two solutions for creating the expected behavior were 1) update the integration code to always put the hidden option at the top of the DOM order, or 2) change the Nimble Select behavior to provide the expected behavior in this case. I opted with 2 because it feels like a gap that any user of the Nimble Select could possibly hit.

## 👩‍💻 Implementation

Now handling the `ArrowDown` case directly in the key handling code of the `Select`.

## 🧪 Testing

Added some unit tests. Manually checked behavior in Angular example app with dynamic options.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
