### PR TITLE
Update HLD with clarification about Angular form validation

### DIFF
--- a/specs/required-inputs/README.md
+++ b/specs/required-inputs/README.md
@@ -85,6 +85,8 @@ We will file a Chromium bug for the issue affecting the `nimble-combobox` and `n
 
 The `required` attribute only plays a role in validation for template-driven forms (with reactive forms, it is only used for accessibility purposes). Nimble inputs already support setting the `required` attribute via template, but we will add it to the directive wrappers for completeness.
 
+Note also that Angular's form validation support [automatically disables the native HTML form validation](https://v17.angular.io/api/forms/NgForm#native-dom-validation-ui) that would otherwise be triggered by setting the `required` attribute. This means that our Angular clients are not exposed to any of the native HTML validation bugs listed earlier in this document.
+
 #### Blazor
 
 Typically, form validation is handled via a `DataAnnotationsValidator`, and an input is treated as required if it is bound to a model property annotated with `RequiredAttribute` (i.e. `[Required]`). The Nimble component's `required` attribute is still needed to turn on the visual affordance, though, so we will add it to the Razor API.

--- a/specs/required-inputs/README.md
+++ b/specs/required-inputs/README.md
@@ -85,7 +85,7 @@ When the user attempts to submit a form and a `required` input is missing a valu
 
 ![Missing value indicator](missing-value.png)
 
-We would expect this to already work, since the FAST components we derive from provide forms support. Unfortunately, this support is broken or incomplete for multiple components:
+Because of FAST's form-associated polyfill implementation we end up leveraging a native form control with validation properties forwarded to it. This results in the unexpected behavior of the native form presentation (ARIA and popups) being presented / conflicting with Nimble's defined presentation. The following are specific issues encountered:
 
 - `nimble-combobox`: 
     - In Chrome/Edge, a missing required value properly blocks form submission and updates the control's `validity` flags, but the visual indicator of the validation error is not shown, and instead an error is printed to the console: "An invalid form control with name='' is not focusable." Presumably, something is trying to focus the host element, though it delegates focus to the shadow DOM. The error comes from a call to [`form.requestSubmit()` in the FAST button code](https://github.com/microsoft/fast/blob/913c27e7e8503de1f7cd50bdbc9388134f52ef5d/packages/web-components/fast-foundation/src/button/button.ts#L221), which we cannot debug into. Things work properly in Firefox.

--- a/specs/required-inputs/README.md
+++ b/specs/required-inputs/README.md
@@ -26,18 +26,14 @@ Any other controls that could possibly be considered inputs are out of scope.
 
 ### API
 
-The [native API](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/required) for marking an input required (which is also the [Angular API](https://v17.angular.io/guide/form-validation#validating-input-in-template-driven-forms)) is:
-
-- `required`: boolean attribute whose presence indicates that a value must be provided to submit
-
-There are behavioral and presentational aspects of making an input participate in validation. In an ideal world, validation-related attributes like `required`, `min`, `max`, etc. would control both behavior and presentation, and frameworks like Angular and Blazor would utilize native form association APIs rather than implementing their own systems. However, given that frameworks like Angular automatically opt out of native form validation ([by setting `novalidate` on the `form` element](https://v17.angular.io/api/forms/NgForm#native-dom-validation-ui)), we don't want our validation presentations (e.g. "required" asterisk, error text/icon, and associated accessibility) coupled to the native validation system. Instead, we introduce a new attribute that controls just the presentation:
+There are behavioral and presentational aspects of making an input participate in validation. In an ideal world, native, validation-related attributes like `required`, `min`, `max`, etc. would control both behavior and presentation, and frameworks like Angular and Blazor would utilize native form association APIs rather than implementing their own systems. However, given that frameworks like Angular automatically opt out of native form validation ([by setting `novalidate` on the `form` element](https://v17.angular.io/api/forms/NgForm#native-dom-validation-ui)), we don't want our validation presentations (e.g. "required" asterisk, error text/icon, and associated accessibility) coupled to the native validation system. Instead, we introduce a new attribute that controls just the presentation:
 
 - `required-visible`: boolean attribute whose presence turns on a visual affordance (red asterisk) and accessible indication (`aria-required="true"`) that an input is required
 
 This approach is consistent with our existing approach to validation error presentation. Rather than using the native validation state (e.g. via the `:invalid` CSS pseudo-selector) to trigger the display of error text or error icon (red exclamation mark), we have the `error-visible` attribute which gives explicit control over the error presentation. Today, `error-visible` does not manage ARIA properly (e.g. setting `aria-invalid` and `aria-errormessage`), which seems to be an oversight.
 
 #### Radio buttons
-`required-visible` will be exposed on radio button groups, but not radio buttons, since the visual only appears on the radio button group label. This is a departure from the the native API, where the `required` attribute is only exposed on radio buttons, but affects the entire radio button group. We are prioritizing an intuitive API over consistency with the native 
+`required-visible` will be exposed on radio button groups, but not radio buttons, since the visual only appears on the radio button group label. This is a departure from the the native API, where the `required` attribute is only exposed on radio buttons, but affects the entire radio button group. We are prioritizing an intuitive API over consistency with the native API.
 
 #### Readonly/disabled required inputs
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Questions were raised at stand-up about whether setting the `required` attribute on native elements would trigger native HTML form validation that could interfere with Angular's own validation experience.

## 👩‍💻 Implementation

Added clarifying note to HLD.

