### PR TITLE
Update waitForDataUpdatesToRender to work with fit-rows-height token

### DIFF
--- a/change/@ni-nimble-angular-b2bb30fd-6c9d-4444-891e-83de07c4d458.json
+++ b/change/@ni-nimble-angular-b2bb30fd-6c9d-4444-891e-83de07c4d458.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update waitForDataUpdatesToRender to work with fit-rows-height token",
+  "packageName": "@ni/nimble-angular",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/angular-workspace/nimble-angular/table/testing/table.pageobject.ts
+++ b/packages/angular-workspace/nimble-angular/table/testing/table.pageobject.ts
@@ -30,6 +30,9 @@ export class TablePageObject<T extends TableRecord> extends NimbleComponentsTabl
         if (this.mostRecentSetDataPromise) {
             await this.mostRecentSetDataPromise;
         }
+        // If the table is styled with the `fit-rows-height` token, wait for the height to be calculated
+        await waitForUpdatesAsync();
+        // Wait for the rows to be rendered
         await waitForUpdatesAsync();
     }
 }

--- a/packages/angular-workspace/nimble-angular/table/testing/table.pageobject.ts
+++ b/packages/angular-workspace/nimble-angular/table/testing/table.pageobject.ts
@@ -30,9 +30,10 @@ export class TablePageObject<T extends TableRecord> extends NimbleComponentsTabl
         if (this.mostRecentSetDataPromise) {
             await this.mostRecentSetDataPromise;
         }
-        // If the table is styled with the `fit-rows-height` token, wait for the height to be calculated
-        await waitForUpdatesAsync();
         // Wait for the rows to be rendered
+        await waitForUpdatesAsync();
+        // Wait for the table height to be updated, if necessary, when
+        // using the fit-rows-height token.
         await waitForUpdatesAsync();
     }
 }

--- a/packages/angular-workspace/nimble-angular/table/testing/tests/table.pageobject.spec.ts
+++ b/packages/angular-workspace/nimble-angular/table/testing/tests/table.pageobject.spec.ts
@@ -4,6 +4,7 @@ import { Subject } from 'rxjs';
 import { waitForUpdatesAsync } from '@ni/nimble-angular';
 import { NimbleTableModule, Table, TableRecord } from '@ni/nimble-angular/table';
 import { NimbleTableColumnTextModule } from '@ni/nimble-angular/table-column/text';
+import { tableFitRowsHeight } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { TablePageObject } from '../table.pageobject';
 
 describe('Table page object', () => {
@@ -22,7 +23,7 @@ describe('Table page object', () => {
             `,
             styles: [`
                 .fit-height {
-                    height: var(--ni-nimble-table-fit-rows-height);
+                    height: var(${tableFitRowsHeight.cssCustomProperty});
                 }
             `]
         })


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

When I went to use the new `ni-nimble-table-fit-rows-height` token in an Angular app, I realized that the existing `waitForDataUpdatesToRender` doesn't wait long enough when the table's height is styled with that token. That's because the new height is calculated, and then the virtualizer needs to update to render the appropriate number of rows based on the height. Therefore, I'm updating `waitForDataUpdatesToRender` on the page object to wait the appropriate amount of time.

## 👩‍💻 Implementation

Add an additional `await waitForUpdatesAsync()` call within the `waitForUpdatesToRender` page object function for the Angular table.

## 🧪 Testing

Created unit test for the page object that passes with the change and fails without it.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
