### PR TITLE
Update select pageobject

### DIFF
--- a/change/@ni-nimble-components-ad496afe-7270-451c-a2bd-d4c7fb338c30.json
+++ b/change/@ni-nimble-components-ad496afe-7270-451c-a2bd-d4c7fb338c30.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add processUpdates call to select page object function clicking the clear button",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/select/testing/select.pageobject.ts
+++ b/packages/nimble-components/src/select/testing/select.pageobject.ts
@@ -8,7 +8,10 @@ import {
 } from '@microsoft/fast-web-utilities';
 import type { Select } from '..';
 import type { ListOption } from '../../list-option';
-import { processUpdates, waitForUpdatesAsync } from '../../testing/async-helpers';
+import {
+    processUpdates,
+    waitForUpdatesAsync
+} from '../../testing/async-helpers';
 import { FilterMode } from '../types';
 import type { Button } from '../../button';
 import type { ListOptionGroup } from '../../list-option-group';

--- a/packages/nimble-components/src/select/testing/select.pageobject.ts
+++ b/packages/nimble-components/src/select/testing/select.pageobject.ts
@@ -8,7 +8,7 @@ import {
 } from '@microsoft/fast-web-utilities';
 import type { Select } from '..';
 import type { ListOption } from '../../list-option';
-import { waitForUpdatesAsync } from '../../testing/async-helpers';
+import { processUpdates, waitForUpdatesAsync } from '../../testing/async-helpers';
 import { FilterMode } from '../types';
 import type { Button } from '../../button';
 import type { ListOptionGroup } from '../../list-option-group';
@@ -199,6 +199,7 @@ export class SelectPageObject {
 
         const clearButton = this.getClearButton();
         clearButton?.click();
+        processUpdates();
     }
 
     public async clickAway(): Promise<void> {

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -1614,7 +1614,6 @@ describe('Select', () => {
 
         it('clear button is visible after selecting an option', async () => {
             pageObject.clickClearButton();
-            await waitForUpdatesAsync();
             expect(pageObject.isClearButtonVisible()).toBeFalse();
             await clickAndWaitForOpen(element);
             pageObject.clickOptionWithDisplayText('Two');
@@ -1623,9 +1622,8 @@ describe('Select', () => {
             expect(pageObject.isClearButtonVisible()).toBeTrue();
         });
 
-        it('clicking clear button does not open dropdown', async () => {
+        it('clicking clear button does not open dropdown', () => {
             pageObject.clickClearButton();
-            await waitForUpdatesAsync();
             expect(element.open).toBeFalse();
         });
 
@@ -1660,9 +1658,8 @@ describe('Select', () => {
         });
 
         describe('without placeholder', () => {
-            it('after clicking clear button, display text is empty and clear button is hidden', async () => {
+            it('after clicking clear button, display text is empty and clear button is hidden', () => {
                 pageObject.clickClearButton();
-                await waitForUpdatesAsync();
 
                 expect(pageObject.getDisplayText()).toBe('');
                 expect(pageObject.isClearButtonVisible()).toBeFalse();
@@ -1694,7 +1691,6 @@ describe('Select', () => {
                 pageObject.clickOptionWithDisplayText('Two');
                 await waitForUpdatesAsync();
                 pageObject.clickClearButton();
-                await waitForUpdatesAsync();
 
                 expect(pageObject.getDisplayText()).toBe('One');
             });
@@ -1719,7 +1715,6 @@ describe('Select', () => {
                     await waitForUpdatesAsync();
                     expect(pageObject.isClearButtonVisible()).toBeTrue();
                     pageObject.clickClearButton();
-                    await waitForUpdatesAsync();
 
                     expect(pageObject.getDisplayText()).toBe('');
                 });


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Most tests that call `clickClearButton` on the select page object have to call `processUpdates`. Therefore, it makes sense for the page object function to include the call to `processUpdates`.

## 👩‍💻 Implementation

- Call `processUpdates` at the end of `clickClearButton`
- Update callers within the select tests

## 🧪 Testing

Verified tests still pass

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
