### PR TITLE
Add a table page object function to get an icon's severity

### DIFF
--- a/change/@ni-nimble-components-9d9491f3-1f39-4a0b-8196-7d5a25ae3b8f.json
+++ b/change/@ni-nimble-components-9d9491f3-1f39-4a0b-8196-7d5a25ae3b8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add a table page object function to get an icon's severity",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/testing/table.pageobject.ts
+++ b/packages/nimble-components/src/table/testing/table.pageobject.ts
@@ -20,6 +20,7 @@ import type { Button } from '../../button';
 import { Icon } from '../../icon-base';
 import { Spinner, spinnerTag } from '../../spinner';
 import { borderHoverColor } from '../../theme-provider/design-tokens';
+import { IconSeverity } from '../../icon-base/types';
 
 /**
  * Summary information about a column that is sorted in the table for use in the `TablePageObject`.
@@ -205,6 +206,18 @@ export class TablePageObject<T extends TableRecord> {
             this.getRenderedCellView(rowIndex, columnIndex)
         );
         return iconOrSpinner.tagName.toLocaleLowerCase();
+    }
+
+    public getRenderedMappingColumnCellIconSeverity(
+        rowIndex: number,
+        columnIndex: number
+    ): IconSeverity {
+        const iconOrSpinner = this.getRenderedMappingColumnIconOrSpinner(
+            this.getRenderedCellView(rowIndex, columnIndex)
+        );
+        return iconOrSpinner instanceof Icon
+            ? iconOrSpinner.severity
+            : undefined;
     }
 
     public getRenderedGroupHeaderTextContent(groupRowIndex: number): string {

--- a/packages/nimble-components/src/table/testing/table.pageobject.ts
+++ b/packages/nimble-components/src/table/testing/table.pageobject.ts
@@ -18,9 +18,9 @@ import { Anchor, anchorTag } from '../../anchor';
 import { tableGroupRowTag, type TableGroupRow } from '../components/group-row';
 import type { Button } from '../../button';
 import { Icon } from '../../icon-base';
+import type { IconSeverity } from '../../icon-base/types';
 import { Spinner, spinnerTag } from '../../spinner';
 import { borderHoverColor } from '../../theme-provider/design-tokens';
-import { IconSeverity } from '../../icon-base/types';
 
 /**
  * Summary information about a column that is sorted in the table for use in the `TablePageObject`.
@@ -215,9 +215,10 @@ export class TablePageObject<T extends TableRecord> {
         const iconOrSpinner = this.getRenderedMappingColumnIconOrSpinner(
             this.getRenderedCellView(rowIndex, columnIndex)
         );
-        return iconOrSpinner instanceof Icon
-            ? iconOrSpinner.severity
-            : undefined;
+        if (iconOrSpinner instanceof Icon) {
+            return iconOrSpinner.severity;
+        }
+        throw new Error('Cell does not contain an icon');
     }
 
     public getRenderedGroupHeaderTextContent(groupRowIndex: number): string {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

I'd like to be able to verify that icon severities are being set correctly in the Assets table.

## 👩‍💻 Implementation

Added a new page object function that gets the icon severity for a particular cell. It is very similar to the existing function for getting a cell's icon/spinner tag name.

## 🧪 Testing

N/A

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
