### PR TITLE
Add note about boolean attr defaults to CONTRIBUTING

### DIFF
--- a/change/@ni-nimble-components-60e0a6d8-a7ba-4156-9132-7296b589ddc3.json
+++ b/change/@ni-nimble-components-60e0a6d8-a7ba-4156-9132-7296b589ddc3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add note about boolean attr defaults to CONTRIBUTING",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/CONTRIBUTING.md
+++ b/packages/nimble-components/CONTRIBUTING.md
@@ -217,6 +217,7 @@ It is common in web development to represent variations of control states using 
 ##### Attribute common value patterns
 
 -   When applicable, the default value for an attribute that is allowed to be unconfigured should be first in the enum object, have a descriptive enum name, such as `default`, `none`, etc, based on the context, and be the enum value `undefined`.
+-   Boolean attributes must always default to `false`. Otherwise, the configuration in HTML becomes meaningless, as both `<element></element>` and `<element bool-attr></element>` result in `bool-attr` being set to `true`.
 -   States representing the following ideas should use those names: `success`, `error`, `warning`, `information`.
 
     Avoid shorthands, i.e. `warn`, `info` and avoid alternatives, i.e. `pass`, `fail`, `invalid`.


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

See [this PR thread](https://github.com/ni/nimble/pull/2361#discussion_r1739943606).

## 👩‍💻 Implementation

Added bullet point under "Attribute common value patterns".

## 🧪 Testing

N/A

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
