### PR TITLE
Add font styles to README example

### DIFF
--- a/change/@ni-nimble-components-5f76c42c-4745-4dbb-b07f-777976e5bafa.json
+++ b/change/@ni-nimble-components-5f76c42c-4745-4dbb-b07f-777976e5bafa.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update README example content",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/README.md
+++ b/packages/nimble-components/README.md
@@ -31,8 +31,13 @@ If you have an existing application that incorporates a module bundler like [Web
 If you have a static webpage without a bundler, you can use `@ni/nimble-components` by including one of the bundled distribution files. For example:
 
 ```html
-<html>
+<!DOCTYPE html>
+<html lang="en">
     <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width">
+        <title>Nimble Example</title>
+        <link rel="stylesheet" href="https://unpkg.com/@ni/nimble-tokens/dist/fonts/css/fonts.css">
         <script src="https://unpkg.com/@ni/nimble-components/dist/all-components-bundle.js"></script>
     </head>
     <body>

--- a/packages/nimble-components/README.md
+++ b/packages/nimble-components/README.md
@@ -31,13 +31,16 @@ If you have an existing application that incorporates a module bundler like [Web
 If you have a static webpage without a bundler, you can use `@ni/nimble-components` by including one of the bundled distribution files. For example:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width">
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width" />
         <title>Nimble Example</title>
-        <link rel="stylesheet" href="https://unpkg.com/@ni/nimble-tokens/dist/fonts/css/fonts.css">
+        <link
+            rel="stylesheet"
+            href="https://unpkg.com/@ni/nimble-tokens/dist/fonts/css/fonts.css"
+        />
         <script src="https://unpkg.com/@ni/nimble-components/dist/all-components-bundle.js"></script>
     </head>
     <body>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The README JS example pulling from unpkg is missing font styles from nimble-tokens.

## 👩‍💻 Implementation

- Added the unpkg `<link rel="stylesheet">` to nimble-tokens font css
- Also added the basic [HTML 5 doc outline](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/HTML_basics#anatomy_of_an_html_document) pieces that were missing 

## 🧪 Testing

Copy and pasted to jsbin.com and looked good. Also validated on https://validator.w3.org/nu/#textarea
Which has no errors but gives the following suggestions (which I ignored to avoid fighting with prettier which wants trailing slashes):

> Info: Trailing slash on void elements [has no effect](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-in-void-element-start-tags-do-not-mark-the-start-tags-as-self-closing) and [interacts badly with unquoted attribute values](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-directly-preceded-by-unquoted-attribute-values).

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
