### PR TITLE
Fix parsing of large exponent values for NimbleNumberField

### DIFF
--- a/change/@ni-nimble-blazor-73e33cf9-b7f6-405e-8bc8-6871a1fd6ac9.json
+++ b/change/@ni-nimble-blazor-73e33cf9-b7f6-405e-8bc8-6871a1fd6ac9.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "Fix parsing of large exponent values for NimbleNumberField",
   "packageName": "@ni/nimble-blazor",
-  "email": "eric.peterson@ni.com",
+  "email": "77290847+epetersoni@users.noreply.github.com",
   "dependentChangeType": "patch"
 }

--- a/change/@ni-nimble-blazor-73e33cf9-b7f6-405e-8bc8-6871a1fd6ac9.json
+++ b/change/@ni-nimble-blazor-73e33cf9-b7f6-405e-8bc8-6871a1fd6ac9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix parsing of large exponent values for NimbleNumberField",
+  "packageName": "@ni/nimble-blazor",
+  "email": "eric.peterson@ni.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/blazor-workspace/NimbleBlazor/Components/NimbleNumberField.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Components/NimbleNumberField.razor.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Microsoft.AspNetCore.Components;
 
 namespace NimbleBlazor;
 
@@ -75,4 +77,30 @@ public partial class NimbleNumberField : NimbleInputBase<double?>
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
+
+    /// <inheritdoc />
+    protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out double? result, [NotNullWhen(false)] out string? validationErrorMessage)
+    {
+        if (TryConvertToDouble(value, out result))
+        {
+            validationErrorMessage = null;
+            return true;
+        }
+        validationErrorMessage = string.Format(CultureInfo.InvariantCulture, $"Could not convert {value} to type {typeof(double)}.");
+        return false;
+    }
+
+    private bool TryConvertToDouble(string? stringValue, out double? value)
+    {
+        if (string.IsNullOrEmpty(stringValue)
+            || !double.TryParse(stringValue, NumberStyles.Float | NumberStyles.Number, CultureInfo.InvariantCulture, out var converted)
+            || double.IsInfinity(converted)
+            || double.IsNaN(converted))
+        {
+            value = default;
+            return false;
+        }
+        value = converted;
+        return true;
+    }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleNumberFieldTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleNumberFieldTests.cs
@@ -10,16 +10,34 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// </summary>
 public class NimbleNumberFieldTests
 {
+    private const string NumberFieldMarkup = "nimble-number-field";
+
     [Fact]
     public void NimbleNumberField_Rendered_HasNumberFieldMarkup()
     {
         var context = new TestContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-number-field";
 
         var textField = context.RenderComponent<NimbleNumberField>();
 
-        Assert.Contains(expectedMarkup, textField.Markup);
+        Assert.Contains(NumberFieldMarkup, textField.Markup);
+    }
+
+    [Theory]
+    [InlineData("42.42")]
+    [InlineData("1E+20")]
+    [InlineData("1E+50")]
+    [InlineData("1E+100")]
+    public void Render_ChangeValue_HasMatchingValue(string value)
+    {
+        var context = new TestContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        var field = context.RenderComponent<NimbleNumberField>();
+
+        field.Find(NumberFieldMarkup).Change(value);
+
+        Assert.NotNull(field.Instance.Value);
+        Assert.Equal(value, field.Instance.Value.ToString());
     }
 
     [Fact]


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #2357 .

## 👩‍💻 Implementation

On `NimbleNumericField`, override `TryParseValueFromString` and ultimately have it use `double.TryParse` with `NumberStyles.Float | NumberStyles.Number`.

## 🧪 Testing

Added a `Theory` that changes the text in a `NimbleNumberField` to various values, and verifies that the string gets parsed into a double whose `ToString` yields the same string.

Verified that the exponent cases fail without the `NimbleNumberField` change and pass with it.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.