### PR TITLE
Listbox padding

### DIFF
--- a/change/@ni-nimble-components-0548119c-1705-4f5d-84e4-12189f61da41.json
+++ b/change/@ni-nimble-components-0548119c-1705-4f5d-84e4-12189f61da41.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix listbox padding. Add scroll-snap behavior.",
+  "packageName": "@ni/nimble-components",
+  "email": "1458528+fredvisser@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-0548119c-1705-4f5d-84e4-12189f61da41.json
+++ b/change/@ni-nimble-components-0548119c-1705-4f5d-84e4-12189f61da41.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix listbox padding. Add scroll-snap behavior.",
+  "comment": "Fix listbox padding",
   "packageName": "@ni/nimble-components",
   "email": "1458528+fredvisser@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/nimble-components/src/combobox/index.ts
+++ b/packages/nimble-components/src/combobox/index.ts
@@ -129,6 +129,12 @@ export class Combobox
      * @internal
      */
     @observable
+    public scrollableRegion!: HTMLElement;
+
+    /**
+     * @internal
+     */
+    @observable
     public readonly dropdownButton?: ToggleButton;
 
     /**

--- a/packages/nimble-components/src/combobox/template.ts
+++ b/packages/nimble-components/src/combobox/template.ts
@@ -91,7 +91,8 @@ ComboboxOptions
                 style="--ni-private-listbox-available-viewport-height: ${x => x.availableViewportHeight}px;"
                 ${ref('listbox')}
             >
-                <div class="scrollable-region">
+                <div ${ref('scrollableRegion')}
+                class="scrollable-region">
                     <slot name="option"
                         ${slotted({
                             filter: (n: Node) => n instanceof HTMLElement && Listbox.slottedOptionFilter(n),

--- a/packages/nimble-components/src/combobox/template.ts
+++ b/packages/nimble-components/src/combobox/template.ts
@@ -82,7 +82,6 @@ ComboboxOptions
             <div
                 class="
                     listbox
-                    scrollable-region
                     ${x => (x.filteredOptions.length === 0 ? 'empty' : '')}
                 "
                 id="${x => x.listboxId}"
@@ -92,18 +91,20 @@ ComboboxOptions
                 style="--ni-private-listbox-available-viewport-height: ${x => x.availableViewportHeight}px;"
                 ${ref('listbox')}
             >
-                <slot name="option"
-                    ${slotted({
-                        filter: (n: Node) => n instanceof HTMLElement && Listbox.slottedOptionFilter(n),
-                        flatten: true,
-                        property: 'slottedOptions',
-                    })}
-                ></slot>
-                ${when(x => x.filteredOptions.length === 0, html<Combobox>`
-                    <span class="no-results-label">
-                        ${x => filterNoResultsLabel.getValueFor(x)}
-                    </span>
-                `)}
+                <div class="scrollable-region">
+                    <slot name="option"
+                        ${slotted({
+                            filter: (n: Node) => n instanceof HTMLElement && Listbox.slottedOptionFilter(n),
+                            flatten: true,
+                            property: 'slottedOptions',
+                        })}
+                    ></slot>
+                    ${when(x => x.filteredOptions.length === 0, html<Combobox>`
+                        <span class="no-results-label">
+                            ${x => filterNoResultsLabel.getValueFor(x)}
+                        </span>
+                    `)}
+                </div>
             </div>
         </${anchoredRegionTag}>
     </template>

--- a/packages/nimble-components/src/combobox/tests/combobox.spec.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox.spec.ts
@@ -555,11 +555,11 @@ describe('Combobox', () => {
         it('should scroll the selected option into view when opened #SkipWebkit', async () => {
             await pageObject.commitValue('300');
             await pageObject.clickAndWaitForOpen();
-            expect(element.listbox.scrollTop).toBeGreaterThan(9000);
+            expect(element.scrollableRegion.scrollTop).toBeGreaterThan(9000);
 
             await pageObject.commitValue('0');
             await pageObject.clickAndWaitForOpen();
-            expect(element.listbox.scrollTop).toBeCloseTo(4);
+            expect(element.scrollableRegion.scrollTop).toBeCloseTo(0);
         });
 
         it('when typing in value with inline autocomplete, option at bottom of list scrolls into view', async () => {

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -220,6 +220,7 @@ export const styles = css`
         box-shadow: ${elevation2BoxShadow};
         border: ${borderWidth} solid ${popupBorderColor};
         background-color: ${applicationBackgroundColor};
+        padding: var(--ni-private-listbox-padding);
     }
 
     .listbox:has(.filter-field) {
@@ -247,7 +248,6 @@ export const styles = css`
     .listbox slot {
         display: block;
         background: transparent;
-        padding: var(--ni-private-listbox-padding);
     }
 
     .listbox.empty slot {

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -243,7 +243,6 @@ export const styles = css`
 
     .scrollable-region {
         overflow-y: auto;
-        scroll-snap-type: y mandatory;
     }
 
     .listbox slot {
@@ -258,7 +257,6 @@ export const styles = css`
     ::slotted([role='option']),
     ::slotted(option) {
         flex: none;
-        scroll-snap-align: start none;
     }
 
     .no-results-label {

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -243,6 +243,7 @@ export const styles = css`
 
     .scrollable-region {
         overflow-y: auto;
+        scroll-snap-type: y mandatory;
     }
 
     .listbox slot {
@@ -257,6 +258,7 @@ export const styles = css`
     ::slotted([role='option']),
     ::slotted(option) {
         flex: none;
+        scroll-snap-align: start none;
     }
 
     .no-results-label {

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -220,7 +220,26 @@ export const styles = css`
         box-shadow: ${elevation2BoxShadow};
         border: ${borderWidth} solid ${popupBorderColor};
         background-color: ${applicationBackgroundColor};
-        padding: var(--ni-private-listbox-padding);
+    }
+
+    .listbox::before {
+        content: '';
+        position: absolute;
+        display: block;
+        top: calc(${smallPadding} + ${borderWidth});
+        height: var(--ni-private-listbox-padding);
+        width: calc(100% - 2px);
+        background-color: ${applicationBackgroundColor};
+    }
+
+    .listbox::after {
+        content: '';
+        position: absolute;
+        display: block;
+        bottom: 0;
+        height: var(--ni-private-listbox-padding);
+        width: calc(100% - 2px);
+        background-color: ${applicationBackgroundColor};
     }
 
     .listbox:has(.filter-field) {
@@ -243,6 +262,7 @@ export const styles = css`
 
     .scrollable-region {
         overflow-y: auto;
+        padding: var(--ni-private-listbox-padding);
     }
 
     .listbox slot {

--- a/packages/nimble-components/src/rich-text/mention-listbox/index.ts
+++ b/packages/nimble-components/src/rich-text/mention-listbox/index.ts
@@ -64,6 +64,12 @@ export class RichTextMentionListbox extends FoundationListbox {
      */
     public listbox!: HTMLDivElement;
 
+    /**
+     * @internal
+     */
+    @observable
+    public scrollableRegion!: HTMLElement;
+
     @observable
     private anchorElement?: HTMLElement;
 

--- a/packages/nimble-components/src/rich-text/mention-listbox/template.ts
+++ b/packages/nimble-components/src/rich-text/mention-listbox/template.ts
@@ -22,7 +22,6 @@ export const template = html<RichTextMentionListbox>`
             <div
                 class="
                     listbox
-                    scrollable-region
                     ${x => (x.filteredOptions.length === 0 ? 'empty' : '')}
                 "
                 part="listbox"
@@ -32,19 +31,21 @@ export const template = html<RichTextMentionListbox>`
                 style="--ni-private-listbox-available-viewport-height: ${x => x.availableViewportHeight}px;"
                 ${ref('listbox')}
             >
-                <slot name="option"
-                    ${slotted({
-                        filter: (n: Node) => n instanceof HTMLElement && Listbox.slottedOptionFilter(n),
-                        flatten: true,
-                        property: 'slottedOptions'
-                    })}
-                >
-                </slot>
-                ${when(x => x.filteredOptions.length === 0, html<RichTextMentionListbox>`
-                    <span class="no-results-label">
-                        ${x => filterNoResultsLabel.getValueFor(x)}
-                    </span>
-                `)}
+                <div class="scrollable-region">
+                    <slot name="option"
+                        ${slotted({
+                            filter: (n: Node) => n instanceof HTMLElement && Listbox.slottedOptionFilter(n),
+                            flatten: true,
+                            property: 'slottedOptions'
+                        })}
+                    >
+                    </slot>
+                    ${when(x => x.filteredOptions.length === 0, html<RichTextMentionListbox>`
+                        <span class="no-results-label">
+                            ${x => filterNoResultsLabel.getValueFor(x)}
+                        </span>
+                    `)}
+                </div>
             </div>
         </${anchoredRegionTag}>
     </template>

--- a/packages/nimble-components/src/rich-text/mention-listbox/template.ts
+++ b/packages/nimble-components/src/rich-text/mention-listbox/template.ts
@@ -31,7 +31,8 @@ export const template = html<RichTextMentionListbox>`
                 style="--ni-private-listbox-available-viewport-height: ${x => x.availableViewportHeight}px;"
                 ${ref('listbox')}
             >
-                <div class="scrollable-region">
+                <div ${ref('scrollableRegion')}
+                class="scrollable-region">
                     <slot name="option"
                         ${slotted({
                             filter: (n: Node) => n instanceof HTMLElement && Listbox.slottedOptionFilter(n),

--- a/packages/nimble-components/src/rich-text/mention-listbox/tests/mention-listbox.spec.ts
+++ b/packages/nimble-components/src/rich-text/mention-listbox/tests/mention-listbox.spec.ts
@@ -82,11 +82,11 @@ describe('RichTextMentionListbox', () => {
 
         element.selectedIndex = 300;
         await waitForSelectionUpdateAsync();
-        expect(element.listbox.scrollTop).toBeGreaterThan(8000);
+        expect(element.scrollableRegion.scrollTop).toBeGreaterThan(8000);
 
         element.selectedIndex = 0;
         await waitForSelectionUpdateAsync();
-        expect(element.listbox.scrollTop).toBeCloseTo(4);
+        expect(element.scrollableRegion.scrollTop).toBeCloseTo(0);
     });
 
     // Intermittent, see: https://github.com/ni/nimble/issues/2269
@@ -98,7 +98,7 @@ describe('RichTextMentionListbox', () => {
         await showAndWaitForOpen();
         const fullyVisible = await checkFullyInViewport(element.listbox);
 
-        expect(element.listbox.scrollHeight).toBeGreaterThan(
+        expect(element.scrollableRegion.scrollHeight).toBeGreaterThan(
             window.innerHeight
         );
         expect(fullyVisible).toBe(true);

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -843,7 +843,7 @@ describe('Select', () => {
             await waitForUpdatesAsync();
             await waitAnimationFrame(); // necessary because scrolling is queued with requestAnimationFrame
 
-            expect(element.scrollableRegion.scrollTop).toBeCloseTo(4);
+            expect(element.scrollableRegion.scrollTop).toBeCloseTo(0);
 
             await disconnect();
         });


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Brandon noted that the visual design for select, combobox, and mention, specifies a 4px 'mat' around the options, even when the content is scrolling. 

## 👩‍💻 Implementation

<img width="375" alt="Screenshot 2024-08-09 at 3 31 01 PM" src="https://github.com/user-attachments/assets/4db6a06f-3b0a-48be-b58f-637fe5992e5d">

https://github.com/user-attachments/assets/5df5ffa1-be2d-482c-90d2-4578e3f6c978

- Moved `padding: var(--ni-private-listbox-padding);` from the scrollable content, to the fixed listbox container
- Made the `combobox` template more consistent with the `select` template, so the shared styling at the same effect (i.e. moved the `scrollable-region` class into it's own div)

## 🧪 Testing

- Manual Storybook review
- Chromatic

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
