### PR TITLE
Radio group error

### DIFF
--- a/change/@ni-nimble-components-e5bfd621-8ece-4d9c-a6ea-eb128a70e8ac.json
+++ b/change/@ni-nimble-components-e5bfd621-8ece-4d9c-a6ea-eb128a70e8ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Implement error states on nimble-radio-group",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/radio-group/index.ts
+++ b/packages/nimble-components/src/radio-group/index.ts
@@ -1,10 +1,12 @@
 import {
     RadioGroup as FoundationRadioGroup,
-    radioGroupTemplate as template,
     DesignSystem
 } from '@microsoft/fast-foundation';
 import { Orientation } from '@microsoft/fast-web-utilities';
+import { attr } from '@microsoft/fast-element';
 import { styles } from './styles';
+import { template } from './template';
+import type { ErrorPattern } from '../patterns/error/types';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -17,7 +19,13 @@ export { Orientation };
 /**
  * A nimble-styled grouping element for radio buttons
  */
-export class RadioGroup extends FoundationRadioGroup {}
+export class RadioGroup extends FoundationRadioGroup implements ErrorPattern {
+    @attr({ attribute: 'error-text' })
+    public errorText?: string;
+
+    @attr({ attribute: 'error-visible', mode: 'boolean' })
+    public errorVisible = false;
+}
 
 const nimbleRadioGroup = RadioGroup.compose({
     baseName: 'radio-group',

--- a/packages/nimble-components/src/radio-group/styles.ts
+++ b/packages/nimble-components/src/radio-group/styles.ts
@@ -4,6 +4,7 @@ import {
     controlLabelDisabledFontColor,
     controlLabelFont,
     controlLabelFontColor,
+    controlLabelFontLineHeight,
     smallPadding,
     standardPadding
 } from '../theme-provider/design-tokens';
@@ -29,6 +30,7 @@ export const styles = css`
 
     .label-container {
         display: flex;
+        height: ${controlLabelFontLineHeight};
         gap: ${smallPadding};
         margin-bottom: ${smallPadding};
     }

--- a/packages/nimble-components/src/radio-group/styles.ts
+++ b/packages/nimble-components/src/radio-group/styles.ts
@@ -41,7 +41,7 @@ export const styles = css`
     :host([disabled]) slot[name='label'] {
         color: ${controlLabelDisabledFontColor};
     }
-    
+
     .error-icon {
         margin-left: auto;
         margin-right: ${smallPadding};

--- a/packages/nimble-components/src/radio-group/styles.ts
+++ b/packages/nimble-components/src/radio-group/styles.ts
@@ -4,15 +4,19 @@ import {
     controlLabelDisabledFontColor,
     controlLabelFont,
     controlLabelFontColor,
+    smallPadding,
     standardPadding
 } from '../theme-provider/design-tokens';
+import { styles as errorStyles } from '../patterns/error/styles';
 
 export const styles = css`
     ${display('inline-block')}
+    ${errorStyles}
 
     .positioning-region {
         display: flex;
         gap: ${standardPadding};
+        position: relative;
     }
 
     :host([orientation='vertical']) .positioning-region {
@@ -23,6 +27,12 @@ export const styles = css`
         flex-direction: row;
     }
 
+    .label-container {
+        display: flex;
+        gap: ${smallPadding};
+        margin-bottom: ${smallPadding};
+    }
+
     slot[name='label'] {
         font: ${controlLabelFont};
         color: ${controlLabelFontColor};
@@ -30,5 +40,10 @@ export const styles = css`
 
     :host([disabled]) slot[name='label'] {
         color: ${controlLabelDisabledFontColor};
+    }
+    
+    .error-icon {
+        margin-left: auto;
+        margin-right: ${smallPadding};
     }
 `;

--- a/packages/nimble-components/src/radio-group/template.ts
+++ b/packages/nimble-components/src/radio-group/template.ts
@@ -1,0 +1,42 @@
+import { elements, html, slotted } from '@microsoft/fast-element';
+import type { ViewTemplate } from '@microsoft/fast-element';
+import { Orientation } from '@microsoft/fast-web-utilities';
+import type { FoundationElementTemplate } from '@microsoft/fast-foundation';
+import type { RadioGroup } from '.';
+import { errorTextTemplate } from '../patterns/error/template';
+import { iconExclamationMarkTag } from '../icons/exclamation-mark';
+
+/* eslint-disable @typescript-eslint/indent */
+export const template: FoundationElementTemplate<ViewTemplate<RadioGroup>> = (
+    _context,
+    _definition
+) => html`
+    <template
+        role="radiogroup"
+        aria-disabled="${x => x.disabled}"
+        aria-readonly="${x => x.readOnly}"
+        @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
+        @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
+        @focusout="${(x, c) => x.focusOutHandler(c.event as FocusEvent)}"
+    >
+        <div class="label-container">
+            <slot name="label"></slot>            
+            <${iconExclamationMarkTag}
+                severity="error"
+                class="error-icon"
+            ></${iconExclamationMarkTag}>
+        </div>
+        <div
+            class="positioning-region ${x => (x.orientation === Orientation.horizontal ? 'horizontal' : 'vertical')}"
+            part="positioning-region"
+        >
+            <slot
+                ${slotted({
+                    property: 'slottedRadioButtons',
+                    filter: elements('[role=radio]'),
+                })}
+            ></slot>
+            ${errorTextTemplate}
+        </div>
+    </template>
+`;

--- a/packages/nimble-components/src/radio-group/template.ts
+++ b/packages/nimble-components/src/radio-group/template.ts
@@ -1,16 +1,11 @@
 import { elements, html, slotted } from '@microsoft/fast-element';
-import type { ViewTemplate } from '@microsoft/fast-element';
 import { Orientation } from '@microsoft/fast-web-utilities';
-import type { FoundationElementTemplate } from '@microsoft/fast-foundation';
 import type { RadioGroup } from '.';
 import { errorTextTemplate } from '../patterns/error/template';
 import { iconExclamationMarkTag } from '../icons/exclamation-mark';
 
 /* eslint-disable @typescript-eslint/indent */
-export const template: FoundationElementTemplate<ViewTemplate<RadioGroup>> = (
-    _context,
-    _definition
-) => html`
+export const template = html<RadioGroup>`
     <template
         role="radiogroup"
         aria-disabled="${x => x.disabled}"

--- a/packages/nimble-components/src/radio-group/template.ts
+++ b/packages/nimble-components/src/radio-group/template.ts
@@ -33,7 +33,7 @@ export const template: FoundationElementTemplate<ViewTemplate<RadioGroup>> = (
             <slot
                 ${slotted({
                     property: 'slottedRadioButtons',
-                    filter: elements('[role=radio]'),
+                    filter: elements('[role=radio]')
                 })}
             ></slot>
             ${errorTextTemplate}

--- a/packages/nimble-components/src/radio-group/tests/radio-group.foundation.spec.ts
+++ b/packages/nimble-components/src/radio-group/tests/radio-group.foundation.spec.ts
@@ -1,7 +1,10 @@
 // Based on tests in FAST repo: https://github.com/microsoft/fast/blob/913c27e7e8503de1f7cd50bdbc9388134f52ef5d/packages/web-components/fast-foundation/src/radio-group/radio-group.spec.ts
 
 import { DOM } from '@microsoft/fast-element';
-import { Radio, radioTemplate as itemTemplate } from '@microsoft/fast-foundation';
+import {
+    Radio,
+    radioTemplate as itemTemplate
+} from '@microsoft/fast-foundation';
 import { Orientation } from '@microsoft/fast-web-utilities';
 import { RadioGroup } from '..';
 import { fixture } from '../../utilities/tests/fixture';
@@ -22,8 +25,19 @@ describe('Radio Group', () => {
         template: itemTemplate
     });
 
-    async function setup(): Promise<{ element: RadioGroup, connect: () => Promise<void>, disconnect: () => Promise<void>, parent: HTMLElement, radio1: Radio, radio2: Radio, radio3: Radio }> {
-        const { element, connect, disconnect, parent } = await fixture([FASTRadioGroup(), FASTRadio()]);
+    async function setup(): Promise<{
+        element: RadioGroup,
+        connect: () => Promise<void>,
+        disconnect: () => Promise<void>,
+        parent: HTMLElement,
+        radio1: Radio,
+        radio2: Radio,
+        radio3: Radio
+    }> {
+        const { element, connect, disconnect, parent } = await fixture([
+            FASTRadioGroup(),
+            FASTRadio()
+        ]);
 
         const radio1 = document.createElement(radioTag);
         const radio2 = document.createElement(radioTag);
@@ -131,13 +145,19 @@ describe('Radio Group', () => {
         await connect();
         await DOM.nextUpdate();
 
-        expect((element.querySelector<Radio>('.one')!).disabled).toBeTrue();
-        expect((element.querySelector<Radio>('.two')!).disabled).toBeTrue();
-        expect((element.querySelector<Radio>('.three')!).disabled).toBeTrue();
+        expect(element.querySelector<Radio>('.one')!.disabled).toBeTrue();
+        expect(element.querySelector<Radio>('.two')!.disabled).toBeTrue();
+        expect(element.querySelector<Radio>('.three')!.disabled).toBeTrue();
 
-        expect(element.querySelector('.one')?.getAttribute('aria-disabled')).toBe('true');
-        expect(element.querySelector('.two')?.getAttribute('aria-disabled')).toBe('true');
-        expect(element.querySelector('.three')?.getAttribute('aria-disabled')).toBe('true');
+        expect(
+            element.querySelector('.one')?.getAttribute('aria-disabled')
+        ).toBe('true');
+        expect(
+            element.querySelector('.two')?.getAttribute('aria-disabled')
+        ).toBe('true');
+        expect(
+            element.querySelector('.three')?.getAttribute('aria-disabled')
+        ).toBe('true');
 
         await disconnect();
     });
@@ -177,19 +197,28 @@ describe('Radio Group', () => {
         await connect();
         await DOM.nextUpdate();
 
-        expect((element.querySelector<Radio>('.one')!).readOnly).toBeTrue();
-        expect((element.querySelector<Radio>('.two')!).readOnly).toBeTrue();
-        expect((element.querySelector<Radio>('.three')!).readOnly).toBeTrue();
+        expect(element.querySelector<Radio>('.one')!.readOnly).toBeTrue();
+        expect(element.querySelector<Radio>('.two')!.readOnly).toBeTrue();
+        expect(element.querySelector<Radio>('.three')!.readOnly).toBeTrue();
 
-        expect(element.querySelector('.one')?.getAttribute('aria-readonly')).toBe('true');
-        expect(element.querySelector('.two')?.getAttribute('aria-readonly')).toBe('true');
-        expect(element.querySelector('.three')?.getAttribute('aria-readonly')).toBe('true');
+        expect(
+            element.querySelector('.one')?.getAttribute('aria-readonly')
+        ).toBe('true');
+        expect(
+            element.querySelector('.two')?.getAttribute('aria-readonly')
+        ).toBe('true');
+        expect(
+            element.querySelector('.three')?.getAttribute('aria-readonly')
+        ).toBe('true');
 
         await disconnect();
     });
 
     it('should set tabindex of 0 to a child radio with a matching `value`', async () => {
-        const { element, connect, disconnect } = await fixture([FASTRadioGroup(), FASTRadio()]);
+        const { element, connect, disconnect } = await fixture([
+            FASTRadioGroup(),
+            FASTRadio()
+        ]);
 
         element.value = 'baz';
 
@@ -220,7 +249,10 @@ describe('Radio Group', () => {
     });
 
     it('should NOT set tabindex of 0 to a child radio if its value does not match the radiogroup `value`', async () => {
-        const { element, connect, disconnect } = await fixture([FASTRadioGroup(), FASTRadio()]);
+        const { element, connect, disconnect } = await fixture([
+            FASTRadioGroup(),
+            FASTRadio()
+        ]);
 
         element.value = 'baz';
 
@@ -254,7 +286,10 @@ describe('Radio Group', () => {
     });
 
     it('should set a child radio with a matching `value` to `checked`', async () => {
-        const { element, connect, disconnect } = await fixture([FASTRadioGroup(), FASTRadio()]);
+        const { element, connect, disconnect } = await fixture([
+            FASTRadioGroup(),
+            FASTRadio()
+        ]);
 
         element.value = 'baz';
 
@@ -277,7 +312,7 @@ describe('Radio Group', () => {
         await connect();
         await DOM.nextUpdate();
 
-        expect((element.querySelectorAll(radioTag)[2]!).checked).toBeTrue();
+        expect(element.querySelectorAll(radioTag)[2]!.checked).toBeTrue();
         expect(
             element.querySelectorAll(radioTag)[2]!.getAttribute('aria-checked')
         ).toBe('true');
@@ -286,7 +321,10 @@ describe('Radio Group', () => {
     });
 
     it('should set a child radio with a matching `value` to `checked` when value changes', async () => {
-        const { element, connect, disconnect } = await fixture([FASTRadioGroup(), FASTRadio()]);
+        const { element, connect, disconnect } = await fixture([
+            FASTRadioGroup(),
+            FASTRadio()
+        ]);
 
         element.value = 'baz';
 
@@ -313,7 +351,7 @@ describe('Radio Group', () => {
 
         await DOM.nextUpdate();
 
-        expect((element.querySelectorAll(radioTag)[0]!).checked).toBeTrue();
+        expect(element.querySelectorAll(radioTag)[0]!.checked).toBeTrue();
         expect(
             element.querySelectorAll(radioTag)[0]!.getAttribute('aria-checked')
         ).toBe('true');
@@ -322,7 +360,10 @@ describe('Radio Group', () => {
     });
 
     it('should mark the last radio defaulted to checked as checked, the rest should not be checked', async () => {
-        const { element, connect, disconnect } = await fixture([FASTRadioGroup(), FASTRadio()]);
+        const { element, connect, disconnect } = await fixture([
+            FASTRadioGroup(),
+            FASTRadio()
+        ]);
 
         const radio1 = document.createElement(radioTag);
         const radio2 = document.createElement(radioTag);
@@ -354,7 +395,10 @@ describe('Radio Group', () => {
     });
 
     it('should mark radio matching value on radio-group over any checked attributes', async () => {
-        const { element, connect, disconnect } = await fixture([FASTRadioGroup(), FASTRadio()]);
+        const { element, connect, disconnect } = await fixture([
+            FASTRadioGroup(),
+            FASTRadio()
+        ]);
 
         element.value = 'bar';
 
@@ -385,14 +429,19 @@ describe('Radio Group', () => {
 
         // radio-group explicitly sets non-matching radio's checked to false if a value match was found,
         // but the attribute should still persist.
-        expect((radios[2] as HTMLInputElement).hasAttribute('checked')).toBeTrue();
+        expect(
+            (radios[2] as HTMLInputElement).hasAttribute('checked')
+        ).toBeTrue();
         expect((radios[2] as HTMLInputElement).checked).toBeFalse();
 
         await disconnect();
     });
 
     it('should NOT set a child radio to `checked` if its value does not match the radiogroup `value`', async () => {
-        const { element, connect, disconnect } = await fixture([FASTRadioGroup(), FASTRadio()]);
+        const { element, connect, disconnect } = await fixture([
+            FASTRadioGroup(),
+            FASTRadio()
+        ]);
 
         element.value = 'baz';
 
@@ -415,12 +464,12 @@ describe('Radio Group', () => {
         await connect();
         await DOM.nextUpdate();
 
-        expect((element.querySelectorAll(radioTag)[0]!).checked).toBeFalse();
+        expect(element.querySelectorAll(radioTag)[0]!.checked).toBeFalse();
         expect(
             element.querySelectorAll(radioTag)[0]!.getAttribute('aria-checked')
         ).toBe('false');
 
-        expect((element.querySelectorAll(radioTag)[1]!).checked).toBeFalse();
+        expect(element.querySelectorAll(radioTag)[1]!.checked).toBeFalse();
         expect(
             element.querySelectorAll(radioTag)[1]!.getAttribute('aria-checked')
         ).toBe('false');
@@ -429,15 +478,7 @@ describe('Radio Group', () => {
     });
 
     it('should allow resetting of elements by the parent form', async () => {
-        const {
-            element,
-            connect,
-            disconnect,
-            parent,
-            radio1,
-            radio2,
-            radio3,
-        } = await setup();
+        const { element, connect, disconnect, parent, radio1, radio2, radio3 } = await setup();
 
         radio2.setAttribute('checked', '');
 

--- a/packages/nimble-components/src/radio-group/tests/radio-group.foundation.spec.ts
+++ b/packages/nimble-components/src/radio-group/tests/radio-group.foundation.spec.ts
@@ -1,0 +1,464 @@
+// Based on tests in FAST repo: https://github.com/microsoft/fast/blob/913c27e7e8503de1f7cd50bdbc9388134f52ef5d/packages/web-components/fast-foundation/src/radio-group/radio-group.spec.ts
+
+import { DOM } from '@microsoft/fast-element';
+import { Radio, radioTemplate as itemTemplate } from '@microsoft/fast-foundation';
+import { Orientation } from '@microsoft/fast-web-utilities';
+import { RadioGroup } from '..';
+import { fixture } from '../../utilities/tests/fixture';
+import { template } from '../template';
+import { radioTag } from '../../radio';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const FASTRadioGroup = RadioGroup.compose({
+    baseName: 'radio-group',
+    template
+});
+
+// TODO: Need to add tests for keyboard handling & focus management
+describe('Radio Group', () => {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const FASTRadio = Radio.compose({
+        baseName: 'radio',
+        template: itemTemplate
+    });
+
+    async function setup(): Promise<{ element: RadioGroup, connect: () => Promise<void>, disconnect: () => Promise<void>, parent: HTMLElement, radio1: Radio, radio2: Radio, radio3: Radio }> {
+        const { element, connect, disconnect, parent } = await fixture([FASTRadioGroup(), FASTRadio()]);
+
+        const radio1 = document.createElement(radioTag);
+        const radio2 = document.createElement(radioTag);
+        const radio3 = document.createElement(radioTag);
+
+        radio1.className = 'one';
+        radio2.className = 'two';
+        radio3.className = 'three';
+
+        element.appendChild(radio1);
+        element.appendChild(radio2);
+        element.appendChild(radio3);
+
+        return { element, connect, disconnect, parent, radio1, radio2, radio3 };
+    }
+
+    it('should have a role of `radiogroup`', async () => {
+        const { element, connect, disconnect } = await setup();
+
+        await connect();
+
+        expect(element.getAttribute('role')).toEqual('radiogroup');
+
+        await disconnect();
+    });
+
+    it("should set a `horizontal` class on the 'positioning-region' when an orientation of `horizontal` is provided", async () => {
+        const { element, connect, disconnect } = await setup();
+
+        element.orientation = Orientation.horizontal;
+
+        await connect();
+
+        expect(
+            element.shadowRoot
+                ?.querySelector('.positioning-region')
+                ?.classList.contains('horizontal')
+        ).toBeTrue();
+
+        await disconnect();
+    });
+
+    it("should set a `vertical` class on the 'positioning-region' when an orientation of `vertical` is provided", async () => {
+        const { element, connect, disconnect } = await setup();
+
+        element.orientation = Orientation.vertical;
+
+        await connect();
+
+        expect(
+            element.shadowRoot
+                ?.querySelector('.positioning-region')
+                ?.classList.contains('vertical')
+        ).toBeTrue();
+
+        await disconnect();
+    });
+
+    it("should set a default class on the 'positioning-region' of `horizontal` when no orientation is provided", async () => {
+        const { element, connect, disconnect } = await setup();
+
+        await connect();
+
+        expect(
+            element.shadowRoot
+                ?.querySelector('.positioning-region')
+                ?.classList.contains('horizontal')
+        ).toBeTrue();
+
+        await disconnect();
+    });
+
+    it('should set the `aria-disabled` attribute equal to the `disabled` value', async () => {
+        const { element, connect, disconnect } = await setup();
+
+        element.disabled = true;
+
+        await connect();
+
+        expect(element.getAttribute('aria-disabled')).toBe('true');
+
+        element.disabled = false;
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute('aria-disabled')).toBe('false');
+
+        await disconnect();
+    });
+
+    it('should NOT set a default `aria-disabled` value when `disabled` is not defined', async () => {
+        const { element, connect, disconnect } = await setup();
+
+        await connect();
+
+        expect(element.getAttribute('aria-disabled')).toBe(null);
+
+        await disconnect();
+    });
+
+    it('should set all child radio elements to disabled when the`disabled` is passed', async () => {
+        const { element, connect, disconnect } = await setup();
+        element.disabled = true;
+
+        await connect();
+        await DOM.nextUpdate();
+
+        expect((element.querySelector<Radio>('.one')!).disabled).toBeTrue();
+        expect((element.querySelector<Radio>('.two')!).disabled).toBeTrue();
+        expect((element.querySelector<Radio>('.three')!).disabled).toBeTrue();
+
+        expect(element.querySelector('.one')?.getAttribute('aria-disabled')).toBe('true');
+        expect(element.querySelector('.two')?.getAttribute('aria-disabled')).toBe('true');
+        expect(element.querySelector('.three')?.getAttribute('aria-disabled')).toBe('true');
+
+        await disconnect();
+    });
+
+    it('should set the `aria-readonly` attribute equal to the `readonly` value', async () => {
+        const { element, connect, disconnect } = await fixture(FASTRadioGroup());
+
+        element.readOnly = true;
+
+        await connect();
+
+        expect(element.getAttribute('aria-readonly')).toBe('true');
+
+        element.readOnly = false;
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute('aria-readonly')).toBe('false');
+
+        await disconnect();
+    });
+
+    it('should NOT set a default `aria-readonly` value when `readonly` is not defined', async () => {
+        const { element, connect, disconnect } = await fixture(FASTRadioGroup());
+
+        await connect();
+
+        expect(element.getAttribute('aria-readonly')).toBe(null);
+
+        await disconnect();
+    });
+
+    it('should set all child radio elements to readonly when the`readonly` is passed', async () => {
+        const { element, connect, disconnect } = await setup();
+        element.readOnly = true;
+
+        await connect();
+        await DOM.nextUpdate();
+
+        expect((element.querySelector<Radio>('.one')!).readOnly).toBeTrue();
+        expect((element.querySelector<Radio>('.two')!).readOnly).toBeTrue();
+        expect((element.querySelector<Radio>('.three')!).readOnly).toBeTrue();
+
+        expect(element.querySelector('.one')?.getAttribute('aria-readonly')).toBe('true');
+        expect(element.querySelector('.two')?.getAttribute('aria-readonly')).toBe('true');
+        expect(element.querySelector('.three')?.getAttribute('aria-readonly')).toBe('true');
+
+        await disconnect();
+    });
+
+    it('should set tabindex of 0 to a child radio with a matching `value`', async () => {
+        const { element, connect, disconnect } = await fixture([FASTRadioGroup(), FASTRadio()]);
+
+        element.value = 'baz';
+
+        const radio1 = document.createElement(radioTag);
+        const radio2 = document.createElement(radioTag);
+        const radio3 = document.createElement(radioTag);
+
+        radio1.className = 'one';
+        radio2.className = 'two';
+        radio3.className = 'three';
+
+        radio1.value = 'foo';
+        radio2.value = 'bar';
+        radio3.value = 'baz';
+
+        element.appendChild(radio1);
+        element.appendChild(radio2);
+        element.appendChild(radio3);
+
+        await connect();
+        await DOM.nextUpdate();
+
+        expect(
+            element.querySelectorAll(radioTag)[2]!.getAttribute('tabindex')
+        ).toBe('0');
+
+        await disconnect();
+    });
+
+    it('should NOT set tabindex of 0 to a child radio if its value does not match the radiogroup `value`', async () => {
+        const { element, connect, disconnect } = await fixture([FASTRadioGroup(), FASTRadio()]);
+
+        element.value = 'baz';
+
+        const radio1 = document.createElement(radioTag);
+        const radio2 = document.createElement(radioTag);
+        const radio3 = document.createElement(radioTag);
+
+        radio1.className = 'one';
+        radio2.className = 'two';
+        radio3.className = 'three';
+
+        radio1.value = 'foo';
+        radio2.value = 'bar';
+        radio3.value = 'baz';
+
+        element.appendChild(radio1);
+        element.appendChild(radio2);
+        element.appendChild(radio3);
+
+        await connect();
+        await DOM.nextUpdate();
+
+        expect(
+            element.querySelectorAll(radioTag)[0]!.getAttribute('tabindex')
+        ).toBe('-1');
+        expect(
+            element.querySelectorAll(radioTag)[1]!.getAttribute('tabindex')
+        ).toBe('-1');
+
+        await disconnect();
+    });
+
+    it('should set a child radio with a matching `value` to `checked`', async () => {
+        const { element, connect, disconnect } = await fixture([FASTRadioGroup(), FASTRadio()]);
+
+        element.value = 'baz';
+
+        const radio1 = document.createElement(radioTag);
+        const radio2 = document.createElement(radioTag);
+        const radio3 = document.createElement(radioTag);
+
+        radio1.className = 'one';
+        radio2.className = 'two';
+        radio3.className = 'three';
+
+        radio1.value = 'foo';
+        radio2.value = 'bar';
+        radio3.value = 'baz';
+
+        element.appendChild(radio1);
+        element.appendChild(radio2);
+        element.appendChild(radio3);
+
+        await connect();
+        await DOM.nextUpdate();
+
+        expect((element.querySelectorAll(radioTag)[2]!).checked).toBeTrue();
+        expect(
+            element.querySelectorAll(radioTag)[2]!.getAttribute('aria-checked')
+        ).toBe('true');
+
+        await disconnect();
+    });
+
+    it('should set a child radio with a matching `value` to `checked` when value changes', async () => {
+        const { element, connect, disconnect } = await fixture([FASTRadioGroup(), FASTRadio()]);
+
+        element.value = 'baz';
+
+        const radio1 = document.createElement(radioTag);
+        const radio2 = document.createElement(radioTag);
+        const radio3 = document.createElement(radioTag);
+
+        radio1.className = 'one';
+        radio2.className = 'two';
+        radio3.className = 'three';
+
+        radio1.value = 'foo';
+        radio2.value = 'bar';
+        radio3.value = 'baz';
+
+        element.appendChild(radio1);
+        element.appendChild(radio2);
+        element.appendChild(radio3);
+
+        await connect();
+        await DOM.nextUpdate();
+
+        element.value = 'foo';
+
+        await DOM.nextUpdate();
+
+        expect((element.querySelectorAll(radioTag)[0]!).checked).toBeTrue();
+        expect(
+            element.querySelectorAll(radioTag)[0]!.getAttribute('aria-checked')
+        ).toBe('true');
+
+        await disconnect();
+    });
+
+    it('should mark the last radio defaulted to checked as checked, the rest should not be checked', async () => {
+        const { element, connect, disconnect } = await fixture([FASTRadioGroup(), FASTRadio()]);
+
+        const radio1 = document.createElement(radioTag);
+        const radio2 = document.createElement(radioTag);
+        const radio3 = document.createElement(radioTag);
+
+        radio1.className = 'one';
+        radio2.className = 'two';
+        radio3.className = 'three';
+
+        radio1.value = 'foo';
+        radio2.value = 'bar';
+        radio3.value = 'baz';
+
+        radio2.setAttribute('checked', '');
+        radio3.setAttribute('checked', '');
+
+        element.appendChild(radio1);
+        element.appendChild(radio2);
+        element.appendChild(radio3);
+
+        await connect();
+        await DOM.nextUpdate();
+
+        const radios: NodeList = element.querySelectorAll(radioTag);
+        expect((radios[2] as HTMLInputElement).checked).toBeTrue();
+        expect((radios[1] as HTMLInputElement).checked).toBeFalse();
+
+        await disconnect();
+    });
+
+    it('should mark radio matching value on radio-group over any checked attributes', async () => {
+        const { element, connect, disconnect } = await fixture([FASTRadioGroup(), FASTRadio()]);
+
+        element.value = 'bar';
+
+        const radio1 = document.createElement(radioTag);
+        const radio2 = document.createElement(radioTag);
+        const radio3 = document.createElement(radioTag);
+
+        radio1.className = 'one';
+        radio2.className = 'two';
+        radio3.className = 'three';
+
+        radio1.value = 'foo';
+        radio2.value = 'bar';
+        radio3.value = 'baz';
+
+        radio2.setAttribute('checked', '');
+        radio3.setAttribute('checked', '');
+
+        element.appendChild(radio1);
+        element.appendChild(radio2);
+        element.appendChild(radio3);
+
+        await connect();
+        await DOM.nextUpdate();
+
+        const radios: NodeList = element.querySelectorAll(radioTag);
+        expect((radios[1] as HTMLInputElement).checked).toBeTrue();
+
+        // radio-group explicitly sets non-matching radio's checked to false if a value match was found,
+        // but the attribute should still persist.
+        expect((radios[2] as HTMLInputElement).hasAttribute('checked')).toBeTrue();
+        expect((radios[2] as HTMLInputElement).checked).toBeFalse();
+
+        await disconnect();
+    });
+
+    it('should NOT set a child radio to `checked` if its value does not match the radiogroup `value`', async () => {
+        const { element, connect, disconnect } = await fixture([FASTRadioGroup(), FASTRadio()]);
+
+        element.value = 'baz';
+
+        const radio1 = document.createElement(radioTag);
+        const radio2 = document.createElement(radioTag);
+        const radio3 = document.createElement(radioTag);
+
+        radio1.className = 'one';
+        radio2.className = 'two';
+        radio3.className = 'three';
+
+        radio1.value = 'foo';
+        radio2.value = 'bar';
+        radio3.value = 'baz';
+
+        element.appendChild(radio1);
+        element.appendChild(radio2);
+        element.appendChild(radio3);
+
+        await connect();
+        await DOM.nextUpdate();
+
+        expect((element.querySelectorAll(radioTag)[0]!).checked).toBeFalse();
+        expect(
+            element.querySelectorAll(radioTag)[0]!.getAttribute('aria-checked')
+        ).toBe('false');
+
+        expect((element.querySelectorAll(radioTag)[1]!).checked).toBeFalse();
+        expect(
+            element.querySelectorAll(radioTag)[1]!.getAttribute('aria-checked')
+        ).toBe('false');
+
+        await disconnect();
+    });
+
+    it('should allow resetting of elements by the parent form', async () => {
+        const {
+            element,
+            connect,
+            disconnect,
+            parent,
+            radio1,
+            radio2,
+            radio3,
+        } = await setup();
+
+        radio2.setAttribute('checked', '');
+
+        const form = document.createElement('form');
+        form.appendChild(element);
+        parent.appendChild(form);
+
+        await connect();
+
+        radio1.checked = true;
+
+        expect(!!radio1.checked).toBeTrue();
+        expect(!!radio2.checked).toBeFalse();
+        expect(!!radio3.checked).toBeFalse();
+
+        form.reset();
+
+        expect(!!radio1.checked).toBeFalse();
+        expect(!!radio2.checked).toBeTrue();
+        expect(!!radio3.checked).toBeFalse();
+
+        await disconnect();
+    });
+});

--- a/packages/storybook/src/nimble/radio-group/radio-group-matrix.stories.ts
+++ b/packages/storybook/src/nimble/radio-group/radio-group-matrix.stories.ts
@@ -8,7 +8,12 @@ import {
     sharedMatrixParameters,
     createMatrixThemeStory
 } from '../../utilities/matrix';
-import { disabledStates, DisabledState } from '../../utilities/states';
+import {
+    disabledStates,
+    DisabledState,
+    errorStates,
+    ErrorState
+} from '../../utilities/states';
 import { createStory } from '../../utilities/storybook';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -30,19 +35,22 @@ export default metadata;
 
 const component = (
     [disabledName, disabled]: DisabledState,
-    [orientationName, orientation]: OrientationState
+    [orientationName, orientation]: OrientationState,
+    [errorName, errorVisible, errorText]: ErrorState
 ): ViewTemplate => html`<${radioGroupTag}
     orientation="${() => orientation}"
     ?disabled="${() => disabled}"
+    ?error-visible="${() => errorVisible}"
+    error-text="${() => errorText}"
     value="1"
 >
-    <label slot="label">${orientationName} ${disabledName}</label>
+    <label slot="label">${orientationName} ${disabledName} ${errorName}</label>
     <${radioTag} value="1">Option 1</${radioTag}>
     <${radioTag} value="2">Option 2</${radioTag}>
 </${radioGroupTag}>`;
 
 export const radioGroupThemeMatrix: StoryFn = createMatrixThemeStory(
-    createMatrix(component, [disabledStates, orientationStates])
+    createMatrix(component, [disabledStates, orientationStates, errorStates])
 );
 
 export const hiddenRadioGroup: StoryFn = createStory(

--- a/packages/storybook/src/nimble/radio-group/radio-group-matrix.stories.ts
+++ b/packages/storybook/src/nimble/radio-group/radio-group-matrix.stories.ts
@@ -1,6 +1,7 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
 import { Orientation } from '@microsoft/fast-web-utilities';
+import { standardPadding } from '../../../../nimble-components/src/theme-provider/design-tokens';
 import { radioTag } from '../../../../nimble-components/src/radio';
 import { radioGroupTag } from '../../../../nimble-components/src/radio-group';
 import {
@@ -43,6 +44,7 @@ const component = (
     ?error-visible="${() => errorVisible}"
     error-text="${() => errorText}"
     value="1"
+    style="width: 250px; margin: var(${standardPadding.cssCustomProperty});"
 >
     <label slot="label">${orientationName} ${disabledName} ${errorName}</label>
     <${radioTag} value="1">Option 1</${radioTag}>

--- a/packages/storybook/src/nimble/radio-group/radio-group.stories.ts
+++ b/packages/storybook/src/nimble/radio-group/radio-group.stories.ts
@@ -52,7 +52,7 @@ export const radioGroup: StoryObj<RadioGroupArgs> = {
             orientation="${x => x.orientation}"
             ?disabled="${x => x.disabled}"
             name="${x => x.name}"
-            value="${x => x.value}"
+            value="${x => (x.value === 'none' ? undefined : x.value)}"
             ?error-visible="${x => x.errorVisible}"
             error-text="${x => x.errorText}"
             style="min-width: 200px;"

--- a/packages/storybook/src/nimble/radio-group/radio-group.stories.ts
+++ b/packages/storybook/src/nimble/radio-group/radio-group.stories.ts
@@ -8,6 +8,8 @@ import {
     apiCategory,
     createUserSelectedThemeStory,
     disabledDescription,
+    errorTextDescription,
+    errorVisibleDescription,
     slottedLabelDescription
 } from '../../utilities/storybook';
 
@@ -19,6 +21,8 @@ interface RadioGroupArgs {
     value: string;
     buttons: undefined;
     change: undefined;
+    errorVisible: boolean;
+    errorText: string;
 }
 
 interface RadioArgs {
@@ -49,6 +53,9 @@ export const radioGroup: StoryObj<RadioGroupArgs> = {
             ?disabled="${x => x.disabled}"
             name="${x => x.name}"
             value="${x => x.value}"
+            ?error-visible="${x => x.errorVisible}"
+            error-text="${x => x.errorText}"
+            style="min-width: 200px;"
         >
             <label slot="label">${x => x.label}</label>
             <${radioTag} value="apple">Apple</${radioTag}>
@@ -61,7 +68,9 @@ export const radioGroup: StoryObj<RadioGroupArgs> = {
         orientation: Orientation.horizontal,
         disabled: false,
         name: 'fruit',
-        value: 'none'
+        value: 'none',
+        errorVisible: false,
+        errorText: 'Value is invalid'
     },
     argTypes: {
         value: {
@@ -105,6 +114,16 @@ export const radioGroup: StoryObj<RadioGroupArgs> = {
                 'Event emitted when the user selects a new value in the radio group.',
             table: { category: apiCategory.events },
             control: false
+        },
+        errorText: {
+            name: 'error-text',
+            description: errorTextDescription,
+            table: { category: apiCategory.attributes }
+        },
+        errorVisible: {
+            name: 'error-visible',
+            description: errorVisibleDescription,
+            table: { category: apiCategory.attributes }
         }
     }
 };

--- a/packages/storybook/src/utilities/storybook.ts
+++ b/packages/storybook/src/utilities/storybook.ts
@@ -195,7 +195,7 @@ export const placeholderDescription = (options: {
 }): string => `Placeholder text to display when no value has been entered in the ${options.componentName}.`;
 
 export const errorTextDescription = 'A message to be displayed explaining why the value is invalid. Only visible when `error-visible` is set.';
-export const errorVisibleDescription = 'When set to `true`, the `error-text` message will be displayed.';
+export const errorVisibleDescription = 'When set to `true`, an error indicator will be displayed within the control and the `error-text` message will be displayed.';
 
 export const dropdownPositionDescription = (options: {
     componentName: string


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Includes `nimble-component` implementation for #2019

## 👩‍💻 Implementation

- Adds `error-visible` and `error-text` attributes to the `nimble-radio-group`
- Updates the radio group template to include an error icon and error text
    - Note: This required forking FAST's template
- Updated radio group styling to match visual design

## 🧪 Testing

- Manually tested in storybook
- Forked FAST's radio group tests since the template was forked
- Updated matrix tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
