### PR TITLE
Select/combobox built-in labels

### DIFF
--- a/change/@ni-nimble-components-18b7e8bd-7ece-49a0-a662-2a8424f6bfdd.json
+++ b/change/@ni-nimble-components-18b7e8bd-7ece-49a0-a662-2a8424f6bfdd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "nimble-select and nimble-combobox: Built-in label support (via default slot)",
+  "packageName": "@ni/nimble-components",
+  "email": "20709258+msmithNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/angular-workspace/example-client-app/src/app/customapp/customapp.component.html
+++ b/packages/angular-workspace/example-client-app/src/app/customapp/customapp.component.html
@@ -49,6 +49,7 @@
                 <nimble-number-field>Numeric field 1</nimble-number-field>
                 <nimble-number-field>Numeric field 2</nimble-number-field>
                 <nimble-select>
+                    Select
                     <nimble-list-option value="1">Option 1</nimble-list-option>
                     <nimble-list-option value="2">Option 2</nimble-list-option>
                     <nimble-list-option value="3">Option 3</nimble-list-option>
@@ -106,6 +107,7 @@
             <nimble-button (click)="openDrawer()">Open Drawer</nimble-button>
             <nimble-text-field readonly [ngModel]="drawerCloseReason">Closed Reason</nimble-text-field>
             <nimble-select class="drawer-location-select" [(ngModel)]="drawerLocation">
+                Drawer Location
                 <nimble-list-option [value]="drawerLocations.left">Drawer: Left-side</nimble-list-option>
                 <nimble-list-option [value]="drawerLocations.right">Drawer: Right-side</nimble-list-option>
             </nimble-select>
@@ -151,6 +153,7 @@
         <div class="sub-container">
             <div class="container-label">Select</div>
             <nimble-select filter-mode="standard" appearance="underline">
+                Underline Select
                 <nimble-list-option hidden selected disabled>Select an option</nimble-list-option>
                 <nimble-list-option-group label="Group 1">
                     <nimble-list-option>Option 1</nimble-list-option>
@@ -162,6 +165,7 @@
                 </nimble-list-option-group>
             </nimble-select>
             <nimble-select appearance="outline">
+                Outline Select
                 <nimble-list-option hidden selected disabled>Select an option</nimble-list-option>
                 <nimble-list-option-group label="Group 1">
                     <nimble-list-option>Option 1</nimble-list-option>
@@ -173,6 +177,7 @@
                 </nimble-list-option-group>
             </nimble-select>
             <nimble-select appearance="block">
+                Block Select
                 <nimble-list-option hidden selected disabled>Select an option</nimble-list-option>
                 <nimble-list-option-group label="Group 1">
                     <nimble-list-option>Option 1</nimble-list-option>
@@ -194,6 +199,7 @@
         <div class="sub-container">
             <div class="container-label">Combobox</div>
             <nimble-combobox aria-label="Combobox" [(ngModel)]="comboboxSelectedOption" (ngModelChange)="onComboboxChange($event)" appearance="underline" autocomplete="both" placeholder="Select value...">
+                Underline Combobox
                 <nimble-list-option *ngFor="let item of comboboxItems" [ngValue]="item">{{ item ? item.first : '' }}</nimble-list-option>
             </nimble-combobox>
             <div>
@@ -202,9 +208,11 @@
                 </span>
             </div>
             <nimble-combobox aria-label="Combobox" [(ngModel)]="comboboxSelectedOption" (ngModelChange)="onComboboxChange($event)" appearance="outline" autocomplete="both" placeholder="Select value...">
+                Outline Combobox
                 <nimble-list-option *ngFor="let item of comboboxItems" [ngValue]="item">{{ item ? item.first : '' }}</nimble-list-option>
             </nimble-combobox>
             <nimble-combobox aria-label="Combobox" [(ngModel)]="comboboxSelectedOption" (ngModelChange)="onComboboxChange($event)" appearance="block" autocomplete="both" placeholder="Select value...">
+                Block Combobox
                 <nimble-list-option *ngFor="let item of comboboxItems" [ngValue]="item">{{ item ? item.first : '' }}</nimble-list-option>
             </nimble-combobox>
         </div>

--- a/packages/blazor-workspace/Examples/Demo.Shared/Pages/ComponentsDemo.razor
+++ b/packages/blazor-workspace/Examples/Demo.Shared/Pages/ComponentsDemo.razor
@@ -66,6 +66,7 @@
                 <NimbleNumberField>Numeric field 1</NimbleNumberField>
                 <NimbleNumberField>Numeric field 2</NimbleNumberField>
                 <NimbleSelect>
+                    Select
                     <NimbleListOption Value="1">Option 1</NimbleListOption>
                     <NimbleListOption Value="2">Option 2</NimbleListOption>
                     <NimbleListOption Value="3">Option 3</NimbleListOption>
@@ -111,6 +112,7 @@
             <div class="container-label">Drawer</div>
             <NimbleButton Appearance="ButtonAppearance.Outline" @onclick="OpenDrawerAsync">Open Drawer</NimbleButton>
             <NimbleSelect class="drawer-location-select" @bind-Value="@DrawerLocationAsString">
+                Drawer Location
                 <NimbleListOption Value="@DrawerLocation.Left.ToString()">Drawer: Left-side</NimbleListOption>
                 <NimbleListOption Value="@DrawerLocation.Right.ToString()">Drawer: Right-side</NimbleListOption>
             </NimbleSelect>
@@ -171,6 +173,7 @@
         <div class="sub-container">
             <div class="container-label">Select</div>
             <NimbleSelect Appearance="DropdownAppearance.Underline" FilterMode="FilterMode.Standard" Clearable="true">
+                Underline Select
                 <NimbleListOptionGroup Label="Group 1">
                     <NimbleListOption>Option 1</NimbleListOption>
                     <NimbleListOption>Option 2</NimbleListOption>
@@ -181,6 +184,7 @@
                 </NimbleListOptionGroup>
             </NimbleSelect>
             <NimbleSelect Appearance="DropdownAppearance.Outline">
+                Outline Select
                 <NimbleListOptionGroup Label="Group 1">
                     <NimbleListOption>Option 1</NimbleListOption>
                     <NimbleListOption>Option 2</NimbleListOption>
@@ -191,6 +195,7 @@
                 </NimbleListOptionGroup>
             </NimbleSelect>
             <NimbleSelect Appearance="DropdownAppearance.Block">
+                Block Select
                 <NimbleListOptionGroup Label="Group 1">
                     <NimbleListOption>Option 1</NimbleListOption>
                     <NimbleListOption>Option 2</NimbleListOption>
@@ -204,16 +209,19 @@
         <div class="sub-container">
             <div class="container-label">Combobox</div>
             <NimbleCombobox AutoComplete="AutoComplete.Both" Placeholder="Select value..." Appearance="DropdownAppearance.Underline">
+                Underline Combobox
                 <NimbleListOption>Mary</NimbleListOption>
                 <NimbleListOption>Sue</NimbleListOption>
                 <NimbleListOption>Dexter</NimbleListOption>
             </NimbleCombobox>
             <NimbleCombobox AutoComplete="AutoComplete.Both" Placeholder="Select value..." Appearance="DropdownAppearance.Outline">
+                Outline Combobox
                 <NimbleListOption>Mary</NimbleListOption>
                 <NimbleListOption>Sue</NimbleListOption>
                 <NimbleListOption>Dexter</NimbleListOption>
             </NimbleCombobox>
             <NimbleCombobox AutoComplete="AutoComplete.Both" Placeholder="Select value..." Appearance="DropdownAppearance.Block">
+                Block Combobox
                 <NimbleListOption>Mary</NimbleListOption>
                 <NimbleListOption>Sue</NimbleListOption>
                 <NimbleListOption>Dexter</NimbleListOption>

--- a/packages/nimble-components/src/combobox/index.ts
+++ b/packages/nimble-components/src/combobox/index.ts
@@ -838,6 +838,7 @@ const nimbleCombobox = Combobox.compose<ComboboxOptions>({
                 @keydown="${(x, c) => x.toggleButtonKeyDownHandler(c.event as KeyboardEvent)}"
                 class="dropdown-button"
                 part="button"
+                aria-hidden="true"
                 aria-haspopup="true"
                 aria-expanded="${x => x.open}"
                 tabindex="-1"

--- a/packages/nimble-components/src/combobox/index.ts
+++ b/packages/nimble-components/src/combobox/index.ts
@@ -882,8 +882,6 @@ const nimbleCombobox = Combobox.compose<ComboboxOptions>({
                 class="dropdown-button"
                 part="button"
                 aria-hidden="true"
-                aria-haspopup="true"
-                aria-expanded="${x => x.open}"
                 tabindex="-1"
             >
                 <${iconArrowExpanderDownTag}

--- a/packages/nimble-components/src/combobox/template.ts
+++ b/packages/nimble-components/src/combobox/template.ts
@@ -34,6 +34,9 @@ ComboboxOptions
         @focusout="${(x, c) => x.focusoutHandler(c.event as FocusEvent)}"
         @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
     >
+        <label part="label" class="label">
+            <slot></slot>
+        </label>
         <div class="control" part="control" ${ref('controlWrapper')}>
             ${startSlotTemplate(context, definition)}
             <slot name="control">

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -18,7 +18,10 @@ import {
     mediumPadding,
     failColor,
     elevation2BoxShadow,
-    placeholderFontColor
+    placeholderFontColor,
+    controlLabelFontColor,
+    controlLabelFont,
+    controlLabelDisabledFontColor
 } from '../../theme-provider/design-tokens';
 import { Theme } from '../../theme-provider/types';
 import { appearanceBehavior } from '../../utilities/style/appearance';
@@ -35,9 +38,9 @@ export const styles = css`
     :host {
         color: ${bodyFontColor};
         font: ${bodyFont};
-        height: ${controlHeight};
         position: relative;
-        justify-content: center;
+        flex-direction: column;
+        justify-content: flex-start;
         ${userSelectNone}
         min-width: ${menuMinWidth};
         outline: none;
@@ -53,7 +56,7 @@ export const styles = css`
         bottom: calc(${borderWidth} + var(--ni-private-indicator-lines-gap));
         width: 0px;
         height: 0px;
-        justify-self: center;
+        align-self: center;
         border-bottom: ${borderHoverColor}
             var(--ni-private-focus-indicator-width) solid;
         transition: width ${smallDelay} ease-in;
@@ -79,7 +82,7 @@ export const styles = css`
         bottom: calc(-1 * ${borderWidth});
         width: 0px;
         height: 0px;
-        justify-self: center;
+        align-self: center;
         border-bottom: ${borderHoverColor}
             var(--ni-private-hover-indicator-width) solid;
         transition: width ${smallDelay} ease-in;
@@ -104,12 +107,22 @@ export const styles = css`
         width: 0px;
     }
 
+    .label {
+        display: flex;
+        color: ${controlLabelFontColor};
+        font: ${controlLabelFont};
+    }
+
+    :host([disabled]) .label {
+        color: ${controlLabelDisabledFontColor};
+    }
+
     .control {
         align-items: center;
         cursor: pointer;
         display: flex;
-        min-height: 100%;
         width: 100%;
+        height: ${controlHeight};
         border: 0px solid rgba(${borderRgbPartialColor}, 0.3);
         background-color: transparent;
         padding: ${borderWidth};

--- a/packages/nimble-components/src/select/index.ts
+++ b/packages/nimble-components/src/select/index.ts
@@ -199,6 +199,23 @@ export class Select
         return !(this.multiple || typeof this.size === 'number');
     }
 
+    /** @internal */
+    public labelSlot!: HTMLSlotElement;
+
+    /** @internal */
+    @volatile
+    public get labelContent(): string {
+        if (!this.$fastController.isConnected) {
+            return '';
+        }
+
+        const nodes = this.labelSlot.assignedNodes();
+        return nodes
+            .filter(node => node.textContent?.trim() !== '')
+            .map(node => node.textContent?.trim())
+            .join(' ');
+    }
+
     private _value = '';
     private forcedPosition = false;
     private openActiveIndex?: number;

--- a/packages/nimble-components/src/select/specs/built-in-labels.md
+++ b/packages/nimble-components/src/select/specs/built-in-labels.md
@@ -39,16 +39,15 @@ Default Slot:
 Template updates:
 
 -   A new `label` element will be added at the root of the control template, which will reflect the default slotted content (minus the list options which are already handled elsewhere)
--   A new container `div` will be added at the same level, to contain the control part (`div[part="control"]`)
--   Update element host `display` mode so the label is laid out correctly. (Formerly `inline-flex`, which will move to the container `div`. Prototyped as `inline-block`, but `inline-flex` / `inline-grid` is probably more in line with what we want for our controls layouts going forward.)
-
-Currently our shared dropdown styling (`patterns/dropdown/styles.ts`) applies focus/error-visible styling directly on `::host` - most of those styles will instead target the container `div`.
+-   Update shared dropdown styling as needed for label layout (`flex-direction` to `column`, move fixed height from `::host` down to the `div[part="control"]`)
 
 Other considerations:
 
 -   The label will get disabled visually if the control is disabled.
 -   If the label is not provided, vertical space should not be reserved for it.
--   Behavior if label length exceeds control width (most likely we'll grow to fit like our other controls)
+-   Behavior if label length exceeds control width will match our other controls:
+    -   If a fixed `width` style is not set, the control grows to fit the entire label on 1 line.
+    -   If a fixed `width` style is set, the label will wrap if needed to fit within that width.
 
 ### Accessibility / ARIA
 
@@ -67,8 +66,7 @@ Other considerations:
 
 ### Impact to nimble-rich-text-mention-listbox
 
-`nimble-rich-text-mention-listbox` will not support this feature, meaning it will not contain a `label` element in its template. The current plan is to not address any ARIA label issues on it either, but we should note the gap in [Align rich-text mention listbox implementation behavior](https://github.com/ni/nimble/issues/1926).  
-However, since we have shared dropdown styling, its template may need minor updates (e.g. to add the same parent/container `div` as select/combobox are getting), but we'll ensure it has the same visual appearance as before.
+`nimble-rich-text-mention-listbox` will not support this feature, meaning it will not contain a `label` element in its template. The current plan is to not address any ARIA label issues on it either, but we should note the gap in [Align rich-text mention listbox implementation behavior](https://github.com/ni/nimble/issues/1926).
 
 ## Alternative Implementations / Designs
 

--- a/packages/nimble-components/src/select/template.ts
+++ b/packages/nimble-components/src/select/template.ts
@@ -58,6 +58,7 @@ SelectOptions
         aria-disabled="${x => x.ariaDisabled}"
         aria-expanded="${x => x.ariaExpanded}"
         aria-haspopup="${x => (x.collapsible ? 'listbox' : null)}"
+        aria-label="${x => x.labelContent}"
         aria-multiselectable="${x => x.ariaMultiSelectable}"
         ?open="${x => x.open}"
         role="combobox"
@@ -69,6 +70,9 @@ SelectOptions
         @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
         @mousedown="${(x, c) => x.mousedownHandler(c.event as MouseEvent)}"
     >
+        <label part="label" class="label">
+            <slot ${ref('labelSlot')}></slot>
+        </label>
         ${when(x => x.collapsible, html<Select>`
             <div
                 class="control"

--- a/packages/nimble-components/src/select/template.ts
+++ b/packages/nimble-components/src/select/template.ts
@@ -70,7 +70,7 @@ SelectOptions
         @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
         @mousedown="${(x, c) => x.mousedownHandler(c.event as MouseEvent)}"
     >
-        <label part="label" class="label">
+        <label part="label" class="label" aria-hidden="true">
             <slot ${ref('labelSlot')}></slot>
         </label>
         ${when(x => x.collapsible, html<Select>`

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -585,6 +585,78 @@ describe('Select', () => {
         await disconnect();
     });
 
+    describe('labels', () => {
+        it('if slotted label is provided as a span, labelContent is set to slotted label', async () => {
+            const { element, connect, disconnect } = await setup();
+            await connect();
+            const slottedLabel = document.createElement('span');
+            slottedLabel.textContent = 'Slotted Label';
+            element.appendChild(slottedLabel);
+            await waitForUpdatesAsync();
+
+            expect(element.labelContent).toBe('Slotted Label');
+
+            await disconnect();
+        });
+
+        it('if slotted label is provided as text node, labelContent is set to slotted label', async () => {
+            const { element, connect, disconnect } = await setup();
+            await connect();
+            const slottedLabel = document.createTextNode('Slotted Label');
+            element.appendChild(slottedLabel);
+            await waitForUpdatesAsync();
+
+            expect(element.labelContent).toBe('Slotted Label');
+
+            await disconnect();
+        });
+
+        it('if multiple slotted labels are provided, labelContent is set to joined strings of slotted labels', async () => {
+            const { element, connect, disconnect } = await setup();
+            await connect();
+            const slottedLabel = document.createElement('span');
+            slottedLabel.textContent = 'Slotted Label';
+            element.appendChild(slottedLabel);
+            const slottedLabel2 = document.createElement('span');
+            slottedLabel2.textContent = 'Slotted Label 2';
+            element.appendChild(slottedLabel2);
+            await waitForUpdatesAsync();
+
+            expect(element.labelContent).toBe('Slotted Label Slotted Label 2');
+
+            await disconnect();
+        });
+
+        it('if multiple slotted labels are provided with extra whitespace, labelContent result is trimmed', async () => {
+            const { element, connect, disconnect } = await setup();
+            await connect();
+            const slottedLabel1 = document.createElement('span');
+            slottedLabel1.textContent = '  Slotted Label 1 ';
+            element.appendChild(slottedLabel1);
+            const slottedLabel2 = document.createElement('span');
+            slottedLabel2.textContent = '     Slotted Label 2 ';
+            element.appendChild(slottedLabel2);
+            await waitForUpdatesAsync();
+
+            expect(element.labelContent).toBe(
+                'Slotted Label 1 Slotted Label 2'
+            );
+            await disconnect();
+        });
+
+        it('label content is reflected to aria-label attribute on element', async () => {
+            const { element, connect, disconnect } = await setup();
+            await connect();
+            const slottedLabel = document.createTextNode('Slotted Label');
+            element.appendChild(slottedLabel);
+            await waitForUpdatesAsync();
+
+            expect(element.ariaLabel).toBe('Slotted Label');
+
+            await disconnect();
+        });
+    });
+
     describe('with all options disabled', () => {
         async function setupAllDisabled(): Promise<Fixture<Select>> {
             const viewTemplate = html`
@@ -664,6 +736,7 @@ describe('Select', () => {
                 '--ni-private-listbox-visible-option-count',
                 '10000'
             );
+            // await waitForUpdatesAsync();
             const fullyVisible = await checkFullyInViewport(element.listbox);
 
             expect(element.scrollableRegion.scrollHeight).toBeGreaterThan(

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -736,7 +736,6 @@ describe('Select', () => {
                 '--ni-private-listbox-visible-option-count',
                 '10000'
             );
-            // await waitForUpdatesAsync();
             const fullyVisible = await checkFullyInViewport(element.listbox);
 
             expect(element.scrollableRegion.scrollHeight).toBeGreaterThan(

--- a/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
@@ -53,34 +53,24 @@ const component = (
     [errorName, errorVisible, errorText]: ErrorState,
     [valueName, value, placeholder]: ValueState
 ): ViewTemplate => html`
-    <div style="
-        display: inline-flex;
-        flex-direction: column;
-        margin: var(${standardPadding.cssCustomProperty});
-        font: var(${controlLabelFont.cssCustomProperty});
-        color: var(${controlLabelFontColor.cssCustomProperty});"
+    <${comboboxTag} 
+        ?disabled="${() => disabled}"
+        appearance="${() => appearance}"
+        ?error-visible="${() => errorVisible}"
+        error-text="${() => errorText}"
+        value="${() => value}"
+        placeholder="${() => placeholder}"
+        style="width: 250px; margin: var(${standardPadding.cssCustomProperty});"
     >
-        <label>
-            ${() => disabledName}
-            ${() => appearanceName}
-            ${() => errorName}
-            ${() => valueName}
-        </label>
-        <${comboboxTag} 
-            ?disabled="${() => disabled}"
-            appearance="${() => appearance}"
-            ?error-visible="${() => errorVisible}"
-            error-text="${() => errorText}"
-            value="${() => value}"
-            placeholder="${() => placeholder}"
-            style="width: 250px;"
-        >
-            <${listOptionTag} value="1">Option 1</${listOptionTag}>
-            <${listOptionTag} value="2" disabled>Option 2</${listOptionTag}>
-            <${listOptionTag} value="3">Option 3</${listOptionTag}>
-            <${listOptionTag} value="4" hidden>Option 4</${listOptionTag}>
-        </${comboboxTag}>
-    </div>
+        ${() => disabledName}
+        ${() => appearanceName}
+        ${() => errorName}
+        ${() => valueName}
+        <${listOptionTag} value="1">Option 1</${listOptionTag}>
+        <${listOptionTag} value="2" disabled>Option 2</${listOptionTag}>
+        <${listOptionTag} value="3">Option 3</${listOptionTag}>
+        <${listOptionTag} value="4" hidden>Option 4</${listOptionTag}>
+    </${comboboxTag}>
 `;
 
 export const comboboxThemeMatrix: StoryFn = createMatrixThemeStory(
@@ -105,4 +95,18 @@ export const blankListOption: StoryFn = createStory(
         <${listOptionTag} value="1">Option 1</${listOptionTag}>
         <${listOptionTag}></${listOptionTag}>
     </${comboboxTag}>`
+);
+
+export const heightTest: StoryFn = createStory(
+    html`
+        <div style="display: flex; flex-direction: column">
+            <${comboboxTag} style="border: 1px dashed; width: 250px">
+                With Label
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${comboboxTag}>
+            <${comboboxTag} style="border: 1px dashed; width: 250px">
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${comboboxTag}>
+        </div>
+    `
 );

--- a/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
@@ -1,10 +1,6 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import {
-    controlLabelFont,
-    controlLabelFontColor,
-    standardPadding
-} from '../../../../nimble-components/src/theme-provider/design-tokens';
+import { standardPadding } from '../../../../nimble-components/src/theme-provider/design-tokens';
 import { listOptionTag } from '../../../../nimble-components/src/list-option';
 import { comboboxTag } from '../../../../nimble-components/src/combobox';
 import { DropdownAppearance } from '../../../../nimble-components/src/patterns/dropdown/types';

--- a/packages/storybook/src/nimble/combobox/combobox.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox.stories.ts
@@ -19,10 +19,12 @@ import {
     errorTextDescription,
     errorVisibleDescription,
     optionsDescription,
-    placeholderDescription
+    placeholderDescription,
+    slottedLabelDescription
 } from '../../utilities/storybook';
 
 interface ComboboxArgs {
+    label: string;
     disabled: boolean;
     dropDownPosition: DropdownPosition;
     autocomplete: ComboboxAutocomplete;
@@ -113,14 +115,20 @@ const metadata: Meta<ComboboxArgs> = {
             appearance="${x => x.appearance}"
             value="${x => x.currentValue}"
             placeholder="${x => x.placeholder}"
-            style="width: 250px;"
+            style="min-width: 250px;"
         >
+            ${x => x.label}
             ${repeat(x => optionSets[x.optionsType], html<OptionArgs>`
                 <${listOptionTag} ?disabled="${x => x.disabled}">${x => x.label}</${listOptionTag}>
             `)}
         </${comboboxTag}>
     `),
     argTypes: {
+        label: {
+            name: 'default',
+            description: `${slottedLabelDescription({ componentName: 'combobox' })}`,
+            table: { category: apiCategory.slots }
+        },
         autocomplete: {
             options: Object.values(ComboboxAutocomplete),
             control: { type: 'radio' },
@@ -191,6 +199,7 @@ const metadata: Meta<ComboboxArgs> = {
         }
     },
     args: {
+        label: 'Combobox',
         disabled: false,
         dropDownPosition: 'below',
         autocomplete: ComboboxAutocomplete.both,

--- a/packages/storybook/src/nimble/select/select-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-matrix.stories.ts
@@ -1,11 +1,7 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
 import { keyArrowDown } from '@microsoft/fast-web-utilities';
-import {
-    controlLabelFont,
-    controlLabelFontColor,
-    standardPadding
-} from '../../../../nimble-components/src/theme-provider/design-tokens';
+import { standardPadding } from '../../../../nimble-components/src/theme-provider/design-tokens';
 import { listOptionTag } from '../../../../nimble-components/src/list-option';
 import { listOptionGroupTag } from '../../../../nimble-components/src/list-option-group';
 import { Select, selectTag } from '../../../../nimble-components/src/select';

--- a/packages/storybook/src/nimble/select/select-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-matrix.stories.ts
@@ -63,28 +63,20 @@ const component = (
     [valueName, valueValue]: ValueState,
     [clearableName, clearable]: ClearableState
 ): ViewTemplate => html`
-    <div style="
-        display: inline-flex;
-        flex-direction: column;
-        margin: var(${standardPadding.cssCustomProperty});
-        font: var(${controlLabelFont.cssCustomProperty});
-        color: var(${controlLabelFontColor.cssCustomProperty});"
+    <${selectTag}
+        ?error-visible="${() => errorVisible}"
+        error-text="${() => errorText}"
+        ?disabled="${() => disabled}"
+        ?clearable="${() => clearable}"
+        appearance="${() => appearance}"
+        style="width: 250px; margin: var(${standardPadding.cssCustomProperty});"
     >
-        <label>${() => errorName} ${() => disabledName} ${() => appearanceName} ${() => valueName} ${() => clearableName}</label>
-        <${selectTag}
-            ?error-visible="${() => errorVisible}"
-            error-text="${() => errorText}"
-            ?disabled="${() => disabled}"
-            ?clearable="${() => clearable}"
-            appearance="${() => appearance}"
-            style="width: 250px;"
-        >
-            <${listOptionTag} value="1">${valueValue}</${listOptionTag}>
-            <${listOptionTag} value="2" disabled>Option 2</${listOptionTag}>
-            <${listOptionTag} value="3">Option 3</${listOptionTag}>
-            <${listOptionTag} value="4" hidden>Option 4</${listOptionTag}>
-        </${selectTag}>
-    </div>
+        ${() => errorName} ${() => disabledName} ${() => appearanceName} ${() => valueName} ${() => clearableName}
+        <${listOptionTag} value="1">${valueValue}</${listOptionTag}>
+        <${listOptionTag} value="2" disabled>Option 2</${listOptionTag}>
+        <${listOptionTag} value="3">Option 3</${listOptionTag}>
+        <${listOptionTag} value="4" hidden>Option 4</${listOptionTag}>
+    </${selectTag}>
 `;
 
 export const selectThemeMatrix: StoryFn = createMatrixThemeStory(
@@ -158,4 +150,18 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
             </${selectTag}>
         `
     )
+);
+
+export const heightTest: StoryFn = createStory(
+    html`
+        <div style="display: flex; flex-direction: column">
+            <${selectTag} style="border: 1px dashed; width: 250px">
+                With Label
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${selectTag}>
+            <${selectTag} style="border: 1px dashed; width: 250px">
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${selectTag}>
+        </div>
+    `
 );

--- a/packages/storybook/src/nimble/select/select.stories.ts
+++ b/packages/storybook/src/nimble/select/select.stories.ts
@@ -16,11 +16,13 @@ import {
     dropdownPositionDescription,
     errorTextDescription,
     errorVisibleDescription,
-    optionsDescription
+    optionsDescription,
+    slottedLabelDescription
 } from '../../utilities/storybook';
 import { ExampleOptionsType } from './types';
 
 interface SelectArgs {
+    label: string;
     disabled: boolean;
     errorVisible: boolean;
     errorText: string;
@@ -127,8 +129,9 @@ const metadata: Meta<SelectArgs> = {
             appearance="${x => x.appearance}"
             filter-mode="${x => (x.filterMode === 'none' ? undefined : x.filterMode)}"
             ?loading-visible="${x => x.loadingVisible}"
-            style="width: 250px;"
+            style="min-width: 250px;"
         >
+            ${x => x.label}
             ${when(x => x.optionsType === ExampleOptionsType.groupedOptions, html<SelectArgs>`
                 ${repeat(_ => getGroupedOptions(), html<GroupedOptionArgs>`
                     <${listOptionGroupTag}
@@ -154,6 +157,11 @@ const metadata: Meta<SelectArgs> = {
         </${selectTag}>
     `),
     argTypes: {
+        label: {
+            name: 'default',
+            description: `${slottedLabelDescription({ componentName: 'select' })}`,
+            table: { category: apiCategory.slots }
+        },
         dropDownPosition: {
             name: 'position',
             options: ['above', 'below'],
@@ -235,6 +243,7 @@ const metadata: Meta<SelectArgs> = {
         }
     },
     args: {
+        label: 'Select',
         disabled: false,
         errorVisible: false,
         errorText: 'Value is invalid',


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Implementation for #2183 . (Work item includes figuring out usage guidance, so won't close it with this PR yet)

## 👩‍💻 Implementation

See updated HLD in this PR.

## 🧪 Testing

- Local testing in Storybook
- Added autotests to cover the select's new (internal) labelContent property and that it sets aria-label (similar to those in `list-option-group.spec.ts`)
- Storybook: Added the 'height test' stories present in other controls that have labels
- Inspected Chromatic diffs. The changes are all expected:
   - Disabled controls now have disabled labels
   - If a `width` style is set on the control (as it is in the theme matrix tests), labels will wrap to multiple lines if needed. This matches existing control behavior (see text area / number field stories)
- Verified pre-existing accessibility violations for [select](https://nimble.ni.dev/storybook/?path=/story/components-select--select) / [combobox](https://nimble.ni.dev/storybook/?path=/story/components-combobox--underline-combobox) are resolved

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
   - Updated Storybook docs to document label support for select/combobox
