### PR TITLE
Support dynamic tabbableChildren for TableCellView

### DIFF
--- a/change/@ni-nimble-components-8499a62b-64ea-41e0-877c-6bacca7ae0c8.json
+++ b/change/@ni-nimble-components-8499a62b-64ea-41e0-877c-6bacca7ae0c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update TableCellView tabbableChildren to be an observable property",
+  "packageName": "@ni/nimble-components",
+  "email": "20709258+msmithNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table-column/anchor/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/anchor/cell-view/index.ts
@@ -31,6 +31,7 @@ TableColumnAnchorColumnConfig
     public isPlaceholder = false;
 
     /** @internal */
+    @observable
     public anchor?: Anchor;
 
     @volatile
@@ -60,11 +61,8 @@ TableColumnAnchorColumnConfig
         return typeof this.cellRecord?.href === 'string';
     }
 
-    public override get tabbableChildren(): HTMLElement[] {
-        if (this.showAnchor) {
-            return [this.anchor!];
-        }
-        return [];
+    private anchorChanged(): void {
+        this.tabbableChildren = this.anchor ? [this.anchor] : [];
     }
 }
 

--- a/packages/nimble-components/src/table-column/anchor/cell-view/template.ts
+++ b/packages/nimble-components/src/table-column/anchor/cell-view/template.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/indent */
-import { html, ref, when } from '@microsoft/fast-element';
+import { html, when } from '@microsoft/fast-element';
 import type { TableColumnAnchorCellView } from '.';
 import { anchorTag } from '../../../anchor';
 import { overflow } from '../../../utilities/directive/overflow';
+import { dynamicRef } from '../../../utilities/directive/dynamic-ref';
 
 // prettier-ignore
 export const template = html<TableColumnAnchorCellView>`
@@ -17,7 +18,7 @@ export const template = html<TableColumnAnchorCellView>`
     >
         ${when(x => x.showAnchor, html<TableColumnAnchorCellView>`
             <${anchorTag}
-                ${ref('anchor')}
+                ${dynamicRef('anchor')}
                 ${overflow('hasOverflow')}
                 ${'' /* tabindex managed dynamically by KeyboardNavigationManager */}
                 tabindex="-1"

--- a/packages/nimble-components/src/table-column/base/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/base/cell-view/index.ts
@@ -30,12 +30,11 @@ export abstract class TableCellView<
     public recordId?: string;
 
     /**
-     * Gets the child elements in this cell view that should be able to be reached via Tab/ Shift-Tab,
+     * The child elements in this cell view that should be able to be reached via Tab/ Shift-Tab,
      * if any.
      */
-    public get tabbableChildren(): HTMLElement[] {
-        return [];
-    }
+    @observable
+    public tabbableChildren: Element[] = [];
 
     private delegatedEvents: readonly string[] = [];
 
@@ -72,4 +71,8 @@ export abstract class TableCellView<
     }
 
     private delegatedEventHandler: (event: Event) => void = () => {};
+
+    private tabbableChildrenChanged(): void {
+        this.$emit('cell-tabbable-children-change', this);
+    }
 }

--- a/packages/nimble-components/src/table-column/menu-button/cell-view/index.ts
+++ b/packages/nimble-components/src/table-column/menu-button/cell-view/index.ts
@@ -26,6 +26,7 @@ TableColumnMenuButtonCellRecord,
 TableColumnMenuButtonColumnConfig
 > {
     /** @internal */
+    @observable
     public menuButton?: MenuButton;
 
     /** @internal */
@@ -39,13 +40,6 @@ TableColumnMenuButtonColumnConfig
     @volatile
     public get showMenuButton(): boolean {
         return !!this.cellRecord?.value;
-    }
-
-    public override get tabbableChildren(): HTMLElement[] {
-        if (this.showMenuButton) {
-            return [this.menuButton!];
-        }
-        return [];
     }
 
     /** @internal */
@@ -81,6 +75,10 @@ TableColumnMenuButtonColumnConfig
         // Stop propagation of the click event to prevent clicking the menu button
         // from affecting row selection.
         e.stopPropagation();
+    }
+
+    private menuButtonChanged(): void {
+        this.tabbableChildren = this.menuButton ? [this.menuButton] : [];
     }
 }
 

--- a/packages/nimble-components/src/table-column/menu-button/cell-view/templates.ts
+++ b/packages/nimble-components/src/table-column/menu-button/cell-view/templates.ts
@@ -7,12 +7,13 @@ import {
 } from '../../../menu-button/types';
 import { iconArrowExpanderDownTag } from '../../../icons/arrow-expander-down';
 import { cellViewMenuSlotName } from '../types';
+import { dynamicRef } from '../../../utilities/directive/dynamic-ref';
 
 // prettier-ignore
 export const template = html<TableColumnMenuButtonCellView>`
     ${when(x => x.showMenuButton, html<TableColumnMenuButtonCellView>`
         <${menuButtonTag}
-            ${ref('menuButton')}
+            ${dynamicRef('menuButton')}
             appearance="${ButtonAppearance.ghost}"
             @beforetoggle="${(x, c) => x.onMenuButtonBeforeToggle(c.event as CustomEvent<MenuButtonToggleEventDetail>)}"
             @mouseover="${x => x.onMenuButtonMouseOver()}"

--- a/packages/nimble-components/src/table/models/keyboard-navigation-manager.ts
+++ b/packages/nimble-components/src/table/models/keyboard-navigation-manager.ts
@@ -1335,8 +1335,8 @@ implements Subscriber {
                     newColumnIndex,
                     true
                 );
+                return true;
             }
-            return true;
         }
 
         return false;

--- a/packages/nimble-components/src/table/tests/table-keyboard-navigation.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-keyboard-navigation.spec.ts
@@ -1,13 +1,5 @@
 /* eslint-disable no-await-in-loop */
-import {
-    children,
-    customElement,
-    elements,
-    html,
-    observable,
-    ref,
-    when
-} from '@microsoft/fast-element';
+import { customElement, html, observable, when } from '@microsoft/fast-element';
 import { FoundationElement } from '@microsoft/fast-foundation';
 import {
     keyArrowDown,
@@ -1443,11 +1435,14 @@ describe('Table keyboard navigation', () => {
                     cellView.isTabbable = false;
                     await waitForUpdatesAsync();
 
-                    // Note: At this point, the table lost focus already, because the focused element in the cell has been removed from the DOM, and
-                    // KeyboardNavigationManager will only set focus to new elements when the table is already focused (so we don't steal focus from
-                    // elsewhere on the page if the table isn't being interacted with).
-                    element.focus();
-                    await waitForUpdatesAsync();
+                    // Note: At this point, the focused element in the cell has been already removed from the DOM.
+                    // KeyboardNavigationManager will only set focus to new elements when the table is already focused (so we don't
+                    // steal focus from elsewhere on the page if the table isn't being interacted with).
+                    // In Chrome, the table loses focus entirely, but not in Firefox/WebKit.
+                    if (element.shadowRoot!.activeElement === null) {
+                        element.focus(); // Refocus table if it's been lost
+                        await waitForUpdatesAsync();
+                    }
 
                     expect(currentFocusedElement()).toBe(
                         pageObject.getCell(0, 1)

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -1,17 +1,11 @@
-import { attr, customElement, html } from '@microsoft/fast-element';
+import { html } from '@microsoft/fast-element';
 import { parameterizeSpec } from '@ni/jasmine-parameterized';
 import { Table, tableTag } from '..';
-import { TableColumn } from '../../table-column/base';
 import { TableColumnText, tableColumnTextTag } from '../../table-column/text';
-import { TableColumnTextCellView } from '../../table-column/text/cell-view';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { controlHeight } from '../../theme-provider/design-tokens';
 import { waitForEvent } from '../../utilities/testing/component';
-import {
-    type Fixture,
-    fixture,
-    uniqueElementName
-} from '../../utilities/tests/fixture';
+import { type Fixture, fixture } from '../../utilities/tests/fixture';
 import {
     TableColumnAlignment,
     TableColumnSortDirection,
@@ -21,12 +15,9 @@ import {
 } from '../types';
 import { TablePageObject } from '../testing/table.pageobject';
 import {
-    tableColumnEmptyGroupHeaderViewTag,
     TableColumnValidationTest,
     tableColumnValidationTestTag
 } from '../../table-column/base/tests/table-column.fixtures';
-import type { ColumnInternalsOptions } from '../../table-column/base/models/column-internals';
-import { ColumnValidator } from '../../table-column/base/models/column-validator';
 
 interface SimpleTableRecord extends TableRecord {
     stringData: string;

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -650,39 +650,6 @@ describe('Table', () => {
         });
 
         describe('uses virtualization', () => {
-            const focusableCellViewName = uniqueElementName();
-            const focusableColumnName = uniqueElementName();
-            @customElement({
-                name: focusableCellViewName,
-                template: html<TestFocusableCellView>`<span tabindex="0"
-                    >${x => x.text}</span
-                >`
-            })
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            class TestFocusableCellView extends TableColumnTextCellView {
-                public override get tabbableChildren(): HTMLElement[] {
-                    return [this.shadowRoot!.firstElementChild as HTMLElement];
-                }
-            }
-            @customElement({
-                name: focusableColumnName
-            })
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            class TestFocusableTableColumn extends TableColumn {
-                @attr({ attribute: 'field-name' })
-                public fieldName?: string;
-
-                protected override getColumnInternalsOptions(): ColumnInternalsOptions {
-                    return {
-                        cellViewTag: focusableCellViewName,
-                        cellRecordFieldNames: ['value'],
-                        groupHeaderViewTag: tableColumnEmptyGroupHeaderViewTag,
-                        delegatedEvents: [],
-                        validator: new ColumnValidator<[]>([])
-                    };
-                }
-            }
-
             it('to render fewer rows (based on viewport size)', async () => {
                 await connect();
 

--- a/packages/nimble-components/src/utilities/directive/dynamic-ref.ts
+++ b/packages/nimble-components/src/utilities/directive/dynamic-ref.ts
@@ -1,0 +1,62 @@
+import {
+    AttachedBehaviorHTMLDirective,
+    type Behavior,
+    type CaptureType
+} from '@microsoft/fast-element';
+
+/**
+ * A directive that updates a property with a reference to the element.
+ * Similar to RefBehavior, but sets the property back to undefined when unbound
+ * (when the source element is removed from the DOM).
+ * @public
+ */
+export class DynamicRefBehavior implements Behavior {
+    private readonly target: unknown;
+    private propertyName: string;
+
+    /**
+     * Creates an instance of DynamicRefBehavior.
+     * @param target - The element to reference.
+     * @param propertyName - The name of the property to assign the reference to.
+     */
+    public constructor(target: unknown, propertyName: string) {
+        this.target = target;
+        this.propertyName = propertyName;
+    }
+
+    /**
+     * Bind this behavior to the source.
+     * @param source - The source to bind to.
+     */
+
+    public bind(source: unknown): void {
+        // @ts-expect-error set property on source
+        source[this.propertyName] = this.target;
+    }
+
+    /**
+     * Unbinds this behavior from the source.
+     * @param source - The source to unbind from.
+     */
+    public unbind(source: unknown): void {
+        // @ts-expect-error set property on source
+        source[this.propertyName] = undefined;
+    }
+}
+
+/**
+ * A directive that updates a property with a reference to the source element.
+ * Similar to RefBehavior, but sets the property back to undefined when unbound
+ * (when the source element is removed from the DOM).
+ * @param propertyName - The name of the property to assign the reference to.
+ * @public
+ */
+export function dynamicRef<T = unknown>(
+    propertyName: keyof T & string
+): CaptureType<T> {
+    return new AttachedBehaviorHTMLDirective(
+        'nimble-dynamic-ref',
+        DynamicRefBehavior,
+        propertyName
+    );
+}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

#2210 

## 👩‍💻 Implementation

Summary of changes:
- `TableCellView` `tabbableChildren` changed from a getter to be an `@observable` property
- Both anchor & menu button columns only have a tabbable/focusable element in cells in some cases, so opt them into this change.
- Create a new `dynamicRef` directive, used in the anchor/ menu button cell templates. The issue with the `ref` directive is that once a reference is initialized, it's never cleared. So, for example, if an anchor column starts out with valid URL data then gets data without URLs, `cellView.anchor` would still be set (to an element no longer in the DOM) with `ref`, whereas `dynamicRef` clears out the property
    - As an alternative, I considered the `children` directive with a filter, but it seemed like that would require adding yet another extra container div to the cell views, which didn't seem desirable.
- When `tabbableChildren` changes, the cell view fires a bubbling `'cell-tabbable-children-change'` event, handled by `KeyboardNavigationManager`, which focuses the cell instead (if the cell content was previously focused, and is no longer present)

Implementation concerns:
- `'cell-tabbable-children-change'` event
    - This works, but feels somewhat heavy handed (but I couldn't really think of a better alternative).
    - This fires for every visible row, not just the focused row (extra events firing that won't be handled)
    - `KeyboardNavigationManager` keeps track of focused rows/ cells via index, whereas most of the rest of the table code uses `recordId` and `columnId`. In order to only handle the event for the focused row, there's some new code in `KeyboardNavigationManager` that keeps track of the `columnId` / `recordId` if cell content is focused, which complicates that class a bit more.

UX concerns:
- In Chrome, if a focused element inside a cell is removed from the DOM, the table loses focus entirely. `KeyboardNavigationManager` tracks when the table gains/ loses focus, and won't programmatically set focus if the table doesn't already contain focus. So in this case (in Chrome) the user would need to manually refocus the table, at which point the cell would get focused. I discovered this fairly recently so haven't spent too much time pondering what it would take to have the keyboard nav code handle this specific case.
   - This didn't occur in Firefox / WebKit, which is why the new test only conditionally refocuses the table right now.

## 🧪 Testing

- Existing keyboard nav / tabbableChildren tests still pass
- Add new test ensuring that if tabbableChildren are changed (removed), focus reverts to the cell
- No tests for `dynamicRef` currently (we'd want some if we went with this approach)

## ✅ Checklist

N/A for now since this draft PR is to get feedback on this approach.
<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). 
- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
-->
