### PR TITLE
waitForEvent utility refactor

### DIFF
--- a/change/@ni-nimble-components-7bc7e96c-27af-478f-9777-971bded5efdb.json
+++ b/change/@ni-nimble-components-7bc7e96c-27af-478f-9777-971bded5efdb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updates to underlying helpers used by page objects in nimble",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/banner/tests/banner.spec.ts
+++ b/packages/nimble-components/src/banner/tests/banner.spec.ts
@@ -3,7 +3,7 @@ import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Banner, bannerTag } from '..';
 import { BannerSeverity } from '../types';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
-import { createEventListener } from '../../utilities/testing/component';
+import { waitForEvent } from '../../utilities/testing/component';
 import { themeProviderTag, type ThemeProvider } from '../../theme-provider';
 import {
     LabelProviderCore,
@@ -68,10 +68,11 @@ describe('Banner', () => {
 
     it("should fire 'toggle' when 'open' is changed", async () => {
         element.open = false;
-        const toggleListener = createEventListener(element, 'toggle');
+        const spy = jasmine.createSpy();
+        const toggleListener = waitForEvent(element, 'toggle', spy);
         element.open = true;
-        await toggleListener.promise;
-        expect(toggleListener.spy).toHaveBeenCalledOnceWith(
+        await toggleListener;
+        expect(spy).toHaveBeenCalledOnceWith(
             new CustomEvent('toggle', {
                 detail: { oldState: false, newState: true }
             })

--- a/packages/nimble-components/src/combobox/testing/combobox.pageobject.ts
+++ b/packages/nimble-components/src/combobox/testing/combobox.pageobject.ts
@@ -7,7 +7,7 @@ import type { Combobox } from '..';
 import { listOptionTag } from '../../list-option';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import {
-    createEventListener,
+    waitForEvent,
     waitAnimationFrame
 } from '../../utilities/testing/component';
 
@@ -16,7 +16,7 @@ import {
  * of querying and interacting with the component during tests.
  */
 export class ComboboxPageObject {
-    private readonly regionLoadedListener = createEventListener(
+    private readonly regionLoadedListener = waitForEvent(
         this.comboboxElement,
         'loaded'
     );
@@ -212,6 +212,6 @@ export class ComboboxPageObject {
     }
 
     private async waitForAnchoredRegionLoaded(): Promise<void> {
-        await this.regionLoadedListener.promise;
+        await this.regionLoadedListener;
     }
 }

--- a/packages/nimble-components/src/menu-button/testing/menu-button.pageobject.ts
+++ b/packages/nimble-components/src/menu-button/testing/menu-button.pageobject.ts
@@ -6,7 +6,7 @@ import {
     keySpace
 } from '@microsoft/fast-web-utilities';
 import type { MenuButton } from '..';
-import { waitForEventAsync } from '../../utilities/testing/component';
+import { waitForEvent } from '../../utilities/testing/component';
 
 /**
  * Page object for `nimble-menu-button` component to provide consistent ways
@@ -34,7 +34,7 @@ export class MenuButtonPageObject {
             return;
         }
 
-        const toggleEventPromise = waitForEventAsync(
+        const toggleEventPromise = waitForEvent(
             this.menuButtonElement,
             'toggle'
         );

--- a/packages/nimble-components/src/menu-button/tests/menu-button.spec.ts
+++ b/packages/nimble-components/src/menu-button/tests/menu-button.spec.ts
@@ -11,7 +11,7 @@ import {
     processUpdates,
     waitForUpdatesAsync
 } from '../../testing/async-helpers';
-import { createEventListener } from '../../utilities/testing/component';
+import { waitForEvent } from '../../utilities/testing/component';
 import { MenuButtonPageObject } from '../testing/menu-button.pageobject';
 
 class TestSlottedElement extends FoundationElement {}
@@ -30,39 +30,6 @@ async function setup(): Promise<Fixture<MenuButton>> {
 
 async function slottedSetup(): Promise<Fixture<TestSlottedElement>> {
     return fixture(composedTestSlottedElement());
-}
-
-/** A helper function to abstract adding a `beforetoggle` event listener, spying
- * on the event being called, and removing the event listener. The returned promise
- * should be resolved prior to completing a test.
- *
- * The function asserts that the menu button has the expected `open` value when the
- * `beforetoggle` is fired and that when the `beforetoggle` event is fired, the
- * `toggleSpy` has not been called.
- */
-function createBeforeToggleListener(
-    menuButton: MenuButton,
-    expectedOpenState: boolean,
-    toggleSpy: jasmine.Spy
-): {
-        promise: Promise<void>,
-        spy: jasmine.Spy
-    } {
-    const spy = jasmine.createSpy();
-    return {
-        promise: new Promise(resolve => {
-            const handler = (...args: unknown[]): void => {
-                expect(menuButton.open).toEqual(expectedOpenState);
-                expect(toggleSpy).not.toHaveBeenCalled();
-
-                menuButton.removeEventListener('beforetoggle', handler);
-                spy(...args);
-                resolve();
-            };
-            menuButton.addEventListener('beforetoggle', handler);
-        }),
-        spy
-    };
 }
 
 describe('MenuButton', () => {
@@ -256,15 +223,16 @@ describe('MenuButton', () => {
 
         it("should fire 'toggle' event when the menu is opened", async () => {
             await connect();
-            const toggleListener = createEventListener(element, 'toggle');
+            const spy = jasmine.createSpy();
+            const toggleListener = waitForEvent(element, 'toggle', spy);
             element.open = true;
-            await toggleListener.promise;
-            expect(toggleListener.spy).toHaveBeenCalledTimes(1);
+            await toggleListener;
+            expect(spy).toHaveBeenCalledTimes(1);
             const expectedDetails: MenuButtonToggleEventDetail = {
                 newState: true,
                 oldState: false
             };
-            const event = toggleListener.spy.calls.first()
+            const event = spy.calls.first()
                 .args[0] as CustomEvent;
             expect(event.detail).toEqual(expectedDetails);
         });
@@ -272,53 +240,67 @@ describe('MenuButton', () => {
         it("should fire 'toggle' event when the menu is closed", async () => {
             element.open = true;
             await connect();
-            const toggleListener = createEventListener(element, 'toggle');
+            const spy = jasmine.createSpy();
+            const toggleListener = waitForEvent(element, 'toggle', spy);
             element.open = false;
-            await toggleListener.promise;
-            expect(toggleListener.spy).toHaveBeenCalledTimes(1);
+            await toggleListener;
+            expect(spy).toHaveBeenCalledTimes(1);
             const expectedDetails: MenuButtonToggleEventDetail = {
                 newState: false,
                 oldState: true
             };
-            const event = toggleListener.spy.calls.first()
+            const event = spy.calls.first()
                 .args[0] as CustomEvent;
             expect(event.detail).toEqual(expectedDetails);
         });
 
         it("should fire 'beforetoggle' event before the menu opens", async () => {
             await connect();
-            const toggleListener = createEventListener(element, 'toggle');
-            const beforeToggleListener = createBeforeToggleListener(
+            const toggleSpy = jasmine.createSpy();
+            const togglePromise = waitForEvent(element, 'toggle', toggleSpy);
+
+            expect(element.open).toEqual(false);
+            expect(toggleSpy).not.toHaveBeenCalled();
+
+            const beforeToggleSpy = jasmine.createSpy();
+            const beforeTogglePromise = waitForEvent(
                 element,
-                false,
-                toggleListener.spy
+                'beforetoggle',
+                beforeToggleSpy
             );
             const expectedDetails: MenuButtonToggleEventDetail = {
                 newState: true,
                 oldState: false
             };
-
             pageObject.clickMenuButton();
-            await beforeToggleListener.promise;
-            expect(beforeToggleListener.spy).toHaveBeenCalledTimes(1);
-            const event = beforeToggleListener.spy.calls.first()
+            await beforeTogglePromise;
+
+            expect(beforeToggleSpy).toHaveBeenCalledTimes(1);
+            const event = beforeToggleSpy.calls.first()
                 .args[0] as CustomEvent;
             expect(event.detail).toEqual(expectedDetails);
-            beforeToggleListener.spy.calls.reset();
 
-            await toggleListener.promise;
-            expect(beforeToggleListener.spy).not.toHaveBeenCalled();
-            expect(toggleListener.spy).toHaveBeenCalledTimes(1);
+            beforeToggleSpy.calls.reset();
+            await togglePromise;
+
+            expect(beforeToggleSpy).not.toHaveBeenCalled();
+            expect(toggleSpy).toHaveBeenCalledTimes(1);
         });
 
         it("should fire 'beforetoggle' event before the menu is closed", async () => {
             element.open = true;
             await connect();
-            const toggleListener = createEventListener(element, 'toggle');
-            const beforeToggleListener = createBeforeToggleListener(
+            const spy = jasmine.createSpy();
+            const togglePromise = waitForEvent(element, 'toggle', spy);
+
+            expect(element.open).toEqual(true);
+            expect(togglePromise).not.toHaveBeenCalled();
+
+            const beforeToggleSpy = jasmine.createSpy();
+            const beforeTogglePromise = waitForEvent(
                 element,
-                true,
-                toggleListener.spy
+                'beforetoggle',
+                spy
             );
             const expectedDetails: MenuButtonToggleEventDetail = {
                 newState: false,
@@ -326,16 +308,16 @@ describe('MenuButton', () => {
             };
 
             pageObject.clickMenuButton();
-            await beforeToggleListener.promise;
-            expect(beforeToggleListener.spy).toHaveBeenCalledTimes(1);
-            const event = beforeToggleListener.spy.calls.first()
+            await beforeTogglePromise;
+            expect(beforeToggleSpy).toHaveBeenCalledTimes(1);
+            const event = beforeToggleSpy.calls.first()
                 .args[0] as CustomEvent;
             expect(event.detail).toEqual(expectedDetails);
-            beforeToggleListener.spy.calls.reset();
+            beforeToggleSpy.calls.reset();
 
-            await toggleListener.promise;
-            expect(beforeToggleListener.spy).not.toHaveBeenCalled();
-            expect(toggleListener.spy).toHaveBeenCalledTimes(1);
+            await togglePromise;
+            expect(beforeToggleSpy).not.toHaveBeenCalled();
+            expect(spy).toHaveBeenCalledTimes(1);
         });
     });
 
@@ -372,57 +354,57 @@ describe('MenuButton', () => {
             });
 
             it('should open the menu and focus first menu item when the toggle button is clicked', async () => {
-                const toggleListener = createEventListener(
+                const toggleListener = waitForEvent(
                     menuButton,
                     'toggle'
                 );
                 pageObject.clickMenuButton();
                 expect(menuButton.open).toBeTrue();
-                await toggleListener.promise;
+                await toggleListener;
                 expect(document.activeElement).toEqual(menuItem1);
             });
 
             it("should open the menu and focus first menu item when 'Enter' is pressed while the toggle button is focused", async () => {
-                const toggleListener = createEventListener(
+                const toggleListener = waitForEvent(
                     menuButton,
                     'toggle'
                 );
                 pageObject.pressEnterKey();
                 expect(menuButton.open).toBeTrue();
-                await toggleListener.promise;
+                await toggleListener;
                 expect(document.activeElement).toEqual(menuItem1);
             });
 
             it("should open the menu and focus first menu item when 'Space' is pressed while the toggle button is focused", async () => {
-                const toggleListener = createEventListener(
+                const toggleListener = waitForEvent(
                     menuButton,
                     'toggle'
                 );
                 pageObject.pressSpaceKey();
                 expect(menuButton.open).toBeTrue();
-                await toggleListener.promise;
+                await toggleListener;
                 expect(document.activeElement).toEqual(menuItem1);
             });
 
             it('should open the menu and focus first menu item when the down arrow is pressed while the toggle button is focused', async () => {
-                const toggleListener = createEventListener(
+                const toggleListener = waitForEvent(
                     menuButton,
                     'toggle'
                 );
                 pageObject.pressArrowDownKey();
                 expect(menuButton.open).toBeTrue();
-                await toggleListener.promise;
+                await toggleListener;
                 expect(document.activeElement).toEqual(menuItem1);
             });
 
             it('should open the menu and focus last menu item when the up arrow is pressed while the toggle button is focused', async () => {
-                const toggleListener = createEventListener(
+                const toggleListener = waitForEvent(
                     menuButton,
                     'toggle'
                 );
                 pageObject.pressArrowUpKey();
                 expect(menuButton.open).toBeTrue();
-                await toggleListener.promise;
+                await toggleListener;
                 expect(document.activeElement).toEqual(menuItem3);
             });
 
@@ -532,91 +514,101 @@ describe('MenuButton', () => {
             });
 
             it('should transition to the open state when the toggle button is clicked', async () => {
-                const toggleListener = createEventListener(
+                const spy = jasmine.createSpy();
+                const toggleListener = waitForEvent(
                     menuButton,
-                    'toggle'
+                    'toggle',
+                    spy
                 );
                 pageObject.clickMenuButton();
                 expect(menuButton.open).toBeTrue();
-                await toggleListener.promise;
-                expect(toggleListener.spy).toHaveBeenCalledTimes(1);
+                await toggleListener;
+                expect(spy).toHaveBeenCalledTimes(1);
                 const expectedDetails: MenuButtonToggleEventDetail = {
                     newState: true,
                     oldState: false
                 };
-                const event = toggleListener.spy.calls.first()
+                const event = spy.calls.first()
                     .args[0] as CustomEvent;
                 expect(event.detail).toEqual(expectedDetails);
             });
 
             it("should transition to the open state when 'Enter' is pressed while the toggle button is focused", async () => {
-                const toggleListener = createEventListener(
+                const spy = jasmine.createSpy();
+                const toggleListener = waitForEvent(
                     menuButton,
-                    'toggle'
+                    'toggle',
+                    spy
                 );
                 pageObject.pressEnterKey();
                 expect(menuButton.open).toBeTrue();
-                await toggleListener.promise;
-                expect(toggleListener.spy).toHaveBeenCalledTimes(1);
+                await toggleListener;
+                expect(spy).toHaveBeenCalledTimes(1);
                 const expectedDetails: MenuButtonToggleEventDetail = {
                     newState: true,
                     oldState: false
                 };
-                const toggleEvent = toggleListener.spy.calls.first()
+                const toggleEvent = spy.calls.first()
                     .args[0] as CustomEvent;
                 expect(toggleEvent.detail).toEqual(expectedDetails);
             });
 
             it("should transition to the open state when 'Space' is pressed while the toggle button is focused", async () => {
-                const toggleListener = createEventListener(
+                const spy = jasmine.createSpy();
+                const toggleListener = waitForEvent(
                     menuButton,
-                    'toggle'
+                    'toggle',
+                    spy
                 );
                 pageObject.pressSpaceKey();
                 expect(menuButton.open).toBeTrue();
-                await toggleListener.promise;
-                expect(toggleListener.spy).toHaveBeenCalledTimes(1);
+                await toggleListener;
+                expect(spy).toHaveBeenCalledTimes(1);
                 const expectedDetails: MenuButtonToggleEventDetail = {
                     newState: true,
                     oldState: false
                 };
-                const toggleEvent = toggleListener.spy.calls.first()
+                const toggleEvent = spy.calls.first()
                     .args[0] as CustomEvent;
                 expect(toggleEvent.detail).toEqual(expectedDetails);
             });
 
             it('should transition to the open state when the down arrow is pressed while the toggle button is focused', async () => {
-                const toggleListener = createEventListener(
+                const spy = jasmine.createSpy();
+                const toggleListener = waitForEvent(
                     menuButton,
-                    'toggle'
+                    'toggle',
+                    spy
                 );
                 pageObject.pressArrowDownKey();
                 expect(menuButton.open).toBeTrue();
-                await toggleListener.promise;
-                expect(toggleListener.spy).toHaveBeenCalledTimes(1);
+                await toggleListener;
+                expect(spy).toHaveBeenCalledTimes(1);
                 const expectedDetails: MenuButtonToggleEventDetail = {
                     newState: true,
                     oldState: false
                 };
-                const toggleEvent = toggleListener.spy.calls.first()
+                const toggleEvent = spy.calls.first()
                     .args[0] as CustomEvent;
                 expect(toggleEvent.detail).toEqual(expectedDetails);
             });
 
             it('should transition to the open state when the up arrow is pressed while the toggle button is focused', async () => {
-                const toggleListener = createEventListener(
+                const spy = jasmine.createSpy();
+                const toggleListener = waitForEvent(
                     menuButton,
-                    'toggle'
+                    'toggle',
+                    spy
                 );
                 pageObject.pressArrowUpKey();
                 expect(menuButton.open).toBeTrue();
-                await toggleListener.promise;
-                expect(toggleListener.spy).toHaveBeenCalledTimes(1);
+                await toggleListener;
+                expect(spy).toHaveBeenCalledTimes(1);
                 const expectedDetails: MenuButtonToggleEventDetail = {
                     newState: true,
                     oldState: false
                 };
-                const toggleEvent = toggleListener.spy.calls.first()
+                const toggleEvent = spy.calls.first()
                     .args[0] as CustomEvent;
                 expect(toggleEvent.detail).toEqual(expectedDetails);
             });

--- a/packages/nimble-components/src/menu-button/tests/menu-button.spec.ts
+++ b/packages/nimble-components/src/menu-button/tests/menu-button.spec.ts
@@ -236,8 +236,7 @@ describe('MenuButton', () => {
                 newState: true,
                 oldState: false
             };
-            const event = spy.calls.first()
-                .args[0];
+            const event = spy.calls.first().args[0];
             expect(event.detail).toEqual(expectedDetails);
         });
 
@@ -253,8 +252,7 @@ describe('MenuButton', () => {
                 newState: false,
                 oldState: true
             };
-            const event = spy.calls.first()
-                .args[0];
+            const event = spy.calls.first().args[0];
             expect(event.detail).toEqual(expectedDetails);
         });
 
@@ -351,10 +349,7 @@ describe('MenuButton', () => {
             });
 
             it('should open the menu and focus first menu item when the toggle button is clicked', async () => {
-                const toggleListener = waitForEvent(
-                    menuButton,
-                    'toggle'
-                );
+                const toggleListener = waitForEvent(menuButton, 'toggle');
                 pageObject.clickMenuButton();
                 expect(menuButton.open).toBeTrue();
                 await toggleListener;
@@ -362,10 +357,7 @@ describe('MenuButton', () => {
             });
 
             it("should open the menu and focus first menu item when 'Enter' is pressed while the toggle button is focused", async () => {
-                const toggleListener = waitForEvent(
-                    menuButton,
-                    'toggle'
-                );
+                const toggleListener = waitForEvent(menuButton, 'toggle');
                 pageObject.pressEnterKey();
                 expect(menuButton.open).toBeTrue();
                 await toggleListener;
@@ -373,10 +365,7 @@ describe('MenuButton', () => {
             });
 
             it("should open the menu and focus first menu item when 'Space' is pressed while the toggle button is focused", async () => {
-                const toggleListener = waitForEvent(
-                    menuButton,
-                    'toggle'
-                );
+                const toggleListener = waitForEvent(menuButton, 'toggle');
                 pageObject.pressSpaceKey();
                 expect(menuButton.open).toBeTrue();
                 await toggleListener;
@@ -384,10 +373,7 @@ describe('MenuButton', () => {
             });
 
             it('should open the menu and focus first menu item when the down arrow is pressed while the toggle button is focused', async () => {
-                const toggleListener = waitForEvent(
-                    menuButton,
-                    'toggle'
-                );
+                const toggleListener = waitForEvent(menuButton, 'toggle');
                 pageObject.pressArrowDownKey();
                 expect(menuButton.open).toBeTrue();
                 await toggleListener;
@@ -395,10 +381,7 @@ describe('MenuButton', () => {
             });
 
             it('should open the menu and focus last menu item when the up arrow is pressed while the toggle button is focused', async () => {
-                const toggleListener = waitForEvent(
-                    menuButton,
-                    'toggle'
-                );
+                const toggleListener = waitForEvent(menuButton, 'toggle');
                 pageObject.pressArrowUpKey();
                 expect(menuButton.open).toBeTrue();
                 await toggleListener;
@@ -512,11 +495,7 @@ describe('MenuButton', () => {
 
             it('should transition to the open state when the toggle button is clicked', async () => {
                 const spy = jasmine.createSpy<MenuButtonToggleEventHandler>();
-                const toggleListener = waitForEvent(
-                    menuButton,
-                    'toggle',
-                    spy
-                );
+                const toggleListener = waitForEvent(menuButton, 'toggle', spy);
                 pageObject.clickMenuButton();
                 expect(menuButton.open).toBeTrue();
                 await toggleListener;
@@ -525,18 +504,13 @@ describe('MenuButton', () => {
                     newState: true,
                     oldState: false
                 };
-                const event = spy.calls.first()
-                    .args[0];
+                const event = spy.calls.first().args[0];
                 expect(event.detail).toEqual(expectedDetails);
             });
 
             it("should transition to the open state when 'Enter' is pressed while the toggle button is focused", async () => {
                 const spy = jasmine.createSpy<MenuButtonToggleEventHandler>();
-                const toggleListener = waitForEvent(
-                    menuButton,
-                    'toggle',
-                    spy
-                );
+                const toggleListener = waitForEvent(menuButton, 'toggle', spy);
                 pageObject.pressEnterKey();
                 expect(menuButton.open).toBeTrue();
                 await toggleListener;
@@ -545,18 +519,13 @@ describe('MenuButton', () => {
                     newState: true,
                     oldState: false
                 };
-                const toggleEvent = spy.calls.first()
-                    .args[0];
+                const toggleEvent = spy.calls.first().args[0];
                 expect(toggleEvent.detail).toEqual(expectedDetails);
             });
 
             it("should transition to the open state when 'Space' is pressed while the toggle button is focused", async () => {
                 const spy = jasmine.createSpy<MenuButtonToggleEventHandler>();
-                const toggleListener = waitForEvent(
-                    menuButton,
-                    'toggle',
-                    spy
-                );
+                const toggleListener = waitForEvent(menuButton, 'toggle', spy);
                 pageObject.pressSpaceKey();
                 expect(menuButton.open).toBeTrue();
                 await toggleListener;
@@ -565,18 +534,13 @@ describe('MenuButton', () => {
                     newState: true,
                     oldState: false
                 };
-                const toggleEvent = spy.calls.first()
-                    .args[0];
+                const toggleEvent = spy.calls.first().args[0];
                 expect(toggleEvent.detail).toEqual(expectedDetails);
             });
 
             it('should transition to the open state when the down arrow is pressed while the toggle button is focused', async () => {
                 const spy = jasmine.createSpy<MenuButtonToggleEventHandler>();
-                const toggleListener = waitForEvent(
-                    menuButton,
-                    'toggle',
-                    spy
-                );
+                const toggleListener = waitForEvent(menuButton, 'toggle', spy);
                 pageObject.pressArrowDownKey();
                 expect(menuButton.open).toBeTrue();
                 await toggleListener;
@@ -585,18 +549,13 @@ describe('MenuButton', () => {
                     newState: true,
                     oldState: false
                 };
-                const toggleEvent = spy.calls.first()
-                    .args[0];
+                const toggleEvent = spy.calls.first().args[0];
                 expect(toggleEvent.detail).toEqual(expectedDetails);
             });
 
             it('should transition to the open state when the up arrow is pressed while the toggle button is focused', async () => {
                 const spy = jasmine.createSpy<MenuButtonToggleEventHandler>();
-                const toggleListener = waitForEvent(
-                    menuButton,
-                    'toggle',
-                    spy
-                );
+                const toggleListener = waitForEvent(menuButton, 'toggle', spy);
                 pageObject.pressArrowUpKey();
                 expect(menuButton.open).toBeTrue();
                 await toggleListener;
@@ -605,8 +564,7 @@ describe('MenuButton', () => {
                     newState: true,
                     oldState: false
                 };
-                const toggleEvent = spy.calls.first()
-                    .args[0];
+                const toggleEvent = spy.calls.first().args[0];
                 expect(toggleEvent.detail).toEqual(expectedDetails);
             });
 

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
@@ -7,7 +7,7 @@ import { wackyStrings } from '../../../utilities/tests/wacky-strings';
 import type { Button } from '../../../button';
 import type { ToggleButton } from '../../../toggle-button';
 import { ToolbarButton } from '../testing/types';
-import { createEventListener } from '../../../utilities/testing/component';
+import { waitForEvent } from '../../../utilities/testing/component';
 import { waitForUpdatesAsync } from '../../../testing/async-helpers';
 
 async function setup(): Promise<Fixture<RichTextEditor>> {
@@ -1771,34 +1771,38 @@ describe('RichTextEditor', () => {
     });
 
     it('should fire "input" event when there is an input to the editor', async () => {
-        const inputEventListener = createEventListener(element, 'input');
+        const spy = jasmine.createSpy();
+        const inputEventListener = waitForEvent(element, 'input', spy);
 
         await pageObject.setEditorTextContent('input');
-        await inputEventListener.promise;
+        await inputEventListener;
 
-        expect(inputEventListener.spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should not fire "input" event when setting the content through "setMarkdown"', () => {
-        const inputEventListener = createEventListener(element, 'input');
+        const spy = jasmine.createSpy();
+        void waitForEvent(element, 'input', spy);
 
         element.setMarkdown('input');
 
-        expect(inputEventListener.spy).not.toHaveBeenCalled();
+        expect(spy).not.toHaveBeenCalled();
     });
 
     it('should fire "input" event when the text is updated/removed from the editor', async () => {
-        const inputEventListener = createEventListener(element, 'input');
-
+        const updateSpy = jasmine.createSpy();
+        const updatePromise = waitForEvent(element, 'input', updateSpy);
         await pageObject.setEditorTextContent('update');
-        await inputEventListener.promise;
+        await updatePromise;
 
-        expect(inputEventListener.spy).toHaveBeenCalledTimes(1);
+        expect(updateSpy).toHaveBeenCalledTimes(1);
 
+        const removedSpy = jasmine.createSpy();
+        const removedPromise = waitForEvent(element, 'input', removedSpy);
         await pageObject.replaceEditorContent('');
-        await inputEventListener.promise;
+        await removedPromise;
 
-        expect(inputEventListener.spy).toHaveBeenCalledTimes(1);
+        expect(removedSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should initialize "empty" to true and set false when there is content', async () => {

--- a/packages/nimble-components/src/rich-text/mention-listbox/tests/mention-listbox.spec.ts
+++ b/packages/nimble-components/src/rich-text/mention-listbox/tests/mention-listbox.spec.ts
@@ -4,7 +4,7 @@ import { waitForUpdatesAsync } from '../../../testing/async-helpers';
 import { type Fixture, fixture } from '../../../utilities/tests/fixture';
 import { listOptionTag } from '../../../list-option';
 import {
-    createEventListener,
+    waitForEvent,
     waitAnimationFrame
 } from '../../../utilities/testing/component';
 import { checkFullyInViewport } from '../../../utilities/tests/intersection-observer';
@@ -55,12 +55,12 @@ describe('RichTextMentionListbox', () => {
     }
 
     async function showAndWaitForOpen(filter = ''): Promise<void> {
-        const regionLoadedListener = createEventListener(element, 'loaded');
+        const regionLoadedPromise = waitForEvent(element, 'loaded');
         element.show({
             anchorNode: anchor,
             filter
         });
-        await regionLoadedListener.promise;
+        await regionLoadedPromise;
     }
 
     beforeEach(async () => {

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -24,9 +24,7 @@ type SelectFilterInputEventHandler = (
     evt: CustomEvent<SelectFilterInputEventDetail>
 ) => void;
 
-type CustomEventHandler = (
-    evt: CustomEvent
-) => void;
+type CustomEventHandler = (evt: CustomEvent) => void;
 
 type OptionInitialState =
     | 'selected'
@@ -1483,11 +1481,16 @@ describe('Select', () => {
 
             it('emits filter-input event with empty filterText when dropdown is closed', async () => {
                 const filterInputEvent = jasmine.createSpy<SelectFilterInputEventHandler>();
-                element.addEventListener('filter-input', filterInputEvent as unknown as EventListener);
+                element.addEventListener(
+                    'filter-input',
+                    filterInputEvent as unknown as EventListener
+                );
                 await pageObject.openAndSetFilterText('o');
                 await pageObject.clickAway();
                 expect(filterInputEvent).toHaveBeenCalledTimes(2);
-                expect(filterInputEvent.calls.argsFor(1)[0].detail.filterText).toBe('');
+                expect(
+                    filterInputEvent.calls.argsFor(1)[0].detail.filterText
+                ).toBe('');
             });
         });
     });
@@ -2147,34 +2150,38 @@ describe('Select', () => {
             it('when clicking value, filter-input event occurs after value has been updated', async () => {
                 await clickAndWaitForOpen(element);
                 const eventSpy = jasmine.createSpy<CustomEventHandler>();
-                element.addEventListener('filter-input', eventSpy as unknown as EventListener);
-                element.addEventListener('change', eventSpy as unknown as EventListener);
+                element.addEventListener(
+                    'filter-input',
+                    eventSpy as unknown as EventListener
+                );
+                element.addEventListener(
+                    'change',
+                    eventSpy as unknown as EventListener
+                );
 
                 pageObject.clickOptionWithDisplayText('Two');
                 expect(eventSpy).toHaveBeenCalledTimes(2);
-                expect(eventSpy.calls.argsFor(0)[0].type).toBe(
-                    'change'
-                );
-                expect(eventSpy.calls.argsFor(1)[0].type).toBe(
-                    'filter-input'
-                );
+                expect(eventSpy.calls.argsFor(0)[0].type).toBe('change');
+                expect(eventSpy.calls.argsFor(1)[0].type).toBe('filter-input');
             });
 
             it('when selecting a value with <Enter>, filter-input event occurs after value has been updated', async () => {
                 await clickAndWaitForOpen(element);
                 const eventSpy = jasmine.createSpy<CustomEventHandler>();
-                element.addEventListener('filter-input', eventSpy as unknown as EventListener);
-                element.addEventListener('change', eventSpy as unknown as EventListener);
+                element.addEventListener(
+                    'filter-input',
+                    eventSpy as unknown as EventListener
+                );
+                element.addEventListener(
+                    'change',
+                    eventSpy as unknown as EventListener
+                );
 
                 pageObject.pressArrowDownKey();
                 pageObject.pressEnterKey();
                 expect(eventSpy).toHaveBeenCalledTimes(2);
-                expect(eventSpy.calls.argsFor(0)[0].type).toBe(
-                    'change'
-                );
-                expect(eventSpy.calls.argsFor(1)[0].type).toBe(
-                    'filter-input'
-                );
+                expect(eventSpy.calls.argsFor(0)[0].type).toBe('change');
+                expect(eventSpy.calls.argsFor(1)[0].type).toBe('filter-input');
             });
 
             it('pressing <Esc> issues one filter-input event with empty filterText', async () => {
@@ -2190,8 +2197,7 @@ describe('Select', () => {
                 const expectedDetails: SelectFilterInputEventDetail = {
                     filterText: ''
                 };
-                const event = spy.calls.first()
-                    .args[0];
+                const event = spy.calls.first().args[0];
                 expect(spy).toHaveBeenCalledTimes(1);
                 expect(event.detail).toEqual(expectedDetails);
             });
@@ -2209,8 +2215,7 @@ describe('Select', () => {
                 const expectedDetails: SelectFilterInputEventDetail = {
                     filterText: ''
                 };
-                const event = spy.calls.first()
-                    .args[0];
+                const event = spy.calls.first().args[0];
                 expect(spy).toHaveBeenCalledTimes(1);
                 expect(event.detail).toEqual(expectedDetails);
             });
@@ -2291,11 +2296,7 @@ describe('Select', () => {
 
         it('exercise setFilter', () => {
             const spy = jasmine.createSpy();
-            element.addEventListener(
-                'filter-input',
-                spy,
-                { once: true }
-            );
+            element.addEventListener('filter-input', spy, { once: true });
             pageObject.clickSelect();
             pageObject.setFilter('Two');
 

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -20,6 +20,14 @@ const disabledOption = 'disabled';
 const disabledSelectedOption = 'disabled selected';
 const placeholderSelectedOption = 'disabled selected hidden';
 
+type SelectFilterInputEventHandler = (
+    evt: CustomEvent<SelectFilterInputEventDetail>
+) => void;
+
+type CustomEventHandler = (
+    evt: CustomEvent
+) => void;
+
 type OptionInitialState =
     | 'selected'
     | 'disabled'
@@ -1461,9 +1469,6 @@ describe('Select', () => {
             });
 
             it('emits filter-input event when filter text is entered', async () => {
-                type SelectFilterInputEventHandler = (
-                    evt: CustomEvent<SelectFilterInputEventDetail>
-                ) => void;
                 const filterInputEvent = jasmine.createSpy<SelectFilterInputEventHandler>();
                 element.addEventListener(
                     'filter-input',
@@ -1477,17 +1482,12 @@ describe('Select', () => {
             });
 
             it('emits filter-input event with empty filterText when dropdown is closed', async () => {
-                const filterInputEvent = jasmine.createSpy();
-                element.addEventListener('filter-input', filterInputEvent);
+                const filterInputEvent = jasmine.createSpy<SelectFilterInputEventHandler>();
+                element.addEventListener('filter-input', filterInputEvent as unknown as EventListener);
                 await pageObject.openAndSetFilterText('o');
                 await pageObject.clickAway();
                 expect(filterInputEvent).toHaveBeenCalledTimes(2);
-                expect(
-                    (
-                        (filterInputEvent.calls.argsFor(1)[0] as CustomEvent)
-                            .detail as SelectFilterInputEventDetail
-                    ).filterText
-                ).toBe('');
+                expect(filterInputEvent.calls.argsFor(1)[0].detail.filterText).toBe('');
             });
         });
     });
@@ -2146,40 +2146,40 @@ describe('Select', () => {
 
             it('when clicking value, filter-input event occurs after value has been updated', async () => {
                 await clickAndWaitForOpen(element);
-                const eventSpy = jasmine.createSpy();
-                element.addEventListener('filter-input', eventSpy);
-                element.addEventListener('change', eventSpy);
+                const eventSpy = jasmine.createSpy<CustomEventHandler>();
+                element.addEventListener('filter-input', eventSpy as unknown as EventListener);
+                element.addEventListener('change', eventSpy as unknown as EventListener);
 
                 pageObject.clickOptionWithDisplayText('Two');
                 expect(eventSpy).toHaveBeenCalledTimes(2);
-                expect((eventSpy.calls.argsFor(0)[0] as CustomEvent).type).toBe(
+                expect(eventSpy.calls.argsFor(0)[0].type).toBe(
                     'change'
                 );
-                expect((eventSpy.calls.argsFor(1)[0] as CustomEvent).type).toBe(
+                expect(eventSpy.calls.argsFor(1)[0].type).toBe(
                     'filter-input'
                 );
             });
 
             it('when selecting a value with <Enter>, filter-input event occurs after value has been updated', async () => {
                 await clickAndWaitForOpen(element);
-                const eventSpy = jasmine.createSpy();
-                element.addEventListener('filter-input', eventSpy);
-                element.addEventListener('change', eventSpy);
+                const eventSpy = jasmine.createSpy<CustomEventHandler>();
+                element.addEventListener('filter-input', eventSpy as unknown as EventListener);
+                element.addEventListener('change', eventSpy as unknown as EventListener);
 
                 pageObject.pressArrowDownKey();
                 pageObject.pressEnterKey();
                 expect(eventSpy).toHaveBeenCalledTimes(2);
-                expect((eventSpy.calls.argsFor(0)[0] as CustomEvent).type).toBe(
+                expect(eventSpy.calls.argsFor(0)[0].type).toBe(
                     'change'
                 );
-                expect((eventSpy.calls.argsFor(1)[0] as CustomEvent).type).toBe(
+                expect(eventSpy.calls.argsFor(1)[0].type).toBe(
                     'filter-input'
                 );
             });
 
             it('pressing <Esc> issues one filter-input event with empty filterText', async () => {
                 await clickAndWaitForOpen(element);
-                const spy = jasmine.createSpy();
+                const spy = jasmine.createSpy<SelectFilterInputEventHandler>();
                 const filterInputEventPromise = waitForEvent(
                     element,
                     'filter-input',
@@ -2191,14 +2191,14 @@ describe('Select', () => {
                     filterText: ''
                 };
                 const event = spy.calls.first()
-                    .args[0] as CustomEvent;
+                    .args[0];
                 expect(spy).toHaveBeenCalledTimes(1);
                 expect(event.detail).toEqual(expectedDetails);
             });
 
             it('clicking outside of dropdown issues one filter-input event with empty filterText', async () => {
                 await clickAndWaitForOpen(element);
-                const spy = jasmine.createSpy();
+                const spy = jasmine.createSpy<CustomEventHandler>();
                 const filterInputEventPromise = waitForEvent(
                     element,
                     'filter-input',
@@ -2210,7 +2210,7 @@ describe('Select', () => {
                     filterText: ''
                 };
                 const event = spy.calls.first()
-                    .args[0] as CustomEvent;
+                    .args[0];
                 expect(spy).toHaveBeenCalledTimes(1);
                 expect(event.detail).toEqual(expectedDetails);
             });

--- a/packages/nimble-components/src/table-column/menu-button/tests/table-column-menu-button.spec.ts
+++ b/packages/nimble-components/src/table-column/menu-button/tests/table-column-menu-button.spec.ts
@@ -12,7 +12,7 @@ import { wackyStrings } from '../../../utilities/tests/wacky-strings';
 import { MenuButtonPageObject } from '../../../menu-button/testing/menu-button.pageobject';
 import type { MenuButtonColumnToggleEventDetail } from '../types';
 import {
-    createEventListener,
+    waitForEvent,
     sendKeyDownEvent
 } from '../../../utilities/testing/component';
 import { Menu, menuTag } from '../../../menu';
@@ -320,13 +320,17 @@ describe('TableColumnMenuButton', () => {
         });
 
         it('opening menu button fires "menu-button-column-beforetoggle" followed by "menu-button-column-toggle"', async () => {
-            const beforeToggleListener = createEventListener(
+            const beforeToggleSpy = jasmine.createSpy();
+            const beforeTogglePromise = waitForEvent(
                 column,
-                'menu-button-column-beforetoggle'
+                'menu-button-column-beforetoggle',
+                beforeToggleSpy
             );
-            const toggleListener = createEventListener(
+            const toggleSpy = jasmine.createSpy();
+            const togglePromise = waitForEvent(
                 column,
-                'menu-button-column-toggle'
+                'menu-button-column-toggle',
+                toggleSpy
             );
 
             menuButton.clickMenuButton();
@@ -337,29 +341,33 @@ describe('TableColumnMenuButton', () => {
                 oldState: false
             };
 
-            await beforeToggleListener.promise;
-            expect(beforeToggleListener.spy).toHaveBeenCalledTimes(1);
-            let eventDetail = getEventDetailFromSpy(beforeToggleListener.spy);
+            await beforeTogglePromise;
+            expect(beforeToggleSpy).toHaveBeenCalledTimes(1);
+            let eventDetail = getEventDetailFromSpy(beforeToggleSpy);
             expect(eventDetail).toEqual(expectedDetails);
-            beforeToggleListener.spy.calls.reset();
+            beforeToggleSpy.calls.reset();
 
-            await toggleListener.promise;
-            expect(beforeToggleListener.spy).not.toHaveBeenCalled();
-            expect(toggleListener.spy).toHaveBeenCalledTimes(1);
-            eventDetail = getEventDetailFromSpy(toggleListener.spy);
+            await togglePromise;
+            expect(beforeToggleSpy).not.toHaveBeenCalled();
+            expect(toggleSpy).toHaveBeenCalledTimes(1);
+            eventDetail = getEventDetailFromSpy(beforeToggleSpy);
             expect(eventDetail).toEqual(expectedDetails);
         });
 
         it('closing menu button with ESC fires "menu-button-column-beforetoggle" followed by "menu-button-column-toggle"', async () => {
             await menuButton.openMenu();
 
-            const beforeToggleListener = createEventListener(
+            const beforeToggleSpy = jasmine.createSpy();
+            const beforeTogglePromise = waitForEvent(
                 column,
-                'menu-button-column-beforetoggle'
+                'menu-button-column-beforetoggle',
+                beforeToggleSpy
             );
-            const toggleListener = createEventListener(
+            const toggleSpy = jasmine.createSpy();
+            const togglePromise = waitForEvent(
                 column,
-                'menu-button-column-toggle'
+                'menu-button-column-toggle',
+                toggleSpy
             );
 
             menuButton.closeMenuWithEscape();
@@ -370,16 +378,16 @@ describe('TableColumnMenuButton', () => {
                 oldState: true
             };
 
-            await beforeToggleListener.promise;
-            expect(beforeToggleListener.spy).toHaveBeenCalledTimes(1);
-            let eventDetail = getEventDetailFromSpy(beforeToggleListener.spy);
+            await beforeTogglePromise;
+            expect(beforeToggleSpy).toHaveBeenCalledTimes(1);
+            let eventDetail = getEventDetailFromSpy(beforeToggleSpy);
             expect(eventDetail).toEqual(expectedDetails);
-            beforeToggleListener.spy.calls.reset();
+            beforeToggleSpy.calls.reset();
 
-            await toggleListener.promise;
-            expect(beforeToggleListener.spy).not.toHaveBeenCalled();
-            expect(toggleListener.spy).toHaveBeenCalledTimes(1);
-            eventDetail = getEventDetailFromSpy(toggleListener.spy);
+            await togglePromise;
+            expect(beforeToggleSpy).not.toHaveBeenCalled();
+            expect(toggleSpy).toHaveBeenCalledTimes(1);
+            eventDetail = getEventDetailFromSpy(toggleSpy);
             expect(eventDetail).toEqual(expectedDetails);
 
             expect(menuButton.isOpen()).toBeFalse();
@@ -388,13 +396,17 @@ describe('TableColumnMenuButton', () => {
         it('closing menu button by clicking fires "menu-button-column-beforetoggle" followed by "menu-button-column-toggle"', async () => {
             await menuButton.openMenu();
 
-            const beforeToggleListener = createEventListener(
+            const beforeToggleSpy = jasmine.createSpy();
+            const beforeTogglePromise = waitForEvent(
                 column,
-                'menu-button-column-beforetoggle'
+                'menu-button-column-beforetoggle',
+                beforeToggleSpy
             );
-            const toggleListener = createEventListener(
+            const toggleSpy = jasmine.createSpy();
+            const togglePromise = waitForEvent(
                 column,
-                'menu-button-column-toggle'
+                'menu-button-column-toggle',
+                toggleSpy
             );
 
             menuButton.clickMenuButton();
@@ -405,16 +417,16 @@ describe('TableColumnMenuButton', () => {
                 oldState: true
             };
 
-            await beforeToggleListener.promise;
-            expect(beforeToggleListener.spy).toHaveBeenCalledTimes(1);
-            let eventDetail = getEventDetailFromSpy(beforeToggleListener.spy);
+            await beforeTogglePromise;
+            expect(beforeToggleSpy).toHaveBeenCalledTimes(1);
+            let eventDetail = getEventDetailFromSpy(beforeToggleSpy);
             expect(eventDetail).toEqual(expectedDetails);
-            beforeToggleListener.spy.calls.reset();
+            beforeToggleSpy.calls.reset();
 
-            await toggleListener.promise;
-            expect(beforeToggleListener.spy).not.toHaveBeenCalled();
-            expect(toggleListener.spy).toHaveBeenCalledTimes(1);
-            eventDetail = getEventDetailFromSpy(toggleListener.spy);
+            await togglePromise;
+            expect(beforeToggleSpy).not.toHaveBeenCalled();
+            expect(toggleSpy).toHaveBeenCalledTimes(1);
+            eventDetail = getEventDetailFromSpy(toggleSpy);
             expect(eventDetail).toEqual(expectedDetails);
 
             expect(menuButton.isOpen()).toBeFalse();
@@ -496,12 +508,12 @@ describe('TableColumnMenuButton', () => {
                     elementReferences.menu.slot = slotName;
                     await waitForUpdatesAsync();
 
-                    const toggleListener = createEventListener(
+                    const togglePromise = waitForEvent(
                         column,
                         'menu-button-column-toggle'
                     );
                     value.action();
-                    await toggleListener.promise;
+                    await togglePromise;
                     const expectedFocusedItem = value.expectedFocus === 'first'
                         ? elementReferences.firstMenuItem
                         : elementReferences.lastMenuItem;
@@ -518,32 +530,52 @@ describe('TableColumnMenuButton', () => {
                 column2BeforeToggleEmitCount: number,
                 column2ToggleEmitCount: number
             }> {
-            const column1BeforeToggleListener = createEventListener(
-                elementReferences.column1,
-                'menu-button-column-beforetoggle'
+            const column1BeforeToggleSpy = jasmine.createSpy();
+            elementReferences.column1.addEventListener(
+                'menu-button-column-beforetoggle',
+                column1BeforeToggleSpy
             );
-            const column1ToggleListener = createEventListener(
-                elementReferences.column1,
-                'menu-button-column-toggle'
+            const column1ToggleSpy = jasmine.createSpy();
+            elementReferences.column1.addEventListener(
+                'menu-button-column-toggle',
+                column1ToggleSpy
             );
-            const column2BeforeToggleListener = createEventListener(
-                elementReferences.column2,
-                'menu-button-column-beforetoggle'
+            const column2BeforeToggleSpy = jasmine.createSpy();
+            elementReferences.column2.addEventListener(
+                'menu-button-column-beforetoggle',
+                column2BeforeToggleSpy
             );
-            const column2ToggleListener = createEventListener(
-                elementReferences.column2,
-                'menu-button-column-toggle'
+            const column2ToggleSpy = jasmine.createSpy();
+            elementReferences.column2.addEventListener(
+                'menu-button-column-toggle',
+                column2ToggleSpy
             );
 
             await menuButtonToOpen.openMenu();
+            elementReferences.column1.removeEventListener(
+                'menu-button-column-beforetoggle',
+                column1BeforeToggleSpy
+            );
+            elementReferences.column1.removeEventListener(
+                'menu-button-column-toggle',
+                column1ToggleSpy
+            );
+            elementReferences.column2.removeEventListener(
+                'menu-button-column-beforetoggle',
+                column2BeforeToggleSpy
+            );
+            elementReferences.column2.removeEventListener(
+                'menu-button-column-toggle',
+                column2ToggleSpy
+            );
 
             return {
                 column1BeforeToggleEmitCount:
-                    column1BeforeToggleListener.spy.calls.count(),
-                column1ToggleEmitCount: column1ToggleListener.spy.calls.count(),
+                    column1BeforeToggleSpy.calls.count(),
+                column1ToggleEmitCount: column1ToggleSpy.calls.count(),
                 column2BeforeToggleEmitCount:
-                    column2BeforeToggleListener.spy.calls.count(),
-                column2ToggleEmitCount: column2ToggleListener.spy.calls.count()
+                    column2BeforeToggleSpy.calls.count(),
+                column2ToggleEmitCount: column2ToggleSpy.calls.count()
             };
         }
 

--- a/packages/nimble-components/src/table-column/menu-button/tests/table-column-menu-button.spec.ts
+++ b/packages/nimble-components/src/table-column/menu-button/tests/table-column-menu-button.spec.ts
@@ -25,6 +25,10 @@ interface SimpleTableRecord extends TableRecord {
     anotherField?: string | null;
 }
 
+type MenuButtonColumnToggleEvent = (
+    evt: CustomEvent<MenuButtonColumnToggleEventDetail>
+) => void;
+
 class ElementReferences {
     public table!: Table;
     public column1!: TableColumnMenuButton;
@@ -304,14 +308,6 @@ describe('TableColumnMenuButton', () => {
             { id: recordId, field: 'value', anotherField: 'another value' }
         ] as const;
 
-        function getEventDetailFromSpy(
-            spy: jasmine.Spy
-        ): MenuButtonColumnToggleEventDetail {
-            const event = spy.calls.first()
-                .args[0] as CustomEvent<MenuButtonColumnToggleEventDetail>;
-            return event.detail;
-        }
-
         beforeEach(async () => {
             table.idFieldName = 'id';
             await table.setData(originalData);
@@ -320,96 +316,80 @@ describe('TableColumnMenuButton', () => {
         });
 
         it('opening menu button fires "menu-button-column-beforetoggle" followed by "menu-button-column-toggle"', async () => {
-            const beforeToggleSpy = jasmine.createSpy();
-            const beforeTogglePromise = waitForEvent(
+            const spy = jasmine.createSpy<MenuButtonColumnToggleEvent>();
+            const beforetogglePromise = waitForEvent(
                 column,
                 'menu-button-column-beforetoggle',
-                beforeToggleSpy
+                spy
             );
-            const toggleSpy = jasmine.createSpy();
             const togglePromise = waitForEvent(
                 column,
                 'menu-button-column-toggle',
-                toggleSpy
+                spy
             );
-
             menuButton.clickMenuButton();
+            await Promise.all([beforetogglePromise, togglePromise]);
 
             const expectedDetails: MenuButtonColumnToggleEventDetail = {
                 recordId,
                 newState: true,
                 oldState: false
             };
-
-            await beforeTogglePromise;
-            expect(beforeToggleSpy).toHaveBeenCalledTimes(1);
-            let eventDetail = getEventDetailFromSpy(beforeToggleSpy);
-            expect(eventDetail).toEqual(expectedDetails);
-            beforeToggleSpy.calls.reset();
-
-            await togglePromise;
-            expect(beforeToggleSpy).not.toHaveBeenCalled();
-            expect(toggleSpy).toHaveBeenCalledTimes(1);
-            eventDetail = getEventDetailFromSpy(beforeToggleSpy);
-            expect(eventDetail).toEqual(expectedDetails);
+            expect(spy).toHaveBeenCalledTimes(2);
+            const beforetoggleEvent = spy.calls.argsFor(0)[0];
+            expect(beforetoggleEvent.type).toEqual('menu-button-column-beforetoggle');
+            expect(beforetoggleEvent.detail).toEqual(expectedDetails);
+            const toggleEvent = spy.calls.argsFor(1)[0];
+            expect(toggleEvent.type).toEqual('menu-button-column-toggle');
+            expect(toggleEvent.detail).toEqual(expectedDetails);
         });
 
         it('closing menu button with ESC fires "menu-button-column-beforetoggle" followed by "menu-button-column-toggle"', async () => {
             await menuButton.openMenu();
-
-            const beforeToggleSpy = jasmine.createSpy();
-            const beforeTogglePromise = waitForEvent(
+            const spy = jasmine.createSpy<MenuButtonColumnToggleEvent>();
+            const beforetogglePromise = waitForEvent(
                 column,
                 'menu-button-column-beforetoggle',
-                beforeToggleSpy
+                spy
             );
-            const toggleSpy = jasmine.createSpy();
             const togglePromise = waitForEvent(
                 column,
                 'menu-button-column-toggle',
-                toggleSpy
+                spy
             );
-
             menuButton.closeMenuWithEscape();
+            await Promise.all([beforetogglePromise, togglePromise]);
 
             const expectedDetails: MenuButtonColumnToggleEventDetail = {
                 recordId,
                 newState: false,
                 oldState: true
             };
-
-            await beforeTogglePromise;
-            expect(beforeToggleSpy).toHaveBeenCalledTimes(1);
-            let eventDetail = getEventDetailFromSpy(beforeToggleSpy);
-            expect(eventDetail).toEqual(expectedDetails);
-            beforeToggleSpy.calls.reset();
-
-            await togglePromise;
-            expect(beforeToggleSpy).not.toHaveBeenCalled();
-            expect(toggleSpy).toHaveBeenCalledTimes(1);
-            eventDetail = getEventDetailFromSpy(toggleSpy);
-            expect(eventDetail).toEqual(expectedDetails);
-
+            expect(spy).toHaveBeenCalledTimes(2);
+            const beforetoggleEvent = spy.calls.argsFor(0)[0];
+            expect(beforetoggleEvent.type).toEqual('menu-button-column-beforetoggle');
+            expect(beforetoggleEvent.detail).toEqual(expectedDetails);
+            const toggleEvent = spy.calls.argsFor(1)[0];
+            expect(toggleEvent.type).toEqual('menu-button-column-toggle');
+            expect(toggleEvent.detail).toEqual(expectedDetails);
             expect(menuButton.isOpen()).toBeFalse();
         });
 
         it('closing menu button by clicking fires "menu-button-column-beforetoggle" followed by "menu-button-column-toggle"', async () => {
             await menuButton.openMenu();
-
-            const beforeToggleSpy = jasmine.createSpy();
-            const beforeTogglePromise = waitForEvent(
+            const spy = jasmine.createSpy<MenuButtonColumnToggleEvent>();
+            const beforetogglePromise = waitForEvent(
                 column,
                 'menu-button-column-beforetoggle',
-                beforeToggleSpy
+                spy
             );
-            const toggleSpy = jasmine.createSpy();
             const togglePromise = waitForEvent(
                 column,
                 'menu-button-column-toggle',
-                toggleSpy
+                spy
             );
-
             menuButton.clickMenuButton();
+            await Promise.all([beforetogglePromise, togglePromise]);
 
             const expectedDetails: MenuButtonColumnToggleEventDetail = {
                 recordId,
@@ -417,18 +397,13 @@ describe('TableColumnMenuButton', () => {
                 oldState: true
             };
 
-            await beforeTogglePromise;
-            expect(beforeToggleSpy).toHaveBeenCalledTimes(1);
-            let eventDetail = getEventDetailFromSpy(beforeToggleSpy);
-            expect(eventDetail).toEqual(expectedDetails);
-            beforeToggleSpy.calls.reset();
-
-            await togglePromise;
-            expect(beforeToggleSpy).not.toHaveBeenCalled();
-            expect(toggleSpy).toHaveBeenCalledTimes(1);
-            eventDetail = getEventDetailFromSpy(toggleSpy);
-            expect(eventDetail).toEqual(expectedDetails);
-
+            expect(spy).toHaveBeenCalledTimes(2);
+            const beforetoggleEvent = spy.calls.argsFor(0)[0];
+            expect(beforetoggleEvent.type).toEqual('menu-button-column-beforetoggle');
+            expect(beforetoggleEvent.detail).toEqual(expectedDetails);
+            const toggleEvent = spy.calls.argsFor(1)[0];
+            expect(toggleEvent.type).toEqual('menu-button-column-toggle');
+            expect(toggleEvent.detail).toEqual(expectedDetails);
             expect(menuButton.isOpen()).toBeFalse();
         });
 

--- a/packages/nimble-components/src/table-column/menu-button/tests/table-column-menu-button.spec.ts
+++ b/packages/nimble-components/src/table-column/menu-button/tests/table-column-menu-button.spec.ts
@@ -337,7 +337,9 @@ describe('TableColumnMenuButton', () => {
             };
             expect(spy).toHaveBeenCalledTimes(2);
             const beforetoggleEvent = spy.calls.argsFor(0)[0];
-            expect(beforetoggleEvent.type).toEqual('menu-button-column-beforetoggle');
+            expect(beforetoggleEvent.type).toEqual(
+                'menu-button-column-beforetoggle'
+            );
             expect(beforetoggleEvent.detail).toEqual(expectedDetails);
             const toggleEvent = spy.calls.argsFor(1)[0];
             expect(toggleEvent.type).toEqual('menu-button-column-toggle');
@@ -367,7 +369,9 @@ describe('TableColumnMenuButton', () => {
             };
             expect(spy).toHaveBeenCalledTimes(2);
             const beforetoggleEvent = spy.calls.argsFor(0)[0];
-            expect(beforetoggleEvent.type).toEqual('menu-button-column-beforetoggle');
+            expect(beforetoggleEvent.type).toEqual(
+                'menu-button-column-beforetoggle'
+            );
             expect(beforetoggleEvent.detail).toEqual(expectedDetails);
             const toggleEvent = spy.calls.argsFor(1)[0];
             expect(toggleEvent.type).toEqual('menu-button-column-toggle');
@@ -399,7 +403,9 @@ describe('TableColumnMenuButton', () => {
 
             expect(spy).toHaveBeenCalledTimes(2);
             const beforetoggleEvent = spy.calls.argsFor(0)[0];
-            expect(beforetoggleEvent.type).toEqual('menu-button-column-beforetoggle');
+            expect(beforetoggleEvent.type).toEqual(
+                'menu-button-column-beforetoggle'
+            );
             expect(beforetoggleEvent.detail).toEqual(expectedDetails);
             const toggleEvent = spy.calls.argsFor(1)[0];
             expect(toggleEvent.type).toEqual('menu-button-column-toggle');

--- a/packages/nimble-components/src/table/components/cell/tests/table-cell.spec.ts
+++ b/packages/nimble-components/src/table/components/cell/tests/table-cell.spec.ts
@@ -10,7 +10,7 @@ import type { TableCellRecord } from '../../../../table-column/base/types';
 import { TableCellPageObject } from './table-cell.pageobject';
 import { TableCellView } from '../../../../table-column/base/cell-view';
 import { createCellViewTemplate } from '../../../../table-column/base/cell-view/template';
-import { createEventListener } from '../../../../utilities/testing/component';
+import { waitForEvent } from '../../../../utilities/testing/component';
 
 interface SimpleTableCellRecord extends TableCellRecord {
     stringData: string;
@@ -85,35 +85,40 @@ describe('TableCell', () => {
         await connect();
         await waitForUpdatesAsync();
 
-        const cellViewFocusInListener = createEventListener(
+        const cellViewFocusInSpy = jasmine.createSpy();
+        const cellViewFocusInPromise = waitForEvent(
             element,
-            'cell-view-focus-in'
+            'cell-view-focus-in',
+            cellViewFocusInSpy
         );
-        const cellFocusInListener = createEventListener(
+        const cellFocusInSpy = jasmine.createSpy();
+        const cellFocusInPromise = waitForEvent(
             element,
-            'cell-focus-in'
+            'cell-focus-in',
+            cellFocusInSpy
         );
-        const cellBlurListener = createEventListener(element, 'cell-blur');
+        const cellBlurSpy = jasmine.createSpy();
+        const cellBlurPromise = waitForEvent(element, 'cell-blur', cellBlurSpy);
         const renderedCellView = pageObject.getRenderedCellView();
         const span = renderedCellView.shadowRoot
             ?.firstElementChild as HTMLSpanElement;
         span.tabIndex = 0;
         span.focus();
-        await cellViewFocusInListener.promise;
-        await cellFocusInListener.promise;
+        await cellViewFocusInPromise;
+        await cellFocusInPromise;
 
-        expect(cellViewFocusInListener.spy).toHaveBeenCalledOnceWith(
+        expect(cellViewFocusInSpy).toHaveBeenCalledOnceWith(
             jasmine.objectContaining({ detail: element })
         );
-        expect(cellFocusInListener.spy).toHaveBeenCalledOnceWith(
+        expect(cellFocusInSpy).toHaveBeenCalledOnceWith(
             jasmine.objectContaining({ detail: element })
         );
-        expect(cellBlurListener.spy).not.toHaveBeenCalled();
+        expect(cellBlurSpy).not.toHaveBeenCalled();
 
         span.blur();
-        await cellBlurListener.promise;
+        await cellBlurPromise;
 
-        expect(cellBlurListener.spy).toHaveBeenCalledOnceWith(
+        expect(cellBlurSpy).toHaveBeenCalledOnceWith(
             jasmine.objectContaining({ detail: element })
         );
     });
@@ -122,24 +127,26 @@ describe('TableCell', () => {
         await connect();
         await waitForUpdatesAsync();
 
-        const cellViewFocusInListener = createEventListener(
+        const spy = jasmine.createSpy();
+        const cellViewFocusInPromise = waitForEvent(
             element,
-            'cell-view-focus-in'
+            'cell-view-focus-in',
+            spy
         );
         const renderedCellView = pageObject.getRenderedCellView();
         element.tabIndex = 0;
         element.focus();
         await waitForUpdatesAsync();
 
-        expect(cellViewFocusInListener.spy).not.toHaveBeenCalled();
+        expect(spy).not.toHaveBeenCalled();
 
         const span = renderedCellView.shadowRoot
             ?.firstElementChild as HTMLSpanElement;
         span.tabIndex = 0;
         span.focus();
-        await cellViewFocusInListener.promise;
+        await cellViewFocusInPromise;
 
-        expect(cellViewFocusInListener.spy).toHaveBeenCalledOnceWith(
+        expect(spy).toHaveBeenCalledOnceWith(
             jasmine.objectContaining({ detail: element })
         );
     });

--- a/packages/nimble-components/src/table/components/group-row/tests/table-group-row.spec.ts
+++ b/packages/nimble-components/src/table/components/group-row/tests/table-group-row.spec.ts
@@ -1,6 +1,6 @@
 import { html } from '@microsoft/fast-element';
 import { TableGroupRow } from '..';
-import { createEventListener } from '../../../../utilities/testing/component';
+import { waitForEvent } from '../../../../utilities/testing/component';
 import { fixture, Fixture } from '../../../../utilities/tests/fixture';
 import { waitForUpdatesAsync } from '../../../../testing/async-helpers';
 import {
@@ -41,14 +41,16 @@ describe('TableGroupRow', () => {
 
     it('clicking group row emits group-expand-toggle event', async () => {
         await connect();
-        const groupExpandListener = createEventListener(
+        const spy = jasmine.createSpy();
+        const groupExpandListener = waitForEvent(
             element,
-            'group-expand-toggle'
+            'group-expand-toggle',
+            spy
         );
 
         element.click();
-        await groupExpandListener.promise;
-        expect(groupExpandListener.spy).toHaveBeenCalledTimes(1);
+        await groupExpandListener;
+        expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('shows selection checkbox when row is selectable', async () => {
@@ -109,16 +111,17 @@ describe('TableGroupRow', () => {
         element.selectionState = TableRowSelectionState.notSelected;
         await connect();
 
-        const listener = createEventListener(element, 'group-selection-toggle');
+        const spy = jasmine.createSpy();
+        const listener = waitForEvent(element, 'group-selection-toggle', spy);
         element.selectionCheckbox!.click();
-        await listener.promise;
+        await listener;
 
-        expect(listener.spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledTimes(1);
         const expectedDetails: TableRowSelectionToggleEventDetail = {
             newState: true,
             oldState: false
         };
-        const event = listener.spy.calls.first().args[0] as CustomEvent;
+        const event = spy.calls.first().args[0] as CustomEvent;
         expect(event.detail).toEqual(expectedDetails);
     });
 
@@ -127,16 +130,17 @@ describe('TableGroupRow', () => {
         element.selectionState = TableRowSelectionState.selected;
         await connect();
 
-        const listener = createEventListener(element, 'group-selection-toggle');
+        const spy = jasmine.createSpy();
+        const listener = waitForEvent(element, 'group-selection-toggle', spy);
         element.selectionCheckbox!.click();
-        await listener.promise;
+        await listener;
 
-        expect(listener.spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledTimes(1);
         const expectedDetails: TableRowSelectionToggleEventDetail = {
             newState: false,
             oldState: true
         };
-        const event = listener.spy.calls.first().args[0] as CustomEvent;
+        const event = spy.calls.first().args[0] as CustomEvent;
         expect(event.detail).toEqual(expectedDetails);
     });
 
@@ -145,16 +149,17 @@ describe('TableGroupRow', () => {
         element.selectionState = TableRowSelectionState.partiallySelected;
         await connect();
 
-        const listener = createEventListener(element, 'group-selection-toggle');
+        const spy = jasmine.createSpy();
+        const listener = waitForEvent(element, 'group-selection-toggle', spy);
         element.selectionCheckbox!.click();
-        await listener.promise;
+        await listener;
 
-        expect(listener.spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledTimes(1);
         const expectedDetails: TableRowSelectionToggleEventDetail = {
             newState: true,
             oldState: false
         };
-        const event = listener.spy.calls.first().args[0] as CustomEvent;
+        const event = spy.calls.first().args[0] as CustomEvent;
         expect(event.detail).toEqual(expectedDetails);
     });
 
@@ -163,25 +168,30 @@ describe('TableGroupRow', () => {
         element.selectionState = TableRowSelectionState.selected;
         await connect();
 
-        const listener = createEventListener(element, 'group-selection-toggle');
+        const spy = jasmine.createSpy();
+        element.addEventListener('group-selection-toggle', spy);
         element.selectionState = TableRowSelectionState.notSelected;
         await waitForUpdatesAsync();
 
-        expect(listener.spy).not.toHaveBeenCalled();
+        expect(spy).not.toHaveBeenCalled();
+
+        element.removeEventListener('group-selection-toggle', spy);
     });
 
     it('clicking selection checkbox does not fire "group-expand-toggle" event', async () => {
         element.selectable = true;
         await connect();
 
-        const groupExpandListener = createEventListener(
-            element,
-            'group-expand-toggle'
+        const spy = jasmine.createSpy();
+        element.addEventListener(
+            'group-expand-toggle',
+            spy
         );
         element.selectionCheckbox!.click();
         await waitForUpdatesAsync();
 
-        expect(groupExpandListener.spy).not.toHaveBeenCalled();
+        expect(spy).not.toHaveBeenCalled();
+        element.removeEventListener('group-expand-toggle', spy);
     });
 
     it('has aria-expanded attribute set to "true" when it is expanded', async () => {

--- a/packages/nimble-components/src/table/components/group-row/tests/table-group-row.spec.ts
+++ b/packages/nimble-components/src/table/components/group-row/tests/table-group-row.spec.ts
@@ -8,6 +8,10 @@ import {
     TableRowSelectionToggleEventDetail
 } from '../../../types';
 
+type TableRowSelectionToggleEventHandler = (
+    evt: CustomEvent<TableRowSelectionToggleEventDetail>
+) => void;
+
 // prettier-ignore
 async function setup(): Promise<Fixture<TableGroupRow>> {
     return fixture<TableGroupRow>(
@@ -111,7 +115,7 @@ describe('TableGroupRow', () => {
         element.selectionState = TableRowSelectionState.notSelected;
         await connect();
 
-        const spy = jasmine.createSpy();
+        const spy = jasmine.createSpy<TableRowSelectionToggleEventHandler>();
         const listener = waitForEvent(element, 'group-selection-toggle', spy);
         element.selectionCheckbox!.click();
         await listener;
@@ -121,7 +125,7 @@ describe('TableGroupRow', () => {
             newState: true,
             oldState: false
         };
-        const event = spy.calls.first().args[0] as CustomEvent;
+        const event = spy.calls.first().args[0];
         expect(event.detail).toEqual(expectedDetails);
     });
 
@@ -130,7 +134,7 @@ describe('TableGroupRow', () => {
         element.selectionState = TableRowSelectionState.selected;
         await connect();
 
-        const spy = jasmine.createSpy();
+        const spy = jasmine.createSpy<TableRowSelectionToggleEventHandler>();
         const listener = waitForEvent(element, 'group-selection-toggle', spy);
         element.selectionCheckbox!.click();
         await listener;
@@ -140,7 +144,7 @@ describe('TableGroupRow', () => {
             newState: false,
             oldState: true
         };
-        const event = spy.calls.first().args[0] as CustomEvent;
+        const event = spy.calls.first().args[0];
         expect(event.detail).toEqual(expectedDetails);
     });
 
@@ -149,7 +153,7 @@ describe('TableGroupRow', () => {
         element.selectionState = TableRowSelectionState.partiallySelected;
         await connect();
 
-        const spy = jasmine.createSpy();
+        const spy = jasmine.createSpy<TableRowSelectionToggleEventHandler>();
         const listener = waitForEvent(element, 'group-selection-toggle', spy);
         element.selectionCheckbox!.click();
         await listener;
@@ -159,7 +163,7 @@ describe('TableGroupRow', () => {
             newState: true,
             oldState: false
         };
-        const event = spy.calls.first().args[0] as CustomEvent;
+        const event = spy.calls.first().args[0];
         expect(event.detail).toEqual(expectedDetails);
     });
 

--- a/packages/nimble-components/src/table/components/group-row/tests/table-group-row.spec.ts
+++ b/packages/nimble-components/src/table/components/group-row/tests/table-group-row.spec.ts
@@ -187,10 +187,7 @@ describe('TableGroupRow', () => {
         await connect();
 
         const spy = jasmine.createSpy();
-        element.addEventListener(
-            'group-expand-toggle',
-            spy
-        );
+        element.addEventListener('group-expand-toggle', spy);
         element.selectionCheckbox!.click();
         await waitForUpdatesAsync();
 

--- a/packages/nimble-components/src/table/components/row/tests/table-row.spec.ts
+++ b/packages/nimble-components/src/table/components/row/tests/table-row.spec.ts
@@ -192,11 +192,7 @@ describe('TableRow', () => {
             await connect();
 
             const spy = jasmine.createSpy<TableRowSelectionToggleEventHandler>();
-            const listener = waitForEvent(
-                element,
-                'row-selection-toggle',
-                spy
-            );
+            const listener = waitForEvent(element, 'row-selection-toggle', spy);
             element.selectionCheckbox!.click();
             await listener;
 
@@ -216,11 +212,7 @@ describe('TableRow', () => {
             await connect();
 
             const spy = jasmine.createSpy<TableRowSelectionToggleEventHandler>();
-            const listener = waitForEvent(
-                element,
-                'row-selection-toggle',
-                spy
-            );
+            const listener = waitForEvent(element, 'row-selection-toggle', spy);
             element.selectionCheckbox!.click();
             await listener;
 
@@ -240,18 +232,12 @@ describe('TableRow', () => {
             await connect();
 
             const spy = jasmine.createSpy();
-            element.addEventListener(
-                'row-selection-toggle',
-                spy
-            );
+            element.addEventListener('row-selection-toggle', spy);
             element.selected = false;
             await waitForUpdatesAsync();
 
             expect(spy).not.toHaveBeenCalled();
-            element.removeEventListener(
-                'row-selection-toggle',
-                spy
-            );
+            element.removeEventListener('row-selection-toggle', spy);
         });
 
         it('shows expand-collapse button when isParentRow is true', async () => {

--- a/packages/nimble-components/src/table/components/row/tests/table-row.spec.ts
+++ b/packages/nimble-components/src/table/components/row/tests/table-row.spec.ts
@@ -14,7 +14,7 @@ import type {
     TableRowSelectionToggleEventDetail
 } from '../../../types';
 import { TableRowPageObject } from './table-row.pageobject';
-import { createEventListener } from '../../../../utilities/testing/component';
+import { waitForEvent } from '../../../../utilities/testing/component';
 import { tableTag, type Table } from '../../..';
 import {
     TableColumnDateText,
@@ -183,19 +183,21 @@ describe('TableRow', () => {
             element.selected = false;
             await connect();
 
-            const listener = createEventListener(
+            const spy = jasmine.createSpy();
+            const listener = waitForEvent(
                 element,
-                'row-selection-toggle'
+                'row-selection-toggle',
+                spy
             );
             element.selectionCheckbox!.click();
-            await listener.promise;
+            await listener;
 
-            expect(listener.spy).toHaveBeenCalledTimes(1);
+            expect(spy).toHaveBeenCalledTimes(1);
             const expectedDetails: TableRowSelectionToggleEventDetail = {
                 newState: true,
                 oldState: false
             };
-            const event = listener.spy.calls.first().args[0] as CustomEvent;
+            const event = spy.calls.first().args[0] as CustomEvent;
             expect(event.detail).toEqual(expectedDetails);
         });
 
@@ -205,19 +207,21 @@ describe('TableRow', () => {
             element.selected = true;
             await connect();
 
-            const listener = createEventListener(
+            const spy = jasmine.createSpy();
+            const listener = waitForEvent(
                 element,
-                'row-selection-toggle'
+                'row-selection-toggle',
+                spy
             );
             element.selectionCheckbox!.click();
-            await listener.promise;
+            await listener;
 
-            expect(listener.spy).toHaveBeenCalledTimes(1);
+            expect(spy).toHaveBeenCalledTimes(1);
             const expectedDetails: TableRowSelectionToggleEventDetail = {
                 newState: false,
                 oldState: true
             };
-            const event = listener.spy.calls.first().args[0] as CustomEvent;
+            const event = spy.calls.first().args[0] as CustomEvent;
             expect(event.detail).toEqual(expectedDetails);
         });
 
@@ -227,14 +231,19 @@ describe('TableRow', () => {
             element.selected = true;
             await connect();
 
-            const listener = createEventListener(
-                element,
-                'row-selection-toggle'
+            const spy = jasmine.createSpy();
+            element.addEventListener(
+                'row-selection-toggle',
+                spy
             );
             element.selected = false;
             await waitForUpdatesAsync();
 
-            expect(listener.spy).not.toHaveBeenCalled();
+            expect(spy).not.toHaveBeenCalled();
+            element.removeEventListener(
+                'row-selection-toggle',
+                spy
+            );
         });
 
         it('shows expand-collapse button when isParentRow is true', async () => {
@@ -265,17 +274,18 @@ describe('TableRow', () => {
             await waitForUpdatesAsync();
             const expandCollapseButton = pageObject.getExpandCollapseButton();
 
-            const listener = createEventListener(element, 'row-expand-toggle');
+            const spy = jasmine.createSpy();
+            const listener = waitForEvent(element, 'row-expand-toggle', spy);
             expandCollapseButton!.click();
-            await listener.promise;
+            await listener;
 
-            expect(listener.spy).toHaveBeenCalledTimes(1);
+            expect(spy).toHaveBeenCalledTimes(1);
             const expandDetails: TableRowExpansionToggleEventDetail = {
                 newState: true,
                 oldState: false,
                 recordId: 'foo'
             };
-            const event = listener.spy.calls.first().args[0] as CustomEvent;
+            const event = spy.calls.first().args[0] as CustomEvent;
             expect(event.detail).toEqual(expandDetails);
         });
 
@@ -287,17 +297,18 @@ describe('TableRow', () => {
             await waitForUpdatesAsync();
             const expandCollapseButton = pageObject.getExpandCollapseButton();
 
-            const listener = createEventListener(element, 'row-expand-toggle');
+            const spy = jasmine.createSpy();
+            const listener = waitForEvent(element, 'row-expand-toggle', spy);
             element.expanded = true;
             expandCollapseButton!.click();
-            await listener.promise;
-            expect(listener.spy).toHaveBeenCalledTimes(1);
+            await listener;
+            expect(spy).toHaveBeenCalledTimes(1);
             const collapseDetails: TableRowExpansionToggleEventDetail = {
                 newState: false,
                 oldState: true,
                 recordId: 'foo'
             };
-            const event = listener.spy.calls.first().args[0] as CustomEvent;
+            const event = spy.calls.first().args[0] as CustomEvent;
             expect(event.detail).toEqual(collapseDetails);
         });
 

--- a/packages/nimble-components/src/table/components/row/tests/table-row.spec.ts
+++ b/packages/nimble-components/src/table/components/row/tests/table-row.spec.ts
@@ -27,6 +27,14 @@ interface SimpleTableRecord extends TableRecord {
     numberData: number;
 }
 
+type TableRowExpansionToggleEventHandler = (
+    evt: CustomEvent<TableRowExpansionToggleEventDetail>
+) => void;
+
+type TableRowSelectionToggleEventHandler = (
+    evt: CustomEvent<TableRowSelectionToggleEventDetail>
+) => void;
+
 describe('TableRow', () => {
     describe('standalone', () => {
         // prettier-ignore
@@ -183,7 +191,7 @@ describe('TableRow', () => {
             element.selected = false;
             await connect();
 
-            const spy = jasmine.createSpy();
+            const spy = jasmine.createSpy<TableRowSelectionToggleEventHandler>();
             const listener = waitForEvent(
                 element,
                 'row-selection-toggle',
@@ -197,7 +205,7 @@ describe('TableRow', () => {
                 newState: true,
                 oldState: false
             };
-            const event = spy.calls.first().args[0] as CustomEvent;
+            const event = spy.calls.first().args[0];
             expect(event.detail).toEqual(expectedDetails);
         });
 
@@ -207,7 +215,7 @@ describe('TableRow', () => {
             element.selected = true;
             await connect();
 
-            const spy = jasmine.createSpy();
+            const spy = jasmine.createSpy<TableRowSelectionToggleEventHandler>();
             const listener = waitForEvent(
                 element,
                 'row-selection-toggle',
@@ -221,7 +229,7 @@ describe('TableRow', () => {
                 newState: false,
                 oldState: true
             };
-            const event = spy.calls.first().args[0] as CustomEvent;
+            const event = spy.calls.first().args[0];
             expect(event.detail).toEqual(expectedDetails);
         });
 
@@ -274,7 +282,7 @@ describe('TableRow', () => {
             await waitForUpdatesAsync();
             const expandCollapseButton = pageObject.getExpandCollapseButton();
 
-            const spy = jasmine.createSpy();
+            const spy = jasmine.createSpy<TableRowExpansionToggleEventHandler>();
             const listener = waitForEvent(element, 'row-expand-toggle', spy);
             expandCollapseButton!.click();
             await listener;
@@ -285,7 +293,7 @@ describe('TableRow', () => {
                 oldState: false,
                 recordId: 'foo'
             };
-            const event = spy.calls.first().args[0] as CustomEvent;
+            const event = spy.calls.first().args[0];
             expect(event.detail).toEqual(expandDetails);
         });
 
@@ -297,7 +305,7 @@ describe('TableRow', () => {
             await waitForUpdatesAsync();
             const expandCollapseButton = pageObject.getExpandCollapseButton();
 
-            const spy = jasmine.createSpy();
+            const spy = jasmine.createSpy<TableRowExpansionToggleEventHandler>();
             const listener = waitForEvent(element, 'row-expand-toggle', spy);
             element.expanded = true;
             expandCollapseButton!.click();
@@ -308,7 +316,7 @@ describe('TableRow', () => {
                 oldState: true,
                 recordId: 'foo'
             };
-            const event = spy.calls.first().args[0] as CustomEvent;
+            const event = spy.calls.first().args[0];
             expect(event.detail).toEqual(collapseDetails);
         });
 

--- a/packages/nimble-components/src/table/tests/table-action-menu.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-action-menu.spec.ts
@@ -24,6 +24,10 @@ interface SimpleTableRecord extends TableRecord {
     moreStringData: string;
 }
 
+type TableActionMenuToggleEventHandler = (
+    evt: CustomEvent<TableActionMenuToggleEventDetail>
+) => void;
+
 const simpleTableData = [
     {
         stringData: 'string 1',
@@ -61,9 +65,9 @@ describe('Table action menu', () => {
     let pageObject: TablePageObject<SimpleTableRecord>;
     let column1: TableColumn;
     let column2: TableColumn;
-    let beforetoggleSpy: jasmine.Spy;
+    let beforetoggleSpy: jasmine.Spy<TableActionMenuToggleEventHandler>;
     let beforetoggleListener: Promise<void>;
-    let toggleSpy: jasmine.Spy;
+    let toggleSpy: jasmine.Spy<TableActionMenuToggleEventHandler>;
     let toggleListener: Promise<void>;
 
     beforeEach(async () => {
@@ -110,9 +114,9 @@ describe('Table action menu', () => {
         return { menu, items: [menuItem1, menuItem2, menuItem3] };
     }
 
-    function getEmittedRecordIdsFromSpy(spy: jasmine.Spy): string[] {
+    function getEmittedRecordIdsFromSpy(spy: jasmine.Spy<TableActionMenuToggleEventHandler>): string[] {
         const event = spy.calls.first()
-            .args[0] as CustomEvent<TableActionMenuToggleEventDetail>;
+            .args[0];
         return event.detail.recordIds;
     }
 
@@ -332,7 +336,7 @@ describe('Table action menu', () => {
             recordIds: [simpleTableData[1].stringData]
         };
         const event = beforetoggleSpy.calls.first()
-            .args[0] as CustomEvent<TableActionMenuToggleEventDetail>;
+            .args[0];
         expect(event.detail).toEqual(expectedDetails);
     });
 
@@ -348,7 +352,7 @@ describe('Table action menu', () => {
 
         await pageObject.clickCellActionMenu(1, 0);
         await waitForUpdatesAsync();
-        const spy = jasmine.createSpy();
+        const spy = jasmine.createSpy<TableActionMenuToggleEventHandler>();
         const listener = waitForEvent(
             element,
             'action-menu-beforetoggle',
@@ -369,7 +373,7 @@ describe('Table action menu', () => {
             recordIds: [simpleTableData[1].stringData]
         };
         const event = spy.calls.first()
-            .args[0] as CustomEvent<TableActionMenuToggleEventDetail>;
+            .args[0];
         expect(event.detail).toEqual(expectedDetails);
     });
 
@@ -394,7 +398,7 @@ describe('Table action menu', () => {
             recordIds: [simpleTableData[1].stringData]
         };
         const event = toggleSpy.calls.first()
-            .args[0] as CustomEvent<TableActionMenuToggleEventDetail>;
+            .args[0];
         expect(event.detail).toEqual(expectedDetails);
     });
 
@@ -425,7 +429,7 @@ describe('Table action menu', () => {
             recordIds: [simpleTableData[1].stringData]
         };
         const event = toggleSpy.calls.first()
-            .args[0] as CustomEvent<TableActionMenuToggleEventDetail>;
+            .args[0];
         expect(event.detail).toEqual(expectedDetails);
     });
 

--- a/packages/nimble-components/src/table/tests/table-action-menu.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-action-menu.spec.ts
@@ -114,9 +114,10 @@ describe('Table action menu', () => {
         return { menu, items: [menuItem1, menuItem2, menuItem3] };
     }
 
-    function getEmittedRecordIdsFromSpy(spy: jasmine.Spy<TableActionMenuToggleEventHandler>): string[] {
-        const event = spy.calls.first()
-            .args[0];
+    function getEmittedRecordIdsFromSpy(
+        spy: jasmine.Spy<TableActionMenuToggleEventHandler>
+    ): string[] {
+        const event = spy.calls.first().args[0];
         return event.detail.recordIds;
     }
 
@@ -335,8 +336,7 @@ describe('Table action menu', () => {
             columnId: column1.columnId,
             recordIds: [simpleTableData[1].stringData]
         };
-        const event = beforetoggleSpy.calls.first()
-            .args[0];
+        const event = beforetoggleSpy.calls.first().args[0];
         expect(event.detail).toEqual(expectedDetails);
     });
 
@@ -353,11 +353,7 @@ describe('Table action menu', () => {
         await pageObject.clickCellActionMenu(1, 0);
         await waitForUpdatesAsync();
         const spy = jasmine.createSpy<TableActionMenuToggleEventHandler>();
-        const listener = waitForEvent(
-            element,
-            'action-menu-beforetoggle',
-            spy
-        );
+        const listener = waitForEvent(element, 'action-menu-beforetoggle', spy);
         const escEvent = new KeyboardEvent('keydown', {
             key: keyEscape
         } as KeyboardEventInit);
@@ -372,8 +368,7 @@ describe('Table action menu', () => {
             columnId: column1.columnId,
             recordIds: [simpleTableData[1].stringData]
         };
-        const event = spy.calls.first()
-            .args[0];
+        const event = spy.calls.first().args[0];
         expect(event.detail).toEqual(expectedDetails);
     });
 
@@ -397,8 +392,7 @@ describe('Table action menu', () => {
             columnId: column1.columnId,
             recordIds: [simpleTableData[1].stringData]
         };
-        const event = toggleSpy.calls.first()
-            .args[0];
+        const event = toggleSpy.calls.first().args[0];
         expect(event.detail).toEqual(expectedDetails);
     });
 
@@ -428,8 +422,7 @@ describe('Table action menu', () => {
             columnId: column1.columnId,
             recordIds: [simpleTableData[1].stringData]
         };
-        const event = toggleSpy.calls.first()
-            .args[0];
+        const event = toggleSpy.calls.first().args[0];
         expect(event.detail).toEqual(expectedDetails);
     });
 
@@ -483,10 +476,7 @@ describe('Table action menu', () => {
         await pageObject.clickCellActionMenu(0, 0);
         await toggleListener;
 
-        const closeToggleListener = waitForEvent(
-            element,
-            'action-menu-toggle'
-        );
+        const closeToggleListener = waitForEvent(element, 'action-menu-toggle');
         const newTableData: SimpleTableRecord[] = [
             {
                 stringData: 'new string 1',
@@ -532,9 +522,9 @@ describe('Table action menu', () => {
             expect(currentSelection).toEqual([
                 simpleTableData[rowIndex].stringData
             ]);
-            expect(
-                getEmittedRecordIdsFromSpy(beforetoggleSpy)
-            ).toEqual(jasmine.arrayWithExactContents(currentSelection));
+            expect(getEmittedRecordIdsFromSpy(beforetoggleSpy)).toEqual(
+                jasmine.arrayWithExactContents(currentSelection)
+            );
             expect(getEmittedRecordIdsFromSpy(toggleSpy)).toEqual(
                 jasmine.arrayWithExactContents(currentSelection)
             );
@@ -552,9 +542,9 @@ describe('Table action menu', () => {
             expect(currentSelection).toEqual([
                 simpleTableData[rowIndex].stringData
             ]);
-            expect(
-                getEmittedRecordIdsFromSpy(beforetoggleSpy)
-            ).toEqual(jasmine.arrayWithExactContents(currentSelection));
+            expect(getEmittedRecordIdsFromSpy(beforetoggleSpy)).toEqual(
+                jasmine.arrayWithExactContents(currentSelection)
+            );
             expect(getEmittedRecordIdsFromSpy(toggleSpy)).toEqual(
                 jasmine.arrayWithExactContents(currentSelection)
             );
@@ -574,9 +564,9 @@ describe('Table action menu', () => {
             expect(currentSelection).toEqual([
                 simpleTableData[rowIndex].stringData
             ]);
-            expect(
-                getEmittedRecordIdsFromSpy(beforetoggleSpy)
-            ).toEqual(jasmine.arrayWithExactContents(currentSelection));
+            expect(getEmittedRecordIdsFromSpy(beforetoggleSpy)).toEqual(
+                jasmine.arrayWithExactContents(currentSelection)
+            );
             expect(getEmittedRecordIdsFromSpy(toggleSpy)).toEqual(
                 jasmine.arrayWithExactContents(currentSelection)
             );
@@ -616,9 +606,9 @@ describe('Table action menu', () => {
             expect(currentSelection).toEqual([
                 simpleTableData[rowIndex].stringData
             ]);
-            expect(
-                getEmittedRecordIdsFromSpy(beforetoggleSpy)
-            ).toEqual(jasmine.arrayWithExactContents(currentSelection));
+            expect(getEmittedRecordIdsFromSpy(beforetoggleSpy)).toEqual(
+                jasmine.arrayWithExactContents(currentSelection)
+            );
             expect(getEmittedRecordIdsFromSpy(toggleSpy)).toEqual(
                 jasmine.arrayWithExactContents(currentSelection)
             );
@@ -636,9 +626,9 @@ describe('Table action menu', () => {
             expect(currentSelection).toEqual([
                 simpleTableData[rowIndex].stringData
             ]);
-            expect(
-                getEmittedRecordIdsFromSpy(beforetoggleSpy)
-            ).toEqual(jasmine.arrayWithExactContents(currentSelection));
+            expect(getEmittedRecordIdsFromSpy(beforetoggleSpy)).toEqual(
+                jasmine.arrayWithExactContents(currentSelection)
+            );
             expect(getEmittedRecordIdsFromSpy(toggleSpy)).toEqual(
                 jasmine.arrayWithExactContents(currentSelection)
             );
@@ -658,9 +648,9 @@ describe('Table action menu', () => {
             expect(currentSelection).toEqual([
                 simpleTableData[rowIndex].stringData
             ]);
-            expect(
-                getEmittedRecordIdsFromSpy(beforetoggleSpy)
-            ).toEqual(jasmine.arrayWithExactContents(currentSelection));
+            expect(getEmittedRecordIdsFromSpy(beforetoggleSpy)).toEqual(
+                jasmine.arrayWithExactContents(currentSelection)
+            );
             expect(getEmittedRecordIdsFromSpy(toggleSpy)).toEqual(
                 jasmine.arrayWithExactContents(currentSelection)
             );
@@ -681,9 +671,9 @@ describe('Table action menu', () => {
                 simpleTableData[0].stringData,
                 simpleTableData[2].stringData
             ]);
-            expect(
-                getEmittedRecordIdsFromSpy(beforetoggleSpy)
-            ).toEqual(jasmine.arrayWithExactContents(currentSelection));
+            expect(getEmittedRecordIdsFromSpy(beforetoggleSpy)).toEqual(
+                jasmine.arrayWithExactContents(currentSelection)
+            );
             expect(getEmittedRecordIdsFromSpy(toggleSpy)).toEqual(
                 jasmine.arrayWithExactContents(currentSelection)
             );

--- a/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
@@ -18,6 +18,10 @@ interface SimpleTableRecord extends TableRecord {
     moreStringData3: string;
 }
 
+type TableColumnConfigurationChangeEventHandler = (
+    evt: CustomEvent<TableColumnConfigurationChangeEventDetail>
+) => void;
+
 const simpleTableData = [
     {
         stringData: 'string 1',
@@ -1117,7 +1121,7 @@ describe('Table Interactive Column Sizing', () => {
     });
 
     it('resizing columns emits single "column-configuration-change" event with expected state', async () => {
-        const spy = jasmine.createSpy();
+        const spy = jasmine.createSpy<TableColumnConfigurationChangeEventHandler>();
         const listener = waitForEvent(
             element,
             'column-configuration-change',
@@ -1134,8 +1138,8 @@ describe('Table Interactive Column Sizing', () => {
             undefined,
             undefined
         ];
-        const eventDetails = (spy.calls.first().args[0] as CustomEvent)
-            .detail as TableColumnConfigurationChangeEventDetail;
+        const eventDetails = spy.calls.first().args[0]
+            .detail;
         const actualFractionalWidths = eventDetails.columns.map(
             column => column.fractionalWidth
         );

--- a/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
@@ -1138,8 +1138,7 @@ describe('Table Interactive Column Sizing', () => {
             undefined,
             undefined
         ];
-        const eventDetails = spy.calls.first().args[0]
-            .detail;
+        const eventDetails = spy.calls.first().args[0].detail;
         const actualFractionalWidths = eventDetails.columns.map(
             column => column.fractionalWidth
         );

--- a/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
@@ -9,7 +9,7 @@ import type {
     TableRecord
 } from '../types';
 import { TablePageObject } from '../testing/table.pageobject';
-import { createEventListener } from '../../utilities/testing/component';
+import { waitForEvent } from '../../utilities/testing/component';
 
 interface SimpleTableRecord extends TableRecord {
     stringData: string;
@@ -1117,14 +1117,16 @@ describe('Table Interactive Column Sizing', () => {
     });
 
     it('resizing columns emits single "column-configuration-change" event with expected state', async () => {
-        const listener = createEventListener(
+        const spy = jasmine.createSpy();
+        const listener = waitForEvent(
             element,
-            'column-configuration-change'
+            'column-configuration-change',
+            spy
         );
         pageObject.dragSizeColumnByRightDivider(2, [1, 1, 1, 1]);
         await waitForUpdatesAsync();
-
-        expect(listener.spy).toHaveBeenCalledTimes(1);
+        await listener;
+        expect(spy).toHaveBeenCalledTimes(1);
         const expectedFractionalWidths = [1, 1, 1.04, 0.96];
         const expectedPixelWidths = [
             undefined,
@@ -1132,7 +1134,7 @@ describe('Table Interactive Column Sizing', () => {
             undefined,
             undefined
         ];
-        const eventDetails = (listener.spy.calls.first().args[0] as CustomEvent)
+        const eventDetails = (spy.calls.first().args[0] as CustomEvent)
             .detail as TableColumnConfigurationChangeEventDetail;
         const actualFractionalWidths = eventDetails.columns.map(
             column => column.fractionalWidth

--- a/packages/nimble-components/src/table/tests/table-delegated-events.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-delegated-events.spec.ts
@@ -1,7 +1,6 @@
 import { customElement, html } from '@microsoft/fast-element';
 import type { Table } from '..';
 import { TableColumn } from '../../table-column/base';
-import type { DelegatedEventEventDetails } from '../../table-column/base/types';
 import { tableColumnTextCellViewTag } from '../../table-column/text/cell-view';
 import { tableColumnTextGroupHeaderViewTag } from '../../table-column/text/group-header-view';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
@@ -68,18 +67,18 @@ describe('Table delegated events', () => {
         await element.setData(data);
         await connect();
         await waitForUpdatesAsync();
-        let delegatedEvent: Event | null = null;
-        column1.addEventListener('delegated-event', event => {
-            delegatedEvent = (
-                (event as CustomEvent).detail as DelegatedEventEventDetails
-            ).originalEvent;
-        });
+        const spy = jasmine.createSpy();
+        column1.addEventListener('delegated-event', spy);
         const clickEvent = new PointerEvent('click', {
             bubbles: true,
             composed: true
         });
         pageObject.dispatchEventToCell(0, 0, clickEvent);
-        expect(delegatedEvent!).toBe(clickEvent);
+        expect(spy).toHaveBeenCalledOnceWith(
+            jasmine.objectContaining({
+                detail: { originalEvent: clickEvent }
+            })
+        );
     });
 
     it('allows original event to continue bubbling to table by default', async () => {

--- a/packages/nimble-components/src/table/tests/table-delegated-events.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-delegated-events.spec.ts
@@ -76,7 +76,7 @@ describe('Table delegated events', () => {
         pageObject.dispatchEventToCell(0, 0, clickEvent);
         expect(spy).toHaveBeenCalledOnceWith(
             jasmine.objectContaining({
-                detail: { originalEvent: clickEvent }
+                detail: { originalEvent: clickEvent, recordId: '0' }
             })
         );
     });

--- a/packages/nimble-components/src/table/tests/table-keyboard-navigation.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-keyboard-navigation.spec.ts
@@ -631,10 +631,7 @@ describe('Table keyboard navigation', () => {
                 pageObject.setRowHoverState(0, true);
                 await sendKeyPressToTable(keyEnter, { ctrlKey: true });
                 await toggleListener;
-                toggleListener = waitForEvent(
-                    element,
-                    'action-menu-toggle'
-                );
+                toggleListener = waitForEvent(element, 'action-menu-toggle');
 
                 await pageObject.scrollToLastRowAsync();
                 await pageObject.scrollToFirstRowAsync();

--- a/packages/nimble-components/src/table/tests/table-keyboard-navigation.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-keyboard-navigation.spec.ts
@@ -31,7 +31,7 @@ import {
 } from '../types';
 import { TablePageObject } from '../testing/table.pageobject';
 import {
-    createEventListener,
+    waitForEvent,
     sendKeyDownEvent
 } from '../../utilities/testing/component';
 import { TableRow } from '../components/row';
@@ -607,12 +607,12 @@ describe('Table keyboard navigation', () => {
                 await addActionMenu(column1);
                 await sendKeyPressToTable(keyArrowDown);
 
-                const toggleListener = createEventListener(
+                const toggleListener = waitForEvent(
                     element,
                     'action-menu-toggle'
                 );
                 await sendKeyPressToTable(keyEnter, { ctrlKey: true });
-                await toggleListener.promise;
+                await toggleListener;
 
                 expect(pageObject.getCell(0, 0).menuOpen).toBe(true);
             });
@@ -624,21 +624,21 @@ describe('Table keyboard navigation', () => {
                 await addActionMenu(column1);
                 element.focus();
                 await sendKeyPressToTable(keyArrowDown);
-                let toggleListener = createEventListener(
+                let toggleListener = waitForEvent(
                     element,
                     'action-menu-toggle'
                 );
                 pageObject.setRowHoverState(0, true);
                 await sendKeyPressToTable(keyEnter, { ctrlKey: true });
-                await toggleListener.promise;
-                toggleListener = createEventListener(
+                await toggleListener;
+                toggleListener = waitForEvent(
                     element,
                     'action-menu-toggle'
                 );
 
                 await pageObject.scrollToLastRowAsync();
                 await pageObject.scrollToFirstRowAsync();
-                await toggleListener.promise;
+                await toggleListener;
 
                 expect(pageObject.getCell(0, 0).menuOpen).toBe(false);
                 expect(currentFocusedElement()).toBe(pageObject.getCell(0, 0));
@@ -715,7 +715,7 @@ describe('Table keyboard navigation', () => {
                         `pressing ${name} will open the action menu, Esc will close the menu, and another Esc press will focus the (same) cell`,
                         async () => {
                             const actionMenuButton = pageObject.getCellActionMenu(0, 0)!;
-                            const toggleListener = createEventListener(
+                            const toggleListener = waitForEvent(
                                 element,
                                 'action-menu-toggle'
                             );
@@ -723,7 +723,7 @@ describe('Table keyboard navigation', () => {
                                 actionMenuButton.toggleButton!,
                                 value.key
                             );
-                            await toggleListener.promise;
+                            await toggleListener;
 
                             const firstCell = pageObject.getCell(0, 0);
                             expect(firstCell.menuOpen).toBe(true);

--- a/packages/nimble-components/src/table/tests/table-selection.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-selection.spec.ts
@@ -24,6 +24,10 @@ interface SimpleTableRecord extends TableRecord {
     parentId?: string;
 }
 
+type TableRowSelectionEventHandler = (
+    evt: CustomEvent<TableRowSelectionEventDetail>
+) => void;
+
 const simpleTableData = [
     {
         id: '0',
@@ -214,9 +218,9 @@ async function setup(): Promise<Fixture<Table<SimpleTableRecord>>> {
 }
 
 describe('Table row selection', () => {
-    function getEmittedRecordIdsFromSpy(spy: jasmine.Spy): string[] {
+    function getEmittedRecordIdsFromSpy(spy: jasmine.Spy<TableRowSelectionEventHandler>): string[] {
         const event = spy.calls.first()
-            .args[0] as CustomEvent<TableRowSelectionEventDetail>;
+            .args[0];
         return event.detail.selectedRecordIds;
     }
 

--- a/packages/nimble-components/src/table/tests/table-selection.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-selection.spec.ts
@@ -218,9 +218,10 @@ async function setup(): Promise<Fixture<Table<SimpleTableRecord>>> {
 }
 
 describe('Table row selection', () => {
-    function getEmittedRecordIdsFromSpy(spy: jasmine.Spy<TableRowSelectionEventHandler>): string[] {
-        const event = spy.calls.first()
-            .args[0];
+    function getEmittedRecordIdsFromSpy(
+        spy: jasmine.Spy<TableRowSelectionEventHandler>
+    ): string[] {
+        const event = spy.calls.first().args[0];
         return event.detail.selectedRecordIds;
     }
 
@@ -796,12 +797,8 @@ describe('Table row selection', () => {
                                     value.expectedSelection
                                 )
                             );
-                            expect(
-                                selectionChangeSpy
-                            ).toHaveBeenCalledTimes(1);
-                            const emittedIds = getEmittedRecordIdsFromSpy(
-                                selectionChangeSpy
-                            );
+                            expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
+                            const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                             expect(emittedIds).toEqual(
                                 jasmine.arrayWithExactContents(
                                     value.expectedSelection
@@ -848,9 +845,7 @@ describe('Table row selection', () => {
                                     value.initialSelection
                                 )
                             );
-                            expect(
-                                selectionChangeSpy
-                            ).not.toHaveBeenCalled();
+                            expect(selectionChangeSpy).not.toHaveBeenCalled();
                         });
                     });
                 });
@@ -944,12 +939,8 @@ describe('Table row selection', () => {
                                 value.expectedSelection
                             )
                         );
-                        expect(
-                            selectionChangeSpy
-                        ).toHaveBeenCalledTimes(1);
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            selectionChangeSpy
-                        );
+                        expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
+                        const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(
                                 value.expectedSelection
@@ -995,12 +986,8 @@ describe('Table row selection', () => {
                         expect(currentSelection).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
-                        expect(multiSelectSpy).toHaveBeenCalledTimes(
-                            1
-                        );
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            multiSelectSpy
-                        );
+                        expect(multiSelectSpy).toHaveBeenCalledTimes(1);
+                        const emittedIds = getEmittedRecordIdsFromSpy(multiSelectSpy);
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
@@ -1031,12 +1018,8 @@ describe('Table row selection', () => {
                         expect(currentSelection).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
-                        expect(multiSelectSpy).toHaveBeenCalledTimes(
-                            1
-                        );
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            multiSelectSpy
-                        );
+                        expect(multiSelectSpy).toHaveBeenCalledTimes(1);
+                        const emittedIds = getEmittedRecordIdsFromSpy(multiSelectSpy);
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
@@ -1068,12 +1051,8 @@ describe('Table row selection', () => {
                         expect(currentSelection).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
-                        expect(multiSelectSpy).toHaveBeenCalledTimes(
-                            1
-                        );
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            multiSelectSpy
-                        );
+                        expect(multiSelectSpy).toHaveBeenCalledTimes(1);
+                        const emittedIds = getEmittedRecordIdsFromSpy(multiSelectSpy);
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
@@ -1110,12 +1089,8 @@ describe('Table row selection', () => {
                         expect(currentSelection).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
-                        expect(
-                            secondMultiSelectSpy
-                        ).toHaveBeenCalledTimes(1);
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            secondMultiSelectSpy
-                        );
+                        expect(secondMultiSelectSpy).toHaveBeenCalledTimes(1);
+                        const emittedIds = getEmittedRecordIdsFromSpy(secondMultiSelectSpy);
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
@@ -1184,12 +1159,8 @@ describe('Table row selection', () => {
                         expect(currentSelection).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
-                        expect(multiSelectSpy).toHaveBeenCalledTimes(
-                            1
-                        );
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            multiSelectSpy
-                        );
+                        expect(multiSelectSpy).toHaveBeenCalledTimes(1);
+                        const emittedIds = getEmittedRecordIdsFromSpy(multiSelectSpy);
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
@@ -1228,12 +1199,8 @@ describe('Table row selection', () => {
                         expect(currentSelection).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
-                        expect(multiSelectSpy).toHaveBeenCalledTimes(
-                            1
-                        );
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            multiSelectSpy
-                        );
+                        expect(multiSelectSpy).toHaveBeenCalledTimes(1);
+                        const emittedIds = getEmittedRecordIdsFromSpy(multiSelectSpy);
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
@@ -1270,12 +1237,8 @@ describe('Table row selection', () => {
                         expect(currentSelection).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
-                        expect(multiSelectSpy).toHaveBeenCalledTimes(
-                            1
-                        );
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            multiSelectSpy
-                        );
+                        expect(multiSelectSpy).toHaveBeenCalledTimes(1);
+                        const emittedIds = getEmittedRecordIdsFromSpy(multiSelectSpy);
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
@@ -1327,12 +1290,8 @@ describe('Table row selection', () => {
                         expect(currentSelection).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
-                        expect(multiSelectSpy).toHaveBeenCalledTimes(
-                            1
-                        );
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            multiSelectSpy
-                        );
+                        expect(multiSelectSpy).toHaveBeenCalledTimes(1);
+                        const emittedIds = getEmittedRecordIdsFromSpy(multiSelectSpy);
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
@@ -1399,12 +1358,8 @@ describe('Table row selection', () => {
                         expect(currentSelection).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
-                        expect(multiSelectSpy).toHaveBeenCalledTimes(
-                            1
-                        );
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            multiSelectSpy
-                        );
+                        expect(multiSelectSpy).toHaveBeenCalledTimes(1);
+                        const emittedIds = getEmittedRecordIdsFromSpy(multiSelectSpy);
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
@@ -1439,12 +1394,8 @@ describe('Table row selection', () => {
                         expect(currentSelection).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
-                        expect(multiSelectSpy).toHaveBeenCalledTimes(
-                            1
-                        );
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            multiSelectSpy
-                        );
+                        expect(multiSelectSpy).toHaveBeenCalledTimes(1);
+                        const emittedIds = getEmittedRecordIdsFromSpy(multiSelectSpy);
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
@@ -1474,12 +1425,8 @@ describe('Table row selection', () => {
                         expect(currentSelection).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
-                        expect(multiSelectSpy).toHaveBeenCalledTimes(
-                            1
-                        );
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            multiSelectSpy
-                        );
+                        expect(multiSelectSpy).toHaveBeenCalledTimes(1);
+                        const emittedIds = getEmittedRecordIdsFromSpy(multiSelectSpy);
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
@@ -1507,12 +1454,8 @@ describe('Table row selection', () => {
                         expect(currentSelection).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
-                        expect(multiSelectSpy).toHaveBeenCalledTimes(
-                            1
-                        );
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            multiSelectSpy
-                        );
+                        expect(multiSelectSpy).toHaveBeenCalledTimes(1);
+                        const emittedIds = getEmittedRecordIdsFromSpy(multiSelectSpy);
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
@@ -1542,12 +1485,8 @@ describe('Table row selection', () => {
                         expect(currentSelection).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
-                        expect(shiftSelectSpy).toHaveBeenCalledTimes(
-                            1
-                        );
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            shiftSelectSpy
-                        );
+                        expect(shiftSelectSpy).toHaveBeenCalledTimes(1);
+                        const emittedIds = getEmittedRecordIdsFromSpy(shiftSelectSpy);
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
@@ -1577,12 +1516,8 @@ describe('Table row selection', () => {
                         expect(currentSelection).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
-                        expect(shiftSelectSpy).toHaveBeenCalledTimes(
-                            1
-                        );
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            shiftSelectSpy
-                        );
+                        expect(shiftSelectSpy).toHaveBeenCalledTimes(1);
+                        const emittedIds = getEmittedRecordIdsFromSpy(shiftSelectSpy);
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(expectedSelection)
                         );
@@ -1722,12 +1657,8 @@ describe('Table row selection', () => {
                         expect(currentSelection).toEqual(
                             jasmine.arrayWithExactContents(allRecordIds)
                         );
-                        expect(
-                            selectionChangeSpy
-                        ).toHaveBeenCalledTimes(1);
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            selectionChangeSpy
-                        );
+                        expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
+                        const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(allRecordIds)
                         );
@@ -1748,12 +1679,8 @@ describe('Table row selection', () => {
                         expect(currentSelection).toEqual(
                             jasmine.arrayWithExactContents(allRecordIds)
                         );
-                        expect(
-                            selectionChangeSpy
-                        ).toHaveBeenCalledTimes(1);
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            selectionChangeSpy
-                        );
+                        expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
+                        const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                         expect(emittedIds).toEqual(
                             jasmine.arrayWithExactContents(allRecordIds)
                         );
@@ -1770,9 +1697,7 @@ describe('Table row selection', () => {
 
                         const currentSelection = await element.getSelectedRecordIds();
                         expect(currentSelection).toEqual([]);
-                        const emittedIds = getEmittedRecordIdsFromSpy(
-                            selectionChangeSpy
-                        );
+                        const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                         expect(emittedIds).toEqual([]);
                     });
                 });
@@ -1932,9 +1857,7 @@ describe('Table row selection', () => {
                     jasmine.arrayWithExactContents(allRecordIds)
                 );
                 expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
-                const emittedIds = getEmittedRecordIdsFromSpy(
-                    selectionChangeSpy
-                );
+                const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                 expect(emittedIds).toEqual(
                     jasmine.arrayWithExactContents(allRecordIds)
                 );
@@ -1950,9 +1873,7 @@ describe('Table row selection', () => {
                 const currentSelection = await element.getSelectedRecordIds();
                 expect(currentSelection).toEqual([]);
                 expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
-                const emittedIds = getEmittedRecordIdsFromSpy(
-                    selectionChangeSpy
-                );
+                const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                 expect(emittedIds).toEqual([]);
             });
 
@@ -1968,9 +1889,7 @@ describe('Table row selection', () => {
                     jasmine.arrayWithExactContents(allRecordIds)
                 );
                 expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
-                const emittedIds = getEmittedRecordIdsFromSpy(
-                    selectionChangeSpy
-                );
+                const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                 expect(emittedIds).toEqual(
                     jasmine.arrayWithExactContents(allRecordIds)
                 );
@@ -2012,9 +1931,7 @@ describe('Table row selection', () => {
                     jasmine.arrayWithExactContents(expectedSelection)
                 );
                 expect(multiSelectSpy).toHaveBeenCalledTimes(1);
-                const emittedIds = getEmittedRecordIdsFromSpy(
-                    multiSelectSpy
-                );
+                const emittedIds = getEmittedRecordIdsFromSpy(multiSelectSpy);
                 expect(emittedIds).toEqual(
                     jasmine.arrayWithExactContents(expectedSelection)
                 );
@@ -2060,9 +1977,7 @@ describe('Table row selection', () => {
                     jasmine.arrayWithExactContents(expectedSelection)
                 );
                 expect(multiSelectSpy).toHaveBeenCalledTimes(1);
-                const emittedIds = getEmittedRecordIdsFromSpy(
-                    multiSelectSpy
-                );
+                const emittedIds = getEmittedRecordIdsFromSpy(multiSelectSpy);
                 expect(emittedIds).toEqual(
                     jasmine.arrayWithExactContents(expectedSelection)
                 );
@@ -2103,9 +2018,7 @@ describe('Table row selection', () => {
                     jasmine.arrayWithExactContents(expectedSelection)
                 );
                 expect(multiSelectSpy).toHaveBeenCalledTimes(1);
-                const emittedIds = getEmittedRecordIdsFromSpy(
-                    multiSelectSpy
-                );
+                const emittedIds = getEmittedRecordIdsFromSpy(multiSelectSpy);
                 expect(emittedIds).toEqual(
                     jasmine.arrayWithExactContents(expectedSelection)
                 );
@@ -2148,9 +2061,7 @@ describe('Table row selection', () => {
                     jasmine.arrayWithExactContents(expectedSelection)
                 );
                 expect(multiSelectSpy).toHaveBeenCalledTimes(1);
-                const emittedIds = getEmittedRecordIdsFromSpy(
-                    multiSelectSpy
-                );
+                const emittedIds = getEmittedRecordIdsFromSpy(multiSelectSpy);
                 expect(emittedIds).toEqual(
                     jasmine.arrayWithExactContents(expectedSelection)
                 );
@@ -2177,12 +2088,8 @@ describe('Table row selection', () => {
                     expect(currentSelection).toEqual(
                         jasmine.arrayWithExactContents(allBlueRecordIds)
                     );
-                    expect(selectionChangeSpy).toHaveBeenCalledTimes(
-                        1
-                    );
-                    const emittedIds = getEmittedRecordIdsFromSpy(
-                        selectionChangeSpy
-                    );
+                    expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
+                    const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                     expect(emittedIds).toEqual(
                         jasmine.arrayWithExactContents(allBlueRecordIds)
                     );
@@ -2199,12 +2106,8 @@ describe('Table row selection', () => {
 
                     const currentSelection = await element.getSelectedRecordIds();
                     expect(currentSelection).toEqual([]);
-                    expect(selectionChangeSpy).toHaveBeenCalledTimes(
-                        1
-                    );
-                    const emittedIds = getEmittedRecordIdsFromSpy(
-                        selectionChangeSpy
-                    );
+                    expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
+                    const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                     expect(emittedIds).toEqual([]);
                 });
 
@@ -2224,12 +2127,8 @@ describe('Table row selection', () => {
 
                     const currentSelection = await element.getSelectedRecordIds();
                     expect(currentSelection).toEqual([firstGreenRecordId]);
-                    expect(selectionChangeSpy).toHaveBeenCalledTimes(
-                        1
-                    );
-                    const emittedIds = getEmittedRecordIdsFromSpy(
-                        selectionChangeSpy
-                    );
+                    expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
+                    const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                     expect(emittedIds).toEqual([firstGreenRecordId]);
                 });
 
@@ -2247,12 +2146,8 @@ describe('Table row selection', () => {
                     expect(currentSelection).toEqual(
                         jasmine.arrayWithExactContents(allBlueRecordIds)
                     );
-                    expect(selectionChangeSpy).toHaveBeenCalledTimes(
-                        1
-                    );
-                    const emittedIds = getEmittedRecordIdsFromSpy(
-                        selectionChangeSpy
-                    );
+                    expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
+                    const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                     expect(emittedIds).toEqual(
                         jasmine.arrayWithExactContents(allBlueRecordIds)
                     );
@@ -2343,9 +2238,7 @@ describe('Table row selection', () => {
                     jasmine.arrayWithExactContents(allRecordIds)
                 );
                 expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
-                const emittedIds = getEmittedRecordIdsFromSpy(
-                    selectionChangeSpy
-                );
+                const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                 expect(emittedIds).toEqual(
                     jasmine.arrayWithExactContents(allRecordIds)
                 );
@@ -2361,9 +2254,7 @@ describe('Table row selection', () => {
                 const currentSelection = await element.getSelectedRecordIds();
                 expect(currentSelection).toEqual([]);
                 expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
-                const emittedIds = getEmittedRecordIdsFromSpy(
-                    selectionChangeSpy
-                );
+                const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                 expect(emittedIds).toEqual([]);
             });
 
@@ -2379,9 +2270,7 @@ describe('Table row selection', () => {
                     jasmine.arrayWithExactContents(allRecordIds)
                 );
                 expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
-                const emittedIds = getEmittedRecordIdsFromSpy(
-                    selectionChangeSpy
-                );
+                const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                 expect(emittedIds).toEqual(
                     jasmine.arrayWithExactContents(allRecordIds)
                 );
@@ -2428,12 +2317,8 @@ describe('Table row selection', () => {
                     expect(currentSelection).toEqual(
                         jasmine.arrayWithExactContents(allBlueRecordIds)
                     );
-                    expect(selectionChangeSpy).toHaveBeenCalledTimes(
-                        1
-                    );
-                    const emittedIds = getEmittedRecordIdsFromSpy(
-                        selectionChangeSpy
-                    );
+                    expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
+                    const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                     expect(emittedIds).toEqual(
                         jasmine.arrayWithExactContents(allBlueRecordIds)
                     );
@@ -2450,12 +2335,8 @@ describe('Table row selection', () => {
 
                     const currentSelection = await element.getSelectedRecordIds();
                     expect(currentSelection).toEqual([]);
-                    expect(selectionChangeSpy).toHaveBeenCalledTimes(
-                        1
-                    );
-                    const emittedIds = getEmittedRecordIdsFromSpy(
-                        selectionChangeSpy
-                    );
+                    expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
+                    const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                     expect(emittedIds).toEqual([]);
                 });
 
@@ -2475,12 +2356,8 @@ describe('Table row selection', () => {
 
                     const currentSelection = await element.getSelectedRecordIds();
                     expect(currentSelection).toEqual([firstGreenRecordId]);
-                    expect(selectionChangeSpy).toHaveBeenCalledTimes(
-                        1
-                    );
-                    const emittedIds = getEmittedRecordIdsFromSpy(
-                        selectionChangeSpy
-                    );
+                    expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
+                    const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                     expect(emittedIds).toEqual([firstGreenRecordId]);
                 });
 
@@ -2498,12 +2375,8 @@ describe('Table row selection', () => {
                     expect(currentSelection).toEqual(
                         jasmine.arrayWithExactContents(allBlueRecordIds)
                     );
-                    expect(selectionChangeSpy).toHaveBeenCalledTimes(
-                        1
-                    );
-                    const emittedIds = getEmittedRecordIdsFromSpy(
-                        selectionChangeSpy
-                    );
+                    expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
+                    const emittedIds = getEmittedRecordIdsFromSpy(selectionChangeSpy);
                     expect(emittedIds).toEqual(
                         jasmine.arrayWithExactContents(allBlueRecordIds)
                     );

--- a/packages/nimble-components/src/table/tests/table-sorting.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-sorting.spec.ts
@@ -19,6 +19,10 @@ interface SimpleTableRecord extends TableRecord {
     parentId?: string;
 }
 
+type TableColumnConfigurationChangeEventHandler = (
+    evt: CustomEvent<TableColumnConfigurationChangeEventDetail>
+) => void;
+
 // prettier-ignore
 async function setup(): Promise<Fixture<Table<SimpleTableRecord>>> {
     return fixture<Table<SimpleTableRecord>>(
@@ -970,7 +974,7 @@ describe('Table sorting', () => {
             await connect();
             await waitForUpdatesAsync();
 
-            const spy = jasmine.createSpy();
+            const spy = jasmine.createSpy<TableColumnConfigurationChangeEventHandler>();
             const listener = waitForEvent(
                 element,
                 'column-configuration-change',
@@ -981,7 +985,7 @@ describe('Table sorting', () => {
 
             expect(spy).toHaveBeenCalled();
             const args = spy.calls.first()
-                .args[0] as CustomEvent<TableColumnConfigurationChangeEventDetail>;
+                .args[0];
             expect(args.detail).toEqual({
                 columns: [
                     {

--- a/packages/nimble-components/src/table/tests/table-sorting.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-sorting.spec.ts
@@ -9,7 +9,7 @@ import {
     TableRecord
 } from '../types';
 import { SortedColumn, TablePageObject } from '../testing/table.pageobject';
-import { createEventListener } from '../../utilities/testing/component';
+import { waitForEvent } from '../../utilities/testing/component';
 
 interface SimpleTableRecord extends TableRecord {
     id: string;
@@ -576,15 +576,20 @@ describe('Table sorting', () => {
         await connect();
         await waitForUpdatesAsync();
 
-        const listener = createEventListener(
-            element,
-            'column-configuration-change'
+        const spy = jasmine.createSpy();
+        element.addEventListener(
+            'column-configuration-change',
+            spy
         );
         column1.sortDirection = TableColumnSortDirection.ascending;
         column1.sortIndex = 0;
         await waitForUpdatesAsync();
 
-        expect(listener.spy).not.toHaveBeenCalled();
+        expect(spy).not.toHaveBeenCalled();
+        element.removeEventListener(
+            'column-configuration-change',
+            spy
+        );
     });
 
     describe('sort index validation', () => {
@@ -965,14 +970,17 @@ describe('Table sorting', () => {
             await connect();
             await waitForUpdatesAsync();
 
-            const listener = createEventListener(
+            const spy = jasmine.createSpy();
+            const listener = waitForEvent(
                 element,
-                'column-configuration-change'
+                'column-configuration-change',
+                spy
             );
             await pageObject.clickColumnHeader(0);
+            await listener;
 
-            expect(listener.spy).toHaveBeenCalled();
-            const args = listener.spy.calls.first()
+            expect(spy).toHaveBeenCalled();
+            const args = spy.calls.first()
                 .args[0] as CustomEvent<TableColumnConfigurationChangeEventDetail>;
             expect(args.detail).toEqual({
                 columns: [
@@ -1013,13 +1021,18 @@ describe('Table sorting', () => {
             await connect();
             await waitForUpdatesAsync();
 
-            const listener = createEventListener(
-                element,
-                'column-configuration-change'
+            const spy = jasmine.createSpy();
+            element.addEventListener(
+                'column-configuration-change',
+                spy
             );
             await pageObject.clickColumnHeader(0);
 
-            expect(listener.spy).not.toHaveBeenCalled();
+            expect(spy).not.toHaveBeenCalled();
+            element.removeEventListener(
+                'column-configuration-change',
+                spy
+            );
         });
     });
 

--- a/packages/nimble-components/src/table/tests/table-sorting.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-sorting.spec.ts
@@ -581,19 +581,13 @@ describe('Table sorting', () => {
         await waitForUpdatesAsync();
 
         const spy = jasmine.createSpy();
-        element.addEventListener(
-            'column-configuration-change',
-            spy
-        );
+        element.addEventListener('column-configuration-change', spy);
         column1.sortDirection = TableColumnSortDirection.ascending;
         column1.sortIndex = 0;
         await waitForUpdatesAsync();
 
         expect(spy).not.toHaveBeenCalled();
-        element.removeEventListener(
-            'column-configuration-change',
-            spy
-        );
+        element.removeEventListener('column-configuration-change', spy);
     });
 
     describe('sort index validation', () => {
@@ -984,8 +978,7 @@ describe('Table sorting', () => {
             await listener;
 
             expect(spy).toHaveBeenCalled();
-            const args = spy.calls.first()
-                .args[0];
+            const args = spy.calls.first().args[0];
             expect(args.detail).toEqual({
                 columns: [
                     {
@@ -1026,17 +1019,11 @@ describe('Table sorting', () => {
             await waitForUpdatesAsync();
 
             const spy = jasmine.createSpy();
-            element.addEventListener(
-                'column-configuration-change',
-                spy
-            );
+            element.addEventListener('column-configuration-change', spy);
             await pageObject.clickColumnHeader(0);
 
             expect(spy).not.toHaveBeenCalled();
-            element.removeEventListener(
-                'column-configuration-change',
-                spy
-            );
+            element.removeEventListener('column-configuration-change', spy);
         });
     });
 

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -6,7 +6,7 @@ import { TableColumnText, tableColumnTextTag } from '../../table-column/text';
 import { TableColumnTextCellView } from '../../table-column/text/cell-view';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { controlHeight } from '../../theme-provider/design-tokens';
-import { createEventListener } from '../../utilities/testing/component';
+import { waitForEvent } from '../../utilities/testing/component';
 import {
     type Fixture,
     fixture,
@@ -729,12 +729,12 @@ describe('Table', () => {
                 await element.setData(data);
                 await waitForUpdatesAsync();
 
-                const toggleListener = createEventListener(
+                const toggleListener = waitForEvent(
                     element,
                     'action-menu-toggle'
                 );
                 await pageObject.clickCellActionMenu(0, 0);
-                await toggleListener.promise;
+                await toggleListener;
                 expect(pageObject.getCellActionMenu(0, 0)!.open).toBe(true);
 
                 await pageObject.scrollToLastRowAsync();
@@ -832,13 +832,13 @@ describe('Table', () => {
                 await connect();
                 await waitForUpdatesAsync();
 
-                let toggleListener = createEventListener(
+                let toggleListener = waitForEvent(
                     element,
                     'action-menu-toggle'
                 );
                 // Open a menu button for the first row to cause all the menus to be slotted within that row
                 await pageObject.clickCellActionMenu(1, 0);
-                await toggleListener.promise;
+                await toggleListener;
 
                 const updatedSlot = 'my-new-slot';
                 column1.actionMenuSlot = updatedSlot;
@@ -846,12 +846,12 @@ describe('Table', () => {
                 await waitForUpdatesAsync();
 
                 // Reopen the menu so we can verify the slots (changing sort order causes a row recycle which closes action menus)
-                toggleListener = createEventListener(
+                toggleListener = waitForEvent(
                     element,
                     'action-menu-toggle'
                 );
                 await pageObject.clickCellActionMenu(1, 0);
-                await toggleListener.promise;
+                await toggleListener;
 
                 // Verify the slot name is updated
                 const rowSlots = element

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -846,10 +846,7 @@ describe('Table', () => {
                 await waitForUpdatesAsync();
 
                 // Reopen the menu so we can verify the slots (changing sort order causes a row recycle which closes action menus)
-                toggleListener = waitForEvent(
-                    element,
-                    'action-menu-toggle'
-                );
+                toggleListener = waitForEvent(element, 'action-menu-toggle');
                 await pageObject.clickCellActionMenu(1, 0);
                 await toggleListener;
 

--- a/packages/nimble-components/src/utilities/testing/component.ts
+++ b/packages/nimble-components/src/utilities/testing/component.ts
@@ -46,42 +46,23 @@ export async function sendKeyDownEvents(
 /** A helper function to abstract turning waiting for an event to fire into a promise.
  * The returned promise should be resolved prior to completing a test.
  */
-export async function waitForEventAsync(
+export async function waitForEvent(
     element: HTMLElement,
-    eventName: string
+    eventName: string,
+    callback?: (...args: unknown[]) => void
 ): Promise<void> {
     return new Promise(resolve => {
-        const handler = (): void => {
-            element.removeEventListener(eventName, handler);
-            resolve();
-        };
-        element.addEventListener(eventName, handler);
-    });
-}
-
-/** A helper function to abstract adding an event listener, spying
- * on the event being called, and removing the event listener. The returned promise
- * should be resolved prior to completing a test.
- */
-export function createEventListener(
-    element: HTMLElement,
-    eventName: string
-): {
-        promise: Promise<void>,
-        spy: jasmine.Spy
-    } {
-    const spy = jasmine.createSpy();
-    return {
-        promise: new Promise(resolve => {
-            const handler = (...args: unknown[]): void => {
-                element.removeEventListener(eventName, handler);
-                spy(...args);
+        element.addEventListener(
+            eventName,
+            (...args: unknown[]): void => {
+                callback?.(...args);
                 resolve();
-            };
-            element.addEventListener(eventName, handler);
-        }),
-        spy
-    };
+            },
+            {
+                once: true
+            }
+        );
+    });
 }
 
 /**

--- a/packages/nimble-components/src/utilities/testing/component.ts
+++ b/packages/nimble-components/src/utilities/testing/component.ts
@@ -56,13 +56,9 @@ export async function waitForEvent<T extends Event>(
             callback?.(evt);
             resolve();
         }) as EventListener;
-        element.addEventListener(
-            eventName,
-            handler,
-            {
-                once: true
-            }
-        );
+        element.addEventListener(eventName, handler, {
+            once: true
+        });
     });
 }
 

--- a/packages/nimble-components/src/utilities/testing/component.ts
+++ b/packages/nimble-components/src/utilities/testing/component.ts
@@ -46,18 +46,19 @@ export async function sendKeyDownEvents(
 /** A helper function to abstract turning waiting for an event to fire into a promise.
  * The returned promise should be resolved prior to completing a test.
  */
-export async function waitForEvent(
+export async function waitForEvent<T extends Event>(
     element: HTMLElement,
     eventName: string,
-    callback?: (...args: unknown[]) => void
+    callback?: (evt: T) => void
 ): Promise<void> {
     return new Promise(resolve => {
+        const handler = ((evt: T): void => {
+            callback?.(evt);
+            resolve();
+        }) as EventListener;
         element.addEventListener(
             eventName,
-            (...args: unknown[]): void => {
-                callback?.(...args);
-                resolve();
-            },
+            handler,
             {
                 once: true
             }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The previous `createEventListener` helper in nimble testing utilities leveraged a jasmine library feature which indirectly made jasmine a dependency of nimble as several of the page objects had a dependency on it and are part of the public api. This refactor breaks the jasmine dependency in the public api.

## 👩‍💻 Implementation

- The `waitForEvent` helper was updated to take an optional event handler callback. This deprecates the need for the `createEventListener` utility which was removed.
- The tests were refactored to create their own jasmine spies instead of relying on a utility to create them. This had several benefits:
  - Many tests were using the utility that created spies unnecessarily. They should have been using waitForEvent and now do so.
  - Several tests where trying to track ordering of events. This is very natural if the same spy is used in multiple event listeners which you can now do since the spy is provided.
  - Several tests were relying on the idea that the helpers can trigger events multiple times. This is not the case, they are written to only resolve once and to remove their event handlers after the first call
  - Now that the spy is constructed in the test, it is easier to fulfill it's generic and remove a bunch of `as` casting

## 🧪 Testing

Relying on existing test runs.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
