### PR TITLE
Add new base token and update theme aware token for calendar event text

### DIFF
--- a/change/@ni-nimble-components-6d6edf22-cd17-4725-903e-5a2a8677fa57.json
+++ b/change/@ni-nimble-components-6d6edf22-cd17-4725-903e-5a2a8677fa57.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update theme aware token for calendar component",
+  "packageName": "@ni/nimble-components",
+  "email": "sandeep.appachiappan@ni.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-tokens-aaa42ec7-0133-48e9-b406-c92dd3c7b0b1.json
+++ b/change/@ni-nimble-tokens-aaa42ec7-0133-48e9-b406-c92dd3c7b0b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add color token for calendar component",
+  "packageName": "@ni/nimble-tokens",
+  "email": "sandeep.appachiappan@ni.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/theme-provider/design-tokens.ts
+++ b/packages/nimble-components/src/theme-provider/design-tokens.ts
@@ -120,7 +120,7 @@ import {
     Black22,
     PowerGreen30,
     DigitalGreenLight30,
-    PowerGreenText
+    PowerGreenDark50
 } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
 import { Theme } from './types';
 import { tokenNames, styleNameFromTokenName } from './design-token-names';
@@ -374,8 +374,8 @@ export const calendarEventStaticFontColor = DesignToken.create<string>(
 ).withDefault((element: HTMLElement) => getColorForTheme(
     element,
     DigitalGreenDark110,
-    PowerGreenText,
-    PowerGreenText
+    PowerGreenDark50,
+    PowerGreenDark50
 ));
 
 export const calendarEventDynamicFontColor = DesignToken.create<string>(

--- a/packages/nimble-components/src/theme-provider/design-tokens.ts
+++ b/packages/nimble-components/src/theme-provider/design-tokens.ts
@@ -119,7 +119,8 @@ import {
     Black82,
     Black22,
     PowerGreen30,
-    DigitalGreenLight30
+    DigitalGreenLight30,
+    PowerGreenText
 } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
 import { Theme } from './types';
 import { tokenNames, styleNameFromTokenName } from './design-token-names';
@@ -370,7 +371,12 @@ export const calendarEventBorderTransientColor = DesignToken.create<string>(
 
 export const calendarEventStaticFontColor = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.calendarEventStaticFontColor)
-).withDefault((element: HTMLElement) => getColorForTheme(element, DigitalGreenDark110, White, White));
+).withDefault((element: HTMLElement) => getColorForTheme(
+    element,
+    DigitalGreenDark110,
+    PowerGreenText,
+    PowerGreenText
+));
 
 export const calendarEventDynamicFontColor = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.calendarEventDynamicFontColor)

--- a/packages/nimble-tokens/source/styledictionary/properties/colors.json
+++ b/packages/nimble-tokens/source/styledictionary/properties/colors.json
@@ -152,6 +152,10 @@
       "value": "#356D54ff",
       "type": "color"
     },
+    "PowerGreenText": {
+      "value": "#98F5CAff",
+      "type": "color"
+    },
     "Black22": {
       "value": "#E6E6E6ff",
       "type": "color"

--- a/packages/nimble-tokens/source/styledictionary/properties/colors.json
+++ b/packages/nimble-tokens/source/styledictionary/properties/colors.json
@@ -152,7 +152,7 @@
       "value": "#356D54ff",
       "type": "color"
     },
-    "PowerGreenText": {
+    "PowerGreenDark50": {
       "value": "#98F5CAff",
       "type": "color"
     },

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -105,5 +105,5 @@ configureActions({
     depth: 1
 });
 
-// Update the GUID on this line to trigger a turbosnap full rebuild: acea85eb-3c9d-49c3-ae4f-7c12f82bc5a0
+// Update the GUID on this line to trigger a turbosnap full rebuild: c9f91cc3-1168-433f-86e7-b93a9e395ba1
 // See https://www.chromatic.com/docs/turbosnap/#full-rebuilds


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Added a new base color token required to create calendar theme-aware token for the event text.

Nimble issue: https://github.com/ni/nimble/issues/2351

## 👩‍💻 Implementation

Added the new base token - PowerGreenText with hex #98F5CA
Updated the existing theme aware token - calendarEventStaticFontColor

## 🧪 Testing

NA

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
