### PR TITLE
Migrate token stories to nimble table

### DIFF
--- a/change/@ni-nimble-components-dd3f7192-cb91-4148-8df4-f6c570599bdb.json
+++ b/change/@ni-nimble-components-dd3f7192-cb91-4148-8df4-f6c570599bdb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "lint",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
+++ b/packages/nimble-components/src/table-column/base/tests/table-column.fixtures.ts
@@ -1,4 +1,4 @@
-/* eslint-disable max-classes-per-file, @typescript-eslint/no-unused-vars */
+/* eslint-disable max-classes-per-file */
 
 import { attr, customElement } from '@microsoft/fast-element';
 import { TableCellView } from '../cell-view';
@@ -10,7 +10,7 @@ import { ColumnValidator } from '../models/column-validator';
 export const tableColumnEmptyCellViewTag = 'nimble-test-table-column-empty-cell-view';
 declare global {
     interface HTMLElementTagNameMap {
-        [tableColumnEmptyCellViewTag]: TableCellView;
+        [tableColumnEmptyCellViewTag]: EmptyTableCellView;
     }
 }
 /**
@@ -121,4 +121,4 @@ TestColumnValidator
         this.columnInternals.validator.validateBar(this.bar);
     }
 }
-/* eslint-enable max-classes-per-file, @typescript-eslint/no-unused-vars */
+/* eslint-enable max-classes-per-file */

--- a/packages/storybook/src/nimble/theme-provider/table-column-design-token.ts
+++ b/packages/storybook/src/nimble/theme-provider/table-column-design-token.ts
@@ -1,5 +1,11 @@
 /* eslint-disable max-classes-per-file */
-import { attr, css, customElement, html, ViewTemplate } from '@microsoft/fast-element';
+import {
+    attr,
+    css,
+    customElement,
+    html,
+    ViewTemplate
+} from '@microsoft/fast-element';
 
 import { TableCellView } from '../../../../nimble-components/src/table-column/base/cell-view';
 import { TableColumn } from '../../../../nimble-components/src/table-column/base';
@@ -67,7 +73,8 @@ const fontTemplate = html<TableColumnDesignTokenCellView>`
     </div>
 `;
 
-const errorTemplate = html<TableColumnDesignTokenCellView>`error ${x => x.tokenName}`;
+const errorTemplate = html<TableColumnDesignTokenCellView>`error
+${x => x.tokenName}`;
 
 /* eslint-disable @typescript-eslint/naming-convention */
 const tokenTemplates: {
@@ -124,7 +131,10 @@ const tableColumnDesignTokenCellViewTag = 'nimble-table-column-design-token-cell
         }
     `
 })
-class TableColumnDesignTokenCellView extends TableCellView<TableColumnDesignTokenCellRecord, TableColumnDesignTokenColumnConfig> {
+class TableColumnDesignTokenCellView extends TableCellView<
+    TableColumnDesignTokenCellRecord,
+    TableColumnDesignTokenColumnConfig
+    > {
     public updateContentTemplate(): ViewTemplate<TableColumnDesignTokenCellView> {
         const suffix = suffixFromTokenName(this.cellRecord?.value ?? '');
         if (!suffix) {

--- a/packages/storybook/src/nimble/theme-provider/table-column-design-token.ts
+++ b/packages/storybook/src/nimble/theme-provider/table-column-design-token.ts
@@ -1,0 +1,58 @@
+/* eslint-disable max-classes-per-file */
+import { attr, customElement, html } from '@microsoft/fast-element';
+
+import { TableCellView } from '../../../../nimble-components/src/table-column/base/cell-view';
+import { TableColumn } from '../../../../nimble-components/src/table-column/base';
+import { template } from '../../../../nimble-components/src/table-column/base/template';
+import type { TableStringField } from '../../../../nimble-components/src/table/types';
+import type { ColumnInternalsOptions } from '../../../../nimble-components/src/table-column/base/models/column-internals';
+import { ColumnValidator } from '../../../../nimble-components/src/table-column/base/models/column-validator';
+
+type TableColumnDesignTokenCellRecord = TableStringField<'value'>;
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface TableColumnDesignTokenColumnConfig {}
+
+const tableColumnDesignTokenCellViewTag = 'nimble-table-column-design-token-cell-view';
+/**
+ * Design Token Cell View
+ */
+@customElement({
+    name: tableColumnDesignTokenCellViewTag,
+})
+class TableColumnDesignTokenCellView extends TableCellView<TableColumnDesignTokenCellRecord, TableColumnDesignTokenColumnConfig> {}
+declare global {
+    interface HTMLElementTagNameMap {
+        [tableColumnDesignTokenCellViewTag]: TableColumnDesignTokenCellView;
+    }
+}
+
+export const tableColumnDesignTokenTag = 'nimble-table-column-design-token';
+/**
+ * Simple empty table column for testing
+ */
+@customElement({
+    name: tableColumnDesignTokenTag,
+    template
+})
+class TableColumnDesignToken extends TableColumn {
+    @attr({ attribute: 'field-name' })
+    public fieldName?: string;
+
+    protected override getColumnInternalsOptions(): ColumnInternalsOptions {
+        return {
+            cellRecordFieldNames: ['value'],
+            cellViewTag: tableColumnDesignTokenCellViewTag,
+            delegatedEvents: [],
+            validator: new ColumnValidator<[]>([])
+        };
+    }
+
+    protected fieldNameChanged(): void {
+        this.columnInternals.dataRecordFieldNames = [this.fieldName];
+    }
+}
+declare global {
+    interface HTMLElementTagNameMap {
+        [tableColumnDesignTokenTag]: TableColumnDesignToken;
+    }
+}

--- a/packages/storybook/src/nimble/theme-provider/table-column-design-token.ts
+++ b/packages/storybook/src/nimble/theme-provider/table-column-design-token.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-classes-per-file */
-import { attr, customElement, html } from '@microsoft/fast-element';
+import { attr, css, customElement, html, ViewTemplate } from '@microsoft/fast-element';
 
 import { TableCellView } from '../../../../nimble-components/src/table-column/base/cell-view';
 import { TableColumn } from '../../../../nimble-components/src/table-column/base';
@@ -7,6 +7,92 @@ import { template } from '../../../../nimble-components/src/table-column/base/te
 import type { TableStringField } from '../../../../nimble-components/src/table/types';
 import type { ColumnInternalsOptions } from '../../../../nimble-components/src/table-column/base/models/column-internals';
 import { ColumnValidator } from '../../../../nimble-components/src/table-column/base/models/column-validator';
+import { tooltipTag } from '../../../../nimble-components/src/tooltip';
+import { display } from '../../../../nimble-components/src/utilities/style/display';
+import {
+    tokenNames as tokens,
+    suffixFromTokenName,
+    cssPropertyFromTokenName,
+    TokenSuffix
+} from '../../../../nimble-components/src/theme-provider/design-token-names';
+
+type TokenName = keyof typeof tokens;
+
+const computedCSSValueFromTokenName = (tokenName: string): string => {
+    return getComputedStyle(document.documentElement).getPropertyValue(
+        cssPropertyFromTokenName(tokenName)
+    );
+};
+
+const colorTemplate = html<TableColumnDesignTokenCellView>`
+    <div
+        title="${x => computedCSSValueFromTokenName(tokens[x.tokenName])}"
+        style="
+        display: inline-block;
+        height: 24px;
+        width: 24px;
+        border: 1px solid black;
+        background-color: var(${x => cssPropertyFromTokenName(tokens[x.tokenName])});
+    "
+    ></div>
+`;
+
+const rgbColorTemplate = html<TableColumnDesignTokenCellView>`
+    <div
+        title="${x => computedCSSValueFromTokenName(tokens[x.tokenName])}"
+        style="
+        display: inline-block;
+        height: 24px;
+        width: 24px;
+        border: 1px solid black;
+        background-color: rgba(var(${x => cssPropertyFromTokenName(tokens[x.tokenName])}), 1.0);
+    "
+    ></div>
+`;
+
+const stringValueTemplate = html<TableColumnDesignTokenCellView>`
+    <div style="display: inline-block;">
+        ${x => computedCSSValueFromTokenName(tokens[x.tokenName])}
+    </div>
+`;
+
+const fontTemplate = html<TableColumnDesignTokenCellView>`
+    <div
+        style="
+        display: inline-block;
+        font: var(${x => cssPropertyFromTokenName(tokens[x.tokenName])});
+    "
+    >
+        Nimble
+    </div>
+`;
+
+const errorTemplate = html<TableColumnDesignTokenCellView>`error ${x => x.tokenName}`;
+
+/* eslint-disable @typescript-eslint/naming-convention */
+const tokenTemplates: {
+    readonly [key in TokenSuffix]: ViewTemplate<TableColumnDesignTokenCellView>;
+} = {
+    Color: colorTemplate,
+    RgbPartialColor: rgbColorTemplate,
+    DisabledFontColor: colorTemplate,
+    FontColor: colorTemplate,
+    FontLineHeight: stringValueTemplate,
+    FontWeight: stringValueTemplate,
+    FontSize: stringValueTemplate,
+    TextTransform: stringValueTemplate,
+    FontFamily: stringValueTemplate,
+    BoxShadow: stringValueTemplate,
+    MaxHeight: stringValueTemplate,
+    MinWidth: stringValueTemplate,
+    Font: fontTemplate,
+    Size: stringValueTemplate,
+    Width: stringValueTemplate,
+    Height: stringValueTemplate,
+    Delay: stringValueTemplate,
+    Padding: stringValueTemplate
+};
+/* eslint-enable @typescript-eslint/naming-convention */
 
 type TableColumnDesignTokenCellRecord = TableStringField<'value'>;
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -18,8 +104,39 @@ const tableColumnDesignTokenCellViewTag = 'nimble-table-column-design-token-cell
  */
 @customElement({
     name: tableColumnDesignTokenCellViewTag,
+    template: html<TableColumnDesignTokenCellView>`
+        <span
+            id="content"
+            style="align-self:normal;"
+        >
+            ${x => x.updateContentTemplate()}
+        </span>
+        <${tooltipTag}
+            anchor="content"
+        >
+            ${x => x.cellRecord?.value}
+        </${tooltipTag}>
+    `,
+    styles: css`
+        ${display('flex')}
+        :host {
+            align-items: center;
+        }
+    `
 })
-class TableColumnDesignTokenCellView extends TableCellView<TableColumnDesignTokenCellRecord, TableColumnDesignTokenColumnConfig> {}
+class TableColumnDesignTokenCellView extends TableCellView<TableColumnDesignTokenCellRecord, TableColumnDesignTokenColumnConfig> {
+    public updateContentTemplate(): ViewTemplate<TableColumnDesignTokenCellView> {
+        const suffix = suffixFromTokenName(this.cellRecord?.value ?? '');
+        if (!suffix) {
+            return errorTemplate;
+        }
+        return tokenTemplates[suffix];
+    }
+
+    public get tokenName(): TokenName {
+        return this.cellRecord!.value as TokenName;
+    }
+}
 declare global {
     interface HTMLElementTagNameMap {
         [tableColumnDesignTokenCellViewTag]: TableColumnDesignTokenCellView;

--- a/packages/storybook/src/nimble/theme-provider/tokens.stories.ts
+++ b/packages/storybook/src/nimble/theme-provider/tokens.stories.ts
@@ -1,128 +1,24 @@
 import type { Meta, StoryObj } from '@storybook/html';
-import { customElement, html, ref, repeat, ViewTemplate, when } from '@microsoft/fast-element';
-import { waitForUpdatesAsync } from '../../../../nimble-components/src/testing/async-helpers';
+import { html, ref } from '@microsoft/fast-element';
 import { PropertyFormat } from '../../../../nimble-components/src/theme-provider/tests/types';
 import {
     tokenNames as tokens,
     cssPropertyFromTokenName,
-    scssPropertyFromTokenName,
-    TokenSuffix,
-    suffixFromTokenName
+    scssPropertyFromTokenName
 } from '../../../../nimble-components/src/theme-provider/design-token-names';
 import { comments } from '../../../../nimble-components/src/theme-provider/design-token-comments';
 
 import {
-    bodyFont,
-    bodyFontColor,
-    groupHeaderFont,
-    groupHeaderFontColor,
-    groupHeaderTextTransform,
     tableFitRowsHeight
 } from '../../../../nimble-components/src/theme-provider/design-tokens';
 import { createUserSelectedThemeStory } from '../../utilities/storybook';
 import { Table, tableTag } from '../../../../nimble-components/src/table';
-import { TableCellView } from '../../../../nimble-components/src/table-column/base/cell-view';
-import { TableGroupHeaderView } from '../../../../nimble-components/src/table-column/base/group-header-view';
-import { TableColumn } from '../../../../nimble-components/src/table-column/base';
-import type { ColumnInternalsOptions } from '../../../../nimble-components/src/table-column/base/models/column-internals';
-import { ColumnValidator } from '../../../../nimble-components/src/table-column/base/models/column-validator';
-import { mappingIconTag } from '../../../../nimble-components/src/mapping/icon';
 import { tableColumnTextTag } from '../../../../nimble-components/src/table-column/text';
-import { IconSeverity } from '../../../../nimble-components/src/icon-base/types';
-import { iconMetadata } from '../../../../nimble-components/src/icon-base/tests/icon-metadata';
 import { tableColumnDesignTokenTag } from './table-column-design-token';
 
 type TokenName = keyof typeof tokens;
 const tokenNames = Object.keys(tokens) as TokenName[];
 tokenNames.sort((a, b) => a.localeCompare(b));
-const graphTokenNames = tokenNames.filter(x => x.startsWith('graph'));
-const calendarTokenNames = tokenNames.filter(x => x.startsWith('calendar'));
-
-
-const computedCSSValueFromTokenName = (tokenName: string): string => {
-    return getComputedStyle(document.documentElement).getPropertyValue(
-        cssPropertyFromTokenName(tokenName)
-    );
-};
-
-const colorTemplate = html<TokenName>`
-    <div
-        title="${x => computedCSSValueFromTokenName(tokens[x])}"
-        style="
-        display: inline-block;
-        height: 24px;
-        width: 24px;
-        border: 1px solid black;
-        background-color: var(${x => cssPropertyFromTokenName(tokens[x])});
-    "
-    ></div>
-`;
-
-const rgbColorTemplate = html<TokenName>`
-    <div
-        title="${x => computedCSSValueFromTokenName(tokens[x])}"
-        style="
-        display: inline-block;
-        height: 24px;
-        width: 24px;
-        border: 1px solid black;
-        background-color: rgba(var(${x => cssPropertyFromTokenName(tokens[x])}), 1.0);
-    "
-    ></div>
-`;
-
-const stringValueTemplate = html<TokenName>`
-    <div style="display: inline-block;">
-        ${x => computedCSSValueFromTokenName(tokens[x])}
-    </div>
-`;
-
-const fontTemplate = html<TokenName>`
-    <div
-        style="
-        display: inline-block;
-        font: var(${x => cssPropertyFromTokenName(tokens[x])});
-    "
-    >
-        Nimble
-    </div>
-`;
-
-/* eslint-disable @typescript-eslint/naming-convention */
-const tokenTemplates: {
-    readonly [key in TokenSuffix]: ViewTemplate<TokenName>;
-} = {
-    Color: colorTemplate,
-    RgbPartialColor: rgbColorTemplate,
-    DisabledFontColor: colorTemplate,
-    FontColor: colorTemplate,
-    FontLineHeight: stringValueTemplate,
-    FontWeight: stringValueTemplate,
-    FontSize: stringValueTemplate,
-    TextTransform: stringValueTemplate,
-    FontFamily: stringValueTemplate,
-    BoxShadow: stringValueTemplate,
-    MaxHeight: stringValueTemplate,
-    MinWidth: stringValueTemplate,
-    Font: fontTemplate,
-    Size: stringValueTemplate,
-    Width: stringValueTemplate,
-    Height: stringValueTemplate,
-    Delay: stringValueTemplate,
-    Padding: stringValueTemplate
-};
-/* eslint-enable @typescript-eslint/naming-convention */
-
-const templateForTokenName = (
-    tokenName: TokenName
-): ViewTemplate<TokenName> => {
-    const suffix = suffixFromTokenName(tokenName);
-    if (suffix === undefined) {
-        throw new Error(`Cannot identify suffix for token: ${tokenName}`);
-    }
-    const template = tokenTemplates[suffix];
-    return template;
-};
 
 const tokenData = tokenNames.map(tokenName => ({
     id: tokenName,

--- a/packages/storybook/src/nimble/theme-provider/tokens.stories.ts
+++ b/packages/storybook/src/nimble/theme-provider/tokens.stories.ts
@@ -8,9 +8,7 @@ import {
 } from '../../../../nimble-components/src/theme-provider/design-token-names';
 import { comments } from '../../../../nimble-components/src/theme-provider/design-token-comments';
 
-import {
-    tableFitRowsHeight
-} from '../../../../nimble-components/src/theme-provider/design-tokens';
+import { tableFitRowsHeight } from '../../../../nimble-components/src/theme-provider/design-tokens';
 import { createUserSelectedThemeStory } from '../../utilities/storybook';
 import { Table, tableTag } from '../../../../nimble-components/src/table';
 import { tableColumnTextTag } from '../../../../nimble-components/src/table-column/text';
@@ -25,13 +23,13 @@ const tokenData = tokenNames.map(tokenName => ({
     name: tokenName,
     description: comments[tokenName],
     cssProperty: cssPropertyFromTokenName(tokens[tokenName]),
-    scssProperty: scssPropertyFromTokenName(tokens[tokenName]),
+    scssProperty: scssPropertyFromTokenName(tokens[tokenName])
 }));
 
 const graphTokenData = tokenData.filter(x => x.name.startsWith('graph'));
 const calendarTokenData = tokenData.filter(x => x.name.startsWith('calendar'));
 
-type TokenData = typeof tokenData[number];
+type TokenData = (typeof tokenData)[number];
 
 interface TokenArgs {
     metaTitle: string;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The end goal was to make it easier to capture evaluated token values for static css users (LabVIEW HTML Diff Reports / Gainsights). The idea was:

- Requiring an SCSS build config is not out of reach for the teams but does not add additional value. They have very manual integration workflows (copy to gainsights web ui?, copy into labview diagram?).
- Intended workflow is:
  - Open the token stories, configure the controls for CSS Tokens and a theme
  - Enable table multiselect to choose your tokens of interest
  - Use the table action menu to download the tokens as a css file
    - Potentially two options, one for current config based computed tokens and one for computed tokens with prefers-color-scheme detection for light and dark mode

## 👩‍💻 Implementation

Remaining work:
- Clean-up templates for custom table column
  - Move styles to separate styles and use classes, etc, for the different template modes
  - Use the tooltip to show a "larger render" version (potentially optional)
  - Clean-up styling for column view, maybe large fonts should render centered
  - Add sizing mixin
- Add the action menu
  - Fix the calculated style target. It is currently document.documentElement so never reports the correct thing
  - Add the download command

## 🧪 Testing

<!---
Detail the testing done to ensure this submission meets requirements. 

Include automated/manual test additions or modifications, testing done on a local build, private CI run results, and additional testing not covered by automatic pull request validation. If any functionality is not covered by automated testing, provide justification.
-->

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
