### PR TITLE
Fix two sources of references to detached rows

### DIFF
--- a/change/@ni-nimble-components-b9a584ff-3c6d-46d3-afde-b9af6c45ec0e.json
+++ b/change/@ni-nimble-components-b9a584ff-3c6d-46d3-afde-b9af6c45ec0e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix two sources of references to detached rows",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/components/row/index.ts
+++ b/packages/nimble-components/src/table/components/row/index.ts
@@ -170,6 +170,11 @@ export class TableRow<
         return null;
     }
 
+    public override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this.removeColumnObservers();
+    }
+
     /** @internal */
     public onSelectionCheckboxChange(event: CustomEvent): void {
         if (this.ignoreSelectionChangeEvents) {

--- a/packages/nimble-components/src/table/models/keyboard-navigation-manager.ts
+++ b/packages/nimble-components/src/table/models/keyboard-navigation-manager.ts
@@ -171,6 +171,7 @@ implements Subscriber {
             for (const visibleRow of this.table.rowElements) {
                 const rowNotifier = Observable.getNotifier(visibleRow);
                 rowNotifier.subscribe(this, 'resolvedRowIndex');
+                this.visibleRowNotifiers.push(rowNotifier);
                 if (visibleRow.resolvedRowIndex === this.rowIndex) {
                     focusRowAndCell = true;
                 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

While investigating a [memory leak issue](https://ni.visualstudio.com/DevCentral/_workitems/edit/2843309) reported in AzDO, we found a couple places in the Nimble table code that wasn't cleaning up observers/notifiers, causing us to hold references to disconnected row elements.

There is also a FAST bug that contributes to the leak (which is [getting fixed](https://github.com/microsoft/fast/pull/7023)), so the leak will still not be fixed until this PR and the FAST one are both in.

## 👩‍💻 Implementation

1. Rows observe columns, which results in there being a reference chain from each column to each row. When the row is detached, we must remove the column observers.
2. The keyboard navigation manager has logic for storing the row notifiers it creates, so that it can clean them up at the appropriate time. However, by a simple oversight, we were never actually adding the notifiers to the array.

## 🧪 Testing

Verified (in Chrome dev tools) that after these changes, detached rows are no longer referenced via the columns or keyboard navigation manager.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
