### PR TITLE
Pin FAST foundation and element versions until new versions vetted

### DIFF
--- a/change/@ni-nimble-components-17ee807f-bbf8-42ee-95ea-4fcbcd5e9679.json
+++ b/change/@ni-nimble-components-17ee807f-bbf8-42ee-95ea-4fcbcd5e9679.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Pin FAST foundation and element versions until new versions vetted",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-spright-components-8a9c245d-5ce3-458e-be0c-7db806bda3b3.json
+++ b/change/@ni-spright-components-8a9c245d-5ce3-458e-be0c-7db806bda3b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Pin FAST foundation and element versions until new versions vetted",
+  "packageName": "@ni/spright-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28197,7 +28197,7 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/fast-colors": "^5.3.1",
-        "@microsoft/fast-element": "1.12.0",
+        "@microsoft/fast-element": "1.13.0",
         "@microsoft/fast-foundation": "2.49.6",
         "@microsoft/fast-web-utilities": "^6.0.0",
         "@ni/nimble-tokens": "^8.4.0",
@@ -28273,12 +28273,6 @@
         "apache-arrow": "16.1.0"
       }
     },
-    "packages/nimble-components/node_modules/@microsoft/fast-element": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.12.0.tgz",
-      "integrity": "sha512-gQutuDHPKNxUEcQ4pypZT4Wmrbapus+P9s3bR/SEOLsMbNqNoXigGImITygI5zhb+aA5rzflM6O8YWkmRbGkPA==",
-      "license": "MIT"
-    },
     "packages/nimble-tokens": {
       "name": "@ni/nimble-tokens",
       "version": "8.4.0",
@@ -28321,7 +28315,7 @@
       "version": "4.1.17",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "1.12.0",
+        "@microsoft/fast-element": "1.13.0",
         "@microsoft/fast-foundation": "2.49.6",
         "@ni/nimble-components": "^32.5.1",
         "tslib": "^2.2.0"
@@ -28359,18 +28353,12 @@
         "webpack-dev-middleware": "^7.0.0"
       }
     },
-    "packages/spright-components/node_modules/@microsoft/fast-element": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.12.0.tgz",
-      "integrity": "sha512-gQutuDHPKNxUEcQ4pypZT4Wmrbapus+P9s3bR/SEOLsMbNqNoXigGImITygI5zhb+aA5rzflM6O8YWkmRbGkPA==",
-      "license": "MIT"
-    },
     "packages/storybook": {
       "name": "@ni-private/storybook",
       "version": "1.0.0",
       "devDependencies": {
         "@chromatic-com/storybook": "^2.0.2",
-        "@microsoft/fast-element": "1.12.0",
+        "@microsoft/fast-element": "1.13.0",
         "@microsoft/fast-foundation": "2.49.6",
         "@microsoft/fast-react-wrapper": "^0.3.22",
         "@microsoft/fast-web-utilities": "^6.0.0",
@@ -28409,13 +28397,6 @@
         "eslint-plugin-storybook": "^0.8.0",
         "react": "^18.3.1"
       }
-    },
-    "packages/storybook/node_modules/@microsoft/fast-element": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.12.0.tgz",
-      "integrity": "sha512-gQutuDHPKNxUEcQ4pypZT4Wmrbapus+P9s3bR/SEOLsMbNqNoXigGImITygI5zhb+aA5rzflM6O8YWkmRbGkPA==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/xliff-to-json-converter": {
       "name": "@ni/xliff-to-json-converter",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28197,8 +28197,8 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/fast-colors": "^5.3.1",
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "^2.49.6",
+        "@microsoft/fast-element": "1.12.0",
+        "@microsoft/fast-foundation": "2.49.6",
         "@microsoft/fast-web-utilities": "^6.0.0",
         "@ni/nimble-tokens": "^8.4.0",
         "@tanstack/table-core": "^8.19.3",
@@ -28273,6 +28273,12 @@
         "apache-arrow": "16.1.0"
       }
     },
+    "packages/nimble-components/node_modules/@microsoft/fast-element": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.12.0.tgz",
+      "integrity": "sha512-gQutuDHPKNxUEcQ4pypZT4Wmrbapus+P9s3bR/SEOLsMbNqNoXigGImITygI5zhb+aA5rzflM6O8YWkmRbGkPA==",
+      "license": "MIT"
+    },
     "packages/nimble-tokens": {
       "name": "@ni/nimble-tokens",
       "version": "8.4.0",
@@ -28315,8 +28321,8 @@
       "version": "4.1.17",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "^2.49.6",
+        "@microsoft/fast-element": "1.12.0",
+        "@microsoft/fast-foundation": "2.49.6",
         "@ni/nimble-components": "^32.5.1",
         "tslib": "^2.2.0"
       },
@@ -28353,13 +28359,19 @@
         "webpack-dev-middleware": "^7.0.0"
       }
     },
+    "packages/spright-components/node_modules/@microsoft/fast-element": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.12.0.tgz",
+      "integrity": "sha512-gQutuDHPKNxUEcQ4pypZT4Wmrbapus+P9s3bR/SEOLsMbNqNoXigGImITygI5zhb+aA5rzflM6O8YWkmRbGkPA==",
+      "license": "MIT"
+    },
     "packages/storybook": {
       "name": "@ni-private/storybook",
       "version": "1.0.0",
       "devDependencies": {
         "@chromatic-com/storybook": "^2.0.2",
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "^2.49.6",
+        "@microsoft/fast-element": "1.12.0",
+        "@microsoft/fast-foundation": "2.49.6",
         "@microsoft/fast-react-wrapper": "^0.3.22",
         "@microsoft/fast-web-utilities": "^6.0.0",
         "@ni-private/eslint-config-nimble": "*",
@@ -28397,6 +28409,13 @@
         "eslint-plugin-storybook": "^0.8.0",
         "react": "^18.3.1"
       }
+    },
+    "packages/storybook/node_modules/@microsoft/fast-element": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.12.0.tgz",
+      "integrity": "sha512-gQutuDHPKNxUEcQ4pypZT4Wmrbapus+P9s3bR/SEOLsMbNqNoXigGImITygI5zhb+aA5rzflM6O8YWkmRbGkPA==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/xliff-to-json-converter": {
       "name": "@ni/xliff-to-json-converter",

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -60,8 +60,8 @@
   "homepage": "https://github.com/ni/nimble#readme",
   "dependencies": {
     "@microsoft/fast-colors": "^5.3.1",
-    "@microsoft/fast-element": "^1.12.0",
-    "@microsoft/fast-foundation": "^2.49.6",
+    "@microsoft/fast-element": "1.12.0",
+    "@microsoft/fast-foundation": "2.49.6",
     "@microsoft/fast-web-utilities": "^6.0.0",
     "@ni/nimble-tokens": "^8.4.0",
     "@tanstack/table-core": "^8.19.3",

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -60,7 +60,7 @@
   "homepage": "https://github.com/ni/nimble#readme",
   "dependencies": {
     "@microsoft/fast-colors": "^5.3.1",
-    "@microsoft/fast-element": "1.12.0",
+    "@microsoft/fast-element": "1.13.0",
     "@microsoft/fast-foundation": "2.49.6",
     "@microsoft/fast-web-utilities": "^6.0.0",
     "@ni/nimble-tokens": "^8.4.0",

--- a/packages/spright-components/package.json
+++ b/packages/spright-components/package.json
@@ -48,8 +48,8 @@
   },
   "homepage": "https://github.com/ni/nimble#readme",
   "dependencies": {
-    "@microsoft/fast-element": "^1.12.0",
-    "@microsoft/fast-foundation": "^2.49.6",
+    "@microsoft/fast-element": "1.12.0",
+    "@microsoft/fast-foundation": "2.49.6",
     "@ni/nimble-components": "^32.5.1",
     "tslib": "^2.2.0"
   },

--- a/packages/spright-components/package.json
+++ b/packages/spright-components/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/ni/nimble#readme",
   "dependencies": {
-    "@microsoft/fast-element": "1.12.0",
+    "@microsoft/fast-element": "1.13.0",
     "@microsoft/fast-foundation": "2.49.6",
     "@ni/nimble-components": "^32.5.1",
     "tslib": "^2.2.0"

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^2.0.2",
-    "@microsoft/fast-element": "1.12.0",
+    "@microsoft/fast-element": "1.13.0",
     "@microsoft/fast-foundation": "2.49.6",
     "@microsoft/fast-react-wrapper": "^0.3.22",
     "@microsoft/fast-web-utilities": "^6.0.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -18,8 +18,8 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^2.0.2",
-    "@microsoft/fast-element": "^1.12.0",
-    "@microsoft/fast-foundation": "^2.49.6",
+    "@microsoft/fast-element": "1.12.0",
+    "@microsoft/fast-foundation": "2.49.6",
     "@microsoft/fast-react-wrapper": "^0.3.22",
     "@microsoft/fast-web-utilities": "^6.0.0",
     "@ni/nimble-components": "*",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Unit tests on Firefox seem to be sporadically timing out when we update to the latest exports of `fast-foundation` (2.50.0) and `fast-element` (1.14.0). We want to pin our dependency versions to the prior versions until we are confident that the new versions do not introduce real problems for clients.

## 👩‍💻 Implementation

Pinned `fast-element` to 1.13.0 and `fast-foundation` to 2.49.6 in the three packages that reference them.

## 🧪 Testing

N/A

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
