### PR TITLE
Fix blazor meta package nimble dependencies

### DIFF
--- a/change/@ni-nimble-blazor-50c6b44a-f229-4e0e-a0df-749196f0a031.json
+++ b/change/@ni-nimble-blazor-50c6b44a-f229-4e0e-a0df-749196f0a031.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Align blazor and component releases",
+  "packageName": "@ni/nimble-blazor",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-spright-blazor-50869971-089f-4cd7-aabe-e29a03090ab5.json
+++ b/change/@ni-spright-blazor-50869971-089f-4cd7-aabe-e29a03090ab5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Align blazor and component releases",
+  "packageName": "@ni/spright-blazor",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-spright-components-67c0b6d3-8c37-4cbf-a3cb-3f41ce91bc8f.json
+++ b/change/@ni-spright-components-67c0b6d3-8c37-4cbf-a3cb-3f41ce91bc8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove unused dependencies",
+  "packageName": "@ni/spright-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29473,6 +29473,8 @@
       "version": "17.6.1",
       "license": "MIT",
       "peerDependencies": {
+        "@ni/nimble-components": "^31.2.0",
+        "@ni/nimble-tokens": "^8.0.1",
         "cross-env": "^7.0.3",
         "rimraf": "^6.0.0"
       }
@@ -29500,6 +29502,7 @@
       "version": "1.0.2",
       "license": "MIT",
       "peerDependencies": {
+        "@ni/spright-components": "^3.0.6",
         "cross-env": "^7.0.3",
         "rimraf": "^6.0.0"
       }
@@ -29655,12 +29658,9 @@
       "version": "3.0.6",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-colors": "^5.3.1",
         "@microsoft/fast-element": "^1.12.0",
         "@microsoft/fast-foundation": "^2.49.6",
-        "@microsoft/fast-web-utilities": "^6.0.0",
-        "@ni/nimble-components": "31.2.0",
-        "@ni/nimble-tokens": "^8.0.1",
+        "@ni/nimble-components": "^31.2.0",
         "tslib": "^2.2.0"
       },
       "devDependencies": {

--- a/packages/blazor-workspace/NimbleBlazor/package.json
+++ b/packages/blazor-workspace/NimbleBlazor/package.json
@@ -25,6 +25,8 @@
     "!*"
   ],
   "peerDependencies": {
+    "@ni/nimble-components": "^31.2.0",
+    "@ni/nimble-tokens": "^8.0.1",
     "cross-env": "^7.0.3",
     "rimraf": "^6.0.0"
   }

--- a/packages/blazor-workspace/SprightBlazor/package.json
+++ b/packages/blazor-workspace/SprightBlazor/package.json
@@ -25,6 +25,7 @@
     "!*"
   ],
   "peerDependencies": {
+    "@ni/spright-components": "^3.0.6",
     "cross-env": "^7.0.3",
     "rimraf": "^6.0.0"
   }

--- a/packages/spright-components/package.json
+++ b/packages/spright-components/package.json
@@ -51,12 +51,9 @@
   },
   "homepage": "https://github.com/ni/nimble#readme",
   "dependencies": {
-    "@microsoft/fast-colors": "^5.3.1",
     "@microsoft/fast-element": "^1.12.0",
     "@microsoft/fast-foundation": "^2.49.6",
-    "@microsoft/fast-web-utilities": "^6.0.0",
-    "@ni/nimble-components": "31.2.0",
-    "@ni/nimble-tokens": "^8.0.1",
+    "@ni/nimble-components": "^31.2.0",
     "tslib": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The meta packages used for blazor to participate in beachball publishing lost their dependency relationship to the nimble packages. As a result changes to just the components did not cause the blazor packages to re-release. Only explicit blazor changes were causing new blazor releases.

## 👩‍💻 Implementation

- Re-establish blazor `package.json` dependencies to nimble packages
- Clean-up unused spright-components package dependencies

## 🧪 Testing

Will rely on pipeline release to validate.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
