### PR TITLE
Remove unnecessary font size precision

### DIFF
--- a/change/@ni-nimble-tokens-38aa7ecf-8de0-4533-a3db-6a8857b62713.json
+++ b/change/@ni-nimble-tokens-38aa7ecf-8de0-4533-a3db-6a8857b62713.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove unnecessary font precision",
+  "packageName": "@ni/nimble-tokens",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-tokens/source/styledictionary/properties/fonts.json
+++ b/packages/nimble-tokens/source/styledictionary/properties/fonts.json
@@ -296,7 +296,7 @@
         "value": "14"
       },
       "Headline_2": {
-        "value": "29.100000381469727"
+        "value": "29.1"
       },
       "Placeholder": {
         "value": "14"
@@ -311,7 +311,7 @@
         "value": "16"
       },
       "Subtitle_1": {
-        "value": "12.800000190734863"
+        "value": "12.8"
       },
       "Title_3": {
         "value": "25"
@@ -350,7 +350,7 @@
         "value": "14"
       },
       "Grid_Header": {
-        "value": "12.800000190734863"
+        "value": "12.8"
       },
       "GroupLabel_Expander": {
         "value": "14"

--- a/packages/storybook/.storybook/blocks/story-layout.css
+++ b/packages/storybook/.storybook/blocks/story-layout.css
@@ -1,5 +1,3 @@
-@import url('@ni/nimble-tokens/dist/styledictionary/css/variables.css');
-
 .story-layout-container {
     display: grid;
     align-items: center;

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -105,5 +105,5 @@ configureActions({
     depth: 1
 });
 
-// Update the GUID on this line to trigger a turbosnap full rebuild: 9dcbc852-77bd-4b61-afee-f086f31b74f5
+// Update the GUID on this line to trigger a turbosnap full rebuild: 300cddbf-b808-403a-8561-9e41eed8a155
 // See https://www.chromatic.com/docs/turbosnap/#full-rebuilds


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Aligns the font values with Figma:
![image](https://github.com/user-attachments/assets/b2ec25c5-c1cf-4ebf-bd21-df392e5e4fbb)

Only real motivation was I was tired of seeing it in devtools 😅
![image](https://github.com/user-attachments/assets/bcd716dd-405e-4748-a09d-cdcb0b172549)

## 👩‍💻 Implementation

Update font values with excess precision.

## 🧪 Testing

Rely on chromatic

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
