### PR TITLE
Assigned nodes text content

### DIFF
--- a/change/@ni-nimble-components-6b68144b-7319-4952-aaed-8935d99e9ea8.json
+++ b/change/@ni-nimble-components-6b68144b-7319-4952-aaed-8935d99e9ea8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Consistent slot text content",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/list-option-group/index.ts
+++ b/packages/nimble-components/src/list-option-group/index.ts
@@ -8,6 +8,7 @@ import {
 import { styles } from './styles';
 import { template } from './template';
 import { ListOption } from '../list-option';
+import { slotTextContent } from '../utilities/models/slot-text-content';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -85,11 +86,7 @@ export class ListOptionGroup extends FoundationElement {
             return '';
         }
 
-        const nodes = this.labelSlot.assignedNodes();
-        return nodes
-            .filter(node => node.textContent?.trim() !== '')
-            .map(node => node.textContent?.trim())
-            .join(' ');
+        return slotTextContent(this.labelSlot);
     }
 
     private readonly hiddenOptions: Set<ListOption> = new Set();

--- a/packages/nimble-components/src/list-option/index.ts
+++ b/packages/nimble-components/src/list-option/index.ts
@@ -6,6 +6,7 @@ import { observable, attr } from '@microsoft/fast-element';
 import { styles } from './styles';
 import { template } from './template';
 import type { ListOptionOwner } from '../patterns/dropdown/types';
+import { slotTextContent } from '../utilities/models/slot-text-content';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -58,10 +59,7 @@ export class ListOption extends FoundationListboxOption {
 
     /** @internal */
     public get elementTextContent(): string {
-        return this.contentSlot
-            .assignedNodes()
-            .map(node => node.textContent?.trim())
-            .join(' ');
+        return slotTextContent(this.contentSlot);
     }
 
     public override connectedCallback(): void {

--- a/packages/nimble-components/src/select/index.ts
+++ b/packages/nimble-components/src/select/index.ts
@@ -43,6 +43,7 @@ import { FilterMode, SelectFilterInputEventDetail } from './types';
 import { diacriticInsensitiveStringNormalizer } from '../utilities/models/string-normalizers';
 import { FormAssociatedSelect } from './models/select-form-associated';
 import type { ListOptionGroup } from '../list-option-group';
+import { slotTextContent } from '../utilities/models/slot-text-content';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -209,11 +210,7 @@ export class Select
             return '';
         }
 
-        const nodes = this.labelSlot.assignedNodes();
-        return nodes
-            .filter(node => node.textContent?.trim() !== '')
-            .map(node => node.textContent?.trim())
-            .join(' ');
+        return slotTextContent(this.labelSlot);
     }
 
     private _value = '';

--- a/packages/nimble-components/src/table-column/base/index.ts
+++ b/packages/nimble-components/src/table-column/base/index.ts
@@ -6,6 +6,7 @@ import {
 } from './models/column-internals';
 import type { TableColumnValidity } from './types';
 import type { ColumnValidator } from './models/column-validator';
+import { slotTextContent } from '../../utilities/models/slot-text-content';
 
 /**
  * The base class for table columns
@@ -53,10 +54,7 @@ export abstract class TableColumn<
 
     /** @internal */
     public get headerTextContent(): string {
-        return this.contentSlot
-            .assignedNodes()
-            .map(node => node.textContent?.trim())
-            .join(' ');
+        return slotTextContent(this.contentSlot);
     }
 
     public override connectedCallback(): void {

--- a/packages/nimble-components/src/utilities/models/slot-text-content.ts
+++ b/packages/nimble-components/src/utilities/models/slot-text-content.ts
@@ -1,3 +1,6 @@
+/**
+ * Finds all text content within a slot and returns it as a space-delimited string.
+ */
 export const slotTextContent = (slot: HTMLSlotElement): string => {
     return slot
         .assignedNodes()

--- a/packages/nimble-components/src/utilities/models/slot-text-content.ts
+++ b/packages/nimble-components/src/utilities/models/slot-text-content.ts
@@ -2,6 +2,6 @@ export const slotTextContent = (slot: HTMLSlotElement): string => {
     return slot
         .assignedNodes()
         .map(node => node.textContent?.trim())
-        .filter(content => (content !== undefined && content !== ''))
+        .filter(content => content !== undefined && content !== '')
         .join(' ');
 };

--- a/packages/nimble-components/src/utilities/models/slot-text-content.ts
+++ b/packages/nimble-components/src/utilities/models/slot-text-content.ts
@@ -1,0 +1,7 @@
+export const slotTextContent = (slot: HTMLSlotElement): string => {
+    return slot
+        .assignedNodes()
+        .map(node => node.textContent?.trim())
+        .filter(content => (content !== undefined && content !== ''))
+        .join(' ');
+};

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -105,5 +105,5 @@ configureActions({
     depth: 1
 });
 
-// Update the GUID on this line to trigger a turbosnap full rebuild: 123e4567-e89b-12d3-a456-426614174000
+// Update the GUID on this line to trigger a turbosnap full rebuild: 9dcbc852-77bd-4b61-afee-f086f31b74f5
 // See https://www.chromatic.com/docs/turbosnap/#full-rebuilds


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes https://github.com/ni/nimble/issues/2322 by creating a shared helper for slot text content.

## 👩‍💻 Implementation

- Create a shared utility and use it

## 🧪 Testing

- Relying on chromatic and CI tests
- Found story changes to icon story from the checkmark change. Expect that the rename of the check icon didn't correctly retrigger a build of the story because our [externals ](https://github.com/ni/nimble/blob/a62f247447a1476a7825c905f3f861a3a21b03ba/.github/workflows/main.yml#L94-L97) aren't configured correctly. Re-triggered all the stories so we can approve new baselines.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
