### PR TITLE
Add nimble token for toolbar height

### DIFF
--- a/change/@ni-nimble-components-a9107da1-a4c4-492b-9842-3d65680f0a8c.json
+++ b/change/@ni-nimble-components-a9107da1-a4c4-492b-9842-3d65680f0a8c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add toobar standard height token",
+  "packageName": "@ni/nimble-components",
+  "email": "123377167+aagash-ni@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-a9107da1-a4c4-492b-9842-3d65680f0a8c.json
+++ b/change/@ni-nimble-components-a9107da1-a4c4-492b-9842-3d65680f0a8c.json
@@ -1,6 +1,6 @@
 {
-  "type": "patch",
-  "comment": "Add toobar standard height token",
+  "type": "minor",
+  "comment": "Add nimble token for toolbar height",
   "packageName": "@ni/nimble-components",
   "email": "123377167+aagash-ni@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/nimble-components/src/theme-provider/design-token-comments.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-comments.ts
@@ -322,5 +322,6 @@ export const comments: { readonly [key in TokenName]: string } = {
         'Background fill color for the editable calendar event grab handle',
     calendarGridBorderColor: 'Border color for the calendar grid',
     calendarGroupHeaderBackgroundColor:
-        'Background color for the calendar resource group header'
+        'Background color for the calendar resource group header',
+    toolbarHeight: 'Standard height for the toolbar'
 };

--- a/packages/nimble-components/src/theme-provider/design-token-names.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-names.ts
@@ -263,7 +263,8 @@ export const tokenNames: { readonly [key in TokenName]: string } = {
     calendarEventFillBlockedColor: 'calendar-event-fill-blocked-color',
     calendarGrabHandleBackgroundColor: 'calendar-grab-handle-background-color',
     calendarGridBorderColor: 'calendar-grid-border-color',
-    calendarGroupHeaderBackgroundColor: 'calendar-group-header-background-color',
+    calendarGroupHeaderBackgroundColor:
+        'calendar-group-header-background-color',
     toolbarHeight: 'toolbar-height'
 };
 

--- a/packages/nimble-components/src/theme-provider/design-token-names.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-names.ts
@@ -263,7 +263,8 @@ export const tokenNames: { readonly [key in TokenName]: string } = {
     calendarEventFillBlockedColor: 'calendar-event-fill-blocked-color',
     calendarGrabHandleBackgroundColor: 'calendar-grab-handle-background-color',
     calendarGridBorderColor: 'calendar-grid-border-color',
-    calendarGroupHeaderBackgroundColor: 'calendar-group-header-background-color'
+    calendarGroupHeaderBackgroundColor: 'calendar-group-header-background-color',
+    toolbarHeight: 'toolbar-height'
 };
 
 const prefix = 'ni-nimble';

--- a/packages/nimble-components/src/theme-provider/design-tokens.ts
+++ b/packages/nimble-components/src/theme-provider/design-tokens.ts
@@ -520,6 +520,10 @@ export const spinnerLargeHeight = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.spinnerLargeHeight)
 ).withDefault('64px');
 
+export const toolbarHeight = DesignToken.create<string>(
+    styleNameFromTokenName(tokenNames.toolbarHeight)
+).withDefault('40px');
+
 // The token gets a default value of the table's default height (480px)
 // but is given a calculated value in the table styles.
 export const tableFitRowsHeight = DesignToken.create<string>(


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
Added the Nimble token `40px` for `toolbar height` as it is required in the following areas:

- **Rich Text Editor Footer Section**: Currently implemented using an internal CSS variable.  

![image](https://github.com/user-attachments/assets/1a978b0e-2cb6-4f37-b15a-671264bdda27)
- **SlToolbarComponent** in `systemlink-lib-angular`: Currently uses an internal CSS variable.  
- **Schedule Assistant Page Toolbar**: A custom implementation is temporarily used to address the blur (mousedown) issue in `fast-toolbar` for Chrome and Edge browsers. For more details: https://dev.azure.com/ni/DevCentral/_git/Skyline/pullRequest/850146#1733521296

   - Issue link: https://github.com/ni/nimble/issues/2494


## 👩‍💻 Implementation

- Added `40px` height token for toolbar `$ni-nimble-toolbar-height`.

<!---
Describe how the change addresses the problem. Consider factors such as complexity, alternative solutions, performance impact, etc. 

Consider listing files with important changes or comment on them directly in the pull request.
-->

## 🧪 Testing
NA
<!---
Detail the testing done to ensure this submission meets requirements. 

Include automated/manual test additions or modifications, testing done on a local build, private CI run results, and additional testing not covered by automatic pull request validation. If any functionality is not covered by automated testing, provide justification.
-->

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
