### PR TITLE
Disable dotnet rollForward

### DIFF
--- a/packages/blazor-workspace/global.json
+++ b/packages/blazor-workspace/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "version": "8.0.403",
     "allowPrelease": "false",
-    "rollForward": "latestMinor"
+    "rollForward": "disable"
   }
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The dotnet restore command is failing inconsistently with messages such as:

```
/home/runner/work/nimble/nimble/packages/blazor-workspace/Examples/Demo.Client/Demo.Client.csproj : error NU1004: The package reference Microsoft.NET.ILLink.Tasks version has changed from [8.0.10, ) to [8.0.11, ).The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode. Disable the RestoreLockedMode MSBuild property or pass an explicit --force-evaluate option to run restore to update the lock file. [/home/runner/work/nimble/nimble/packages/blazor-workspace/BlazorWorkspace.sln]
  Failed to restore /home/runner/work/nimble/nimble/packages/blazor-workspace/Examples/Demo.Client/Demo.Client.csproj (in 190 ms).
```

## 👩‍💻 Implementation

Attempted to disable `rollForward` so that exact SDK versions will be used on CI and locally as described here: https://github.com/dotnet/runtime/issues/100082#issuecomment-2015144108, but also as described that does not seem reliable.

## 🧪 Testing

Rely on CI builds.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
