### PR TITLE
Update lighthouse accessibility minScore back to 0.9

### DIFF
--- a/packages/angular-workspace/lighthouserc.js
+++ b/packages/angular-workspace/lighthouserc.js
@@ -17,7 +17,7 @@ module.exports = {
         assert: {
             assertions: {
                 'categories:performance': ['error', { minScore: 0.8 }],
-                'categories:accessibility': ['error', { minScore: 0.8 }]
+                'categories:accessibility': ['error', { minScore: 0.9 }]
             }
         },
         upload: {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #280. Thanks to some recent fixes, the accessibility score for the Angular app is now back above 0.9 (it's 93%). We'd like to prevent regressions by ratcheting the `minScore` back to where it was originally before #1809.

## 👩‍💻 Implementation

`0.8` ➡️ `0.9` in angular example app lighthouse config

## 🧪 Testing

The Lighthouse step passed in the [main / build (push) PR check](https://github.com/ni/nimble/actions/runs/10394512684/job/28784465522?pr=2346) and the [Lighthouse report looks sane](https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1723668148618-11515.report.html).

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
