### PR TITLE
Consistent tags

### DIFF
--- a/change/@ni-nimble-components-f31b32ac-57bb-4930-9c62-963b33be9e56.json
+++ b/change/@ni-nimble-components-f31b32ac-57bb-4930-9c62-963b33be9e56.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove hard-coded nimble tag name strings",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-spright-components-a82462a5-daa8-4d83-9f17-b81c520b40b3.json
+++ b/change/@ni-spright-components-a82462a5-daa8-4d83-9f17-b81c520b40b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove hard-coded nimble tag name strings",
+  "packageName": "@ni/spright-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/anchor-button/tests/anchor-button.spec.ts
+++ b/packages/nimble-components/src/anchor-button/tests/anchor-button.spec.ts
@@ -1,6 +1,6 @@
 import { html } from '@microsoft/fast-element';
 import { parameterizeSpec } from '@ni/jasmine-parameterized';
-import { AnchorButton } from '..';
+import { AnchorButton, anchorButtonTag } from '..';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 
@@ -24,7 +24,7 @@ describe('AnchorButton', () => {
     });
 
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-anchor-button')).toBeInstanceOf(
+        expect(document.createElement(anchorButtonTag)).toBeInstanceOf(
             AnchorButton
         );
     });

--- a/packages/nimble-components/src/anchor-button/tests/anchor-button.spec.ts
+++ b/packages/nimble-components/src/anchor-button/tests/anchor-button.spec.ts
@@ -6,7 +6,7 @@ import { fixture, Fixture } from '../../utilities/tests/fixture';
 
 async function setup(): Promise<Fixture<AnchorButton>> {
     return await fixture<AnchorButton>(
-        html`<nimble-anchor-button></nimble-anchor-button>`
+        html`<${anchorButtonTag}></${anchorButtonTag}>`
     );
 }
 

--- a/packages/nimble-components/src/anchor-menu-item/tests/anchor-menu-item.spec.ts
+++ b/packages/nimble-components/src/anchor-menu-item/tests/anchor-menu-item.spec.ts
@@ -1,7 +1,7 @@
 import { customElement, html, ref } from '@microsoft/fast-element';
 import { MenuItem as FoundationMenuItem } from '@microsoft/fast-foundation';
 import { parameterizeSpec } from '@ni/jasmine-parameterized';
-import { AnchorMenuItem } from '..';
+import { AnchorMenuItem, anchorMenuItemTag } from '..';
 import type { IconCheck } from '../../icons/check';
 import type { IconXmark } from '../../icons/xmark';
 import type { Menu } from '../../menu';
@@ -49,9 +49,9 @@ describe('Anchor Menu Item', () => {
         });
 
         it('can construct an element instance', () => {
-            expect(
-                document.createElement('nimble-anchor-menu-item')
-            ).toBeInstanceOf(AnchorMenuItem);
+            expect(document.createElement(anchorMenuItemTag)).toBeInstanceOf(
+                AnchorMenuItem
+            );
         });
 
         it('should set the role to menuitem', async () => {

--- a/packages/nimble-components/src/anchor-menu-item/tests/anchor-menu-item.spec.ts
+++ b/packages/nimble-components/src/anchor-menu-item/tests/anchor-menu-item.spec.ts
@@ -2,11 +2,12 @@ import { customElement, html, ref } from '@microsoft/fast-element';
 import { MenuItem as FoundationMenuItem } from '@microsoft/fast-foundation';
 import { parameterizeSpec } from '@ni/jasmine-parameterized';
 import { AnchorMenuItem, anchorMenuItemTag } from '..';
-import type { IconCheck } from '../../icons/check';
-import type { IconXmark } from '../../icons/xmark';
-import type { Menu } from '../../menu';
+import { iconCheckTag, type IconCheck } from '../../icons/check';
+import { iconXmarkTag, type IconXmark } from '../../icons/xmark';
+import { menuTag, type Menu } from '../../menu';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
+import { menuItemTag } from '../../menu-item';
 
 @customElement('foundation-menu-item')
 export class TestMenuItem extends FoundationMenuItem {}
@@ -20,16 +21,16 @@ describe('Anchor Menu Item', () => {
 
         async function setup(source: Model): Promise<Fixture<AnchorMenuItem>> {
             return await fixture<AnchorMenuItem>(
-                html`<nimble-anchor-menu-item href="#">
-                    <nimble-xmark-icon
+                html`<${anchorMenuItemTag} href="#">
+                    <${iconXmarkTag}
                         ${ref('xmarkIcon')}
                         slot="start"
-                    ></nimble-xmark-icon>
-                    <nimble-check-icon
+                    ></${iconXmarkTag}>
+                    <${iconCheckTag}
                         ${ref('checkIcon')}
                         slot="end"
-                    ></nimble-check-icon>
-                </nimble-anchor-menu-item>`,
+                    ></${iconCheckTag}>
+                </${anchorMenuItemTag}>`,
                 { source }
             );
         }
@@ -118,32 +119,32 @@ describe('Anchor Menu Item', () => {
         async function setup(source: Model): Promise<Fixture<Menu>> {
             return await fixture<Menu>(
                 html`
-                    <nimble-menu>
-                        <nimble-menu-item>
-                            <nimble-icon-xmark slot="start"></nimble-icon-xmark>
+                    <${menuTag}>
+                        <${menuItemTag}>
+                            <${iconXmarkTag} slot="start"></${iconXmarkTag}>
                             Item 1
-                        </nimble-menu-item>
-                        <nimble-anchor-menu-item ${ref('item2')} href="a"
-                            >Item 2</nimble-anchor-menu-item
+                        </${menuItemTag}>
+                        <${anchorMenuItemTag} ${ref('item2')} href="a"
+                            >Item 2</${anchorMenuItemTag}
                         >
-                        <nimble-anchor-menu-item ${ref('item3')} href="b"
-                            >Item 3</nimble-anchor-menu-item
+                        <${anchorMenuItemTag} ${ref('item3')} href="b"
+                            >Item 3</${anchorMenuItemTag}
                         >
-                        <nimble-menu-item>
-                            <nimble-menu>
-                                <nimble-menu-item>Item 4.1</nimble-menu-item>
-                                <nimble-anchor-menu-item
+                        <${menuItemTag}>
+                            <${menuTag}>
+                                <${menuItemTag}>Item 4.1</${menuItemTag}>
+                                <${anchorMenuItemTag}
                                     ${ref('item4dot2')}
                                     href="c"
-                                    >Item 4.2</nimble-anchor-menu-item
+                                    >Item 4.2</${anchorMenuItemTag}
                                 >
-                                <nimble-anchor-menu-item href="d"
-                                    >Item 4.3</nimble-anchor-menu-item
+                                <${anchorMenuItemTag} href="d"
+                                    >Item 4.3</${anchorMenuItemTag}
                                 >
-                            </nimble-menu>
+                            </${menuTag}>
                             Item 4
-                        </nimble-menu-item>
-                    </nimble-menu>
+                        </${menuItemTag}>
+                    </${menuTag}>
                 `,
                 { source }
             );

--- a/packages/nimble-components/src/anchor-tab/tests/anchor-tab.spec.ts
+++ b/packages/nimble-components/src/anchor-tab/tests/anchor-tab.spec.ts
@@ -5,9 +5,7 @@ import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { Fixture, fixture } from '../../utilities/tests/fixture';
 
 async function setup(): Promise<Fixture<AnchorTab>> {
-    return await fixture<AnchorTab>(
-        html`<${anchorTabTag}></${anchorTabTag}>`
-    );
+    return await fixture<AnchorTab>(html`<${anchorTabTag}></${anchorTabTag}>`);
 }
 
 describe('AnchorTab', () => {

--- a/packages/nimble-components/src/anchor-tab/tests/anchor-tab.spec.ts
+++ b/packages/nimble-components/src/anchor-tab/tests/anchor-tab.spec.ts
@@ -1,6 +1,6 @@
 import { html } from '@microsoft/fast-element';
 import { parameterizeSpec } from '@ni/jasmine-parameterized';
-import { AnchorTab } from '..';
+import { AnchorTab, anchorTabTag } from '..';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { Fixture, fixture } from '../../utilities/tests/fixture';
 
@@ -24,9 +24,7 @@ describe('AnchorTab', () => {
     });
 
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-anchor-tab')).toBeInstanceOf(
-            AnchorTab
-        );
+        expect(document.createElement(anchorTabTag)).toBeInstanceOf(AnchorTab);
     });
 
     const attributeNames = [

--- a/packages/nimble-components/src/anchor-tab/tests/anchor-tab.spec.ts
+++ b/packages/nimble-components/src/anchor-tab/tests/anchor-tab.spec.ts
@@ -6,7 +6,7 @@ import { Fixture, fixture } from '../../utilities/tests/fixture';
 
 async function setup(): Promise<Fixture<AnchorTab>> {
     return await fixture<AnchorTab>(
-        html`<nimble-anchor-tab></nimble-anchor-tab>`
+        html`<${anchorTabTag}></${anchorTabTag}>`
     );
 }
 

--- a/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
+++ b/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
@@ -31,11 +31,11 @@ describe('AnchorTabs', () => {
     describe('without hrefs', () => {
         async function setup(): Promise<Fixture<AnchorTabs>> {
             return await fixture<AnchorTabs>(
-                html`<nimble-anchor-tabs activeid="tab-two">
-                    <nimble-anchor-tab></nimble-anchor-tab>
-                    <nimble-anchor-tab id="tab-two"></nimble-anchor-tab>
-                    <nimble-anchor-tab id="tab-three"></nimble-anchor-tab>
-                </nimble-anchor-tabs>`
+                html`<${anchorTabsTag} activeid="tab-two">
+                    <${anchorTabTag}></${anchorTabTag}>
+                    <${anchorTabTag} id="tab-two"></${anchorTabTag}>
+                    <${anchorTabTag} id="tab-three"></${anchorTabTag}>
+                </${anchorTabsTag}>`
             );
         }
 
@@ -153,17 +153,17 @@ describe('AnchorTabs', () => {
     describe('with hrefs', () => {
         async function setupWithHrefs(): Promise<Fixture<AnchorTabs>> {
             return await fixture<AnchorTabs>(
-                html`<nimble-anchor-tabs activeid="tab-two">
-                    <nimble-anchor-tab href="foo"></nimble-anchor-tab>
-                    <nimble-anchor-tab
+                html`<${anchorTabsTag} activeid="tab-two">
+                    <${anchorTabTag} href="foo"></${anchorTabTag}>
+                    <${anchorTabTag}
                         href="foo"
                         id="tab-two"
-                    ></nimble-anchor-tab>
-                    <nimble-anchor-tab
+                    ></${anchorTabTag}>
+                    <${anchorTabTag}
                         href="foo"
                         id="tab-three"
-                    ></nimble-anchor-tab>
-                </nimble-anchor-tabs>`
+                    ></${anchorTabTag}>
+                </${anchorTabsTag}>`
             );
         }
 

--- a/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
+++ b/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
@@ -9,9 +9,9 @@ import {
     keyTab
 } from '@microsoft/fast-web-utilities';
 import { parameterizeSpec } from '@ni/jasmine-parameterized';
-import { AnchorTabs } from '..';
+import { AnchorTabs, anchorTabsTag } from '..';
 import '../../anchor-tab';
-import type { AnchorTab } from '../../anchor-tab';
+import { anchorTabTag, type AnchorTab } from '../../anchor-tab';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 
@@ -49,7 +49,7 @@ describe('AnchorTabs', () => {
         });
 
         it('can construct an element instance', () => {
-            expect(document.createElement('nimble-anchor-tabs')).toBeInstanceOf(
+            expect(document.createElement(anchorTabsTag)).toBeInstanceOf(
                 AnchorTabs
             );
         });
@@ -83,15 +83,9 @@ describe('AnchorTabs', () => {
 
         it('should populate tabs array with anchor tabs', () => {
             expect(element.tabs.length).toBe(3);
-            expect(element.tabs[0]?.nodeName.toLowerCase()).toBe(
-                'nimble-anchor-tab'
-            );
-            expect(element.tabs[1]?.nodeName.toLowerCase()).toBe(
-                'nimble-anchor-tab'
-            );
-            expect(element.tabs[2]?.nodeName.toLowerCase()).toBe(
-                'nimble-anchor-tab'
-            );
+            expect(element.tabs[0]?.nodeName.toLowerCase()).toBe(anchorTabTag);
+            expect(element.tabs[1]?.nodeName.toLowerCase()).toBe(anchorTabTag);
+            expect(element.tabs[2]?.nodeName.toLowerCase()).toBe(anchorTabTag);
         });
 
         it('should set activetab property based on activeid', () => {

--- a/packages/nimble-components/src/anchor-tree-item/tests/anchor-tree-item.spec.ts
+++ b/packages/nimble-components/src/anchor-tree-item/tests/anchor-tree-item.spec.ts
@@ -2,11 +2,11 @@ import { customElement, html, ref } from '@microsoft/fast-element';
 import { TreeItem as FoundationTreeItem } from '@microsoft/fast-foundation';
 import { parameterizeSpec } from '@ni/jasmine-parameterized';
 import { AnchorTreeItem, anchorTreeItemTag } from '..';
-import type { IconCheck } from '../../icons/check';
-import type { IconXmark } from '../../icons/xmark';
+import { iconCheckTag, type IconCheck } from '../../icons/check';
+import { iconXmarkTag, type IconXmark } from '../../icons/xmark';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
-import type { TreeItem } from '../../tree-item';
-import type { TreeView } from '../../tree-view';
+import { treeItemTag, type TreeItem } from '../../tree-item';
+import { treeViewTag, type TreeView } from '../../tree-view';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 
 @customElement('foundation-tree-item')
@@ -21,16 +21,16 @@ describe('Anchor Tree Item', () => {
 
         async function setup(source: Model): Promise<Fixture<AnchorTreeItem>> {
             return await fixture<AnchorTreeItem>(
-                html`<nimble-anchor-tree-item href="#">
-                    <nimble-xmark-icon
+                html`<${anchorTreeItemTag} href="#">
+                    <${iconXmarkTag}
                         ${ref('xmarkIcon')}
                         slot="start"
-                    ></nimble-xmark-icon>
-                    <nimble-check-icon
+                    ></${iconXmarkTag}>
+                    <${iconCheckTag}
                         ${ref('checkIcon')}
                         slot="end"
-                    ></nimble-check-icon>
-                </nimble-anchor-tree-item>`,
+                    ></${iconCheckTag}>
+                </${anchorTreeItemTag}>`,
                 { source }
             );
         }
@@ -128,19 +128,19 @@ describe('Anchor Tree Item', () => {
             return await fixture<TreeView>(
                 // prettier-ignore
                 html<Model>`
-                <nimble-tree-view ${ref('treeView')}>
-                    <nimble-tree-item ${ref('root1')}>Root1
-                        <nimble-tree-item ${ref('subRoot1')}>SubRoot
-                            <nimble-anchor-tree-item ${ref('leaf1')} href="#" selected>Leaf1</nimble-anchor-tree-item>
-                        </nimble-tree-item>
-                        <nimble-anchor-tree-item ${ref('leaf2')} href="#">Leaf 2</nimble-anchor-tree-item>
-                    </nimble-tree-item>
-                    <nimble-tree-item ${ref('root2')}>Root2
-                        <nimble-tree-item ${ref('subRoot2')}>SubRoot 2
-                            <nimble-anchor-tree-item ${ref('leaf3')} href="#">Leaf 3</nimble-anchor-tree-item>
-                        </nimble-tree-item>
-                    </nimble-tree-item>
-                </nimble-tree-view>`,
+                <${treeViewTag} ${ref('treeView')}>
+                    <${treeItemTag} ${ref('root1')}>Root1
+                        <${treeItemTag} ${ref('subRoot1')}>SubRoot
+                            <${anchorTreeItemTag} ${ref('leaf1')} href="#" selected>Leaf1</${anchorTreeItemTag}>
+                        </${treeItemTag}>
+                        <${anchorTreeItemTag} ${ref('leaf2')} href="#">Leaf 2</${anchorTreeItemTag}>
+                    </${treeItemTag}>
+                    <${treeItemTag} ${ref('root2')}>Root2
+                        <${treeItemTag} ${ref('subRoot2')}>SubRoot 2
+                            <${anchorTreeItemTag} ${ref('leaf3')} href="#">Leaf 3</${anchorTreeItemTag}>
+                        </${treeItemTag}>
+                    </${treeItemTag}>
+                </${treeViewTag}>`,
                 { source }
             );
         }

--- a/packages/nimble-components/src/anchor-tree-item/tests/anchor-tree-item.spec.ts
+++ b/packages/nimble-components/src/anchor-tree-item/tests/anchor-tree-item.spec.ts
@@ -1,7 +1,7 @@
 import { customElement, html, ref } from '@microsoft/fast-element';
 import { TreeItem as FoundationTreeItem } from '@microsoft/fast-foundation';
 import { parameterizeSpec } from '@ni/jasmine-parameterized';
-import { AnchorTreeItem } from '..';
+import { AnchorTreeItem, anchorTreeItemTag } from '..';
 import type { IconCheck } from '../../icons/check';
 import type { IconXmark } from '../../icons/xmark';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
@@ -50,9 +50,9 @@ describe('Anchor Tree Item', () => {
         });
 
         it('can construct an element instance', () => {
-            expect(
-                document.createElement('nimble-anchor-tree-item')
-            ).toBeInstanceOf(AnchorTreeItem);
+            expect(document.createElement(anchorTreeItemTag)).toBeInstanceOf(
+                AnchorTreeItem
+            );
         });
 
         it('should set the role to treeitem', async () => {

--- a/packages/nimble-components/src/anchor/tests/anchor.spec.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor.spec.ts
@@ -5,7 +5,7 @@ import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 
 async function setup(): Promise<Fixture<Anchor>> {
-    return await fixture<Anchor>(html`<nimble-anchor></nimble-anchor>`);
+    return await fixture<Anchor>(html`<${anchorTag}></${anchorTag}>`);
 }
 
 describe('Anchor', () => {
@@ -153,7 +153,7 @@ describe('Anchor', () => {
     describe('with contenteditable without value', () => {
         async function setupWithContenteditable(): Promise<Fixture<Anchor>> {
             return await fixture<Anchor>(
-                html`<nimble-anchor contenteditable></nimble-anchor>`
+                html`<${anchorTag} contenteditable></${anchorTag}>`
             );
         }
 

--- a/packages/nimble-components/src/anchor/tests/anchor.spec.ts
+++ b/packages/nimble-components/src/anchor/tests/anchor.spec.ts
@@ -21,12 +21,8 @@ describe('Anchor', () => {
         await disconnect();
     });
 
-    it('should export its tag', () => {
-        expect(anchorTag).toBe('nimble-anchor');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-anchor')).toBeInstanceOf(Anchor);
+        expect(document.createElement(anchorTag)).toBeInstanceOf(Anchor);
     });
 
     it('should set the "control" class on the internal control', async () => {

--- a/packages/nimble-components/src/anchored-region/tests/anchored-region.spec.ts
+++ b/packages/nimble-components/src/anchored-region/tests/anchored-region.spec.ts
@@ -1,12 +1,8 @@
 import { AnchoredRegion, anchoredRegionTag } from '..';
 
 describe('Anchored Region', () => {
-    it('should export its tag', () => {
-        expect(anchoredRegionTag).toBe('nimble-anchored-region');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-anchored-region')).toBeInstanceOf(
+        expect(document.createElement(anchoredRegionTag)).toBeInstanceOf(
             AnchoredRegion
         );
     });

--- a/packages/nimble-components/src/banner/tests/banner.spec.ts
+++ b/packages/nimble-components/src/banner/tests/banner.spec.ts
@@ -13,10 +13,10 @@ import { buttonTag } from '../../button';
 
 async function setup(): Promise<Fixture<Banner>> {
     return await fixture<Banner>(html`
-        <nimble-banner>
+        <${bannerTag}>
             <span slot="title">Title</span>
             Message text
-        </nimble-banner>
+        </${bannerTag}>
     `);
 }
 
@@ -24,10 +24,10 @@ async function setupWithLabelProvider(): Promise<Fixture<ThemeProvider>> {
     return await fixture<ThemeProvider>(html`
         <${themeProviderTag}>
             <${labelProviderCoreTag}></${labelProviderCoreTag}>
-            <nimble-banner>
+            <${bannerTag}>
                 <span slot="title">Title</span>
                 Message text
-            </nimble-banner>
+            </${bannerTag}>
         </${themeProviderTag}>
     `);
 }

--- a/packages/nimble-components/src/banner/tests/banner.spec.ts
+++ b/packages/nimble-components/src/banner/tests/banner.spec.ts
@@ -47,7 +47,7 @@ describe('Banner', () => {
     });
 
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-banner')).toBeInstanceOf(Banner);
+        expect(document.createElement(bannerTag)).toBeInstanceOf(Banner);
     });
 
     it("should initialize 'open' to false", () => {
@@ -81,7 +81,7 @@ describe('Banner', () => {
 
     it("should remove 'open' when dismiss button is clicked", () => {
         element.open = true;
-        element.shadowRoot?.querySelector('nimble-button')?.click();
+        element.shadowRoot?.querySelector(buttonTag)?.click();
         expect(element.open).toBeFalse();
     });
 
@@ -92,13 +92,13 @@ describe('Banner', () => {
     it("should hide dismiss button when 'preventDismiss' set", async () => {
         element.preventDismiss = true;
         await waitForUpdatesAsync();
-        expect(element.shadowRoot?.querySelector('nimble-button')).toBeNull();
+        expect(element.shadowRoot?.querySelector(buttonTag)).toBeNull();
     });
 
     it("should default label of dismiss button to 'Close'", () => {
         expect(
             element.shadowRoot
-                ?.querySelector('nimble-button')
+                ?.querySelector(buttonTag)
                 ?.innerText.includes('Close')
         ).toBeTrue();
     });

--- a/packages/nimble-components/src/breadcrumb-item/tests/breadcrumb-item.spec.ts
+++ b/packages/nimble-components/src/breadcrumb-item/tests/breadcrumb-item.spec.ts
@@ -1,12 +1,8 @@
 import { BreadcrumbItem, breadcrumbItemTag } from '..';
 
 describe('Breadcrumb Item', () => {
-    it('should export its tag', () => {
-        expect(breadcrumbItemTag).toBe('nimble-breadcrumb-item');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-breadcrumb-item')).toBeInstanceOf(
+        expect(document.createElement(breadcrumbItemTag)).toBeInstanceOf(
             BreadcrumbItem
         );
     });

--- a/packages/nimble-components/src/breadcrumb/tests/breadcrumb.spec.ts
+++ b/packages/nimble-components/src/breadcrumb/tests/breadcrumb.spec.ts
@@ -1,12 +1,8 @@
 import { Breadcrumb, breadcrumbTag } from '..';
 
 describe('Breadcrumb', () => {
-    it('should export its tag', () => {
-        expect(breadcrumbTag).toBe('nimble-breadcrumb');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-breadcrumb')).toBeInstanceOf(
+        expect(document.createElement(breadcrumbTag)).toBeInstanceOf(
             Breadcrumb
         );
     });

--- a/packages/nimble-components/src/button/tests/button.spec.ts
+++ b/packages/nimble-components/src/button/tests/button.spec.ts
@@ -8,12 +8,8 @@ describe('Button', () => {
         return await fixture<Button>(html`<${buttonTag}></${buttonTag}>`);
     }
 
-    it('should export its tag', () => {
-        expect(buttonTag).toBe('nimble-button');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-button')).toBeInstanceOf(Button);
+        expect(document.createElement(buttonTag)).toBeInstanceOf(Button);
     });
 
     it('should default tabIndex on the internal button to 0', async () => {

--- a/packages/nimble-components/src/card-button/tests/card-button.spec.ts
+++ b/packages/nimble-components/src/card-button/tests/card-button.spec.ts
@@ -1,8 +1,8 @@
-import { CardButton } from '..';
+import { CardButton, cardButtonTag } from '..';
 
 describe('Card Button', () => {
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-card-button')).toBeInstanceOf(
+        expect(document.createElement(cardButtonTag)).toBeInstanceOf(
             CardButton
         );
     });

--- a/packages/nimble-components/src/card/tests/card.spec.ts
+++ b/packages/nimble-components/src/card/tests/card.spec.ts
@@ -1,11 +1,7 @@
 import { Card, cardTag } from '..';
 
 describe('Card', () => {
-    it('should export its tag', () => {
-        expect(cardTag).toBe('nimble-card');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-card')).toBeInstanceOf(Card);
+        expect(document.createElement(cardTag)).toBeInstanceOf(Card);
     });
 });

--- a/packages/nimble-components/src/checkbox/tests/checkbox.spec.ts
+++ b/packages/nimble-components/src/checkbox/tests/checkbox.spec.ts
@@ -8,14 +8,8 @@ describe('Checkbox', () => {
         return await fixture<Checkbox>(html`<${checkboxTag}></${checkboxTag}>`);
     }
 
-    it('should export its tag', () => {
-        expect(checkboxTag).toBe('nimble-checkbox');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-checkbox')).toBeInstanceOf(
-            Checkbox
-        );
+        expect(document.createElement(checkboxTag)).toBeInstanceOf(Checkbox);
     });
 
     it('should honor provided `tabindex` value', async () => {

--- a/packages/nimble-components/src/combobox/testing/tests/combobox.pageobject.spec.ts
+++ b/packages/nimble-components/src/combobox/testing/tests/combobox.pageobject.spec.ts
@@ -1,25 +1,26 @@
 import { html } from '@microsoft/fast-element';
 import { fixture, Fixture } from '../../../utilities/tests/fixture';
-import type { Combobox } from '../..';
+import { comboboxTag, type Combobox } from '../..';
 import { ComboboxPageObject } from '../combobox.pageobject';
+import { listOptionTag } from '../../../list-option';
 
 async function setup(): Promise<Fixture<Combobox>> {
     const viewTemplate = html`
-        <nimble-combobox>
-            <nimble-list-option value="one">One</nimble-list-option>
-            <nimble-list-option value="two">Two</nimble-list-option>
-        </nimble-combobox>
+        <${comboboxTag}>
+            <${listOptionTag} value="one">One</${listOptionTag}>
+            <${listOptionTag} value="two">Two</${listOptionTag}>
+        </${comboboxTag}>
     `;
     return await fixture<Combobox>(viewTemplate);
 }
 
 async function setupWithLabel(): Promise<Fixture<Combobox>> {
     const viewTemplate = html`
-        <nimble-combobox>
+        <${comboboxTag}>
             Custom Label Text
-            <nimble-list-option value="one">One</nimble-list-option>
-            <nimble-list-option value="two">Two</nimble-list-option>
-        </nimble-combobox>
+            <${listOptionTag} value="one">One</${listOptionTag}>
+            <${listOptionTag} value="two">Two</${listOptionTag}>
+        </${comboboxTag}>
     `;
     return await fixture<Combobox>(viewTemplate);
 }

--- a/packages/nimble-components/src/combobox/tests/combobox.spec.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox.spec.ts
@@ -9,14 +9,8 @@ import { listOptionTag } from '../../list-option';
 import { ComboboxPageObject } from '../testing/combobox.pageobject';
 
 describe('Combobox', () => {
-    it('should export its tag', () => {
-        expect(comboboxTag).toBe('nimble-combobox');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-combobox')).toBeInstanceOf(
-            Combobox
-        );
+        expect(document.createElement(comboboxTag)).toBeInstanceOf(Combobox);
     });
 
     describe('with common setup', () => {

--- a/packages/nimble-components/src/dialog/tests/dialog.spec.ts
+++ b/packages/nimble-components/src/dialog/tests/dialog.spec.ts
@@ -2,6 +2,7 @@ import { html } from '@microsoft/fast-element';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Dialog, dialogTag, UserDismissed } from '..';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
+import { buttonTag } from '../../button';
 
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 async function setup<CloseReason = void>(
@@ -25,12 +26,8 @@ describe('Dialog', () => {
         return nimbleDialogElement.shadowRoot!.querySelector('dialog')!;
     }
 
-    it('should export its tag', () => {
-        expect(dialogTag).toBe('nimble-dialog');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-dialog')).toBeInstanceOf(Dialog);
+        expect(document.createElement(dialogTag)).toBeInstanceOf(Dialog);
     });
 
     it('should initially be hidden', async () => {
@@ -304,8 +301,8 @@ describe('Dialog', () => {
     it('supports opening multiple dialogs on top of each other #SkipFirefox #SkipWebkit', async () => {
         const { element, connect, disconnect } = await setup();
         await connect();
-        const secondDialog = document.createElement('nimble-dialog');
-        const secondDialogButton = document.createElement('nimble-button');
+        const secondDialog = document.createElement(dialogTag);
+        const secondDialogButton = document.createElement(buttonTag);
         secondDialog.append(secondDialogButton);
         element.parentElement!.append(secondDialog);
         await waitForUpdatesAsync();

--- a/packages/nimble-components/src/dialog/tests/dialog.spec.ts
+++ b/packages/nimble-components/src/dialog/tests/dialog.spec.ts
@@ -9,12 +9,12 @@ async function setup<CloseReason = void>(
     preventDismiss = false
 ): Promise<Fixture<Dialog<CloseReason>>> {
     const viewTemplate = html`
-        <nimble-dialog ?prevent-dismiss="${() => preventDismiss}">
-            <nimble-button id="ok">OK</nimble-button>
-            <nimble-button id="cancel">Cancel</nimble-button>
-        </nimble-dialog>
-        <nimble-button id="button1">Button 1</nimble-button>
-        <nimble-button id="button2">Button 2</nimble-button>
+        <${dialogTag} ?prevent-dismiss="${() => preventDismiss}">
+            <${buttonTag} id="ok">OK</${buttonTag}>
+            <${buttonTag} id="cancel">Cancel</${buttonTag}>
+        </${dialogTag}>
+        <${buttonTag} id="button1">Button 1</${buttonTag}>
+        <${buttonTag} id="button2">Button 2</${buttonTag}>
     `;
     return await fixture<Dialog<CloseReason>>(viewTemplate);
 }

--- a/packages/nimble-components/src/drawer/tests/drawer.spec.ts
+++ b/packages/nimble-components/src/drawer/tests/drawer.spec.ts
@@ -14,12 +14,12 @@ async function setup<CloseReason = void>(
     preventDismiss = false
 ): Promise<Fixture<Drawer<CloseReason>>> {
     const viewTemplate = html`
-        <nimble-drawer ?prevent-dismiss="${() => preventDismiss}">
-            <nimble-button id="ok">OK</nimble-button>
-            <nimble-button id="cancel">Cancel</nimble-button>
-        </nimble-drawer>
-        <nimble-button id="button1">Button 1</nimble-button>
-        <nimble-button id="button2">Button 2</nimble-button>
+        <${drawerTag} ?prevent-dismiss="${() => preventDismiss}">
+            <${buttonTag} id="ok">OK</${buttonTag}>
+            <${buttonTag} id="cancel">Cancel</${buttonTag}>
+        </${drawerTag}>
+        <${buttonTag} id="button1">Button 1</${buttonTag}>
+        <${buttonTag} id="button2">Button 2</${buttonTag}>
     `;
     return await fixture<Drawer<CloseReason>>(viewTemplate);
 }

--- a/packages/nimble-components/src/drawer/tests/drawer.spec.ts
+++ b/packages/nimble-components/src/drawer/tests/drawer.spec.ts
@@ -1,12 +1,13 @@
 import { html } from '@microsoft/fast-element';
 import { eventAnimationEnd } from '@microsoft/fast-web-utilities';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
-import { Drawer, UserDismissed } from '..';
+import { Drawer, drawerTag, UserDismissed } from '..';
 import { DrawerLocation } from '../types';
 import {
     processUpdates,
     waitForUpdatesAsync
 } from '../../testing/async-helpers';
+import { buttonTag } from '../../button';
 
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 async function setup<CloseReason = void>(
@@ -65,9 +66,7 @@ describe('Drawer', () => {
         });
 
         it('can construct an element instance', () => {
-            expect(document.createElement('nimble-drawer')).toBeInstanceOf(
-                Drawer
-            );
+            expect(document.createElement(drawerTag)).toBeInstanceOf(Drawer);
         });
 
         it('should default the location to right', () => {
@@ -252,8 +251,8 @@ describe('Drawer', () => {
 
         // Some browsers skipped, see: https://github.com/ni/nimble/issues/1936
         it('supports opening multiple drawers on top of each other #SkipFirefox #SkipWebkit', () => {
-            const secondDrawer = document.createElement('nimble-drawer');
-            const secondDrawerButton = document.createElement('nimble-button');
+            const secondDrawer = document.createElement(drawerTag);
+            const secondDrawerButton = document.createElement(buttonTag);
             secondDrawer.append(secondDrawerButton);
             element.parentElement!.append(secondDrawer);
             void element.show();

--- a/packages/nimble-components/src/label-provider/core/tests/label-provider-core.spec.ts
+++ b/packages/nimble-components/src/label-provider/core/tests/label-provider-core.spec.ts
@@ -40,9 +40,9 @@ describe('Label Provider Core', () => {
     });
 
     it('can construct an element instance', () => {
-        expect(
-            document.createElement('nimble-label-provider-core')
-        ).toBeInstanceOf(LabelProviderCore);
+        expect(document.createElement(labelProviderCoreTag)).toBeInstanceOf(
+            LabelProviderCore
+        );
     });
 
     describe('token JS key should match DesignToken.name', () => {

--- a/packages/nimble-components/src/label-provider/rich-text/tests/label-provider-rich-text.spec.ts
+++ b/packages/nimble-components/src/label-provider/rich-text/tests/label-provider-rich-text.spec.ts
@@ -41,9 +41,9 @@ describe('Label Provider Rich Text', () => {
     });
 
     it('can construct an element instance', () => {
-        expect(
-            document.createElement('nimble-label-provider-rich-text')
-        ).toBeInstanceOf(LabelProviderRichText);
+        expect(document.createElement(labelProviderRichTextTag)).toBeInstanceOf(
+            LabelProviderRichText
+        );
     });
 
     describe('token JS key should match DesignToken.name', () => {

--- a/packages/nimble-components/src/label-provider/table/tests/label-provider-table.spec.ts
+++ b/packages/nimble-components/src/label-provider/table/tests/label-provider-table.spec.ts
@@ -41,9 +41,9 @@ describe('Label Provider Table', () => {
     });
 
     it('can construct an element instance', () => {
-        expect(
-            document.createElement('nimble-label-provider-table')
-        ).toBeInstanceOf(LabelProviderTable);
+        expect(document.createElement(labelProviderTableTag)).toBeInstanceOf(
+            LabelProviderTable
+        );
     });
 
     describe('token JS key should match DesignToken.name', () => {

--- a/packages/nimble-components/src/list-option-group/tests/list-option-group.spec.ts
+++ b/packages/nimble-components/src/list-option-group/tests/list-option-group.spec.ts
@@ -8,8 +8,8 @@ import { listOptionTag } from '../../list-option';
 describe('ListOptionGroup', () => {
     async function setup(): Promise<Fixture<ListOptionGroup>> {
         return await fixture<ListOptionGroup>(
-            html`<nimble-list-option-group style="width: 200px" label="Group 1">
-            </nimble-list-option-group>`
+            html`<${listOptionGroupTag} style="width: 200px" label="Group 1">
+            </${listOptionGroupTag}>`
         );
     }
 

--- a/packages/nimble-components/src/list-option-group/tests/list-option-group.spec.ts
+++ b/packages/nimble-components/src/list-option-group/tests/list-option-group.spec.ts
@@ -13,10 +13,6 @@ describe('ListOptionGroup', () => {
         );
     }
 
-    it('should export its tag', () => {
-        expect(listOptionGroupTag).toBe(listOptionGroupTag);
-    });
-
     it('can construct an element instance', () => {
         expect(document.createElement(listOptionGroupTag)).toBeInstanceOf(
             ListOptionGroup

--- a/packages/nimble-components/src/list-option/tests/list-option.spec.ts
+++ b/packages/nimble-components/src/list-option/tests/list-option.spec.ts
@@ -4,12 +4,8 @@ import { fixture, type Fixture } from '../../utilities/tests/fixture';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 
 describe('ListboxOption', () => {
-    it('should export its tag', () => {
-        expect(listOptionTag).toBe('nimble-list-option');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-list-option')).toBeInstanceOf(
+        expect(document.createElement(listOptionTag)).toBeInstanceOf(
             ListOption
         );
     });

--- a/packages/nimble-components/src/list-option/tests/list-option.spec.ts
+++ b/packages/nimble-components/src/list-option/tests/list-option.spec.ts
@@ -17,9 +17,9 @@ describe('ListboxOption', () => {
 
         async function setup(): Promise<Fixture<ListOption>> {
             return await fixture<ListOption>(
-                html`<nimble-list-option style="width: 200px">
+                html`<${listOptionTag} style="width: 200px">
                     Item 1
-                </nimble-list-option>`
+                </${listOptionTag}>`
             );
         }
 

--- a/packages/nimble-components/src/mapping/empty/tests/mapping-empty.spec.ts
+++ b/packages/nimble-components/src/mapping/empty/tests/mapping-empty.spec.ts
@@ -1,12 +1,8 @@
 import { MappingEmpty, mappingEmptyTag } from '..';
 
 describe('Empty Mapping', () => {
-    it('should export its tag', () => {
-        expect(mappingEmptyTag).toBe('nimble-mapping-empty');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-mapping-empty')).toBeInstanceOf(
+        expect(document.createElement(mappingEmptyTag)).toBeInstanceOf(
             MappingEmpty
         );
     });

--- a/packages/nimble-components/src/mapping/icon/tests/mapping-icon.spec.ts
+++ b/packages/nimble-components/src/mapping/icon/tests/mapping-icon.spec.ts
@@ -26,12 +26,8 @@ describe('Icon Mapping', () => {
         </${mappingIconTag}>`);
     }
 
-    it('should export its tag', () => {
-        expect(mappingIconTag).toBe('nimble-mapping-icon');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-mapping-icon')).toBeInstanceOf(
+        expect(document.createElement(mappingIconTag)).toBeInstanceOf(
             MappingIcon
         );
     });

--- a/packages/nimble-components/src/mapping/spinner/tests/mapping-spinner.spec.ts
+++ b/packages/nimble-components/src/mapping/spinner/tests/mapping-spinner.spec.ts
@@ -1,12 +1,8 @@
 import { MappingSpinner, mappingSpinnerTag } from '..';
 
 describe('Spinner Mapping', () => {
-    it('should export its tag', () => {
-        expect(mappingSpinnerTag).toBe('nimble-mapping-spinner');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-mapping-spinner')).toBeInstanceOf(
+        expect(document.createElement(mappingSpinnerTag)).toBeInstanceOf(
             MappingSpinner
         );
     });

--- a/packages/nimble-components/src/mapping/text/tests/mapping-text.spec.ts
+++ b/packages/nimble-components/src/mapping/text/tests/mapping-text.spec.ts
@@ -1,12 +1,8 @@
 import { MappingText, mappingTextTag } from '..';
 
 describe('Text Mapping', () => {
-    it('should export its tag', () => {
-        expect(mappingTextTag).toBe('nimble-mapping-text');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-mapping-text')).toBeInstanceOf(
+        expect(document.createElement(mappingTextTag)).toBeInstanceOf(
             MappingText
         );
     });

--- a/packages/nimble-components/src/mapping/user/tests/mapping-user.spec.ts
+++ b/packages/nimble-components/src/mapping/user/tests/mapping-user.spec.ts
@@ -13,12 +13,8 @@ describe('User Mapping', () => {
           </${mappingUserTag}>`);
     }
 
-    it('should export its tag', () => {
-        expect(mappingUserTag).toBe('nimble-mapping-user');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-mapping-user')).toBeInstanceOf(
+        expect(document.createElement(mappingUserTag)).toBeInstanceOf(
             MappingUser
         );
     });

--- a/packages/nimble-components/src/menu-button/tests/menu-button.spec.ts
+++ b/packages/nimble-components/src/menu-button/tests/menu-button.spec.ts
@@ -3,9 +3,9 @@ import { eventChange, keyEnter } from '@microsoft/fast-web-utilities';
 import { FoundationElement } from '@microsoft/fast-foundation';
 import { parameterizeSuite } from '@ni/jasmine-parameterized';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
-import type { Menu } from '../../menu';
-import type { MenuItem } from '../../menu-item';
-import { MenuButton } from '..';
+import { menuTag, type Menu } from '../../menu';
+import { menuItemTag, type MenuItem } from '../../menu-item';
+import { MenuButton, menuButtonTag } from '..';
 import { MenuButtonToggleEventDetail, MenuButtonPosition } from '../types';
 import {
     processUpdates,
@@ -13,6 +13,7 @@ import {
 } from '../../testing/async-helpers';
 import { waitForEvent } from '../../utilities/testing/component';
 import { MenuButtonPageObject } from '../testing/menu-button.pageobject';
+import { anchoredRegionTag } from '../../anchored-region';
 
 type MenuButtonToggleEventHandler = (
     evt: CustomEvent<MenuButtonToggleEventDetail>
@@ -46,18 +47,18 @@ describe('MenuButton', () => {
     let menuItem3: MenuItem;
 
     function createAndSlotMenu(parentElement: HTMLElement): void {
-        menu = document.createElement('nimble-menu');
+        menu = document.createElement(menuTag);
         menu.slot = 'menu';
 
-        menuItem1 = document.createElement('nimble-menu-item');
+        menuItem1 = document.createElement(menuItemTag);
         menuItem1.textContent = 'menu item 1';
         menu.appendChild(menuItem1);
 
-        menuItem2 = document.createElement('nimble-menu-item');
+        menuItem2 = document.createElement(menuItemTag);
         menuItem2.textContent = 'menu item 2';
         menu.appendChild(menuItem2);
 
-        menuItem3 = document.createElement('nimble-menu-item');
+        menuItem3 = document.createElement(menuItemTag);
         menuItem3.textContent = 'menu item 3';
         menu.appendChild(menuItem3);
 
@@ -81,7 +82,7 @@ describe('MenuButton', () => {
         });
 
         it('can construct an element instance', () => {
-            expect(document.createElement('nimble-menu-button')).toBeInstanceOf(
+            expect(document.createElement(menuButtonTag)).toBeInstanceOf(
                 MenuButton
             );
         });
@@ -188,7 +189,7 @@ describe('MenuButton', () => {
         it('anchored-region should not exist in DOM when the menu is closed', async () => {
             await connect();
             expect(
-                element.shadowRoot?.querySelector('nimble-anchored-region')
+                element.shadowRoot?.querySelector(anchoredRegionTag)
             ).toBeNull();
         });
 
@@ -196,7 +197,7 @@ describe('MenuButton', () => {
             element.open = true;
             await connect();
             expect(
-                element.shadowRoot?.querySelector('nimble-anchored-region')
+                element.shadowRoot?.querySelector(anchoredRegionTag)
             ).not.toBeNull();
         });
 
@@ -327,7 +328,7 @@ describe('MenuButton', () => {
         {
             name: 'menu passed through slot of additional element',
             setupFunction: slottedSetup,
-            getMenuButton: (element: HTMLElement) => element.shadowRoot!.querySelector('nimble-menu-button')!
+            getMenuButton: (element: HTMLElement) => element.shadowRoot!.querySelector(menuButtonTag)!
         }
     ] as const;
     parameterizeSuite(menuSlotConfigurations, (suite, name, value) => {

--- a/packages/nimble-components/src/menu-button/tests/menu-button.spec.ts
+++ b/packages/nimble-components/src/menu-button/tests/menu-button.spec.ts
@@ -23,15 +23,15 @@ class TestSlottedElement extends FoundationElement {}
 const composedTestSlottedElement = TestSlottedElement.compose({
     baseName: 'test-slotted-element',
     template: html`
-        <nimble-menu-button>
+        <${menuButtonTag}>
             <slot slot="menu" name="menu"></slot>
-        </nimble-menu-button>
+        </${menuButtonTag}>
     `
 });
 
 async function setup(): Promise<Fixture<MenuButton>> {
     return await fixture<MenuButton>(
-        html`<nimble-menu-button></nimble-menu-button>`
+        html`<${menuButtonTag}></${menuButtonTag}>`
     );
 }
 

--- a/packages/nimble-components/src/menu-item/tests/menu-item.spec.ts
+++ b/packages/nimble-components/src/menu-item/tests/menu-item.spec.ts
@@ -1,13 +1,7 @@
 import { MenuItem, menuItemTag } from '..';
 
 describe('MenuItem', () => {
-    it('should export its tag', () => {
-        expect(menuItemTag).toBe('nimble-menu-item');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-menu-item')).toBeInstanceOf(
-            MenuItem
-        );
+        expect(document.createElement(menuItemTag)).toBeInstanceOf(MenuItem);
     });
 });

--- a/packages/nimble-components/src/menu/tests/menu.foundation.spec.ts
+++ b/packages/nimble-components/src/menu/tests/menu.foundation.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@microsoft/fast-foundation';
 import { keyArrowDown, keyArrowUp } from '@microsoft/fast-web-utilities';
 import { Menu } from '..';
-import { MenuItem } from '../../menu-item';
+import { MenuItem, menuItemTag } from '../../menu-item';
 import { fixture } from '../../utilities/tests/fixture';
 
 const menu = Menu.compose({
@@ -46,19 +46,19 @@ async function setup(): Promise<{
         menuItem()
     ]);
 
-    const menuItem1 = document.createElement('nimble-menu-item');
+    const menuItem1 = document.createElement(menuItemTag);
     menuItem1.textContent = 'Foo';
     menuItem1.id = 'id1';
 
-    const menuItem2 = document.createElement('nimble-menu-item');
+    const menuItem2 = document.createElement(menuItemTag);
     menuItem2.textContent = 'Bar';
     menuItem2.id = 'id2';
 
-    const menuItem3 = document.createElement('nimble-menu-item');
+    const menuItem3 = document.createElement(menuItemTag);
     menuItem3.textContent = 'Baz';
     menuItem3.id = 'id3';
 
-    const menuItem4 = document.createElement('nimble-menu-item');
+    const menuItem4 = document.createElement(menuItemTag);
     menuItem4.textContent = 'Bat';
     menuItem4.id = 'id4';
 

--- a/packages/nimble-components/src/menu/tests/menu.spec.ts
+++ b/packages/nimble-components/src/menu/tests/menu.spec.ts
@@ -8,12 +8,8 @@ import { Fixture, fixture } from '../../utilities/tests/fixture';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 
 describe('Menu', () => {
-    it('should export its tag', () => {
-        expect(menuTag).toBe('nimble-menu');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-menu')).toBeInstanceOf(Menu);
+        expect(document.createElement(menuTag)).toBeInstanceOf(Menu);
     });
 
     const menuItemTypes = [

--- a/packages/nimble-components/src/number-field/tests/number-field.spec.ts
+++ b/packages/nimble-components/src/number-field/tests/number-field.spec.ts
@@ -18,10 +18,6 @@ async function setupWithLabelProvider(): Promise<Fixture<ThemeProvider>> {
 }
 
 describe('NumberField', () => {
-    it('should export its tag', () => {
-        expect(numberFieldTag).toBe('nimble-number-field');
-    });
-
     it('can construct an element instance', () => {
         expect(document.createElement(numberFieldTag)).toBeInstanceOf(
             NumberField

--- a/packages/nimble-components/src/radio-group/tests/radio-group.spec.ts
+++ b/packages/nimble-components/src/radio-group/tests/radio-group.spec.ts
@@ -1,12 +1,8 @@
 import { RadioGroup, radioGroupTag } from '..';
 
 describe('Radio Group', () => {
-    it('should export its tag', () => {
-        expect(radioGroupTag).toBe('nimble-radio-group');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-radio-group')).toBeInstanceOf(
+        expect(document.createElement(radioGroupTag)).toBeInstanceOf(
             RadioGroup
         );
     });

--- a/packages/nimble-components/src/radio/tests/radio.spec.ts
+++ b/packages/nimble-components/src/radio/tests/radio.spec.ts
@@ -1,11 +1,7 @@
 import { Radio, radioTag } from '..';
 
 describe('Radio', () => {
-    it('should export its tag', () => {
-        expect(radioTag).toBe('nimble-radio');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-radio')).toBeInstanceOf(Radio);
+        expect(document.createElement(radioTag)).toBeInstanceOf(Radio);
     });
 });

--- a/packages/nimble-components/src/rich-text-mention/base/tests/rich-text-mention.fixtures.ts
+++ b/packages/nimble-components/src/rich-text-mention/base/tests/rich-text-mention.fixtures.ts
@@ -10,6 +10,7 @@ import {
     RichTextMentionValidator,
     baseValidityFlagNames
 } from '../models/mention-validator';
+import { iconExclamationMarkTag } from '../../../icons/exclamation-mark';
 
 export const richTextMentionTestTag = 'nimble-rich-text-test-mention';
 
@@ -40,7 +41,7 @@ class MappingTestConfig extends MappingConfig {}
 export class RichTextMentionTest extends RichTextMention {
     protected override getMentionInternalsOptions(): MentionInternalsOptions {
         return {
-            icon: 'nimble-icon-exclamation-mark',
+            icon: iconExclamationMarkTag,
             character: '!',
             viewElement: richTextMentionUsersViewTag,
             validator: new RichTextMentionTestValidator()

--- a/packages/nimble-components/src/rich-text-mention/users/tests/rich-text-mention-users.spec.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/tests/rich-text-mention-users.spec.ts
@@ -76,14 +76,10 @@ describe('RichTextMentionUsers', () => {
         }
     });
 
-    it('should export its tag', () => {
-        expect(richTextMentionUsersTag).toBe('nimble-rich-text-mention-users');
-    });
-
     it('can construct an element instance', () => {
-        expect(
-            document.createElement('nimble-rich-text-mention-users')
-        ).toBeInstanceOf(RichTextMentionUsers);
+        expect(document.createElement(richTextMentionUsersTag)).toBeInstanceOf(
+            RichTextMentionUsers
+        );
     });
 
     it('should have character, icon and pattern in mention internals', async () => {

--- a/packages/nimble-components/src/rich-text-mention/users/view/tests/rich-text-mention-users-view.spec.ts
+++ b/packages/nimble-components/src/rich-text-mention/users/view/tests/rich-text-mention-users-view.spec.ts
@@ -31,12 +31,6 @@ describe('RichTextMentionUsersView', () => {
         await disconnect();
     });
 
-    it('should export its tag', () => {
-        expect(richTextMentionUsersViewTag).toBe(
-            'nimble-rich-text-mention-users-view'
-        );
-    });
-
     it('can construct an element instance', () => {
         expect(
             document.createElement(richTextMentionUsersViewTag)

--- a/packages/nimble-components/src/rich-text/editor/testing/rich-text-editor.pageobject.ts
+++ b/packages/nimble-components/src/rich-text/editor/testing/rich-text-editor.pageobject.ts
@@ -6,7 +6,7 @@ import {
 } from '@microsoft/fast-web-utilities';
 import type { RichTextEditor } from '..';
 import { waitForUpdatesAsync } from '../../../testing/async-helpers';
-import type { ToggleButton } from '../../../toggle-button';
+import { toggleButtonTag, type ToggleButton } from '../../../toggle-button';
 import {
     ArrowKeyButton,
     MappingConfiguration,
@@ -479,7 +479,7 @@ export class RichTextEditorPageObject {
         button: ToolbarButton
     ): ToggleButton | null | undefined {
         const buttons: NodeListOf<ToggleButton> = this.richTextEditorElement.shadowRoot!.querySelectorAll(
-            'nimble-toggle-button'
+            toggleButtonTag
         );
         return buttons[button];
     }

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
@@ -23,7 +23,7 @@ const ICON_EXCLAMATION_TAG = iconExclamationMarkTag.toUpperCase();
 
 async function setup(): Promise<Fixture<RichTextEditor>> {
     return await fixture<RichTextEditor>(
-        html`<nimble-rich-text-editor></nimble-rich-text-editor>`
+        html`<${richTextEditorTag}></${richTextEditorTag}>`
     );
 }
 

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
@@ -4,7 +4,7 @@ import { richTextEditorTag, RichTextEditor } from '..';
 import { type Fixture, fixture } from '../../../utilities/tests/fixture';
 import { RichTextEditorPageObject } from '../testing/rich-text-editor.pageobject';
 import { wackyStrings } from '../../../utilities/tests/wacky-strings';
-import type { Button } from '../../../button';
+import { buttonTag, type Button } from '../../../button';
 import { toggleButtonTag, type ToggleButton } from '../../../toggle-button';
 import { ToolbarButton } from '../testing/types';
 import { waitForEvent } from '../../../utilities/testing/component';
@@ -12,17 +12,17 @@ import { waitForUpdatesAsync } from '../../../testing/async-helpers';
 
 async function setup(): Promise<Fixture<RichTextEditor>> {
     return await fixture<RichTextEditor>(
-        html`<nimble-rich-text-editor></nimble-rich-text-editor>`
+        html`<${richTextEditorTag}></${richTextEditorTag}>`
     );
 }
 
 async function setupWithFooter(): Promise<Fixture<RichTextEditor>> {
     return await fixture<RichTextEditor>(
         // prettier-ignore
-        html`<nimble-rich-text-editor>
-            <nimble-button slot="footer-actions" id="cancel">Cancel</nimble-button>
-            <nimble-button slot="footer-actions" id="ok">OK</nimble-button>
-        </nimble-rich-text-editor>`
+        html`<${richTextEditorTag}>
+            <${buttonTag} slot="footer-actions" id="cancel">Cancel</${buttonTag}>
+            <${buttonTag} slot="footer-actions" id="ok">OK</${buttonTag}>
+        </${richTextEditorTag}>`
     );
 }
 

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
@@ -5,7 +5,7 @@ import { type Fixture, fixture } from '../../../utilities/tests/fixture';
 import { RichTextEditorPageObject } from '../testing/rich-text-editor.pageobject';
 import { wackyStrings } from '../../../utilities/tests/wacky-strings';
 import type { Button } from '../../../button';
-import type { ToggleButton } from '../../../toggle-button';
+import { toggleButtonTag, type ToggleButton } from '../../../toggle-button';
 import { ToolbarButton } from '../testing/types';
 import { waitForEvent } from '../../../utilities/testing/component';
 import { waitForUpdatesAsync } from '../../../testing/async-helpers';
@@ -44,13 +44,9 @@ describe('RichTextEditor', () => {
     });
 
     it('can construct an element instance', () => {
-        expect(
-            document.createElement('nimble-rich-text-editor')
-        ).toBeInstanceOf(RichTextEditor);
-    });
-
-    it('should export its tag', () => {
-        expect(richTextEditorTag).toBe('nimble-rich-text-editor');
+        expect(document.createElement(richTextEditorTag)).toBeInstanceOf(
+            RichTextEditor
+        );
     });
 
     it('should initialize Tiptap editor', () => {
@@ -245,9 +241,7 @@ describe('RichTextEditor', () => {
             spec(
                 `"${name}" button not propagate change event to parent element`,
                 () => {
-                    const buttons: NodeListOf<ToggleButton> = element.shadowRoot!.querySelectorAll(
-                        'nimble-toggle-button'
-                    );
+                    const buttons: NodeListOf<ToggleButton> = element.shadowRoot!.querySelectorAll(toggleButtonTag);
                     const button = buttons[value.toolbarButtonIndex];
                     const buttonParent = button!.parentElement;
                     const spy = jasmine.createSpy();

--- a/packages/nimble-components/src/rich-text/mention-listbox/tests/mention-listbox.spec.ts
+++ b/packages/nimble-components/src/rich-text/mention-listbox/tests/mention-listbox.spec.ts
@@ -10,15 +10,9 @@ import {
 import { checkFullyInViewport } from '../../../utilities/tests/intersection-observer';
 
 describe('RichTextMentionListbox', () => {
-    it('should export its tag', () => {
-        expect(richTextMentionListboxTag).toBe(
-            'nimble-rich-text-mention-listbox'
-        );
-    });
-
     it('can construct an element instance', () => {
         expect(
-            document.createElement('nimble-rich-text-mention-listbox')
+            document.createElement(richTextMentionListboxTag)
         ).toBeInstanceOf(RichTextMentionListbox);
     });
 

--- a/packages/nimble-components/src/rich-text/models/tests/markdown-serializer.spec.ts
+++ b/packages/nimble-components/src/rich-text/models/tests/markdown-serializer.spec.ts
@@ -1,5 +1,5 @@
 import { html } from '@microsoft/fast-element';
-import type { RichTextEditor } from '../../editor';
+import { richTextEditorTag, type RichTextEditor } from '../../editor';
 import { fixture, type Fixture } from '../../../utilities/tests/fixture';
 import { RichTextEditorPageObject } from '../../editor/testing/rich-text-editor.pageobject';
 import { ToolbarButton } from '../../editor/testing/types';
@@ -11,7 +11,7 @@ import { waitForUpdatesAsync } from '../../../testing/async-helpers';
 
 async function setup(): Promise<Fixture<RichTextEditor>> {
     return await fixture<RichTextEditor>(
-        html`<nimble-rich-text-editor></nimble-rich-text-editor>`
+        html`<${richTextEditorTag}></${richTextEditorTag}>`
     );
 }
 

--- a/packages/nimble-components/src/rich-text/viewer/tests/rich-text-viewer.spec.ts
+++ b/packages/nimble-components/src/rich-text/viewer/tests/rich-text-viewer.spec.ts
@@ -78,10 +78,6 @@ describe('RichTextViewer', () => {
         );
     });
 
-    it('should export its tag', () => {
-        expect(richTextViewerTag).toBe('nimble-rich-text-viewer');
-    });
-
     it('set the markdown attribute and ensure the markdown property is not modified', () => {
         element.setAttribute('markdown', '**markdown string**');
 

--- a/packages/nimble-components/src/select/testing/tests/select.pageobject.spec.ts
+++ b/packages/nimble-components/src/select/testing/tests/select.pageobject.spec.ts
@@ -1,25 +1,26 @@
 import { html } from '@microsoft/fast-element';
 import { fixture, Fixture } from '../../../utilities/tests/fixture';
 import { SelectPageObject } from '../select.pageobject';
-import type { Select } from '../..';
+import { selectTag, type Select } from '../..';
+import { listOptionTag } from '../../../list-option';
 
 async function setup(): Promise<Fixture<Select>> {
     const viewTemplate = html`
-        <nimble-select>
-            <nimble-list-option value="one">One</nimble-list-option>
-            <nimble-list-option value="two">Two</nimble-list-option>
-        </nimble-select>
+        <${selectTag}>
+            <${listOptionTag} value="one">One</${listOptionTag}>
+            <${listOptionTag} value="two">Two</${listOptionTag}>
+        </${selectTag}>
     `;
     return await fixture<Select>(viewTemplate);
 }
 
 async function setupWithLabel(): Promise<Fixture<Select>> {
     const viewTemplate = html`
-        <nimble-select>
+        <${selectTag}>
             Custom Label Text
-            <nimble-list-option value="one">One</nimble-list-option>
-            <nimble-list-option value="two">Two</nimble-list-option>
-        </nimble-select>
+            <${listOptionTag} value="one">One</${listOptionTag}>
+            <${listOptionTag} value="two">Two</${listOptionTag}>
+        </${selectTag}>
     `;
     return await fixture<Select>(viewTemplate);
 }

--- a/packages/nimble-components/src/select/tests/select.pageobject.internal.ts
+++ b/packages/nimble-components/src/select/tests/select.pageobject.internal.ts
@@ -1,5 +1,8 @@
 import type { Select } from '..';
-import type { ListOptionGroup } from '../../list-option-group';
+import {
+    listOptionGroupTag,
+    type ListOptionGroup
+} from '../../list-option-group';
 import { SelectPageObject } from '../testing/select.pageobject';
 
 /**
@@ -17,7 +20,7 @@ export class SelectPageObjectInternal extends SelectPageObject {
     public getAllGroups(): ListOptionGroup[] {
         return Array.from(
             this.selectElement.querySelectorAll<ListOptionGroup>(
-                'nimble-list-option-group'
+                listOptionGroupTag
             )
         );
     }
@@ -32,7 +35,7 @@ export class SelectPageObjectInternal extends SelectPageObject {
 
     public getGroup(index: number): ListOptionGroup {
         const group = this.selectElement.querySelectorAll<ListOptionGroup>(
-            'nimble-list-option-group'
+            listOptionGroupTag
         )[index];
         if (!group) {
             throw new Error(`Group at index ${index} not found`);

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -12,7 +12,7 @@ import {
     waitAnimationFrame
 } from '../../utilities/testing/component';
 import { filterSearchLabel } from '../../label-provider/core/label-tokens';
-import { ListOptionGroup } from '../../list-option-group';
+import { ListOptionGroup, listOptionGroupTag } from '../../list-option-group';
 import type { Button } from '../../button';
 import { isListOptionGroup } from '../template';
 
@@ -43,62 +43,62 @@ async function setup(
     secondOptionState?: OptionInitialState
 ): Promise<Fixture<Select>> {
     const viewTemplate = html`
-        <nimble-select
+        <${selectTag}
             ${position !== undefined ? `position="${position}"` : ''}
             ${open ? 'open' : ''}
         >
-            <nimble-list-option
+            <${listOptionTag}
                 value="one"
                 ${firstOptionState !== undefined ? firstOptionState : ''}
-                >One</nimble-list-option
+                >One</${listOptionTag}
             >
-            <nimble-list-option
+            <${listOptionTag}
                 value="two"
                 ${secondOptionState !== undefined ? secondOptionState : ''}
-                >Two</nimble-list-option
+                >Two</${listOptionTag}
             >
-            <nimble-list-option value="three">Three</nimble-list-option>
-            <nimble-list-option disabled value="t-disabled"
-                >T Disabled</nimble-list-option
+            <${listOptionTag} value="three">Three</${listOptionTag}>
+            <${listOptionTag} disabled value="t-disabled"
+                >T Disabled</${listOptionTag}
             >
-            <nimble-list-option value="zürich">Zürich</nimble-list-option>
-            <nimble-list-option value="has space">Has Space</nimble-list-option>
-        </nimble-select>
+            <${listOptionTag} value="zürich">Zürich</${listOptionTag}>
+            <${listOptionTag} value="has space">Has Space</${listOptionTag}>
+        </${selectTag}>
     `;
     return await fixture<Select>(viewTemplate);
 }
 
 async function setupWithSpanLabels(): Promise<Fixture<Select>> {
     const viewTemplate = html`
-        <nimble-select>
-            <nimble-list-option value="one">
+        <${selectTag}>
+            <${listOptionTag} value="one">
                 <span>One</span>
-            </nimble-list-option>
-            <nimble-list-option value="two">
+            </${listOptionTag}>
+            <${listOptionTag} value="two">
                 <span>Two</span>
-            </nimble-list-option>
-        </nimble-select>
+            </${listOptionTag}>
+        </${selectTag}>
     `;
     return await fixture<Select>(viewTemplate);
 }
 async function setupWithGroups(): Promise<Fixture<Select>> {
     const viewTemplate = html`
-        <nimble-select>
-            <nimble-list-option-group label="Group One">
-                <nimble-list-option value="one">One</nimble-list-option>
-                <nimble-list-option value="two">Two</nimble-list-option>
-                <nimble-list-option value="edge">Edge</nimble-list-option>
-            </nimble-list-option-group>
-            <nimble-list-option-group label="Group Two">
-                <nimble-list-option value="three">Three</nimble-list-option>
-                <nimble-list-option value="four">Four</nimble-list-option>
-            </nimble-list-option-group>
-            <nimble-list-option-group label="Gróup Three">
-                <nimble-list-option value="five">Five</nimble-list-option>
-                <nimble-list-option value="six">Six</nimble-list-option>
-                <nimble-list-option value="edge">Edge</nimble-list-option>
-            </nimble-list-option-group>
-        </nimble-select>
+        <${selectTag}>
+            <${listOptionGroupTag} label="Group One">
+                <${listOptionTag} value="one">One</${listOptionTag}>
+                <${listOptionTag} value="two">Two</${listOptionTag}>
+                <${listOptionTag} value="edge">Edge</${listOptionTag}>
+            </${listOptionGroupTag}>
+            <${listOptionGroupTag} label="Group Two">
+                <${listOptionTag} value="three">Three</${listOptionTag}>
+                <${listOptionTag} value="four">Four</${listOptionTag}>
+            </${listOptionGroupTag}>
+            <${listOptionGroupTag} label="Gróup Three">
+                <${listOptionTag} value="five">Five</${listOptionTag}>
+                <${listOptionTag} value="six">Six</${listOptionTag}>
+                <${listOptionTag} value="edge">Edge</${listOptionTag}>
+            </${listOptionGroupTag}>
+        </${selectTag}>
     `;
     return await fixture<Select>(viewTemplate);
 }
@@ -825,17 +825,17 @@ describe('Select', () => {
     describe('with all options disabled', () => {
         async function setupAllDisabled(): Promise<Fixture<Select>> {
             const viewTemplate = html`
-                <nimble-select>
-                    <nimble-list-option disabled value="one"
-                        >One</nimble-list-option
+                <${selectTag}>
+                    <${listOptionTag} disabled value="one"
+                        >One</${listOptionTag}
                     >
-                    <nimble-list-option disabled value="two"
-                        >Two</nimble-list-option
+                    <${listOptionTag} disabled value="two"
+                        >Two</${listOptionTag}
                     >
-                    <nimble-list-option disabled value="three"
-                        >Three</nimble-list-option
+                    <${listOptionTag} disabled value="three"
+                        >Three</${listOptionTag}
                     >
-                </nimble-select>
+                </${selectTag}>
             `;
             return await fixture<Select>(viewTemplate);
         }
@@ -854,17 +854,17 @@ describe('Select', () => {
     describe('with all options hidden', () => {
         async function setupAllHidden(): Promise<Fixture<Select>> {
             const viewTemplate = html`
-                <nimble-select>
-                    <nimble-list-option hidden value="one"
-                        >One</nimble-list-option
+                <${selectTag}>
+                    <${listOptionTag} hidden value="one"
+                        >One</${listOptionTag}
                     >
-                    <nimble-list-option hidden value="two"
-                        >Two</nimble-list-option
+                    <${listOptionTag} hidden value="two"
+                        >Two</${listOptionTag}
                     >
-                    <nimble-list-option hidden value="three"
-                        >Three</nimble-list-option
+                    <${listOptionTag} hidden value="three"
+                        >Three</${listOptionTag}
                     >
-                </nimble-select>
+                </${selectTag}>
             `;
             return await fixture<Select>(viewTemplate);
         }
@@ -886,7 +886,7 @@ describe('Select', () => {
             const viewTemplate = html`
                 <${selectTag}>
                     ${repeat(() => [...Array(500).keys()], html<number>`
-                        <nimble-list-option value="${x => x}">${x => x}</nimble-list-option>`)}
+                        <${listOptionTag} value="${x => x}">${x => x}</${listOptionTag}>`)}
                 </${selectTag}>
             `;
             return await fixture<Select>(viewTemplate);

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -961,12 +961,8 @@ describe('Select', () => {
         });
     });
 
-    it('should export its tag', () => {
-        expect(selectTag).toBe('nimble-select');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-select')).toBeInstanceOf(Select);
+        expect(document.createElement(selectTag)).toBeInstanceOf(Select);
     });
 
     describe('title overflow', () => {

--- a/packages/nimble-components/src/spinner/tests/spinner.spec.ts
+++ b/packages/nimble-components/src/spinner/tests/spinner.spec.ts
@@ -1,6 +1,6 @@
 import { html } from '@microsoft/fast-element';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
-import { Spinner } from '..';
+import { Spinner, spinnerTag } from '..';
 
 async function setup(): Promise<Fixture<Spinner>> {
     const viewTemplate = html` <nimble-spinner> </nimble-spinner> `;
@@ -33,9 +33,7 @@ describe('Spinner', () => {
         });
 
         it('can construct an element instance', () => {
-            expect(document.createElement('nimble-spinner')).toBeInstanceOf(
-                Spinner
-            );
+            expect(document.createElement(spinnerTag)).toBeInstanceOf(Spinner);
         });
 
         it('should have size 16x16 by default', () => {

--- a/packages/nimble-components/src/spinner/tests/spinner.spec.ts
+++ b/packages/nimble-components/src/spinner/tests/spinner.spec.ts
@@ -3,7 +3,7 @@ import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Spinner, spinnerTag } from '..';
 
 async function setup(): Promise<Fixture<Spinner>> {
-    const viewTemplate = html` <nimble-spinner> </nimble-spinner> `;
+    const viewTemplate = html` <${spinnerTag}> </${spinnerTag}> `;
     return await fixture<Spinner>(viewTemplate);
 }
 

--- a/packages/nimble-components/src/switch/tests/switch.spec.ts
+++ b/packages/nimble-components/src/switch/tests/switch.spec.ts
@@ -5,7 +5,7 @@ import { Switch, switchTag } from '..';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 
 async function setup(): Promise<Fixture<Switch>> {
-    return await fixture<Switch>(html`<nimble-switch></nimble-switch>`);
+    return await fixture<Switch>(html`<${switchTag}></${switchTag}>`);
 }
 
 describe('Switch', () => {

--- a/packages/nimble-components/src/switch/tests/switch.spec.ts
+++ b/packages/nimble-components/src/switch/tests/switch.spec.ts
@@ -22,12 +22,8 @@ describe('Switch', () => {
         await disconnect();
     });
 
-    it('should export its tag', () => {
-        expect(switchTag).toBe('nimble-switch');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-switch')).toBeInstanceOf(Switch);
+        expect(document.createElement(switchTag)).toBeInstanceOf(Switch);
     });
 
     it('should have a role of `switch`', async () => {

--- a/packages/nimble-components/src/tab-panel/tests/tab-panel.spec.ts
+++ b/packages/nimble-components/src/tab-panel/tests/tab-panel.spec.ts
@@ -1,13 +1,7 @@
 import { TabPanel, tabPanelTag } from '..';
 
 describe('TabPanel', () => {
-    it('should export its tag', () => {
-        expect(tabPanelTag).toBe('nimble-tab-panel');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-tab-panel')).toBeInstanceOf(
-            TabPanel
-        );
+        expect(document.createElement(tabPanelTag)).toBeInstanceOf(TabPanel);
     });
 });

--- a/packages/nimble-components/src/tab/tests/tab.spec.ts
+++ b/packages/nimble-components/src/tab/tests/tab.spec.ts
@@ -1,11 +1,7 @@
 import { Tab, tabTag } from '..';
 
 describe('Tab', () => {
-    it('should export its tag', () => {
-        expect(tabTag).toBe('nimble-tab');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-tab')).toBeInstanceOf(Tab);
+        expect(document.createElement(tabTag)).toBeInstanceOf(Tab);
     });
 });

--- a/packages/nimble-components/src/table-column/anchor/cell-view/tests/table-column-anchor-cell-view.spec.ts
+++ b/packages/nimble-components/src/table-column/anchor/cell-view/tests/table-column-anchor-cell-view.spec.ts
@@ -1,15 +1,9 @@
 import { TableColumnAnchorCellView, tableColumnAnchorCellViewTag } from '..';
 
 describe('TableColumnAnchorCellView', () => {
-    it('should export its tag', () => {
-        expect(tableColumnAnchorCellViewTag).toBe(
-            'nimble-table-column-anchor-cell-view'
-        );
-    });
-
     it('can construct an element instance', () => {
         expect(
-            document.createElement('nimble-table-column-anchor-cell-view')
+            document.createElement(tableColumnAnchorCellViewTag)
         ).toBeInstanceOf(TableColumnAnchorCellView);
     });
 });

--- a/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.spec.ts
+++ b/packages/nimble-components/src/table-column/anchor/tests/table-column-anchor.spec.ts
@@ -70,14 +70,10 @@ describe('TableColumnAnchor', () => {
         await disconnect();
     });
 
-    it('should export its tag', () => {
-        expect(tableColumnAnchorTag).toBe('nimble-table-column-anchor');
-    });
-
     it('can construct an element instance', () => {
-        expect(
-            document.createElement('nimble-table-column-anchor')
-        ).toBeInstanceOf(TableColumnAnchor);
+        expect(document.createElement(tableColumnAnchorTag)).toBeInstanceOf(
+            TableColumnAnchor
+        );
     });
 
     it('reports column configuration valid', async () => {

--- a/packages/nimble-components/src/table-column/date-text/cell-view/tests/table-column-date-text-cell-view.spec.ts
+++ b/packages/nimble-components/src/table-column/date-text/cell-view/tests/table-column-date-text-cell-view.spec.ts
@@ -4,15 +4,9 @@ import {
 } from '..';
 
 describe('TableColumnDateTextCellView', () => {
-    it('should export its tag', () => {
-        expect(tableColumnDateTextCellViewTag).toBe(
-            'nimble-table-column-date-text-cell-view'
-        );
-    });
-
     it('can construct an element instance', () => {
         expect(
-            document.createElement('nimble-table-column-date-text-cell-view')
+            document.createElement(tableColumnDateTextCellViewTag)
         ).toBeInstanceOf(TableColumnDateTextCellView);
     });
 });

--- a/packages/nimble-components/src/table-column/date-text/group-header-view/tests/table-column-date-text-group-header-view.spec.ts
+++ b/packages/nimble-components/src/table-column/date-text/group-header-view/tests/table-column-date-text-group-header-view.spec.ts
@@ -4,17 +4,9 @@ import {
 } from '..';
 
 describe('TableColumnDateTextGroupHeaderView', () => {
-    it('should export its tag', () => {
-        expect(tableColumnDateTextGroupHeaderViewTag).toBe(
-            'nimble-table-column-date-text-group-header-view'
-        );
-    });
-
     it('can construct an element instance', () => {
         expect(
-            document.createElement(
-                'nimble-table-column-date-text-group-header-view'
-            )
+            document.createElement(tableColumnDateTextGroupHeaderViewTag)
         ).toBeInstanceOf(TableColumnDateTextGroupHeaderView);
     });
 });

--- a/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.spec.ts
+++ b/packages/nimble-components/src/table-column/date-text/tests/table-column-date-text.spec.ts
@@ -62,15 +62,9 @@ describe('TableColumnDateText', () => {
             await disconnect();
         });
 
-        it('should export its tag', () => {
-            expect(tableColumnDateTextTag).toBe(
-                'nimble-table-column-date-text'
-            );
-        });
-
         it('can construct an element instance', () => {
             expect(
-                document.createElement('nimble-table-column-date-text')
+                document.createElement(tableColumnDateTextTag)
             ).toBeInstanceOf(TableColumnDateText);
         });
 

--- a/packages/nimble-components/src/table-column/duration-text/cell-view/tests/table-column-duration-text-cell-view.spec.ts
+++ b/packages/nimble-components/src/table-column/duration-text/cell-view/tests/table-column-duration-text-cell-view.spec.ts
@@ -4,17 +4,9 @@ import {
 } from '..';
 
 describe('TableColumnDurationTextCellView', () => {
-    it('should export its tag', () => {
-        expect(tableColumnDurationTextCellViewTag).toBe(
-            'nimble-table-column-duration-text-cell-view'
-        );
-    });
-
     it('can construct an element instance', () => {
         expect(
-            document.createElement(
-                'nimble-table-column-duration-text-cell-view'
-            )
+            document.createElement(tableColumnDurationTextCellViewTag)
         ).toBeInstanceOf(TableColumnDurationTextCellView);
     });
 });

--- a/packages/nimble-components/src/table-column/duration-text/group-header-view/tests/table-column-duration-text-group-header-view.spec.ts
+++ b/packages/nimble-components/src/table-column/duration-text/group-header-view/tests/table-column-duration-text-group-header-view.spec.ts
@@ -4,17 +4,9 @@ import {
 } from '..';
 
 describe('TableColumnDurationTextGroupHeaderView', () => {
-    it('should export its tag', () => {
-        expect(tableColumnDurationTextGroupHeaderViewTag).toBe(
-            'nimble-table-column-duration-text-group-header-view'
-        );
-    });
-
     it('can construct an element instance', () => {
         expect(
-            document.createElement(
-                'nimble-table-column-duration-text-group-header-view'
-            )
+            document.createElement(tableColumnDurationTextGroupHeaderViewTag)
         ).toBeInstanceOf(TableColumnDurationTextGroupHeaderView);
     });
 });

--- a/packages/nimble-components/src/table-column/duration-text/tests/table-column-duration-text.spec.ts
+++ b/packages/nimble-components/src/table-column/duration-text/tests/table-column-duration-text.spec.ts
@@ -60,15 +60,9 @@ describe('TableColumnDurationText', () => {
         await disconnect();
     });
 
-    it('should export its tag', () => {
-        expect(tableColumnDurationTextTag).toBe(
-            'nimble-table-column-duration-text'
-        );
-    });
-
     it('can construct an element instance', () => {
         expect(
-            document.createElement('nimble-table-column-duration-text')
+            document.createElement(tableColumnDurationTextTag)
         ).toBeInstanceOf(TableColumnDurationText);
     });
 

--- a/packages/nimble-components/src/table-column/mapping/cell-view/tests/table-column-mapping-cell-view.spec.ts
+++ b/packages/nimble-components/src/table-column/mapping/cell-view/tests/table-column-mapping-cell-view.spec.ts
@@ -1,15 +1,9 @@
 import { TableColumnMappingCellView, tableColumnMappingCellViewTag } from '..';
 
 describe('TableColumnMappingCellView', () => {
-    it('should export its tag', () => {
-        expect(tableColumnMappingCellViewTag).toBe(
-            'nimble-table-column-mapping-cell-view'
-        );
-    });
-
     it('can construct an element instance', () => {
         expect(
-            document.createElement('nimble-table-column-mapping-cell-view')
+            document.createElement(tableColumnMappingCellViewTag)
         ).toBeInstanceOf(TableColumnMappingCellView);
     });
 });

--- a/packages/nimble-components/src/table-column/mapping/group-header-view/tests/table-column-mapping-group-header-view.spec.ts
+++ b/packages/nimble-components/src/table-column/mapping/group-header-view/tests/table-column-mapping-group-header-view.spec.ts
@@ -4,17 +4,9 @@ import {
 } from '..';
 
 describe('TableColumnMappingGroupHeaderView', () => {
-    it('should export its tag', () => {
-        expect(tableColumnMappingGroupHeaderViewTag).toBe(
-            'nimble-table-column-mapping-group-header-view'
-        );
-    });
-
     it('can construct an element instance', () => {
         expect(
-            document.createElement(
-                'nimble-table-column-mapping-group-header-view'
-            )
+            document.createElement(tableColumnMappingGroupHeaderViewTag)
         ).toBeInstanceOf(TableColumnMappingGroupHeaderView);
     });
 });

--- a/packages/nimble-components/src/table-column/mapping/tests/table-column-mapping.spec.ts
+++ b/packages/nimble-components/src/table-column/mapping/tests/table-column-mapping.spec.ts
@@ -113,14 +113,10 @@ describe('TableColumnMapping', () => {
         }
     });
 
-    it('should export its tag', () => {
-        expect(tableColumnMappingTag).toBe('nimble-table-column-mapping');
-    });
-
     it('can construct an element instance', () => {
-        expect(
-            document.createElement('nimble-table-column-mapping')
-        ).toBeInstanceOf(TableColumnMapping);
+        expect(document.createElement(tableColumnMappingTag)).toBeInstanceOf(
+            TableColumnMapping
+        );
     });
 
     describe('various key types', () => {

--- a/packages/nimble-components/src/table-column/menu-button/cell-view/tests/table-column-menu-button-cell-view.spec.ts
+++ b/packages/nimble-components/src/table-column/menu-button/cell-view/tests/table-column-menu-button-cell-view.spec.ts
@@ -4,15 +4,9 @@ import {
 } from '..';
 
 describe('TableColumnMenuButtonCellView', () => {
-    it('should export its tag', () => {
-        expect(tableColumnMenuButtonCellViewTag).toBe(
-            'nimble-table-column-menu-button-cell-view'
-        );
-    });
-
     it('can construct an element instance', () => {
         expect(
-            document.createElement('nimble-table-column-menu-button-cell-view')
+            document.createElement(tableColumnMenuButtonCellViewTag)
         ).toBeInstanceOf(TableColumnMenuButtonCellView);
     });
 });

--- a/packages/nimble-components/src/table-column/menu-button/tests/table-column-menu-button.spec.ts
+++ b/packages/nimble-components/src/table-column/menu-button/tests/table-column-menu-button.spec.ts
@@ -84,16 +84,10 @@ describe('TableColumnMenuButton', () => {
         await disconnect();
     });
 
-    it('should export its tag', () => {
-        expect(tableColumnMenuButtonTag).toBe(
-            'nimble-table-column-menu-button'
-        );
-    });
-
     it('can construct an element instance', () => {
-        expect(
-            document.createElement('nimble-table-column-menu-button')
-        ).toBeInstanceOf(TableColumnMenuButton);
+        expect(document.createElement(tableColumnMenuButtonTag)).toBeInstanceOf(
+            TableColumnMenuButton
+        );
     });
 
     it('reports column configuration valid', async () => {

--- a/packages/nimble-components/src/table-column/number-text/cell-view/tests/table-column-number-text-cell-view.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/cell-view/tests/table-column-number-text-cell-view.spec.ts
@@ -4,15 +4,9 @@ import {
 } from '..';
 
 describe('TableColumnNumberTextCellView', () => {
-    it('should export its tag', () => {
-        expect(tableColumnNumberTextCellViewTag).toBe(
-            'nimble-table-column-number-text-cell-view'
-        );
-    });
-
     it('can construct an element instance', () => {
         expect(
-            document.createElement('nimble-table-column-number-text-cell-view')
+            document.createElement(tableColumnNumberTextCellViewTag)
         ).toBeInstanceOf(TableColumnNumberTextCellView);
     });
 });

--- a/packages/nimble-components/src/table-column/number-text/group-header-view/tests/table-column-number-text-group-header-view.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/group-header-view/tests/table-column-number-text-group-header-view.spec.ts
@@ -4,17 +4,9 @@ import {
 } from '..';
 
 describe('TableColumnNumberTextGroupHeaderView', () => {
-    it('should export its tag', () => {
-        expect(tableColumnNumberTextGroupHeaderTag).toBe(
-            'nimble-table-column-number-text-group-header-view'
-        );
-    });
-
     it('can construct an element instance', () => {
         expect(
-            document.createElement(
-                'nimble-table-column-number-text-group-header-view'
-            )
+            document.createElement(tableColumnNumberTextGroupHeaderTag)
         ).toBeInstanceOf(TableColumnNumberTextGroupHeaderView);
     });
 });

--- a/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.spec.ts
+++ b/packages/nimble-components/src/table-column/number-text/tests/table-column-number-text.spec.ts
@@ -57,16 +57,10 @@ describe('TableColumnNumberText', () => {
         await disconnect();
     });
 
-    it('should export its tag', () => {
-        expect(tableColumnNumberTextTag).toBe(
-            'nimble-table-column-number-text'
-        );
-    });
-
     it('can construct an element instance', () => {
-        expect(
-            document.createElement('nimble-table-column-number-text')
-        ).toBeInstanceOf(TableColumnNumberText);
+        expect(document.createElement(tableColumnNumberTextTag)).toBeInstanceOf(
+            TableColumnNumberText
+        );
     });
 
     it('reports column configuration valid', async () => {

--- a/packages/nimble-components/src/table-column/text/cell-view/tests/table-column-text-cell-view.spec.ts
+++ b/packages/nimble-components/src/table-column/text/cell-view/tests/table-column-text-cell-view.spec.ts
@@ -1,15 +1,9 @@
 import { TableColumnTextCellView, tableColumnTextCellViewTag } from '..';
 
 describe('TableColumnTextCellView', () => {
-    it('should export its tag', () => {
-        expect(tableColumnTextCellViewTag).toBe(
-            'nimble-table-column-text-cell-view'
-        );
-    });
-
     it('can construct an element instance', () => {
         expect(
-            document.createElement('nimble-table-column-text-cell-view')
+            document.createElement(tableColumnTextCellViewTag)
         ).toBeInstanceOf(TableColumnTextCellView);
     });
 });

--- a/packages/nimble-components/src/table-column/text/group-header-view/tests/table-column-text-group-header-view.spec.ts
+++ b/packages/nimble-components/src/table-column/text/group-header-view/tests/table-column-text-group-header-view.spec.ts
@@ -4,15 +4,9 @@ import {
 } from '..';
 
 describe('TableColumnTextGroupHeaderView', () => {
-    it('should export its tag', () => {
-        expect(tableColumnTextGroupHeaderViewTag).toBe(
-            'nimble-table-column-text-group-header-view'
-        );
-    });
-
     it('can construct an element instance', () => {
         expect(
-            document.createElement('nimble-table-column-text-group-header-view')
+            document.createElement(tableColumnTextGroupHeaderViewTag)
         ).toBeInstanceOf(TableColumnTextGroupHeaderView);
     });
 });

--- a/packages/nimble-components/src/table-column/text/tests/table-column-text.spec.ts
+++ b/packages/nimble-components/src/table-column/text/tests/table-column-text.spec.ts
@@ -55,14 +55,10 @@ describe('TableColumnText', () => {
         await disconnect();
     });
 
-    it('should export its tag', () => {
-        expect(tableColumnTextTag).toBe('nimble-table-column-text');
-    });
-
     it('can construct an element instance', () => {
-        expect(
-            document.createElement('nimble-table-column-text')
-        ).toBeInstanceOf(TableColumnText);
+        expect(document.createElement(tableColumnTextTag)).toBeInstanceOf(
+            TableColumnText
+        );
     });
 
     it('reports column configuration valid', async () => {

--- a/packages/nimble-components/src/table/components/cell/tests/table-cell.spec.ts
+++ b/packages/nimble-components/src/table/components/cell/tests/table-cell.spec.ts
@@ -29,8 +29,8 @@ class TestTableColumnCellView extends TableCellView<SimpleTableCellRecord> {}
 // prettier-ignore
 async function setup(): Promise<Fixture<TableCell<SimpleTableCellRecord>>> {
     return await fixture<TableCell<SimpleTableCellRecord>>(
-        html`<nimble-table-cell>
-            </nimble-table-cell>`
+        html`<${tableCellTag}>
+            </${tableCellTag}>`
     );
 }
 

--- a/packages/nimble-components/src/table/components/cell/tests/table-cell.spec.ts
+++ b/packages/nimble-components/src/table/components/cell/tests/table-cell.spec.ts
@@ -1,5 +1,5 @@
 import { html, customElement } from '@microsoft/fast-element';
-import { TableCell } from '..';
+import { TableCell, tableCellTag } from '..';
 import { waitForUpdatesAsync } from '../../../../testing/async-helpers';
 import {
     fixture,
@@ -51,8 +51,7 @@ describe('TableCell', () => {
     });
 
     it('can construct an element instance', () => {
-        // prettier-ignore
-        expect(document.createElement('nimble-table-cell')).toBeInstanceOf(TableCell);
+        expect(document.createElement(tableCellTag)).toBeInstanceOf(TableCell);
     });
 
     it('renders correct cell view type', async () => {

--- a/packages/nimble-components/src/table/components/group-row/tests/table-group-row.spec.ts
+++ b/packages/nimble-components/src/table/components/group-row/tests/table-group-row.spec.ts
@@ -15,8 +15,8 @@ type TableRowSelectionToggleEventHandler = (
 // prettier-ignore
 async function setup(): Promise<Fixture<TableGroupRow>> {
     return await fixture<TableGroupRow>(
-        html`<nimble-table-group-row>
-            </nimble-table-group-row>`
+        html`<${tableGroupRowTag}>
+            </${tableGroupRowTag}>`
     );
 }
 

--- a/packages/nimble-components/src/table/components/group-row/tests/table-group-row.spec.ts
+++ b/packages/nimble-components/src/table/components/group-row/tests/table-group-row.spec.ts
@@ -1,5 +1,5 @@
 import { html } from '@microsoft/fast-element';
-import { TableGroupRow } from '..';
+import { TableGroupRow, tableGroupRowTag } from '..';
 import { waitForEvent } from '../../../../utilities/testing/component';
 import { fixture, Fixture } from '../../../../utilities/tests/fixture';
 import { waitForUpdatesAsync } from '../../../../testing/async-helpers';
@@ -33,8 +33,9 @@ describe('TableGroupRow', () => {
     });
 
     it('can construct an element instance', () => {
-        // prettier-ignore
-        expect(document.createElement('nimble-table-group-row')).toBeInstanceOf(TableGroupRow);
+        expect(document.createElement(tableGroupRowTag)).toBeInstanceOf(
+            TableGroupRow
+        );
     });
 
     it('should have role of row', async () => {

--- a/packages/nimble-components/src/table/components/header/tests/table-header.spec.ts
+++ b/packages/nimble-components/src/table/components/header/tests/table-header.spec.ts
@@ -1,5 +1,5 @@
 import { html } from '@microsoft/fast-element';
-import { TableHeader } from '..';
+import { TableHeader, tableHeaderTag } from '..';
 import { waitForUpdatesAsync } from '../../../../testing/async-helpers';
 import { type Fixture, fixture } from '../../../../utilities/tests/fixture';
 import { TableColumnAlignment, TableColumnSortDirection } from '../../../types';
@@ -28,8 +28,9 @@ describe('TableHeader', () => {
     });
 
     it('can construct an element instance', () => {
-        // prettier-ignore
-        expect(document.createElement('nimble-table-header')).toBeInstanceOf(TableHeader);
+        expect(document.createElement(tableHeaderTag)).toBeInstanceOf(
+            TableHeader
+        );
     });
 
     it('has role of columnheader', () => {

--- a/packages/nimble-components/src/table/components/header/tests/table-header.spec.ts
+++ b/packages/nimble-components/src/table/components/header/tests/table-header.spec.ts
@@ -7,7 +7,7 @@ import { TableHeaderPageObject } from './table-header-pageobject';
 
 async function setup(): Promise<Fixture<TableHeader>> {
     return await fixture<TableHeader>(
-        html`<nimble-table-header> </nimble-table-header>`
+        html`<${tableHeaderTag}> </${tableHeaderTag}>`
     );
 }
 

--- a/packages/nimble-components/src/table/components/row/tests/table-row.spec.ts
+++ b/packages/nimble-components/src/table/components/row/tests/table-row.spec.ts
@@ -1,5 +1,5 @@
 import { html, ref } from '@microsoft/fast-element';
-import { TableRow } from '..';
+import { TableRow, tableRowTag } from '..';
 import {
     tableColumnTextTag,
     TableColumnText,
@@ -58,8 +58,9 @@ describe('TableRow', () => {
         });
 
         it('can construct an element instance', () => {
-            // prettier-ignore
-            expect(document.createElement('nimble-table-row')).toBeInstanceOf(TableRow);
+            expect(document.createElement(tableRowTag)).toBeInstanceOf(
+                TableRow
+            );
         });
 
         it('includes row operations gridcell when rowOperationGridCellHidden is false', async () => {
@@ -386,7 +387,7 @@ describe('TableRow', () => {
                 }
             ]);
             await waitForUpdatesAsync();
-            row = element.shadowRoot!.querySelector('nimble-table-row')!;
+            row = element.shadowRoot!.querySelector(tableRowTag)!;
             pageObject = new TableRowPageObject(row);
         });
 

--- a/packages/nimble-components/src/table/components/row/tests/table-row.spec.ts
+++ b/packages/nimble-components/src/table/components/row/tests/table-row.spec.ts
@@ -40,8 +40,8 @@ describe('TableRow', () => {
         // prettier-ignore
         async function setup(): Promise<Fixture<TableRow<SimpleTableRecord>>> {
             return await fixture<TableRow<SimpleTableRecord>>(
-                html`<nimble-table-row>
-                    </nimble-table-row>`
+                html`<${tableRowTag}>
+                    </${tableRowTag}>`
             );
         }
 

--- a/packages/nimble-components/src/table/testing/table.pageobject.ts
+++ b/packages/nimble-components/src/table/testing/table.pageobject.ts
@@ -2,20 +2,20 @@ import type { Checkbox } from '@microsoft/fast-foundation';
 import { keyShift } from '@microsoft/fast-web-utilities';
 import { parseColor } from '@microsoft/fast-colors';
 import type { Table } from '..';
-import type { TableHeader } from '../components/header';
+import { tableHeaderTag, type TableHeader } from '../components/header';
 import {
     TableColumnSortDirection,
     TableRecord,
     TableRowSelectionState
 } from '../types';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
-import type { MenuButton } from '../../menu-button';
-import type { TableCell } from '../components/cell';
+import { menuButtonTag, type MenuButton } from '../../menu-button';
+import { tableCellTag, type TableCell } from '../components/cell';
 import type { TableGroupHeaderView } from '../../table-column/base/group-header-view';
 import { TableCellView } from '../../table-column/base/cell-view';
-import type { TableRow } from '../components/row';
+import { tableRowTag, type TableRow } from '../components/row';
 import { Anchor, anchorTag } from '../../anchor';
-import type { TableGroupRow } from '../components/group-row';
+import { tableGroupRowTag, type TableGroupRow } from '../components/group-row';
 import type { Button } from '../../button';
 import { Icon } from '../../icon-base';
 import { Spinner, spinnerTag } from '../../spinner';
@@ -37,21 +37,19 @@ export class TablePageObject<T extends TableRecord> {
     public constructor(private readonly tableElement: Table<T>) {}
 
     public getRenderedHeaderCount(): number {
-        const headers = this.tableElement.shadowRoot!.querySelectorAll(
-            'nimble-table-header'
-        )!;
+        const headers = this.tableElement.shadowRoot!.querySelectorAll(tableHeaderTag)!;
         return headers.length;
     }
 
     public getRenderedCellCountForRow(rowIndex: number): number {
         const row = this.getRow(rowIndex);
-        const cells = row.shadowRoot!.querySelectorAll('nimble-table-cell');
+        const cells = row.shadowRoot!.querySelectorAll(tableCellTag);
         return cells.length;
     }
 
     public getHeaderContent(columnIndex: number): Node | undefined {
         const headers = this.tableElement.shadowRoot!.querySelectorAll<TableHeader>(
-            'nimble-table-header'
+            tableHeaderTag
         )!;
         if (columnIndex >= headers.length) {
             throw new Error(
@@ -64,7 +62,7 @@ export class TablePageObject<T extends TableRecord> {
 
     public getHeaderElement(columnIndex: number): TableHeader {
         const headers = this.tableElement.shadowRoot!.querySelectorAll<TableHeader>(
-            'nimble-table-header'
+            tableHeaderTag
         )!;
         if (columnIndex >= headers.length) {
             throw new Error(
@@ -100,7 +98,7 @@ export class TablePageObject<T extends TableRecord> {
 
     public getHeaderRenderedWidth(columnIndex: number): number {
         const headers = this.tableElement.shadowRoot!.querySelectorAll<TableHeader>(
-            'nimble-table-header'
+            tableHeaderTag
         )!;
         if (columnIndex >= headers.length) {
             throw new Error(
@@ -124,26 +122,22 @@ export class TablePageObject<T extends TableRecord> {
     }
 
     public getRenderedRowCount(): number {
-        return this.tableElement.shadowRoot!.querySelectorAll(
-            'nimble-table-row'
-        ).length;
+        return this.tableElement.shadowRoot!.querySelectorAll(tableRowTag)
+            .length;
     }
 
     public getRenderedGroupRowCount(): number {
-        return this.tableElement.shadowRoot!.querySelectorAll(
-            'nimble-table-group-row'
-        ).length;
+        return this.tableElement.shadowRoot!.querySelectorAll(tableGroupRowTag)
+            .length;
     }
 
     public getAllGroupRowsExpandedState(): boolean[] {
-        const groupRows = this.tableElement.shadowRoot!.querySelectorAll(
-            'nimble-table-group-row'
-        );
+        const groupRows = this.tableElement.shadowRoot!.querySelectorAll(tableGroupRowTag);
         return Array.from(groupRows).map(row => row.expanded);
     }
 
     public getAllDataRowsExpandedState(): boolean[] {
-        const rows = this.tableElement.shadowRoot!.querySelectorAll('nimble-table-row');
+        const rows = this.tableElement.shadowRoot!.querySelectorAll(tableRowTag);
         return Array.from(rows).map(row => row.expanded);
     }
 
@@ -222,9 +216,7 @@ export class TablePageObject<T extends TableRecord> {
     }
 
     public getAllRenderedGroupHeaderTextContent(): string[] {
-        const groupRows = this.tableElement.shadowRoot!.querySelectorAll(
-            'nimble-table-group-row'
-        );
+        const groupRows = this.tableElement.shadowRoot!.querySelectorAll(tableGroupRowTag);
         return Array.from(groupRows).map((_, i) => {
             return this.getRenderedGroupHeaderTextContent(i);
         });
@@ -305,7 +297,7 @@ export class TablePageObject<T extends TableRecord> {
 
     public getTotalCellRenderedWidth(): number {
         const row = this.getRow(0);
-        const cells = row?.shadowRoot?.querySelectorAll('nimble-table-cell');
+        const cells = row?.shadowRoot?.querySelectorAll(tableCellTag);
         return Array.from(cells!).reduce((p, c) => {
             return p + c.getBoundingClientRect().width;
         }, 0);
@@ -327,10 +319,9 @@ export class TablePageObject<T extends TableRecord> {
         rowIndex: number,
         columnIndex: number
     ): MenuButton | null {
-        return this.getCell(
-            rowIndex,
-            columnIndex
-        ).shadowRoot!.querySelector<MenuButton>('nimble-menu-button');
+        return this.getCell(rowIndex, columnIndex).shadowRoot!.querySelector(
+            menuButtonTag
+        );
     }
 
     public async clickCellActionMenu(
@@ -362,7 +353,7 @@ export class TablePageObject<T extends TableRecord> {
 
     public setRowHoverState(rowIndex: number, hover: boolean): void {
         const row = this.getRow(rowIndex);
-        const cells = row.shadowRoot!.querySelectorAll('nimble-table-cell');
+        const cells = row.shadowRoot!.querySelectorAll(tableCellTag);
         if (hover) {
             cells.forEach(cell => cell.style.setProperty(
                 '--ni-private-table-cell-action-menu-display',
@@ -641,7 +632,7 @@ export class TablePageObject<T extends TableRecord> {
     /** @internal */
     public isRowHoverStylingEnabled(): boolean {
         const rows: NodeListOf<TableRow | TableGroupRow> = this.tableElement.shadowRoot!.querySelectorAll(
-            'nimble-table-row, nimble-table-group-row'
+            `${tableRowTag}, ${tableGroupRowTag}`
         );
         const firstRowAllowsHover = rows[0]!.allowHover;
         if (Array.from(rows).some(x => x.allowHover !== firstRowAllowsHover)) {
@@ -658,7 +649,7 @@ export class TablePageObject<T extends TableRecord> {
 
     /** @internal */
     public getRow(rowIndex: number): TableRow {
-        const rows = this.tableElement.shadowRoot!.querySelectorAll('nimble-table-row');
+        const rows = this.tableElement.shadowRoot!.querySelectorAll(tableRowTag);
         if (rowIndex >= rows.length) {
             throw new Error(
                 'Attempting to index past the total number of rendered rows'
@@ -671,7 +662,7 @@ export class TablePageObject<T extends TableRecord> {
     /** @internal */
     public getCell(rowIndex: number, columnIndex: number): TableCell {
         const row = this.getRow(rowIndex);
-        const cells = row.shadowRoot!.querySelectorAll('nimble-table-cell');
+        const cells = row.shadowRoot!.querySelectorAll(tableCellTag);
         if (columnIndex >= cells.length) {
             throw new Error(
                 'Attempting to index past the total number of rendered columns'
@@ -767,9 +758,7 @@ export class TablePageObject<T extends TableRecord> {
     }
 
     private getGroupRow(groupRowIndex: number): TableGroupRow {
-        const groupRows = this.tableElement.shadowRoot!.querySelectorAll(
-            'nimble-table-group-row'
-        );
+        const groupRows = this.tableElement.shadowRoot!.querySelectorAll(tableGroupRowTag);
         if (groupRowIndex >= groupRows.length) {
             throw new Error(
                 'Attempting to index past the total number of group rows'

--- a/packages/nimble-components/src/table/tests/table-action-menu.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-action-menu.spec.ts
@@ -6,8 +6,8 @@ import {
 } from '@microsoft/fast-web-utilities';
 import type { Table } from '..';
 import type { TableColumn } from '../../table-column/base';
-import type { Menu } from '../../menu';
-import type { MenuItem } from '../../menu-item';
+import { menuTag, type Menu } from '../../menu';
+import { menuItemTag, type MenuItem } from '../../menu-item';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { waitForEvent } from '../../utilities/testing/component';
 import { type Fixture, fixture } from '../../utilities/tests/fixture';
@@ -17,6 +17,7 @@ import {
     TableRowSelectionMode
 } from '../types';
 import { TablePageObject } from '../testing/table.pageobject';
+import { tableRowTag } from '../components/row';
 
 interface SimpleTableRecord extends TableRecord {
     stringData: string;
@@ -94,18 +95,18 @@ describe('Table action menu', () => {
         menu: Menu,
         items: MenuItem[]
     } {
-        const menu = document.createElement('nimble-menu');
+        const menu = document.createElement(menuTag);
         menu.slot = slot;
 
-        const menuItem1 = document.createElement('nimble-menu-item');
+        const menuItem1 = document.createElement(menuItemTag);
         menuItem1.textContent = 'menu item 1';
         menu.appendChild(menuItem1);
 
-        const menuItem2 = document.createElement('nimble-menu-item');
+        const menuItem2 = document.createElement(menuItemTag);
         menuItem2.textContent = 'menu item 2';
         menu.appendChild(menuItem2);
 
-        const menuItem3 = document.createElement('nimble-menu-item');
+        const menuItem3 = document.createElement(menuItemTag);
         menuItem3.textContent = 'menu item 3';
         menu.appendChild(menuItem3);
 
@@ -265,7 +266,7 @@ describe('Table action menu', () => {
         await toggleListener;
 
         const rowSlots = element
-            .shadowRoot!.querySelectorAll('nimble-table-row')
+            .shadowRoot!.querySelectorAll(tableRowTag)
             ?.item(1)
             .querySelectorAll<HTMLSlotElement>('slot');
         expect(rowSlots.length).toBe(2);
@@ -286,7 +287,7 @@ describe('Table action menu', () => {
         await toggleListener;
 
         const rowSlots = element
-            .shadowRoot!.querySelectorAll('nimble-table-row')
+            .shadowRoot!.querySelectorAll(tableRowTag)
             ?.item(1)
             .querySelectorAll<HTMLSlotElement>('slot');
         expect(rowSlots.length).toBe(1);
@@ -309,7 +310,7 @@ describe('Table action menu', () => {
         await waitForUpdatesAsync();
 
         const rowSlots = element
-            .shadowRoot!.querySelectorAll('nimble-table-row')
+            .shadowRoot!.querySelectorAll(tableRowTag)
             ?.item(1)
             .querySelectorAll<HTMLSlotElement>('slot');
         expect(rowSlots.length).toBe(1);

--- a/packages/nimble-components/src/table/tests/table-action-menu.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-action-menu.spec.ts
@@ -4,7 +4,7 @@ import {
     keyArrowUp,
     keyEscape
 } from '@microsoft/fast-web-utilities';
-import type { Table } from '..';
+import { tableTag, type Table } from '..';
 import type { TableColumn } from '../../table-column/base';
 import { menuTag, type Menu } from '../../menu';
 import { menuItemTag, type MenuItem } from '../../menu-item';
@@ -18,6 +18,8 @@ import {
 } from '../types';
 import { TablePageObject } from '../testing/table.pageobject';
 import { tableRowTag } from '../components/row';
+import { tableColumnTextTag } from '../../table-column/text';
+import { iconCheckTag } from '../../icons/check';
 
 interface SimpleTableRecord extends TableRecord {
     stringData: string;
@@ -50,12 +52,12 @@ const simpleTableData = [
 // prettier-ignore
 async function setup(): Promise<Fixture<Table<SimpleTableRecord>>> {
     return await fixture<Table<SimpleTableRecord>>(
-        html`<nimble-table>
-            <nimble-table-column-text id="first-column" field-name="stringData">stringData</nimble-table-column-text>
-            <nimble-table-column-text id="second-column" field-name="moreStringData">
-                <nimble-icon-check></nimble-icon-check>
-            </nimble-table-column-text>
-        </nimble-table>`
+        html`<${tableTag}>
+            <${tableColumnTextTag} id="first-column" field-name="stringData">stringData</${tableColumnTextTag}>
+            <${tableColumnTextTag} id="second-column" field-name="moreStringData">
+                <${iconCheckTag}></${iconCheckTag}>
+            </${tableColumnTextTag}>
+        </${tableTag}>`
     );
 }
 

--- a/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-column-sizing.spec.ts
@@ -1,6 +1,6 @@
 import { html } from '@microsoft/fast-element';
 import { parameterizeSpec } from '@ni/jasmine-parameterized';
-import type { Table } from '..';
+import { tableTag, type Table } from '..';
 import type { TableColumn } from '../../table-column/base';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { type Fixture, fixture } from '../../utilities/tests/fixture';
@@ -10,6 +10,7 @@ import type {
 } from '../types';
 import { TablePageObject } from '../testing/table.pageobject';
 import { waitForEvent } from '../../utilities/testing/component';
+import { tableColumnTextTag } from '../../table-column/text';
 
 interface SimpleTableRecord extends TableRecord {
     stringData: string;
@@ -55,28 +56,28 @@ const largeTableData = Array.from(Array(500), (_, i) => {
 // prettier-ignore
 async function setup(): Promise<Fixture<Table<SimpleTableRecord>>> {
     return await fixture<Table<SimpleTableRecord>>(
-        html`<nimble-table>
-            <nimble-table-column-text id="first-column" field-name="stringData">
-            </nimble-table-column-text>
-            <nimble-table-column-text id="second-column" field-name="moreStringData">
-            </nimble-table-column-text>
-        </nimble-table>`
+        html`<${tableTag}>
+            <${tableColumnTextTag} id="first-column" field-name="stringData">
+            </${tableColumnTextTag}>
+            <${tableColumnTextTag} id="second-column" field-name="moreStringData">
+            </${tableColumnTextTag}>
+        </${tableTag}>`
     );
 }
 
 // prettier-ignore
 async function setupInteractiveTests(): Promise<Fixture<Table<SimpleTableRecord>>> {
     return await fixture<Table<SimpleTableRecord>>(
-        html`<nimble-table>
-            <nimble-table-column-text id="first-column" field-name="stringData" min-pixel-width="50">
-            </nimble-table-column-text>
-            <nimble-table-column-text id="second-column" field-name="moreStringData" min-pixel-width="50">
-            </nimble-table-column-text>
-            <nimble-table-column-text id="third-column" field-name="moreStringData2" min-pixel-width="50">
-            </nimble-table-column-text>
-            <nimble-table-column-text id="fourth-column" field-name="moreStringData3" min-pixel-width="50">
-            </nimble-table-column-text>
-        </nimble-table>`
+        html`<${tableTag}>
+            <${tableColumnTextTag} id="first-column" field-name="stringData" min-pixel-width="50">
+            </${tableColumnTextTag}>
+            <${tableColumnTextTag} id="second-column" field-name="moreStringData" min-pixel-width="50">
+            </${tableColumnTextTag}>
+            <${tableColumnTextTag} id="third-column" field-name="moreStringData2" min-pixel-width="50">
+            </${tableColumnTextTag}>
+            <${tableColumnTextTag} id="fourth-column" field-name="moreStringData3" min-pixel-width="50">
+            </${tableColumnTextTag}>
+        </${tableTag}>`
     );
 }
 

--- a/packages/nimble-components/src/table/tests/table-delegated-events.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-delegated-events.spec.ts
@@ -1,5 +1,5 @@
 import { customElement, html } from '@microsoft/fast-element';
-import type { Table } from '..';
+import { tableTag, type Table } from '..';
 import { TableColumn } from '../../table-column/base';
 import { tableColumnTextCellViewTag } from '../../table-column/text/cell-view';
 import { tableColumnTextGroupHeaderViewTag } from '../../table-column/text/group-header-view';
@@ -38,9 +38,9 @@ class TestTableColumn extends TableColumn {
 // prettier-ignore
 async function setup(): Promise<Fixture<Table<SimpleTableRecord>>> {
     return await fixture<Table<SimpleTableRecord>>(
-        html`<nimble-table>
+        html`<${tableTag}>
             <${columnName}>Column</${columnName}>
-        </nimble-table>`
+        </${tableTag}>`
     );
 }
 

--- a/packages/nimble-components/src/table/tests/table-grouping.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-grouping.spec.ts
@@ -1,5 +1,5 @@
 import { html } from '@microsoft/fast-element';
-import type { Table } from '..';
+import { tableTag, type Table } from '..';
 import {
     tableColumnTextTag,
     type TableColumnText
@@ -27,20 +27,20 @@ interface HierarchicalTableRecord extends TableRecord {
 // prettier-ignore
 async function setup(): Promise<Fixture<Table<SimpleTableRecord>>> {
     return await fixture<Table<SimpleTableRecord>>(
-        html`<nimble-table id-field-name="id">
-            <nimble-table-column-text id="first-column" field-name="stringData1" column-id="column-1"></nimble-table-column-text>
-            <nimble-table-column-text id="second-column" field-name="stringData2" column-id="column-2"></nimble-table-column-text>
-        </nimble-table>`
+        html`<${tableTag} id-field-name="id">
+            <${tableColumnTextTag} id="first-column" field-name="stringData1" column-id="column-1"></${tableColumnTextTag}>
+            <${tableColumnTextTag} id="second-column" field-name="stringData2" column-id="column-2"></${tableColumnTextTag}>
+        </${tableTag}>`
     );
 }
 
 // prettier-ignore
 async function setupWithHierarchy(): Promise<Fixture<Table<SimpleTableRecord>>> {
     return await fixture<Table<SimpleTableRecord>>(
-        html`<nimble-table id-field-name="id" parent-id-field-name="parentId">
-            <nimble-table-column-text id="first-column" field-name="stringData1" column-id="column-1"></nimble-table-column-text>
-            <nimble-table-column-text id="second-column" field-name="stringData2" column-id="column-2"></nimble-table-column-text>
-        </nimble-table>`
+        html`<${tableTag} id-field-name="id" parent-id-field-name="parentId">
+            <${tableColumnTextTag} id="first-column" field-name="stringData1" column-id="column-1"></${tableColumnTextTag}>
+            <${tableColumnTextTag} id="second-column" field-name="stringData2" column-id="column-2"></${tableColumnTextTag}>
+        </${tableTag}>`
     );
 }
 

--- a/packages/nimble-components/src/table/tests/table-grouping.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-grouping.spec.ts
@@ -1,6 +1,9 @@
 import { html } from '@microsoft/fast-element';
 import type { Table } from '..';
-import type { TableColumnText } from '../../table-column/text';
+import {
+    tableColumnTextTag,
+    type TableColumnText
+} from '../../table-column/text';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { type Fixture, fixture } from '../../utilities/tests/fixture';
 import { TableColumnSortDirection, TableRecord } from '../types';
@@ -513,9 +516,7 @@ describe('Table grouping', () => {
             element.removeChild(column1);
             element.removeChild(column2);
 
-            const newColumn = document.createElement(
-                'nimble-table-column-text'
-            );
+            const newColumn = document.createElement(tableColumnTextTag);
             newColumn.fieldName = fieldName;
             if (typeof groupIndex === 'number') {
                 newColumn.groupIndex = groupIndex;
@@ -531,9 +532,7 @@ describe('Table grouping', () => {
             fieldName: string,
             groupIndex?: number
         ): Promise<TableColumnText> {
-            const newColumn = document.createElement(
-                'nimble-table-column-text'
-            );
+            const newColumn = document.createElement(tableColumnTextTag);
             newColumn.columnId = columnId;
             newColumn.fieldName = fieldName;
             if (typeof groupIndex === 'number') {

--- a/packages/nimble-components/src/table/tests/table-keyboard-navigation.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-keyboard-navigation.spec.ts
@@ -49,6 +49,7 @@ import type { ColumnInternalsOptions } from '../../table-column/base/models/colu
 import { ColumnValidator } from '../../table-column/base/models/column-validator';
 import { mixinSortableColumnAPI } from '../../table-column/mixins/sortable-column';
 import { MenuButtonPageObject } from '../../menu-button/testing/menu-button.pageobject';
+import { menuTag } from '../../menu';
 
 interface SimpleTableRecord extends TableRecord {
     id: string;
@@ -87,10 +88,10 @@ describe('Table keyboard navigation', () => {
         column.actionMenuSlot = `${column.id}-action-menu-slot`;
         column.actionMenuLabel = 'Actions';
 
-        const menu = document.createElement('nimble-menu');
+        const menu = document.createElement(menuTag);
         menu.slot = column.actionMenuSlot;
 
-        const menuItem1 = document.createElement('nimble-menu-item');
+        const menuItem1 = document.createElement(menuItemTag);
         menuItem1.textContent = 'menu item 1';
         menu.appendChild(menuItem1);
 

--- a/packages/nimble-components/src/table/tests/table-keyboard-navigation.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-keyboard-navigation.spec.ts
@@ -17,7 +17,7 @@ import {
     keyTab
 } from '@microsoft/fast-web-utilities';
 import { parameterizeSpec } from '@ni/jasmine-parameterized';
-import type { Table } from '..';
+import { tableTag, type Table } from '..';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import {
     type Fixture,
@@ -221,11 +221,11 @@ describe('Table keyboard navigation', () => {
         // prettier-ignore
         async function setupNonInteractiveTable(): Promise<Fixture<Table<SimpleTableRecord>>> {
             return await fixture<Table<SimpleTableRecord>>(
-                html`<nimble-table id-field-name="id">
+                html`<${tableTag} id-field-name="id">
                 <${nonInteractiveColumnName} id="first-column" column-id="column-1"></${nonInteractiveColumnName}>
                 <${nonInteractiveColumnName} id="second-column" column-id="column-2"></${nonInteractiveColumnName}>
                 <${nonInteractiveColumnName} id="third-column" column-id="column-3"></${nonInteractiveColumnName}>
-            </nimble-table>`
+            </${tableTag}>`
             );
         }
 
@@ -1267,11 +1267,11 @@ describe('Table keyboard navigation', () => {
         // prettier-ignore
         async function setupInteractiveTable(): Promise<Fixture<Table<SimpleTableRecord>>> {
             return await fixture<Table<SimpleTableRecord>>(
-                html`<nimble-table id-field-name="id">
+                html`<${tableTag} id-field-name="id">
                 <${interactiveColumnName} id="first-column" column-id="column-1"></${interactiveColumnName}>
                 <${interactiveColumnName} id="second-column" column-id="column-2"></${interactiveColumnName}>
                 <${interactiveColumnName} id="third-column" column-id="column-3"></${interactiveColumnName}>
-            </nimble-table>`
+            </${tableTag}>`
             );
         }
 

--- a/packages/nimble-components/src/table/tests/table-labels.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-labels.spec.ts
@@ -9,7 +9,10 @@ import {
     LabelProviderTable,
     labelProviderTableTag
 } from '../../label-provider/table';
-import { tableColumnTextTag, type TableColumnText } from '../../table-column/text';
+import {
+    tableColumnTextTag,
+    type TableColumnText
+} from '../../table-column/text';
 import { tableGroupRowTag } from '../components/group-row';
 import { menuTag } from '../../menu';
 import { menuItemTag } from '../../menu-item';

--- a/packages/nimble-components/src/table/tests/table-labels.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-labels.spec.ts
@@ -9,7 +9,7 @@ import {
     LabelProviderTable,
     labelProviderTableTag
 } from '../../label-provider/table';
-import type { TableColumnText } from '../../table-column/text';
+import { tableColumnTextTag, type TableColumnText } from '../../table-column/text';
 import { tableGroupRowTag } from '../components/group-row';
 import { menuTag } from '../../menu';
 import { menuItemTag } from '../../menu-item';
@@ -40,10 +40,10 @@ async function setup(): Promise<Fixture<ThemeProvider>> {
         html`
         <${themeProviderTag}>
             <${labelProviderTableTag}></${labelProviderTableTag}>
-            <nimble-table style="width: 700px">
-                <nimble-table-column-text id="first-column" field-name="stringData">stringData</nimble-table-column-text>
-                <nimble-table-column-text id="second-column" field-name="moreStringData">moreStringData</nimble-table-column-text>
-            </nimble-table>
+            <${tableTag} style="width: 700px">
+                <${tableColumnTextTag} id="first-column" field-name="stringData">stringData</${tableColumnTextTag}>
+                <${tableColumnTextTag} id="second-column" field-name="moreStringData">moreStringData</${tableColumnTextTag}>
+            </${tableTag}>
         <${themeProviderTag}>`
     );
 }

--- a/packages/nimble-components/src/table/tests/table-labels.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-labels.spec.ts
@@ -11,6 +11,8 @@ import {
 } from '../../label-provider/table';
 import type { TableColumnText } from '../../table-column/text';
 import { tableGroupRowTag } from '../components/group-row';
+import { menuTag } from '../../menu';
+import { menuItemTag } from '../../menu-item';
 
 interface SimpleTableRecord extends TableRecord {
     stringData: string;
@@ -110,8 +112,8 @@ describe('Table with LabelProviderTable', () => {
     it('uses correct labels when a column has an action menu (cellActionMenu)', async () => {
         const slot = 'my-action-menu';
         column1.actionMenuSlot = slot;
-        const menu = document.createElement('nimble-menu');
-        const menuItem1 = document.createElement('nimble-menu-item');
+        const menu = document.createElement(menuTag);
+        const menuItem1 = document.createElement(menuItemTag);
         menuItem1.textContent = 'menu item 1';
         menu.appendChild(menuItem1);
         menu.slot = slot;

--- a/packages/nimble-components/src/table/tests/table-pageobject.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-pageobject.spec.ts
@@ -1,10 +1,11 @@
 import { html } from '@microsoft/fast-element';
-import type { Table } from '..';
+import { tableTag, type Table } from '..';
 import type { TableColumn } from '../../table-column/base';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { type Fixture, fixture } from '../../utilities/tests/fixture';
 import { TablePageObject } from '../testing/table.pageobject';
 import type { TableRecord } from '../types';
+import { tableColumnTextTag } from '../../table-column/text';
 
 interface SimpleTableRecord extends TableRecord {
     stringData: string;
@@ -29,10 +30,10 @@ const simpleTableData = [
 // prettier-ignore
 async function setup(): Promise<Fixture<Table<SimpleTableRecord>>> {
     return await fixture<Table<SimpleTableRecord>>(
-        html`<nimble-table>
-            <nimble-table-column-text id="first-column" field-name="stringData">Col1</nimble-table-column-text>
-            <nimble-table-column-text id="second-column" field-name="moreStringData">Col2</nimble-table-column-text>
-        </nimble-table>`
+        html`<${tableTag}>
+            <${tableColumnTextTag} id="first-column" field-name="stringData">Col1</${tableColumnTextTag}>
+            <${tableColumnTextTag} id="second-column" field-name="moreStringData">Col2</${tableColumnTextTag}>
+        </${tableTag}>`
     );
 }
 

--- a/packages/nimble-components/src/table/tests/table-selection.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-selection.spec.ts
@@ -15,7 +15,10 @@ import {
     TableRowSelectionState
 } from '../types';
 import { TablePageObject } from '../testing/table.pageobject';
-import { tableColumnTextTag, type TableColumnText } from '../../table-column/text';
+import {
+    tableColumnTextTag,
+    type TableColumnText
+} from '../../table-column/text';
 
 interface SimpleTableRecord extends TableRecord {
     id: string;

--- a/packages/nimble-components/src/table/tests/table-selection.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-selection.spec.ts
@@ -15,7 +15,7 @@ import {
     TableRowSelectionState
 } from '../types';
 import { TablePageObject } from '../testing/table.pageobject';
-import type { TableColumnText } from '../../table-column/text';
+import { tableColumnTextTag, type TableColumnText } from '../../table-column/text';
 
 interface SimpleTableRecord extends TableRecord {
     id: string;
@@ -210,10 +210,10 @@ const hierarchicalData = [
 // prettier-ignore
 async function setup(): Promise<Fixture<Table<SimpleTableRecord>>> {
     return await fixture<Table<SimpleTableRecord>>(
-        html`<nimble-table>
-            <nimble-table-column-text id="column1" field-name="stringData">stringData</nimble-table-column-text>
-            <nimble-table-column-text id="column2" field-name="stringData2">stringData2</nimble-table-column-text>
-        </nimble-table>`
+        html`<${tableTag}>
+            <${tableColumnTextTag} id="column1" field-name="stringData">stringData</${tableColumnTextTag}>
+            <${tableColumnTextTag} id="column2" field-name="stringData2">stringData2</${tableColumnTextTag}>
+        </${tableTag}>`
     );
 }
 

--- a/packages/nimble-components/src/table/tests/table-sorting.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-sorting.spec.ts
@@ -1,5 +1,5 @@
 import { html } from '@microsoft/fast-element';
-import type { Table } from '..';
+import { tableTag, type Table } from '..';
 import {
     tableColumnTextTag,
     type TableColumnText
@@ -29,11 +29,11 @@ type TableColumnConfigurationChangeEventHandler = (
 // prettier-ignore
 async function setup(): Promise<Fixture<Table<SimpleTableRecord>>> {
     return await fixture<Table<SimpleTableRecord>>(
-        html`<nimble-table id-field-name="id">
-            <nimble-table-column-text id="first-column" field-name="stringData1" column-id="column-1"></nimble-table-column-text>
-            <nimble-table-column-text id="second-column" field-name="stringData2" column-id="column-2"></nimble-table-column-text>
-            <nimble-table-column-text id="third-column" field-name="stringData3" column-id="column-3"></nimble-table-column-text>
-        </nimble-table>`
+        html`<${tableTag} id-field-name="id">
+            <${tableColumnTextTag} id="first-column" field-name="stringData1" column-id="column-1"></${tableColumnTextTag}>
+            <${tableColumnTextTag} id="second-column" field-name="stringData2" column-id="column-2"></${tableColumnTextTag}>
+            <${tableColumnTextTag} id="third-column" field-name="stringData3" column-id="column-3"></${tableColumnTextTag}>
+        </${tableTag}>`
     );
 }
 

--- a/packages/nimble-components/src/table/tests/table-sorting.spec.ts
+++ b/packages/nimble-components/src/table/tests/table-sorting.spec.ts
@@ -1,6 +1,9 @@
 import { html } from '@microsoft/fast-element';
 import type { Table } from '..';
-import type { TableColumnText } from '../../table-column/text';
+import {
+    tableColumnTextTag,
+    type TableColumnText
+} from '../../table-column/text';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { type Fixture, fixture } from '../../utilities/tests/fixture';
 import {
@@ -707,9 +710,7 @@ describe('Table sorting', () => {
             element.removeChild(column2);
             element.removeChild(column3);
 
-            const newColumn = document.createElement(
-                'nimble-table-column-text'
-            );
+            const newColumn = document.createElement(tableColumnTextTag);
             newColumn.fieldName = fieldName;
             if (sortDirection !== TableColumnSortDirection.none) {
                 newColumn.sortDirection = sortDirection;

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -31,6 +31,9 @@ import {
 } from '../../table-column/base/tests/table-column.fixtures';
 import type { ColumnInternalsOptions } from '../../table-column/base/models/column-internals';
 import { ColumnValidator } from '../../table-column/base/models/column-validator';
+import { menuTag } from '../../menu';
+import { menuItemTag } from '../../menu-item';
+import { tableRowTag } from '../components/row';
 
 interface SimpleTableRecord extends TableRecord {
     stringData: string;
@@ -163,9 +166,7 @@ describe('Table', () => {
         });
 
         it('can construct an element instance', () => {
-            expect(document.createElement('nimble-table')).toBeInstanceOf(
-                Table
-            );
+            expect(document.createElement(tableTag)).toBeInstanceOf(Table);
         });
 
         it('element has a role of "treegrid"', async () => {
@@ -754,8 +755,8 @@ describe('Table', () => {
             it('and closes open action menus when a scroll happens', async () => {
                 const slot = 'my-action-menu';
                 column1.actionMenuSlot = slot;
-                const menu = document.createElement('nimble-menu');
-                const menuItem1 = document.createElement('nimble-menu-item');
+                const menu = document.createElement(menuTag);
+                const menuItem1 = document.createElement(menuItemTag);
                 menuItem1.textContent = 'menu item 1';
                 menu.appendChild(menuItem1);
                 menu.slot = slot;
@@ -888,7 +889,7 @@ describe('Table', () => {
 
                 // Verify the slot name is updated
                 const rowSlots = element
-                    .shadowRoot!.querySelectorAll('nimble-table-row')
+                    .shadowRoot!.querySelectorAll(tableRowTag)
                     ?.item(1)
                     .querySelectorAll<HTMLSlotElement>('slot');
                 expect(rowSlots.length).toBe(1);

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -34,6 +34,7 @@ import { ColumnValidator } from '../../table-column/base/models/column-validator
 import { menuTag } from '../../menu';
 import { menuItemTag } from '../../menu-item';
 import { tableRowTag } from '../components/row';
+import { iconCheckTag } from '../../icons/check';
 
 interface SimpleTableRecord extends TableRecord {
     stringData: string;
@@ -78,12 +79,12 @@ const largeTableData = createLargeData(500);
 // prettier-ignore
 async function setup(): Promise<Fixture<Table<SimpleTableRecord>>> {
     return await fixture<Table<SimpleTableRecord>>(
-        html`<nimble-table style="width: 700px">
-            <nimble-table-column-text id="first-column" field-name="stringData">stringData</nimble-table-column-text>
-            <nimble-table-column-text id="second-column" field-name="moreStringData">
-                <nimble-icon-check></nimble-icon-check>
-            </nimble-table-column-text>
-        </nimble-table>`
+        html`<${tableTag} style="width: 700px">
+            <${tableColumnTextTag} id="first-column" field-name="stringData">stringData</${tableColumnTextTag}>
+            <${tableColumnTextTag} id="second-column" field-name="moreStringData">
+                <${iconCheckTag}></${iconCheckTag}>
+            </${tableColumnTextTag}>
+        </${tableTag}>`
     );
 }
 
@@ -2524,10 +2525,10 @@ describe('Table', () => {
         // prettier-ignore
         async function setupWithTestColumns(): Promise<Fixture<Table<SimpleTableRecord>>> {
             return await fixture<Table<SimpleTableRecord>>(
-                html`<nimble-table>
+                html`<${tableTag}>
                     <${tableColumnValidationTestTag} foo bar id="first-column" field-name="stringData">Col 1</${tableColumnValidationTestTag}>
                     <${tableColumnValidationTestTag} foo bar id="second-column" field-name="moreStringData">Col 2</${tableColumnValidationTestTag}>
-                </nimble-table>`
+                </${tableTag}>`
             );
         }
 

--- a/packages/nimble-components/src/tabs-toolbar/tests/tabs-toolbar.spec.ts
+++ b/packages/nimble-components/src/tabs-toolbar/tests/tabs-toolbar.spec.ts
@@ -1,8 +1,8 @@
-import { TabsToolbar } from '..';
+import { TabsToolbar, tabsToolbarTag } from '..';
 
 describe('TabsToolbar', () => {
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-tabs-toolbar')).toBeInstanceOf(
+        expect(document.createElement(tabsToolbarTag)).toBeInstanceOf(
             TabsToolbar
         );
     });

--- a/packages/nimble-components/src/tabs/tests/tabs.spec.ts
+++ b/packages/nimble-components/src/tabs/tests/tabs.spec.ts
@@ -1,11 +1,7 @@
 import { Tabs, tabsTag } from '..';
 
 describe('Tabs', () => {
-    it('should export its tag', () => {
-        expect(tabsTag).toBe('nimble-tabs');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-tabs')).toBeInstanceOf(Tabs);
+        expect(document.createElement(tabsTag)).toBeInstanceOf(Tabs);
     });
 });

--- a/packages/nimble-components/src/text-area/tests/text-area.spec.ts
+++ b/packages/nimble-components/src/text-area/tests/text-area.spec.ts
@@ -21,14 +21,8 @@ describe('Text Area', () => {
         await disconnect();
     });
 
-    it('should export its tag', () => {
-        expect(textAreaTag).toBe('nimble-text-area');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-text-area')).toBeInstanceOf(
-            TextArea
-        );
+        expect(document.createElement(textAreaTag)).toBeInstanceOf(TextArea);
     });
 
     it('should set the "control" class on the internal control', async () => {

--- a/packages/nimble-components/src/text-area/tests/text-area.spec.ts
+++ b/packages/nimble-components/src/text-area/tests/text-area.spec.ts
@@ -5,7 +5,7 @@ import { waitForUpdatesAsync } from '../../testing/async-helpers';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 
 async function setup(): Promise<Fixture<TextArea>> {
-    return await fixture<TextArea>(html`<nimble-text-area></nimble-text-area>`);
+    return await fixture<TextArea>(html`<${textAreaTag}></${textAreaTag}>`);
 }
 
 describe('Text Area', () => {

--- a/packages/nimble-components/src/text-field/tests/text-field.spec.ts
+++ b/packages/nimble-components/src/text-field/tests/text-field.spec.ts
@@ -1,13 +1,7 @@
 import { TextField, textFieldTag } from '..';
 
 describe('TextField', () => {
-    it('should export its tag', () => {
-        expect(textFieldTag).toBe('nimble-text-field');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-text-field')).toBeInstanceOf(
-            TextField
-        );
+        expect(document.createElement(textFieldTag)).toBeInstanceOf(TextField);
     });
 });

--- a/packages/nimble-components/src/theme-provider/tests/theme-provider.spec.ts
+++ b/packages/nimble-components/src/theme-provider/tests/theme-provider.spec.ts
@@ -14,7 +14,7 @@ const designTokenPropertyNames = Object.keys(
 
 describe('Theme Provider', () => {
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-theme-provider')).toBeInstanceOf(
+        expect(document.createElement(themeProviderTag)).toBeInstanceOf(
             ThemeProvider
         );
     });

--- a/packages/nimble-components/src/toggle-button/tests/toggle-button.spec.ts
+++ b/packages/nimble-components/src/toggle-button/tests/toggle-button.spec.ts
@@ -6,7 +6,7 @@ import { waitForUpdatesAsync } from '../../testing/async-helpers';
 
 async function setup(): Promise<Fixture<ToggleButton>> {
     return await fixture<ToggleButton>(
-        html`<nimble-toggle-button></nimble-toggle-button>`
+        html`<${toggleButtonTag}></${toggleButtonTag}>`
     );
 }
 

--- a/packages/nimble-components/src/toggle-button/tests/toggle-button.spec.ts
+++ b/packages/nimble-components/src/toggle-button/tests/toggle-button.spec.ts
@@ -1,7 +1,7 @@
 import { html } from '@microsoft/fast-element';
 import { keyEnter, keySpace } from '@microsoft/fast-web-utilities';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
-import { ToggleButton } from '..';
+import { ToggleButton, toggleButtonTag } from '..';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
 
 async function setup(): Promise<Fixture<ToggleButton>> {
@@ -24,7 +24,7 @@ describe('ToggleButton', () => {
     });
 
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-toggle-button')).toBeInstanceOf(
+        expect(document.createElement(toggleButtonTag)).toBeInstanceOf(
             ToggleButton
         );
     });

--- a/packages/nimble-components/src/toolbar/tests/toolbar.spec.ts
+++ b/packages/nimble-components/src/toolbar/tests/toolbar.spec.ts
@@ -1,13 +1,7 @@
 import { Toolbar, toolbarTag } from '..';
 
 describe('Toolbar', () => {
-    it('should export its tag', () => {
-        expect(toolbarTag).toBe('nimble-toolbar');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-toolbar')).toBeInstanceOf(
-            Toolbar
-        );
+        expect(document.createElement(toolbarTag)).toBeInstanceOf(Toolbar);
     });
 });

--- a/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
@@ -4,6 +4,8 @@ import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Tooltip, tooltipTag } from '..';
 import { anchoredRegionTag } from '../../anchored-region';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
+import { iconExclamationMarkTag } from '../../icons/exclamation-mark';
+import { iconInfoTag } from '../../icons/info';
 
 async function setup(): Promise<Fixture<Tooltip>> {
     return await fixture<Tooltip>(html`<nimble-tooltip></nimble-tooltip>`);
@@ -33,9 +35,7 @@ describe('Tooltip', () => {
         tooltip: Tooltip
     ): Promise<void> {
         await waitForUpdatesAsync();
-        const region = tooltip.shadowRoot!.querySelector(
-            'nimble-anchored-region'
-        )!;
+        const region = tooltip.shadowRoot!.querySelector(anchoredRegionTag)!;
         await new Promise<void>((resolve, _reject) => {
             region.addEventListener('loaded', () => {
                 resolve();
@@ -60,6 +60,10 @@ describe('Tooltip', () => {
 
     afterEach(async () => {
         await disconnect();
+    });
+
+    it('can construct an element instance', () => {
+        expect(document.createElement(tooltipTag)).toBeInstanceOf(Tooltip);
     });
 
     it('should not render the tooltip by default', async () => {
@@ -143,8 +147,8 @@ describe('Tooltip', () => {
         await connect();
         await waitUntilAnchoredRegionLoaded(element);
 
-        expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
-        expect(isIconVisible('nimble-icon-info')).toBeFalse();
+        expect(isIconVisible(iconExclamationMarkTag)).toBeFalse();
+        expect(isIconVisible(iconInfoTag)).toBeFalse();
 
         await disconnect();
     });
@@ -156,8 +160,8 @@ describe('Tooltip', () => {
         await connect();
         await waitUntilAnchoredRegionLoaded(element);
 
-        expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
-        expect(isIconVisible('nimble-icon-info')).toBeFalse();
+        expect(isIconVisible(iconExclamationMarkTag)).toBeFalse();
+        expect(isIconVisible(iconInfoTag)).toBeFalse();
 
         await disconnect();
     });
@@ -169,8 +173,8 @@ describe('Tooltip', () => {
         await connect();
         await waitUntilAnchoredRegionLoaded(element);
 
-        expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
-        expect(isIconVisible('nimble-icon-info')).toBeFalse();
+        expect(isIconVisible(iconExclamationMarkTag)).toBeFalse();
+        expect(isIconVisible(iconInfoTag)).toBeFalse();
 
         await disconnect();
     });
@@ -183,8 +187,8 @@ describe('Tooltip', () => {
         await connect();
         await waitUntilAnchoredRegionLoaded(element);
 
-        expect(isIconVisible('nimble-icon-exclamation-mark')).toBeTrue();
-        expect(isIconVisible('nimble-icon-info')).toBeFalse();
+        expect(isIconVisible(iconExclamationMarkTag)).toBeTrue();
+        expect(isIconVisible(iconInfoTag)).toBeFalse();
 
         await disconnect();
     });
@@ -196,8 +200,8 @@ describe('Tooltip', () => {
         await connect();
         await waitUntilAnchoredRegionLoaded(element);
 
-        expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
-        expect(isIconVisible('nimble-icon-info')).toBeFalse();
+        expect(isIconVisible(iconExclamationMarkTag)).toBeFalse();
+        expect(isIconVisible(iconInfoTag)).toBeFalse();
 
         await disconnect();
     });
@@ -210,13 +214,11 @@ describe('Tooltip', () => {
         await connect();
         await waitUntilAnchoredRegionLoaded(element);
 
-        expect(isIconVisible('nimble-icon-exclamation-mark')).toBeFalse();
-        expect(isIconVisible('nimble-icon-info')).toBeTrue();
+        expect(isIconVisible(iconExclamationMarkTag)).toBeFalse();
+        expect(isIconVisible(iconInfoTag)).toBeTrue();
 
         await disconnect();
     });
-
-    // top position settings
 
     it('should set vertical and horizontal positioning mode to locktodefault when position is set to top', async () => {
         element.position = TooltipPosition.top;
@@ -251,8 +253,6 @@ describe('Tooltip', () => {
         await disconnect();
     });
 
-    // bottom position settings
-
     it('should set vertical positioning mode to locked when position is set to bottom', async () => {
         element.position = TooltipPosition.bottom;
 
@@ -286,8 +286,6 @@ describe('Tooltip', () => {
         await disconnect();
     });
 
-    // left position settings
-
     it('should set positioning mode to locked when position is set to left', async () => {
         element.position = TooltipPosition.left;
 
@@ -320,8 +318,6 @@ describe('Tooltip', () => {
 
         await disconnect();
     });
-
-    // right position settings
 
     it('should set positioning mode to locked when position is set to right', async () => {
         element.position = TooltipPosition.right;
@@ -373,17 +369,5 @@ describe('Tooltip', () => {
         expect(element.anchorElement?.id).toEqual('anchor2');
 
         await disconnect();
-    });
-
-    // end of position tests ^
-
-    it('should export its tag', () => {
-        expect(tooltipTag).toBe('nimble-tooltip');
-    });
-
-    it('can construct an element instance', () => {
-        expect(document.createElement('nimble-tooltip')).toBeInstanceOf(
-            Tooltip
-        );
     });
 });

--- a/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
+++ b/packages/nimble-components/src/tooltip/tests/tooltip.spec.ts
@@ -8,7 +8,7 @@ import { iconExclamationMarkTag } from '../../icons/exclamation-mark';
 import { iconInfoTag } from '../../icons/info';
 
 async function setup(): Promise<Fixture<Tooltip>> {
-    return await fixture<Tooltip>(html`<nimble-tooltip></nimble-tooltip>`);
+    return await fixture<Tooltip>(html`<${tooltipTag}></${tooltipTag}>`);
 }
 
 describe('Tooltip', () => {

--- a/packages/nimble-components/src/tree-item/tests/tree-item.spec.ts
+++ b/packages/nimble-components/src/tree-item/tests/tree-item.spec.ts
@@ -1,13 +1,7 @@
 import { TreeItem, treeItemTag } from '..';
 
 describe('TreeItem', () => {
-    it('should export its tag', () => {
-        expect(treeItemTag).toBe('nimble-tree-item');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-tree-item')).toBeInstanceOf(
-            TreeItem
-        );
+        expect(document.createElement(treeItemTag)).toBeInstanceOf(TreeItem);
     });
 });

--- a/packages/nimble-components/src/tree-view/tests/tree.spec.ts
+++ b/packages/nimble-components/src/tree-view/tests/tree.spec.ts
@@ -71,14 +71,8 @@ describe('TreeView', () => {
         await disconnect();
     });
 
-    it('should export its tag', () => {
-        expect(treeViewTag).toBe('nimble-tree-view');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-tree-view')).toBeInstanceOf(
-            TreeView
-        );
+        expect(document.createElement(treeViewTag)).toBeInstanceOf(TreeView);
     });
 
     it('should include a role of `tree`', () => {

--- a/packages/nimble-components/src/tree-view/tests/tree.spec.ts
+++ b/packages/nimble-components/src/tree-view/tests/tree.spec.ts
@@ -5,8 +5,8 @@ import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { clickElement } from '../../utilities/testing/component';
 import { TreeViewSelectionMode } from '../types';
 import { TreeView, treeViewTag } from '..';
-import type { TreeItem } from '../../tree-item';
-import type { Button } from '../../button';
+import { treeItemTag, type TreeItem } from '../../tree-item';
+import { buttonTag, type Button } from '../../button';
 import '../../tree-item';
 import '../../button';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
@@ -28,20 +28,20 @@ async function setup(source: Model): Promise<Fixture<TreeView>> {
     return await fixture<TreeView>(
         // prettier-ignore
         html<Model>`
-        <nimble-tree-view ${ref('treeView')}>
-            <nimble-tree-item ${ref('root1')}>Root1
-                <nimble-tree-item ${ref('subRoot1')}>SubRoot
-                    <nimble-tree-item ${ref('leaf1')}><nimble-button ${ref('button')}>Leaf1</nimble-button></nimble-tree-item>
-                </nimble-tree-item>
-                <nimble-tree-item ${ref('leaf2')} selected>Leaf 2</nimble-tree-item>
-                <nimble-tree-item ${ref('leafWithIconDisabled')} disabled><svg slot="start">${notebook16X16.data}</svg>Leaf With Icon</nimble-tree-item>
-            </nimble-tree-item>
-            <nimble-tree-item ${ref('root2')}>Root2
-                <nimble-tree-item ${ref('subRoot2')}>SubRoot 2
-                    <nimble-tree-item ${ref('leaf3')}>Leaf 3</nimble-tree-item>
-                </nimble-tree-item>
-            </nimble-tree-item>
-        </nimble-tree-view>`,
+        <${treeViewTag} ${ref('treeView')}>
+            <${treeItemTag} ${ref('root1')}>Root1
+                <${treeItemTag} ${ref('subRoot1')}>SubRoot
+                    <${treeItemTag} ${ref('leaf1')}><${buttonTag} ${ref('button')}>Leaf1</${buttonTag}></${treeItemTag}>
+                </${treeItemTag}>
+                <${treeItemTag} ${ref('leaf2')} selected>Leaf 2</${treeItemTag}>
+                <${treeItemTag} ${ref('leafWithIconDisabled')} disabled><svg slot="start">${notebook16X16.data}</svg>Leaf With Icon</${treeItemTag}>
+            </${treeItemTag}>
+            <${treeItemTag} ${ref('root2')}>Root2
+                <${treeItemTag} ${ref('subRoot2')}>SubRoot 2
+                    <${treeItemTag} ${ref('leaf3')}>Leaf 3</${treeItemTag}>
+                </${treeItemTag}>
+            </${treeItemTag}>
+        </${treeViewTag}>`,
         { source }
     );
 }

--- a/packages/nimble-components/src/unit/byte/tests/unit-byte.spec.ts
+++ b/packages/nimble-components/src/unit/byte/tests/unit-byte.spec.ts
@@ -15,14 +15,8 @@ describe('Byte unit', () => {
     let connect: () => Promise<void>;
     let disconnect: () => Promise<void>;
 
-    it('should export its tag', () => {
-        expect(unitByteTag).toBe('nimble-unit-byte');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-unit-byte')).toBeInstanceOf(
-            UnitByte
-        );
+        expect(document.createElement(unitByteTag)).toBeInstanceOf(UnitByte);
     });
 
     it('returns Byte1024UnitScale when "binary" attribute is set', async () => {

--- a/packages/nimble-components/src/unit/byte/tests/unit-byte.spec.ts
+++ b/packages/nimble-components/src/unit/byte/tests/unit-byte.spec.ts
@@ -6,7 +6,7 @@ import { byteUnitScale } from '../../../utilities/unit-format/unit-scale/byte-un
 
 async function setup(binary: boolean): Promise<Fixture<UnitByte>> {
     return await fixture<UnitByte>(html`
-        <nimble-unit-byte ?binary="${() => binary}"></nimble-unit-byte>
+        <${unitByteTag} ?binary="${() => binary}"></${unitByteTag}>
     `);
 }
 

--- a/packages/nimble-components/src/unit/celsius/tests/unit-celsius.spec.ts
+++ b/packages/nimble-components/src/unit/celsius/tests/unit-celsius.spec.ts
@@ -2,18 +2,14 @@ import { UnitCelsius, unitCelsiusTag } from '..';
 import { celsiusUnitScale } from '../../../utilities/unit-format/unit-scale/celsius-unit-scale';
 
 describe('Celsius unit', () => {
-    it('should export its tag', () => {
-        expect(unitCelsiusTag).toBe('nimble-unit-celsius');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-unit-celsius')).toBeInstanceOf(
+        expect(document.createElement(unitCelsiusTag)).toBeInstanceOf(
             UnitCelsius
         );
     });
 
     it('returns expected formatter', () => {
-        const element = document.createElement('nimble-unit-celsius');
+        const element = document.createElement(unitCelsiusTag);
         expect(element.resolvedUnitScale).toBe(celsiusUnitScale);
     });
 });

--- a/packages/nimble-components/src/unit/fahrenheit/tests/unit-fahrenheit.spec.ts
+++ b/packages/nimble-components/src/unit/fahrenheit/tests/unit-fahrenheit.spec.ts
@@ -2,18 +2,14 @@ import { UnitFahrenheit, unitFahrenheitTag } from '..';
 import { fahrenheitUnitScale } from '../../../utilities/unit-format/unit-scale/fahrenheit-unit-scale';
 
 describe('Fahrenheit unit', () => {
-    it('should export its tag', () => {
-        expect(unitFahrenheitTag).toBe('nimble-unit-fahrenheit');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-unit-fahrenheit')).toBeInstanceOf(
+        expect(document.createElement(unitFahrenheitTag)).toBeInstanceOf(
             UnitFahrenheit
         );
     });
 
     it('returns expected formatter', () => {
-        const element = document.createElement('nimble-unit-fahrenheit');
+        const element = document.createElement(unitFahrenheitTag);
         expect(element.resolvedUnitScale).toBe(fahrenheitUnitScale);
     });
 });

--- a/packages/nimble-components/src/unit/volt/tests/unit-volt.spec.ts
+++ b/packages/nimble-components/src/unit/volt/tests/unit-volt.spec.ts
@@ -2,18 +2,12 @@ import { UnitVolt, unitVoltTag } from '..';
 import { voltUnitScale } from '../../../utilities/unit-format/unit-scale/volt-unit-scale';
 
 describe('Volt unit', () => {
-    it('should export its tag', () => {
-        expect(unitVoltTag).toBe('nimble-unit-volt');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-unit-volt')).toBeInstanceOf(
-            UnitVolt
-        );
+        expect(document.createElement(unitVoltTag)).toBeInstanceOf(UnitVolt);
     });
 
     it('returns expected formatter', () => {
-        const element = document.createElement('nimble-unit-volt');
+        const element = document.createElement(unitVoltTag);
         expect(element.resolvedUnitScale).toBe(voltUnitScale);
     });
 });

--- a/packages/nimble-components/src/utilities/style/tests/theme.spec.ts
+++ b/packages/nimble-components/src/utilities/style/tests/theme.spec.ts
@@ -6,7 +6,7 @@ import {
     ref,
     ElementStyles
 } from '@microsoft/fast-element';
-import type { ThemeProvider } from '../../../theme-provider';
+import { themeProviderTag, type ThemeProvider } from '../../../theme-provider';
 import { Theme } from '../../../theme-provider/types';
 import { uniqueElementName, fixture } from '../../tests/fixture';
 import type { Fixture } from '../../tests/fixture';
@@ -143,9 +143,9 @@ describe('The ThemeStylesheetBehavior', () => {
             FASTElement.define(ThemedElementVariation);
 
             const fixtureTemplate = html<ThemeController>`
-                <nimble-theme-provider theme=${x => x.theme}>
+                <${themeProviderTag} theme=${x => x.theme}>
                     <${name} ${ref('themedElement')}></${name}>
-                </nimble-theme-provider>
+                </${themeProviderTag}>
             `;
 
             return await fixture<ThemeProvider>(fixtureTemplate, {
@@ -297,12 +297,12 @@ describe('The ThemeStylesheetBehavior', () => {
             FASTElement.define(ThemedElementVariation);
 
             const fixtureTemplate = html<ThemeController>`
-                <nimble-theme-provider theme=${x => x.theme1}>
+                <${themeProviderTag} theme=${x => x.theme1}>
                     <${name} ${ref('themedElement1')}></${name}>
-                </nimble-theme-provider>
-                <nimble-theme-provider theme=${x => x.theme2}>
+                </${themeProviderTag}>
+                <${themeProviderTag} theme=${x => x.theme2}>
                     <${name} ${ref('themedElement2')}></${name}>
-                </nimble-theme-provider>
+                </${themeProviderTag}>
             `;
 
             return await fixture<ThemeProvider>(fixtureTemplate, {

--- a/packages/nimble-components/src/wafer-map/tests/data-manager.spec.ts
+++ b/packages/nimble-components/src/wafer-map/tests/data-manager.spec.ts
@@ -3,7 +3,7 @@ import { html } from '@microsoft/fast-element';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { processUpdates } from '../../testing/async-helpers';
 import type { DataManager } from '../modules/data-manager';
-import type { WaferMap } from '..';
+import { waferMapTag, type WaferMap } from '..';
 import { WaferMapColorScaleMode, WaferMapOriginLocation } from '../types';
 import {
     getColorScale,
@@ -13,7 +13,7 @@ import {
 import type { Dimensions, Margin } from '../workers/types';
 
 async function setup(): Promise<Fixture<WaferMap>> {
-    return await fixture<WaferMap>(html`<nimble-wafer-map></nimble-wafer-map>`);
+    return await fixture<WaferMap>(html`<${waferMapTag}></${waferMapTag}>`);
 }
 
 describe('Wafermap Data Manager', () => {

--- a/packages/nimble-components/src/wafer-map/tests/hover-handler.spec.ts
+++ b/packages/nimble-components/src/wafer-map/tests/hover-handler.spec.ts
@@ -2,12 +2,12 @@ import { html } from '@microsoft/fast-element';
 import { parameterizeSpec } from '@ni/jasmine-parameterized';
 import { WaferMapOriginLocation } from '../types';
 import { getWaferMapDiesTable } from './utilities';
-import type { WaferMap } from '..';
+import { waferMapTag, type WaferMap } from '..';
 import { processUpdates } from '../../testing/async-helpers';
 import { Fixture, fixture } from '../../utilities/tests/fixture';
 
 async function setup(): Promise<Fixture<WaferMap>> {
-    return await fixture<WaferMap>(html`<nimble-wafer-map></nimble-wafer-map>`);
+    return await fixture<WaferMap>(html`<${waferMapTag}></${waferMapTag}>`);
 }
 
 // OffscreenCanvas not supported in Playwright's Windows/Linux Webkit build: https://github.com/ni/nimble/issues/2169

--- a/packages/nimble-components/src/wafer-map/tests/wafer-map.spec.ts
+++ b/packages/nimble-components/src/wafer-map/tests/wafer-map.spec.ts
@@ -1,7 +1,7 @@
 import { html } from '@microsoft/fast-element';
 import { Table, tableFromArrays } from 'apache-arrow';
 import type { Remote } from 'comlink';
-import { WaferMap } from '..';
+import { WaferMap, waferMapTag } from '..';
 import {
     processUpdates,
     waitForUpdatesAsync
@@ -32,9 +32,7 @@ describe('WaferMap', () => {
     });
 
     it('can construct an element instance', () => {
-        expect(document.createElement('nimble-wafer-map')).toBeInstanceOf(
-            WaferMap
-        );
+        expect(document.createElement(waferMapTag)).toBeInstanceOf(WaferMap);
     });
 
     describe('update action', () => {

--- a/packages/nimble-components/src/wafer-map/tests/wafer-map.spec.ts
+++ b/packages/nimble-components/src/wafer-map/tests/wafer-map.spec.ts
@@ -15,7 +15,7 @@ import {
 import type { MatrixRenderer } from '../workers/matrix-renderer';
 
 async function setup(): Promise<Fixture<WaferMap>> {
-    return await fixture<WaferMap>(html`<nimble-wafer-map></nimble-wafer-map>`);
+    return await fixture<WaferMap>(html`<${waferMapTag}></${waferMapTag}>`);
 }
 describe('WaferMap', () => {
     let element: WaferMap;

--- a/packages/spright-components/src/rectangle/tests/rectangle.spec.ts
+++ b/packages/spright-components/src/rectangle/tests/rectangle.spec.ts
@@ -21,14 +21,8 @@ describe('Rectangle', () => {
         await disconnect();
     });
 
-    it('should export its tag', () => {
-        expect(rectangleTag).toBe('spright-rectangle');
-    });
-
     it('can construct an element instance', () => {
-        expect(document.createElement('spright-rectangle')).toBeInstanceOf(
-            Rectangle
-        );
+        expect(document.createElement(rectangleTag)).toBeInstanceOf(Rectangle);
     });
 
     it('should have a slot element in the shadow DOM', async () => {

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -105,5 +105,5 @@ configureActions({
     depth: 1
 });
 
-// Update the GUID on this line to trigger a turbosnap full rebuild: c9f91cc3-1168-433f-86e7-b93a9e395ba1
+// Update the GUID on this line to trigger a turbosnap full rebuild: c9f91cc3-1168-433f-86e7-b93a9e395ba2
 // See https://www.chromatic.com/docs/turbosnap/#full-rebuilds

--- a/packages/storybook/src/docs/component-status.stories.ts
+++ b/packages/storybook/src/docs/component-status.stories.ts
@@ -643,7 +643,7 @@ const metadata: Meta<TableArgs> = {
             void (async () => {
                 // Safari workaround: the table element instance is made at this point
                 // but doesn't seem to be upgraded to a custom element yet
-                await customElements.whenDefined('nimble-table');
+                await customElements.whenDefined(tableTag);
                 const isFuture = (
                     component: (typeof components)[number]
                 ): boolean => component.angularStatus

--- a/packages/storybook/src/nimble/dialog/dialog-matrix.stories.ts
+++ b/packages/storybook/src/nimble/dialog/dialog-matrix.stories.ts
@@ -88,7 +88,7 @@ if (remaining.length > 0) {
 }
 
 const playFunction = (): void => {
-    void document.querySelector('nimble-dialog')!.show();
+    void document.querySelector(dialogTag)!.show();
 };
 
 export const dialogLightThemeWhiteBackground: StoryFn = createFixedThemeStory(

--- a/packages/storybook/src/nimble/drawer/drawer-matrix.stories.ts
+++ b/packages/storybook/src/nimble/drawer/drawer-matrix.stories.ts
@@ -32,7 +32,7 @@ if (remaining.length > 0) {
 }
 
 const playFunction = (): void => {
-    void document.querySelector('nimble-drawer')!.show();
+    void document.querySelector(drawerTag)!.show();
 };
 
 export const drawerLightThemeWhiteBackground: StoryFn = createFixedThemeStory(

--- a/packages/storybook/src/nimble/icon-base/icons.stories.ts
+++ b/packages/storybook/src/nimble/icon-base/icons.stories.ts
@@ -57,7 +57,7 @@ const updateData = (tableRef: Table<Data>): void => {
     void (async () => {
         // Safari workaround: the table element instance is made at this point
         // but doesn't seem to be upgraded to a custom element yet
-        await customElements.whenDefined('nimble-table');
+        await customElements.whenDefined(tableTag);
         await tableRef.setData(data);
     })();
 };

--- a/packages/storybook/src/nimble/label-provider/base/label-provider-stories-utils.ts
+++ b/packages/storybook/src/nimble/label-provider/base/label-provider-stories-utils.ts
@@ -103,7 +103,7 @@ export const labelProviderMetadata: Meta<LabelProviderArgs> = {
             void (async () => {
                 // Safari workaround: the table element instance is made at this point
                 // but doesn't seem to be upgraded to a custom element yet
-                await customElements.whenDefined('nimble-table');
+                await customElements.whenDefined(tableTag);
 
                 const data = x.labelTokens.map(token => {
                     return {

--- a/packages/storybook/src/nimble/menu/menu.stories.ts
+++ b/packages/storybook/src/nimble/menu/menu.stories.ts
@@ -44,7 +44,7 @@ interface AnchorMenuItemArgs {
 }
 
 interface ItemArgs extends MenuItemArgsBase {
-    type: 'nimble-menu-item' | 'header' | 'hr';
+    type: typeof menuItemTag | 'header' | 'hr';
 }
 
 const metadata: Meta<MenuArgs> = {
@@ -64,7 +64,7 @@ export const menu: StoryObj<MenuArgs> = {
     render: createUserSelectedThemeStory(html`
         <${menuTag}>
             ${repeat(x => x.itemOptions, html<ItemArgs>`
-                ${when(x => x.type === 'nimble-menu-item', html<ItemArgs>`
+                ${when(x => x.type === menuItemTag, html<ItemArgs>`
                     <${menuItemTag} ?disabled="${x => x.disabled}">
                         ${when(x => x.icon, html`<${iconUserTag} slot="start"></${iconUserTag}>`)}
                         ${x => x.text}
@@ -93,19 +93,19 @@ export const menu: StoryObj<MenuArgs> = {
                 text: 'Item 1',
                 disabled: false,
                 icon: false,
-                type: 'nimble-menu-item'
+                type: menuItemTag
             },
             {
                 text: 'Item 2',
                 disabled: false,
                 icon: false,
-                type: 'nimble-menu-item'
+                type: menuItemTag
             },
             {
                 text: 'Item 3',
                 disabled: false,
                 icon: false,
-                type: 'nimble-menu-item'
+                type: menuItemTag
             },
             {
                 text: 'Divider',
@@ -123,19 +123,19 @@ export const menu: StoryObj<MenuArgs> = {
                 text: 'Item 4',
                 disabled: false,
                 icon: false,
-                type: 'nimble-menu-item'
+                type: menuItemTag
             },
             {
                 text: 'Item 5',
                 disabled: false,
                 icon: false,
-                type: 'nimble-menu-item'
+                type: menuItemTag
             },
             {
                 text: 'Item 6',
                 disabled: false,
                 icon: false,
-                type: 'nimble-menu-item'
+                type: menuItemTag
             }
         ]
     },

--- a/packages/storybook/src/nimble/patterns/anchor/anchor-patterns.stories.ts
+++ b/packages/storybook/src/nimble/patterns/anchor/anchor-patterns.stories.ts
@@ -143,7 +143,7 @@ const metadata: Meta<AnchorPatternsArgs> = {
             void (async () => {
                 // Safari workaround: the nimble-table element instance is made at this point
                 // but doesn't seem to be upgraded to a custom element yet
-                await customElements.whenDefined('nimble-table');
+                await customElements.whenDefined(tableTag);
                 const data = [
                     {
                         label: x.label,
@@ -159,7 +159,7 @@ const metadata: Meta<AnchorPatternsArgs> = {
             void (async () => {
                 // Safari workaround: the nimble-rich-text-viewer element instance is made at this point
                 // but doesn't seem to be upgraded to a custom element yet
-                await customElements.whenDefined('nimble-rich-text-viewer');
+                await customElements.whenDefined(richTextViewerTag);
                 const data = `Absolute link: <${x.disabled ? '' : 'https://nimble.ni.dev?type=nimble-rich-text-viewer'}>`;
                 x.richTextViewerRef.markdown = data;
             })();

--- a/packages/storybook/src/nimble/rich-text/editor/rich-text-editor-matrix.stories.ts
+++ b/packages/storybook/src/nimble/rich-text/editor/rich-text-editor-matrix.stories.ts
@@ -88,12 +88,12 @@ const component = (
 `;
 
 const playFunction = (): void => {
-    const editorNodeList = document.querySelectorAll('nimble-rich-text-editor');
+    const editorNodeList = document.querySelectorAll(richTextEditorTag);
     editorNodeList.forEach(element => element.setMarkdown(richTextMarkdownString));
 };
 
 const longTextPlayFunction = (): void => {
-    const editorNodeList = document.querySelectorAll('nimble-rich-text-editor');
+    const editorNodeList = document.querySelectorAll(richTextEditorTag);
     editorNodeList.forEach(element => element.setMarkdown(
         `${loremIpsum}\n\n **${loremIpsum}**\n\n ${loremIpsum}`
     ));
@@ -204,7 +204,7 @@ const mobileWidthComponent = html`
 
 export const plainTextContentInMobileWidth: StoryFn = createStory(mobileWidthComponent);
 plainTextContentInMobileWidth.play = (): void => {
-    document.querySelector('nimble-rich-text-editor')!.setMarkdown(loremIpsum);
+    document.querySelector(richTextEditorTag)!.setMarkdown(loremIpsum);
 };
 
 const multipleSubPointsContent = `
@@ -221,7 +221,7 @@ const multipleSubPointsContent = `
 export const multipleSubPointsContentInMobileWidth: StoryFn = createStory(mobileWidthComponent);
 multipleSubPointsContentInMobileWidth.play = (): void => {
     document
-        .querySelector('nimble-rich-text-editor')!
+        .querySelector(richTextEditorTag)!
         .setMarkdown(multipleSubPointsContent);
 };
 
@@ -235,14 +235,14 @@ const differentListElementContentInSameLevel = `
 export const differentListElementInSameLevel: StoryFn = createStory(mobileWidthComponent);
 differentListElementInSameLevel.play = (): void => {
     document
-        .querySelector('nimble-rich-text-editor')!
+        .querySelector(richTextEditorTag)!
         .setMarkdown(differentListElementContentInSameLevel);
 };
 
 export const longWordContentInMobileWidth: StoryFn = createStory(mobileWidthComponent);
 longWordContentInMobileWidth.play = (): void => {
     document
-        .querySelector('nimble-rich-text-editor')!
+        .querySelector(richTextEditorTag)!
         .setMarkdown(
             'ThisIsALongWordWithoutSpaceToTestLongWordInSmallWidthThisIsALongWordWithoutSpaceToTestLongWordInSmallWidth'
         );
@@ -264,14 +264,14 @@ This line enters new line in paragraph tag
 export const newLineWithForceLineBreakInMobileWidth: StoryFn = createStory(mobileWidthComponent);
 newLineWithForceLineBreakInMobileWidth.play = (): void => {
     document
-        .querySelector('nimble-rich-text-editor')!
+        .querySelector(richTextEditorTag)!
         .setMarkdown(newLineWithForceLineBreakContent);
 };
 
 export const longLinkInMobileWidth: StoryFn = createStory(mobileWidthComponent);
 longLinkInMobileWidth.play = (): void => {
     document
-        .querySelector('nimble-rich-text-editor')!
+        .querySelector(richTextEditorTag)!
         .setMarkdown(
             '<https://www.google.com/search?q=what+is+nimble&rlz=1C1CHBF_enIN1007IN1007&oq=what+is+nimble&aqs=chrome..69i57j0i512l9.2837j1j7&sourceid=chrome&ie=UTF-8>'
         );

--- a/packages/storybook/src/nimble/rich-text/editor/rich-text-editor.stories.ts
+++ b/packages/storybook/src/nimble/rich-text/editor/rich-text-editor.stories.ts
@@ -269,7 +269,7 @@ const metadata: Meta<RichTextEditorArgs> = {
             void (async () => {
                 // Safari workaround: the nimble-rich-text-editor element instance is made at this point
                 // but doesn't seem to be upgraded to a custom element yet
-                await customElements.whenDefined('nimble-rich-text-editor');
+                await customElements.whenDefined(richTextEditorTag);
                 x.editorRef.setMarkdown(dataSets[x.data]);
             })();
         },

--- a/packages/storybook/src/nimble/rich-text/mention-listbox/mention-listbox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/rich-text/mention-listbox/mention-listbox-matrix.stories.ts
@@ -21,9 +21,7 @@ const metadata: Meta = {
 export default metadata;
 
 const playFunction = (): void => {
-    const editorNodeList = document.querySelectorAll(
-        'nimble-rich-text-mention-listbox'
-    );
+    const editorNodeList = document.querySelectorAll(richTextMentionListboxTag);
     const anchorList = document.querySelectorAll('.anchor');
     editorNodeList.forEach((element, index) => {
         const filter = anchorList[index]?.classList.contains('no-match')

--- a/packages/storybook/src/nimble/select/select-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-matrix.stories.ts
@@ -102,15 +102,13 @@ export const blankListOption: StoryFn = createStory(
 
 const playFunction = async (): Promise<void> => {
     await Promise.all(
-        Array.from(document.querySelectorAll<Select>('nimble-select')).map(
-            async select => {
-                const arrowDownEvent = new KeyboardEvent('keydown', {
-                    key: keyArrowDown
-                });
-                select.dispatchEvent(arrowDownEvent);
-                await waitForUpdatesAsync();
-            }
-        )
+        Array.from(document.querySelectorAll(selectTag)).map(async select => {
+            const arrowDownEvent = new KeyboardEvent('keydown', {
+                key: keyArrowDown
+            });
+            select.dispatchEvent(arrowDownEvent);
+            await waitForUpdatesAsync();
+        })
     );
 };
 

--- a/packages/storybook/src/nimble/select/select-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-matrix.stories.ts
@@ -4,7 +4,7 @@ import { keyArrowDown } from '@microsoft/fast-web-utilities';
 import { standardPadding } from '../../../../nimble-components/src/theme-provider/design-tokens';
 import { listOptionTag } from '../../../../nimble-components/src/list-option';
 import { listOptionGroupTag } from '../../../../nimble-components/src/list-option-group';
-import { Select, selectTag } from '../../../../nimble-components/src/select';
+import { selectTag } from '../../../../nimble-components/src/select';
 import { DropdownAppearance } from '../../../../nimble-components/src/patterns/dropdown/types';
 import { waitForUpdatesAsync } from '../../../../nimble-components/src/testing/async-helpers';
 import { createStory } from '../../utilities/storybook';

--- a/packages/storybook/src/nimble/select/select-opened-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-opened-matrix.stories.ts
@@ -3,7 +3,7 @@ import { html, repeat, ViewTemplate, when } from '@microsoft/fast-element';
 import { DropdownPosition } from '../../../../nimble-components/src/patterns/dropdown/types';
 import { listOptionTag } from '../../../../nimble-components/src/list-option';
 import { listOptionGroupTag } from '../../../../nimble-components/src/list-option-group';
-import { Select, selectTag } from '../../../../nimble-components/src/select';
+import { selectTag } from '../../../../nimble-components/src/select';
 import { FilterMode } from '../../../../nimble-components/src/select/types';
 import { createFixedThemeStory } from '../../utilities/storybook';
 import { sharedMatrixParameters } from '../../utilities/matrix';

--- a/packages/storybook/src/nimble/select/select-opened-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-opened-matrix.stories.ts
@@ -221,7 +221,7 @@ export const selectAboveOpenStandardFilterDarkThemeBlackBackground: StoryFn = cr
 );
 
 const noMatchesFilterPlayFunction = (): void => {
-    const select = document.querySelector<Select>('nimble-select');
+    const select = document.querySelector(selectTag);
     select!.filter = 'abc';
 };
 

--- a/packages/storybook/src/nimble/table-column/anchor/table-column-anchor-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/anchor/table-column-anchor-matrix.stories.ts
@@ -1,7 +1,7 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
 import { iconUserTag } from '../../../../../nimble-components/src/icons/user';
-import { Table, tableTag } from '../../../../../nimble-components/src/table';
+import { tableTag } from '../../../../../nimble-components/src/table';
 import { AnchorAppearance } from '../../../../../nimble-components/src/anchor/types';
 import {
     controlLabelFont,

--- a/packages/storybook/src/nimble/table-column/anchor/table-column-anchor-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/anchor/table-column-anchor-matrix.stories.ts
@@ -93,10 +93,8 @@ export const tableColumnAnchorThemeMatrix: StoryFn = createMatrixThemeStory(
 
 tableColumnAnchorThemeMatrix.play = async (): Promise<void> => {
     await Promise.all(
-        Array.from(document.querySelectorAll<Table>('nimble-table')).map(
-            async table => {
-                await table.setData(data);
-            }
-        )
+        Array.from(document.querySelectorAll(tableTag)).map(async table => {
+            await table.setData(data);
+        })
     );
 };

--- a/packages/storybook/src/nimble/table-column/base/table-column-stories-utils.ts
+++ b/packages/storybook/src/nimble/table-column/base/table-column-stories-utils.ts
@@ -1,4 +1,7 @@
-import type { Table } from '../../../../../nimble-components/src/table';
+import {
+    tableTag,
+    type Table
+} from '../../../../../nimble-components/src/table';
 import {
     TableRecord,
     TableRowSelectionMode
@@ -42,7 +45,7 @@ export const sharedTableArgs = (
             void (async () => {
                 // Safari workaround: the table element instance is made at this point
                 // but doesn't seem to be upgraded to a custom element yet
-                await customElements.whenDefined('nimble-table');
+                await customElements.whenDefined(tableTag);
                 await x.tableRef.setData(data);
             })();
         }

--- a/packages/storybook/src/nimble/table-column/date-text/table-column-date-text-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/date-text/table-column-date-text-matrix.stories.ts
@@ -1,7 +1,7 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
 import { iconUserTag } from '../../../../../nimble-components/src/icons/user';
-import { Table, tableTag } from '../../../../../nimble-components/src/table';
+import { tableTag } from '../../../../../nimble-components/src/table';
 import {
     controlLabelFont,
     controlLabelFontColor

--- a/packages/storybook/src/nimble/table-column/date-text/table-column-date-text-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/date-text/table-column-date-text-matrix.stories.ts
@@ -64,10 +64,8 @@ export const tableColumnDateTextThemeMatrix: StoryFn = createMatrixThemeStory(
 
 tableColumnDateTextThemeMatrix.play = async (): Promise<void> => {
     await Promise.all(
-        Array.from(document.querySelectorAll<Table>('nimble-table')).map(
-            async table => {
-                await table.setData(data);
-            }
-        )
+        Array.from(document.querySelectorAll(tableTag)).map(async table => {
+            await table.setData(data);
+        })
     );
 };

--- a/packages/storybook/src/nimble/table-column/duration-text/table-column-duration-text-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/duration-text/table-column-duration-text-matrix.stories.ts
@@ -61,10 +61,8 @@ export const tableColumnDurationTextThemeMatrix: StoryFn = createMatrixThemeStor
 
 tableColumnDurationTextThemeMatrix.play = async (): Promise<void> => {
     await Promise.all(
-        Array.from(document.querySelectorAll<Table>('nimble-table')).map(
-            async table => {
-                await table.setData(data);
-            }
-        )
+        Array.from(document.querySelectorAll(tableTag)).map(async table => {
+            await table.setData(data);
+        })
     );
 };

--- a/packages/storybook/src/nimble/table-column/duration-text/table-column-duration-text-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/duration-text/table-column-duration-text-matrix.stories.ts
@@ -1,6 +1,6 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import { Table, tableTag } from '../../../../../nimble-components/src/table';
+import { tableTag } from '../../../../../nimble-components/src/table';
 import {
     controlLabelFont,
     controlLabelFontColor

--- a/packages/storybook/src/nimble/table-column/mapping/table-column-mapping-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/mapping/table-column-mapping-matrix.stories.ts
@@ -1,6 +1,6 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import { Table, tableTag } from '../../../../../nimble-components/src/table';
+import { tableTag } from '../../../../../nimble-components/src/table';
 import { iconCheckTag } from '../../../../../nimble-components/src/icons/check';
 import { iconXmarkTag } from '../../../../../nimble-components/src/icons/xmark';
 import { iconQuestionTag } from '../../../../../nimble-components/src/icons/question';

--- a/packages/storybook/src/nimble/table-column/mapping/table-column-mapping-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/mapping/table-column-mapping-matrix.stories.ts
@@ -106,10 +106,8 @@ export const tableColumnMappingThemeMatrix: StoryFn = createMatrixThemeStory(com
 
 tableColumnMappingThemeMatrix.play = async (): Promise<void> => {
     await Promise.all(
-        Array.from(document.querySelectorAll<Table>('nimble-table')).map(
-            async table => {
-                await table.setData(data);
-            }
-        )
+        Array.from(document.querySelectorAll(tableTag)).map(async table => {
+            await table.setData(data);
+        })
     );
 };

--- a/packages/storybook/src/nimble/table-column/menu-button/table-column-menu-button-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/menu-button/table-column-menu-button-matrix.stories.ts
@@ -57,10 +57,8 @@ export const tableColumnMenuButtonThemeMatrix: StoryFn = createMatrixThemeStory(
 
 tableColumnMenuButtonThemeMatrix.play = async (): Promise<void> => {
     await Promise.all(
-        Array.from(document.querySelectorAll<Table>('nimble-table')).map(
-            async table => {
-                await table.setData(data);
-            }
-        )
+        Array.from(document.querySelectorAll(tableTag)).map(async table => {
+            await table.setData(data);
+        })
     );
 };

--- a/packages/storybook/src/nimble/table-column/menu-button/table-column-menu-button-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/menu-button/table-column-menu-button-matrix.stories.ts
@@ -1,6 +1,6 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import { Table, tableTag } from '../../../../../nimble-components/src/table';
+import { tableTag } from '../../../../../nimble-components/src/table';
 import { tableColumnMenuButtonTag } from '../../../../../nimble-components/src/table-column/menu-button';
 import {
     createMatrixThemeStory,

--- a/packages/storybook/src/nimble/table-column/menu-button/table-column-menu-button-opened-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/menu-button/table-column-menu-button-opened-matrix.stories.ts
@@ -1,6 +1,6 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html } from '@microsoft/fast-element';
-import { Table, tableTag } from '../../../../../nimble-components/src/table';
+import { tableTag } from '../../../../../nimble-components/src/table';
 import { menuTag } from '../../../../../nimble-components/src/menu';
 import { menuItemTag } from '../../../../../nimble-components/src/menu-item';
 import { tableColumnMenuButtonTag } from '../../../../../nimble-components/src/table-column/menu-button';
@@ -61,7 +61,7 @@ if (remaining.length > 0) {
 }
 
 const playFunction = async (): Promise<void> => {
-    const table = document.querySelector<Table>('nimble-table')!;
+    const table = document.querySelector(tableTag)!;
     await table.setData(data);
     await waitForUpdatesAsync();
 

--- a/packages/storybook/src/nimble/table-column/number-text/table-column-number-text-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/number-text/table-column-number-text-matrix.stories.ts
@@ -87,10 +87,8 @@ export const tableColumnNumberTextThemeMatrix: StoryFn = createMatrixThemeStory(
 
 tableColumnNumberTextThemeMatrix.play = async (): Promise<void> => {
     await Promise.all(
-        Array.from(document.querySelectorAll<Table>('nimble-table')).map(
-            async table => {
-                await table.setData(data);
-            }
-        )
+        Array.from(document.querySelectorAll(tableTag)).map(async table => {
+            await table.setData(data);
+        })
     );
 };

--- a/packages/storybook/src/nimble/table-column/number-text/table-column-number-text-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/number-text/table-column-number-text-matrix.stories.ts
@@ -1,6 +1,6 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import { Table, tableTag } from '../../../../../nimble-components/src/table';
+import { tableTag } from '../../../../../nimble-components/src/table';
 import {
     controlLabelFont,
     controlLabelFontColor

--- a/packages/storybook/src/nimble/table-column/text/table-column-text-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/text/table-column-text-matrix.stories.ts
@@ -74,10 +74,8 @@ export const tableColumnTextThemeMatrix: StoryFn = createMatrixThemeStory(
 
 tableColumnTextThemeMatrix.play = async (): Promise<void> => {
     await Promise.all(
-        Array.from(document.querySelectorAll<Table>('nimble-table')).map(
-            async table => {
-                await table.setData(data);
-            }
-        )
+        Array.from(document.querySelectorAll(tableTag)).map(async table => {
+            await table.setData(data);
+        })
     );
 };

--- a/packages/storybook/src/nimble/table-column/text/table-column-text-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/text/table-column-text-matrix.stories.ts
@@ -1,6 +1,6 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@microsoft/fast-element';
-import { Table, tableTag } from '../../../../../nimble-components/src/table';
+import { tableTag } from '../../../../../nimble-components/src/table';
 import {
     controlLabelFont,
     controlLabelFontColor

--- a/packages/storybook/src/nimble/table/table-action-menu-opened-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table/table-action-menu-opened-matrix.stories.ts
@@ -5,7 +5,7 @@ import { iconUserTag } from '../../../../nimble-components/src/icons/user';
 import { menuTag } from '../../../../nimble-components/src/menu';
 import { menuItemTag } from '../../../../nimble-components/src/menu-item';
 import { tableColumnTextTag } from '../../../../nimble-components/src/table-column/text';
-import { Table, tableTag } from '../../../../nimble-components/src/table';
+import { tableTag } from '../../../../nimble-components/src/table';
 import { TablePageObject } from '../../../../nimble-components/src/table/testing/table.pageobject';
 import { createFixedThemeStory } from '../../utilities/storybook';
 import { sharedMatrixParameters } from '../../utilities/matrix';

--- a/packages/storybook/src/nimble/table/table-action-menu-opened-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table/table-action-menu-opened-matrix.stories.ts
@@ -72,7 +72,7 @@ if (remaining.length > 0) {
 }
 
 const playFunction = async (): Promise<void> => {
-    const table = document.querySelector<Table>('nimble-table')!;
+    const table = document.querySelector(tableTag)!;
     await table.setData(data);
     await waitForUpdatesAsync();
 

--- a/packages/storybook/src/nimble/table/table-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table/table-matrix.stories.ts
@@ -121,28 +121,26 @@ const component = (
 
 const playFunction = async (): Promise<void> => {
     await Promise.all(
-        Array.from(document.querySelectorAll<Table>('nimble-table')).map(
-            async table => {
-                await table.setData(data);
-                await table.setRecordHierarchyOptions([
-                    {
-                        recordId: '0',
-                        options: {
-                            delayedHierarchyState:
-                                TableRecordDelayedHierarchyState.canLoadChildren
-                        }
-                    },
-                    {
-                        recordId: '1',
-                        options: {
-                            delayedHierarchyState:
-                                TableRecordDelayedHierarchyState.loadingChildren
-                        }
+        Array.from(document.querySelectorAll(tableTag)).map(async table => {
+            await table.setData(data);
+            await table.setRecordHierarchyOptions([
+                {
+                    recordId: '0',
+                    options: {
+                        delayedHierarchyState:
+                            TableRecordDelayedHierarchyState.canLoadChildren
                     }
-                ]);
-                await table.setSelectedRecordIds(['', '2']);
-            }
-        )
+                },
+                {
+                    recordId: '1',
+                    options: {
+                        delayedHierarchyState:
+                            TableRecordDelayedHierarchyState.loadingChildren
+                    }
+                }
+            ]);
+            await table.setSelectedRecordIds(['', '2']);
+        })
     );
 };
 

--- a/packages/storybook/src/nimble/table/table-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table/table-matrix.stories.ts
@@ -3,7 +3,7 @@ import { html, ViewTemplate } from '@microsoft/fast-element';
 import { iconUserTag } from '../../../../nimble-components/src/icons/user';
 import { tableColumnTextTag } from '../../../../nimble-components/src/table-column/text';
 import { tableColumnNumberTextTag } from '../../../../nimble-components/src/table-column/number-text';
-import { Table, tableTag } from '../../../../nimble-components/src/table';
+import { tableTag } from '../../../../nimble-components/src/table';
 import {
     TableRecordDelayedHierarchyState,
     TableRowSelectionMode

--- a/packages/storybook/src/nimble/table/table.stories.ts
+++ b/packages/storybook/src/nimble/table/table.stories.ts
@@ -520,7 +520,7 @@ export const table: StoryObj<TableArgs> = {
                 // Safari workaround: the table element instance is made at this point
                 // but doesn't seem to be upgraded to a custom element yet
                 const args = x as TableArgs;
-                await customElements.whenDefined('nimble-table');
+                await customElements.whenDefined(tableTag);
                 await args.tableRef.setData(dataSets[args.data]);
             })();
         }
@@ -577,7 +577,7 @@ export const delayedHierarchy: Meta<DelayedHierarchyTableArgs> = {
                 // Safari workaround: the table element instance is made at this point
                 // but doesn't seem to be upgraded to a custom element yet
                 const args = x as DelayedHierarchyTableArgs;
-                await customElements.whenDefined('nimble-table');
+                await customElements.whenDefined(tableTag);
                 await args.tableRef.setData(
                     dataSets[ExampleDataType.simpleData]
                 );

--- a/packages/storybook/src/nimble/tabs/tabs-matrix.stories.ts
+++ b/packages/storybook/src/nimble/tabs/tabs-matrix.stories.ts
@@ -77,8 +77,8 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
 );
 
 export const panelOverflow: StoryFn = createStory(html`
-    <nimble-tabs style="height: 120px; width: 400px;">
-        <nimble-tab>Tab One</nimble-tab>
-        <nimble-tab-panel style="width: 450px;">${loremIpsum}</nimble-tab-panel>
-    </nimble-tabs>
+    ${tabsTag} style="height: 120px; width: 400px;">
+        <${tabTag}>Tab One</${tabTag}>
+        <${tabPanelTag} style="width: 450px;">${loremIpsum}</${tabPanelTag}>
+    <${tabsTag}>
 `);

--- a/packages/storybook/src/nimble/tabs/tabs-matrix.stories.ts
+++ b/packages/storybook/src/nimble/tabs/tabs-matrix.stories.ts
@@ -77,8 +77,8 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
 );
 
 export const panelOverflow: StoryFn = createStory(html`
-    ${tabsTag} style="height: 120px; width: 400px;">
+    <${tabsTag} style="height: 120px; width: 400px;">
         <${tabTag}>Tab One</${tabTag}>
         <${tabPanelTag} style="width: 450px;">${loremIpsum}</${tabPanelTag}>
-    <${tabsTag}>
+    </${tabsTag}>
 `);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

- Stops using hard coded element tag names
- Removes unnecessary test asserting tag name string value
- A couple tests used a fixture with invalid tag names, i.e. `nimble-xmark-icon`

## 👩‍💻 Implementation

See above

## 🧪 Testing

Rely on CI.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
