### PR TITLE
Add methods for getting label text to select/combobox page objects

### DIFF
--- a/change/@ni-nimble-components-e1935f27-dcbb-4e83-91ef-373dccf5c865.json
+++ b/change/@ni-nimble-components-e1935f27-dcbb-4e83-91ef-373dccf5c865.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add select/combobox page object methods to get label text",
+  "packageName": "@ni/nimble-components",
+  "email": "20709258+msmithNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/combobox/testing/combobox.pageobject.ts
+++ b/packages/nimble-components/src/combobox/testing/combobox.pageobject.ts
@@ -10,6 +10,7 @@ import {
     waitForEvent,
     waitAnimationFrame
 } from '../../utilities/testing/component';
+import { slotTextContent } from '../../utilities/models/slot-text-content';
 
 /**
  * Page object for the `nimble-combobox` component to provide consistent ways
@@ -37,6 +38,17 @@ export class ComboboxPageObject {
         await this.waitForAnchoredRegionLoaded();
         this.setInputText(text);
         this.pressEnterKey();
+    }
+
+    /**
+     * Gets the label text of the element
+     * @returns The current slotted label text, if any
+     */
+    public getLabelText(): string {
+        const labelSlot = this.comboboxElement.shadowRoot!.querySelector<HTMLSlotElement>(
+            'label > slot'
+        )!;
+        return slotTextContent(labelSlot);
     }
 
     /**

--- a/packages/nimble-components/src/combobox/testing/tests/combobox.pageobject.spec.ts
+++ b/packages/nimble-components/src/combobox/testing/tests/combobox.pageobject.spec.ts
@@ -1,0 +1,49 @@
+import { html } from '@microsoft/fast-element';
+import { fixture, Fixture } from '../../../utilities/tests/fixture';
+import type { Combobox } from '../..';
+import { ComboboxPageObject } from '../combobox.pageobject';
+
+async function setup(): Promise<Fixture<Combobox>> {
+    const viewTemplate = html`
+        <nimble-combobox>
+            <nimble-list-option value="one">One</nimble-list-option>
+            <nimble-list-option value="two">Two</nimble-list-option>
+        </nimble-combobox>
+    `;
+    return fixture<Combobox>(viewTemplate);
+}
+
+async function setupWithLabel(): Promise<Fixture<Combobox>> {
+    const viewTemplate = html`
+        <nimble-combobox>
+            Custom Label Text
+            <nimble-list-option value="one">One</nimble-list-option>
+            <nimble-list-option value="two">Two</nimble-list-option>
+        </nimble-combobox>
+    `;
+    return fixture<Combobox>(viewTemplate);
+}
+
+describe('Combobox Page Object', () => {
+    it('getLabelText() returns empty string if no label provided', async () => {
+        const { element, connect, disconnect } = await setup();
+        const pageObject = new ComboboxPageObject(element);
+
+        await connect();
+
+        expect(pageObject.getLabelText()).toBe('');
+
+        await disconnect();
+    });
+
+    it('getLabelText() returns label text when present', async () => {
+        const { element, connect, disconnect } = await setupWithLabel();
+        const pageObject = new ComboboxPageObject(element);
+
+        await connect();
+
+        expect(pageObject.getLabelText()).toBe('Custom Label Text');
+
+        await disconnect();
+    });
+});

--- a/packages/nimble-components/src/select/testing/select.pageobject.ts
+++ b/packages/nimble-components/src/select/testing/select.pageobject.ts
@@ -104,6 +104,14 @@ export class SelectPageObject {
     }
 
     /**
+     * Gets the label text of the element
+     * @returns The current slotted label text, if any
+     */
+    public getLabelText(): string {
+        return this.selectElement.labelContent;
+    }
+
+    /**
      * Either opens or closes the dropdown depending on its current state
      */
     public clickSelect(): void {

--- a/packages/nimble-components/src/select/testing/tests/select.pageobject.spec.ts
+++ b/packages/nimble-components/src/select/testing/tests/select.pageobject.spec.ts
@@ -1,0 +1,49 @@
+import { html } from '@microsoft/fast-element';
+import { fixture, Fixture } from '../../../utilities/tests/fixture';
+import { SelectPageObject } from '../select.pageobject';
+import type { Select } from '../..';
+
+async function setup(): Promise<Fixture<Select>> {
+    const viewTemplate = html`
+        <nimble-select>
+            <nimble-list-option value="one">One</nimble-list-option>
+            <nimble-list-option value="two">Two</nimble-list-option>
+        </nimble-select>
+    `;
+    return fixture<Select>(viewTemplate);
+}
+
+async function setupWithLabel(): Promise<Fixture<Select>> {
+    const viewTemplate = html`
+        <nimble-select>
+            Custom Label Text
+            <nimble-list-option value="one">One</nimble-list-option>
+            <nimble-list-option value="two">Two</nimble-list-option>
+        </nimble-select>
+    `;
+    return fixture<Select>(viewTemplate);
+}
+
+describe('Select Page Object', () => {
+    it('getLabelText() returns empty string when no label present', async () => {
+        const { element, connect, disconnect } = await setup();
+        const pageObject = new SelectPageObject(element);
+
+        await connect();
+
+        expect(pageObject.getLabelText()).toBe('');
+
+        await disconnect();
+    });
+
+    it('getLabelText() returns label text when provided', async () => {
+        const { element, connect, disconnect } = await setupWithLabel();
+        const pageObject = new SelectPageObject(element);
+
+        await connect();
+
+        expect(pageObject.getLabelText()).toBe('Custom Label Text');
+
+        await disconnect();
+    });
+});


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Followup for #2183 .
Once I started uptaking the built-in label change in SLE, I saw several page objects that will need a Nimble-provided way to get the label text (so the SLE page objects don't need to query inside the Nimble shadow roots).

## 👩‍💻 Implementation

- Add `getLabelText()` to select and combobox page objects

## 🧪 Testing

- Add new test files for these 2 page objects, with 2 tests each for `getLabelText()`.
  - These follow the new guidance in [the discussion in #265](https://github.com/ni/nimble/issues/265#issuecomment-2261191614)

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
