### PR TITLE
Remove icon-check and rename icon-check-large to icon-check

### DIFF
--- a/change/@ni-nimble-components-940ff4dc-a67c-45e2-9b4c-f00e022e0651.json
+++ b/change/@ni-nimble-components-940ff4dc-a67c-45e2-9b4c-f00e022e0651.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Remove icon-check and rename icon-check-large to icon-check",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-940ff4dc-a67c-45e2-9b4c-f00e022e0651.json
+++ b/change/@ni-nimble-components-940ff4dc-a67c-45e2-9b4c-f00e022e0651.json
@@ -1,6 +1,6 @@
 {
-  "type": "major",
-  "comment": "Remove icon-check and rename icon-check-large to icon-check",
+  "type": "patch",
+  "comment": "Update checkbox component to use renamed check icon",
   "packageName": "@ni/nimble-components",
   "email": "20542556+mollykreis@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@ni-nimble-tokens-9e9f7223-3c56-4a3e-a547-a00214a35d34.json
+++ b/change/@ni-nimble-tokens-9e9f7223-3c56-4a3e-a547-a00214a35d34.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Remove icon-check and rename icon-check-large to icon-check",
+  "packageName": "@ni/nimble-tokens",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-tokens-9e9f7223-3c56-4a3e-a547-a00214a35d34.json
+++ b/change/@ni-nimble-tokens-9e9f7223-3c56-4a3e-a547-a00214a35d34.json
@@ -3,5 +3,5 @@
   "comment": "Remove icon-check and rename icon-check-large to icon-check",
   "packageName": "@ni/nimble-tokens",
   "email": "20542556+mollykreis@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "major"
 }

--- a/packages/nimble-components/src/checkbox/index.ts
+++ b/packages/nimble-components/src/checkbox/index.ts
@@ -4,7 +4,7 @@ import {
     Checkbox as FoundationCheckbox,
     CheckboxOptions
 } from '@microsoft/fast-foundation';
-import { checkLarge16X16, minus16X16 } from '@ni/nimble-tokens/dist/icons/js';
+import { check16X16, minus16X16 } from '@ni/nimble-tokens/dist/icons/js';
 import { styles } from './styles';
 import { template } from './template';
 
@@ -40,7 +40,7 @@ const nimbleCheckbox = Checkbox.compose<CheckboxOptions>({
     baseClass: FoundationCheckbox,
     template,
     styles,
-    checkedIndicator: checkLarge16X16.data,
+    checkedIndicator: check16X16.data,
     indeterminateIndicator: minus16X16.data
 });
 

--- a/packages/nimble-components/src/icon-base/tests/icon-metadata.ts
+++ b/packages/nimble-components/src/icon-base/tests/icon-metadata.ts
@@ -151,9 +151,6 @@ export const iconMetadata: {
     IconCheckDot: {
         tags: ['status', 'done']
     },
-    IconCheckLarge: {
-        tags: ['status', 'success']
-    },
     IconCircle: {
         tags: ['status', 'connected']
     },

--- a/packages/nimble-tokens/dist/icons/svg/check-large_16x16.svg
+++ b/packages/nimble-tokens/dist/icons/svg/check-large_16x16.svg
@@ -1,1 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?><svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path class="cls-1" d="M14,4.69298L5.81846,12.87529l-3.81846-3.81846,1.63615-1.63692,2.25019,2.25019L12.43173,3.12471l1.56827,1.56827Z"/></svg>

--- a/packages/nimble-tokens/dist/icons/svg/check_16x16.svg
+++ b/packages/nimble-tokens/dist/icons/svg/check_16x16.svg
@@ -1,4 +1,1 @@
-<svg id="Layer_1" data-name="Layer 1"
-    xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-    <path class="cls-1" d="M13,5.28671,6.18205,12,3,8.86709l1.36346-1.343,1.87517,1.8462L11.69312,4Z"/>
-</svg>
+<?xml version="1.0" encoding="UTF-8"?><svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path class="cls-1" d="M14,4.69298L5.81846,12.87529l-3.81846-3.81846,1.63615-1.63692,2.25019,2.25019L12.43173,3.12471l1.56827,1.56827Z"/></svg>

--- a/packages/storybook/src/nimble/table-column/mapping/table-column-mapping.stories.ts
+++ b/packages/storybook/src/nimble/table-column/mapping/table-column-mapping.stories.ts
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/html';
 import { tableTag } from '../../../../../nimble-components/src/table';
 import { iconXmarkTag } from '../../../../../nimble-components/src/icons/xmark';
 import { tableColumnTextTag } from '../../../../../nimble-components/src/table-column/text';
-import { iconCheckLargeTag } from '../../../../../nimble-components/src/icons/check-large';
+import { iconCheckTag } from '../../../../../nimble-components/src/icons/check';
 import { iconChartDiagramChildFocusTag } from '../../../../../nimble-components/src/icons/chart-diagram-child-focus';
 import { mappingIconTag } from '../../../../../nimble-components/src/mapping/icon';
 import { mappingSpinnerTag } from '../../../../../nimble-components/src/mapping/spinner';
@@ -97,7 +97,7 @@ export const mappingColumn: StoryObj<MappingColumnTableArgs> = {
             <${tableColumnMappingTag} field-name="status" group-index="0">
                 Status
                 <${mappingIconTag} key="fail" icon="${iconXmarkTag}" severity="error" text="Not a Simpson"></${mappingIconTag}>
-                <${mappingIconTag} key="success" icon="${iconCheckLargeTag}" severity="success" text="Is a Simpson"></${mappingIconTag}>
+                <${mappingIconTag} key="success" icon="${iconCheckTag}" severity="success" text="Is a Simpson"></${mappingIconTag}>
                 <${mappingSpinnerTag} key="calculating" text="Calculating" text-hidden></${mappingSpinnerTag}>
                 <${mappingEmptyTag} key="unknown" text="Unknown"></${mappingEmptyTag}>
             </${tableColumnMappingTag}>
@@ -105,7 +105,7 @@ export const mappingColumn: StoryObj<MappingColumnTableArgs> = {
                 <${iconChartDiagramChildFocusTag} title="Is child"></${iconChartDiagramChildFocusTag}> 
             
                 <${mappingIconTag} key="false" icon="${iconXmarkTag}" severity="error" text="Not a child" text-hidden></${mappingIconTag}>
-                <${mappingIconTag} key="true" icon="${iconCheckLargeTag}" severity="success" text="Is a child" text-hidden></${mappingIconTag}>
+                <${mappingIconTag} key="true" icon="${iconCheckTag}" severity="success" text="Is a child" text-hidden></${mappingIconTag}>
             </${tableColumnMappingTag}>
             <${tableColumnMappingTag} field-name="gender" key-type="string">
                 Gender


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

There have been two "check" icons in nimble -- `nimble-icon-check` and `nimble-icon-check-large`. According to @NIbokeefe, the only icon we should be using (both within nimble and our clients) is `nimble-icon-check-large`. However, all client usages I could find and most nimble usages were `nimble-icon-check`. Since there are no valid use cases for the smaller icon, I've deleted it and renamed "check-large" to "check".

Note: As a bit of background, the smaller icon was originally added for use within the `nimble-checkbox` component. However, the visual design and implementation was updated at some point to use the larger icon. When this occurred, there were no longer any places that needed the smaller icon.

## 👩‍💻 Implementation

- Deleted the SVG for the old "check" icon
- Renamed the SVG for the old "check-large" icon to "check"
- Updated the few instances of "check-large" in nimble to "check"

## 🧪 Testing

- Verified there are no usages of "check-large" or "checklarge" in SLE
- Verified there are no unintentional chromatic diffs. Specifically, the `nimble-checkbox` visuals are not affected by this change.
- Verified that instances of `nimble-icon-check` in the Angular and Blazor example apps now correctly render the larger check icon

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
