### PR TITLE
Add nimble contributors badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,5 @@ To report a bug with an existing component, file an issue using the [**🐛 Bug 
 ## Contributing
 
 See `Getting Started` in [`Contributing.md`](/CONTRIBUTING.md#getting-started) to get started with building the monorepo.
+
+[![contributors](https://markupgo.com/github/ni/nimble/contributors?count=0&circleSize=40&circleRadius=40&center=false&width=800)](https://github.com/ni/nimble/graphs/contributors)

--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ To report a bug with an existing component, file an issue using the [**🐛 Bug 
 
 See `Getting Started` in [`Contributing.md`](/CONTRIBUTING.md#getting-started) to get started with building the monorepo.
 
-[![contributors](https://markupgo.com/github/ni/nimble/contributors?count=0&circleSize=40&circleRadius=40&center=false&width=800)](https://github.com/ni/nimble/graphs/contributors)
+[![contributors](https://markupgo.com/github/ni/nimble/contributors?width=800&count=0&circleSpacing=10&removeLogo=true)](https://github.com/ni/nimble/graphs/contributors)


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Add the contributors badge to the top-level README.

## 👩‍💻 Implementation

Add the image with a url pointing to the nimble contributors github page. See docs here: https://markupgo.com/github?username=ni&repo=nimble&width=800&count=0&circleSpacing=10&removeLogo=true&center=false

## 🧪 Testing

Checked README preview in GitHub

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
