### PR TITLE
Disable markdown-it types update

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,6 +27,7 @@
       "matchDepTypes": ["dependencies", "devDependencies", "peerDependencies"],
       "excludePackagePatterns":[
         "^@angular",
+        "@types/markdown-it",
         "apache-arrow",
         "comlink",
         "eslint",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The `@types/markdown-it` updates were disabled due to an issue in prosemirror-markdown. See https://github.com/ni/nimble/issues/2326

## 👩‍💻 Implementation

Disabled `@types/markdown-it` in the renovate config.

## 🧪 Testing

Will see if the renovate merge PR is successful after.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
