### PR TITLE
Exclude Apache Arrow and eslint from Renovate major updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,7 +27,9 @@
       "matchDepTypes": ["dependencies", "devDependencies", "peerDependencies"],
       "excludePackagePatterns":[
         "^@angular",
+        "apache-arrow",
         "comlink",
+        "eslint",
         "ng-packagr",
         "playwright",
         "remark-gfm",
@@ -41,6 +43,7 @@
       "groupName": "nuget dependencies",
       "matchManagers": ["nuget"],
       "excludePackagePatterns":[
+        "Apache.Arrow",
         "NI.CSharp.Analyzers",
         "Microsoft.Playwright"
       ],


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This Renovate PR #2318 is failing builds because it tries to update eslint to 9.x but javascript-styleguide is only compatible with 8.x.

We also don't want Renovate to do major updates of apache arrow in either npm or nuget because it's pinned and needs to stay in sync between npm and nuget so should probably be manually handled.

## 👩‍💻 Implementation

Update Renovate config to exclude those dependencies. I got the names of the dependencies from `packages.json` for npm and `packages.lock.json` for nuget.

## 🧪 Testing

After this goes in we can retrigger the Renovate algorithm and see if the major bump excludes these.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
