### PR TITLE
Update styling for number field when readonly

### DIFF
--- a/change/@ni-nimble-components-b4fd2d0d-e7c3-4b9a-837a-3c423f1681c0.json
+++ b/change/@ni-nimble-components-b4fd2d0d-e7c3-4b9a-837a-3c423f1681c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add styling for readonly number field",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/number-field/styles.ts
+++ b/packages/nimble-components/src/number-field/styles.ts
@@ -66,6 +66,7 @@ export const styles = css`
         border-bottom-color: ${borderHoverColor};
     }
 
+    :host([readonly]) .root,
     :host([disabled]) .root {
         border-color: rgba(${borderRgbPartialColor}, 0.1);
     }
@@ -107,6 +108,7 @@ export const styles = css`
         width: 100%;
     }
 
+    :host([readonly]:hover) .root::after,
     :host([disabled]:hover) .root::after {
         width: 0px;
     }
@@ -195,11 +197,20 @@ export const styles = css`
             }
 
             :host(:hover) .root {
+                border-bottom-width: ${borderWidth};
                 padding-bottom: 0;
             }
 
+            :host([readonly]) .root,
             :host([disabled]) .root {
                 background-color: rgba(${borderRgbPartialColor}, 0.07);
+                border-color: transparent;
+            }
+
+            :host([error-visible][readonly]) .root,
+            :host([error-visible][disabled]) .root {
+                padding-bottom: 0;
+                border-bottom-color: ${failColor};
             }
         `
     ),

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -17,7 +17,9 @@ import {
     ErrorState,
     disabledStateIsEnabled,
     errorStatesNoError,
-    errorStatesErrorWithMessage
+    errorStatesErrorWithMessage,
+    ReadOnlyState,
+    readOnlyStates,
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -53,6 +55,7 @@ const metadata: Meta = {
 export default metadata;
 
 const component = (
+    [readOnlyName, readonly]: ReadOnlyState,
     [disabledName, disabled]: DisabledState,
     [hideStepName, hideStep]: HideStepState,
     [valueName, valueValue, placeholderValue]: ValueState,
@@ -65,17 +68,19 @@ const component = (
         placeholder="${() => placeholderValue}"
         appearance="${() => appearance}"
         ?hide-step="${() => hideStep}"
+        ?readonly="${() => readonly}"
         ?disabled="${() => disabled}"
         error-text="${() => errorText}"
         ?error-visible="${() => errorVisible}"
     >
         ${() => errorName} ${() => appearanceName} ${() => valueName}
-        ${() => hideStepName} ${() => disabledName}
+        ${() => hideStepName} ${() => disabledName} ${() => readOnlyName}
     </${numberFieldTag}>
 `;
 
 export const numberFieldThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
+        readOnlyStates,
         disabledStates,
         hideStepStates,
         valueStates,
@@ -85,6 +90,7 @@ export const numberFieldThemeMatrix: StoryFn = createMatrixThemeStory(
 );
 
 const interactionStatesHover = cartesianProduct([
+    readOnlyStates,
     disabledStates,
     [hideStepStateStepVisible],
     [valueStatesHasValue],
@@ -93,6 +99,7 @@ const interactionStatesHover = cartesianProduct([
 ] as const);
 
 const interactionStates = cartesianProduct([
+    readOnlyStates,
     [disabledStateIsEnabled],
     [hideStepStateStepVisible],
     [valueStatesHasValue],

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -19,7 +19,7 @@ import {
     errorStatesNoError,
     errorStatesErrorWithMessage,
     ReadOnlyState,
-    readOnlyStates,
+    readOnlyStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';

--- a/packages/storybook/src/nimble/number-field/number-field.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field.stories.ts
@@ -17,6 +17,7 @@ import {
     appearanceDescription,
     createUserSelectedThemeStory,
     disabledDescription,
+    readonlyDescription,
     errorTextDescription,
     errorVisibleDescription,
     slottedLabelDescription
@@ -30,6 +31,7 @@ interface NumberFieldArgs extends LabelUserArgs {
     min: number;
     max: number;
     appearance: NumberFieldAppearance;
+    readonly: boolean;
     disabled: boolean;
     errorVisible: boolean;
     errorText: string;
@@ -54,6 +56,7 @@ const metadata: Meta<NumberFieldArgs> = {
             min="${x => x.min}"
             max="${x => x.max}"
             appearance="${x => x.appearance}"
+            ?readonly="${x => x.readonly}"
             ?disabled="${x => x.disabled}"
             ?error-visible="${x => x.errorVisible}"
             error-text="${x => x.errorText}"
@@ -78,6 +81,10 @@ const metadata: Meta<NumberFieldArgs> = {
             description: appearanceDescription({
                 componentName: 'number field'
             }),
+            table: { category: apiCategory.attributes }
+        },
+        readonly: {
+            description: readonlyDescription({ componentName: 'number field' }),
             table: { category: apiCategory.attributes }
         },
         disabled: {
@@ -134,6 +141,7 @@ const metadata: Meta<NumberFieldArgs> = {
         min: -10,
         max: 50,
         appearance: NumberFieldAppearance.underline,
+        readonly: false,
         disabled: false,
         errorVisible: false,
         errorText: 'Value is invalid'

--- a/packages/storybook/src/nimble/text-field/text-field.stories.ts
+++ b/packages/storybook/src/nimble/text-field/text-field.stories.ts
@@ -14,6 +14,7 @@ import {
     appearanceDescription,
     createUserSelectedThemeStory,
     disabledDescription,
+    readonlyDescription,
     errorTextDescription,
     errorVisibleDescription,
     placeholderDescription,
@@ -123,8 +124,7 @@ const metadata: Meta<TextFieldArgs> = {
             table: { category: apiCategory.attributes }
         },
         readonly: {
-            description:
-                'Disallows input on the text field while maintaining enabled appearance.',
+            description: readonlyDescription({ componentName: 'text field' }),
             table: { category: apiCategory.attributes }
         },
         disabled: {

--- a/packages/storybook/src/utilities/storybook.ts
+++ b/packages/storybook/src/utilities/storybook.ts
@@ -181,6 +181,9 @@ export const iconDescription = 'Set `slot="start"` to include an icon before the
 export const disabledDescription = (options: {
     componentName: string
 }): string => `Styles the ${options.componentName} as disabled and prevents focus and user interaction.`;
+export const readonlyDescription = (options: {
+    componentName: string
+}): string => `Disallows input on the ${options.componentName} while maintaining enabled appearance.`;
 export const slottedLabelDescription = (options: {
     componentName: string
 }): string => `Label text to display adjacent to the ${options.componentName} describing its purpose to the user.`;

--- a/packages/storybook/src/utilities/storybook.ts
+++ b/packages/storybook/src/utilities/storybook.ts
@@ -183,7 +183,7 @@ export const disabledDescription = (options: {
 }): string => `Styles the ${options.componentName} as disabled and prevents focus and user interaction.`;
 export const readonlyDescription = (options: {
     componentName: string
-}): string => `Disallows input on the ${options.componentName} while maintaining enabled appearance.`;
+}): string => `Styles the ${options.componentName} as readonly and prevents the user from changing the value.`;
 export const slottedLabelDescription = (options: {
     componentName: string
 }): string => `Label text to display adjacent to the ${options.componentName} describing its purpose to the user.`;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #2402 by adding styling for the `readonly` number field. Those styles were based heavily on the `readonly` styling for the text-field.

## 👩‍💻 Implementation

- Add styling for the number-field when it is `readonly`
- Update storybook page to include `readonly`
- Made shared docs for `readonly`

## 🧪 Testing

- Manually tested combinations of `readonly`, `disabled`, and `error-visible` with the different appearance modes in storybook
- Updated matrix tests, including interactive matrix tests, to include `readonly`
- Verified that `readonly` is exposed in Angular & Blazor APIs even though it was overlooked in storybook, matrix tests, and styling

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
