### PR TITLE
Add missing label values for Angular and Blazor

### DIFF
--- a/change/@ni-nimble-angular-a3a80e57-4706-4f26-a972-f75bb74839b0.json
+++ b/change/@ni-nimble-angular-a3a80e57-4706-4f26-a972-f75bb74839b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add missing string to core label provider",
+  "packageName": "@ni/nimble-angular",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-blazor-77c0e32a-3428-4b68-b738-579b28432867.json
+++ b/change/@ni-nimble-blazor-77c0e32a-3428-4b68-b738-579b28432867.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add missing string to core label provider",
+  "packageName": "@ni/nimble-blazor",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/angular-workspace/nimble-angular/label-provider/core/nimble-label-provider-core-with-defaults.directive.ts
+++ b/packages/angular-workspace/nimble-angular/label-provider/core/nimble-label-provider-core-with-defaults.directive.ts
@@ -20,5 +20,6 @@ export class NimbleLabelProviderCoreWithDefaultsDirective {
         this.elementRef.nativeElement.popupIconInformation = $localize`:Nimble popup icon - information|:Information`;
         this.elementRef.nativeElement.filterSearch = $localize`:Nimble select - search items|:Search`;
         this.elementRef.nativeElement.filterNoResults = $localize`:Nimble select - no items|:No items found`;
+        this.elementRef.nativeElement.loading = $localize`:Nimble loading - loading|:Loading…`;
     }
 }

--- a/packages/angular-workspace/nimble-angular/label-provider/core/nimble-label-provider-core.directive.ts
+++ b/packages/angular-workspace/nimble-angular/label-provider/core/nimble-label-provider-core.directive.ts
@@ -77,4 +77,12 @@ export class NimbleLabelProviderCoreDirective {
     @Input('filter-no-results') public set filterNoResults(value: string | undefined) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'filterNoResults', value);
     }
+
+    public get loading(): string | undefined {
+        return this.elementRef.nativeElement.loading;
+    }
+
+    @Input('loading') public set loading(value: string | undefined) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'loading', value);
+    }
 }

--- a/packages/angular-workspace/nimble-angular/label-provider/core/tests/nimble-label-provider-core-with-defaults.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/label-provider/core/tests/nimble-label-provider-core-with-defaults.directive.spec.ts
@@ -35,7 +35,8 @@ describe('Nimble LabelProviderCore withDefaults directive', () => {
             [computeMsgId('Warning', 'Nimble popup icon - warning')]: 'Translated warning',
             [computeMsgId('Information', 'Nimble popup icon - information')]: 'Translated information',
             [computeMsgId('Search', 'Nimble select - search items')]: 'Translated search',
-            [computeMsgId('No items found', 'Nimble select - no items')]: 'Translated no items found'
+            [computeMsgId('No items found', 'Nimble select - no items')]: 'Translated no items found',
+            [computeMsgId('Loading…', 'Nimble loading - loading')]: 'Translated loading'
         });
         const fixture = TestBed.createComponent(TestHostComponent);
         const testHostComponent = fixture.componentInstance;
@@ -52,5 +53,6 @@ describe('Nimble LabelProviderCore withDefaults directive', () => {
         expect(labelProvider.popupIconInformation).toBe('Translated information');
         expect(labelProvider.filterSearch).toBe('Translated search');
         expect(labelProvider.filterNoResults).toBe('Translated no items found');
+        expect(labelProvider.loading).toBe('Translated loading');
     });
 });

--- a/packages/blazor-workspace/NimbleBlazor/Components/NimbleLabelProviderCore.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Components/NimbleLabelProviderCore.razor
@@ -8,5 +8,6 @@
     popup-icon-information="@PopupIconInformation"
     filter-search="@FilterSearch"
     filter-no-results="@FilterNoResults"
+    loading="@Loading"
     @attributes="AdditionalAttributes">
 </nimble-label-provider-core>

--- a/packages/blazor-workspace/NimbleBlazor/Components/NimbleLabelProviderCore.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Components/NimbleLabelProviderCore.razor.cs
@@ -31,6 +31,9 @@ public partial class NimbleLabelProviderCore : ComponentBase
     [Parameter]
     public string? FilterNoResults { get; set; }
 
+    [Parameter]
+    public string? Loading { get; set; }
+
     /// <summary>
     /// Gets or sets a collection of additional attributes that will be applied to the created element.
     /// </summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleLabelProviderCoreTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleLabelProviderCoreTests.cs
@@ -38,6 +38,7 @@ public class NimbleLabelProviderCoreTests
     [InlineData(nameof(NimbleLabelProviderCore.PopupIconInformation))]
     [InlineData(nameof(NimbleLabelProviderCore.FilterSearch))]
     [InlineData(nameof(NimbleLabelProviderCore.FilterNoResults))]
+    [InlineData(nameof(NimbleLabelProviderCore.Loading))]
     public void NimbleLabelProviderCore_LabelIsSet(string propertyName)
     {
         var labelValue = propertyName + "UpdatedValue";


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

#1747 has a task to validate that label provider strings are synced across all frameworks. There was a new "Loading..." string that was missing for Angular and Blazor.

## 👩‍💻 Implementation

Scanned all the label provider code and tests across all frameworks and ensured parity.

## 🧪 Testing

PR build

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
