### PR TITLE
Remove workaround for drawer close corner case

### DIFF
--- a/change/@ni-nimble-components-357c95fe-f4a8-461d-a073-d662f32da4e7.json
+++ b/change/@ni-nimble-components-357c95fe-f4a8-461d-a073-d662f32da4e7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove workaround for drawer close corner case",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/drawer/index.ts
+++ b/packages/nimble-components/src/drawer/index.ts
@@ -131,16 +131,10 @@ export class Drawer<CloseReason = void> extends FoundationElement {
     }
 
     private triggerAnimation(): void {
-        // Read the offsetHeight of the dialog to trigger a reflow. This guarantees that the browser
-        // has processed the 'animating' class being removed before trying to readd it, even if the previous
-        // animation has just finished. Otherwise, problems can occur. For example, trying to close the
-        // drawer immediately after the opening animation ends does not actually close the drawer.
-        // https://github.com/ni/nimble/issues/1994
-        void this.dialog.offsetHeight;
-
-        this.dialog.classList.add('animating');
         if (this.closing) {
             this.dialog.classList.add('closing');
+        } else {
+            this.dialog.classList.add('opening');
         }
 
         this.dialog.addEventListener(
@@ -154,12 +148,13 @@ export class Drawer<CloseReason = void> extends FoundationElement {
             eventAnimationEnd,
             this.animationEndHandlerFunction
         );
-        this.dialog.classList.remove('animating');
         if (this.closing) {
             this.dialog.classList.remove('closing');
             this.dialog.close();
             this.closing = false;
             this.doResolveShow(this.closeReason);
+        } else {
+            this.dialog.classList.remove('opening');
         }
     }
 }

--- a/packages/nimble-components/src/drawer/styles.ts
+++ b/packages/nimble-components/src/drawer/styles.ts
@@ -54,7 +54,8 @@ export const styles = css`
         background: ${modalBackdropColor};
     }
 
-    dialog.animating::backdrop {
+    dialog.opening::backdrop,
+    dialog.closing::backdrop {
         animation: ni-private-drawer-fade-in-keyframes ${largeDelay} ease-in;
     }
 
@@ -84,7 +85,8 @@ export const styles = css`
         box-shadow: 3px 0px 8px #00000033;
     }
 
-    :host([location='left']) dialog.animating .dialog-contents {
+    :host([location='left']) dialog.opening .dialog-contents,
+    :host([location='left']) dialog.closing .dialog-contents {
         animation: ni-private-drawer-slide-in-left-keyframes ${largeDelay}
             ease-in;
     }
@@ -103,14 +105,17 @@ export const styles = css`
         box-shadow: -3px 0px 8px #00000033;
     }
 
-    :host([location='right']) dialog.animating .dialog-contents {
+    :host([location='right']) dialog.opening .dialog-contents,
+    :host([location='right']) dialog.closing .dialog-contents {
         animation: ni-private-drawer-slide-in-right-keyframes ${largeDelay}
             ease-in;
     }
 
     @media (prefers-reduced-motion) {
-        :host([location='left']) dialog.animating .dialog-contents,
-        :host([location='right']) dialog.animating .dialog-contents {
+        :host([location='left']) dialog.opening .dialog-contents,
+        :host([location='left']) dialog.closing .dialog-contents,
+        :host([location='right']) dialog.opening .dialog-contents,
+        :host([location='right']) dialog.closing .dialog-contents {
             animation: ni-private-drawer-fade-in-keyframes ${largeDelay} ease-in;
         }
     }

--- a/packages/nimble-components/src/drawer/tests/drawer.spec.ts
+++ b/packages/nimble-components/src/drawer/tests/drawer.spec.ts
@@ -34,7 +34,10 @@ describe('Drawer', () => {
         nimbleDrawerElement: Drawer | Drawer<string>
     ): boolean {
         const dialogElement = nativeDialogElement(nimbleDrawerElement);
-        return dialogElement.classList.contains('animating');
+        return (
+            dialogElement.classList.contains('opening')
+            || dialogElement.classList.contains('closing')
+        );
     }
 
     async function completeAnimationAsync(


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #1994 (sort-of)

That issue says we should use the Web Animations API instead of the current issue workaround, but this change takes a different approach.

## 👩‍💻 Implementation

The underlying problem was that opening and immediatlely closing the drawer would have us adding, removing, then immediately re-adding the `animating` class to the `dialog` element. This could result in the browser missing the very brief removal of the class, thereby failing to re-trigger the animation on re-add of the class.

We can just use a separate class for opening and closing instead of `animating` for both opening/closing, plus an extra `closing` class for closing.

## 🧪 Testing

Existing tests should pass.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
