### PR TITLE
Fix tabs toolbar content alignment

### DIFF
--- a/change/@ni-nimble-components-6b9e5a53-7829-4004-820b-a1e8b8217fe1.json
+++ b/change/@ni-nimble-components-6b9e5a53-7829-4004-820b-a1e8b8217fe1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix tabs styling.",
+  "packageName": "@ni/nimble-components",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/patterns/tabs/styles.ts
+++ b/packages/nimble-components/src/patterns/tabs/styles.ts
@@ -33,7 +33,7 @@ export const styles = css`
         margin-left: ${smallPadding};
     }
 
-    .end {
+    [part='end'] {
         flex: 1;
     }
 `;

--- a/packages/nimble-components/src/patterns/tabs/styles.ts
+++ b/packages/nimble-components/src/patterns/tabs/styles.ts
@@ -32,4 +32,8 @@ export const styles = css`
     .scroll-button.right {
         margin-left: ${smallPadding};
     }
+
+    .end {
+        flex: 1;
+    }
 `;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

[SLE bug: Nimble | nimble-tabs-toolbar | alignment of the child elements has been altered.](https://dev.azure.com/ni/DevCentral/_workitems/edit/2913486)

## 👩‍💻 Implementation

Just added styling that will expand the `end` slot to fill the rest of the space of the `Tabs` width.

## 🧪 Testing

There is a Chromatic test in place that is already checking this case, but I must have glossed over that change when examining it for the scrollable tabs submission.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
