### PR TITLE
Required indicator on radio-group, select, combobox, and text-area

### DIFF
--- a/change/@ni-nimble-components-b67fa692-e6d5-42b5-b494-b284fe5833fd.json
+++ b/change/@ni-nimble-components-b67fa692-e6d5-42b5-b494-b284fe5833fd.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add `required-visible` attribute to combobox, select, and text-area",
+  "comment": "Add `required-visible` attribute to radio-group, combobox, select, and text-area",
   "packageName": "@ni/nimble-components",
   "email": "20542556+mollykreis@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@ni-nimble-components-b67fa692-e6d5-42b5-b494-b284fe5833fd.json
+++ b/change/@ni-nimble-components-b67fa692-e6d5-42b5-b494-b284fe5833fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add `required-visible` attribute to combobox, select, and text-area",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7307,23 +7307,6 @@
         }
       }
     },
-    "node_modules/@storybook/addon-mdx-gfm": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-mdx-gfm/-/addon-mdx-gfm-8.4.6.tgz",
-      "integrity": "sha512-wagsSBUN6pwcSZSWxp/aOhE16ZKI8ZW4XeRT6QivySmkJaLcbva+HNvQOijdXIM28W8PprKjqtyVa8nu4YQxsw==",
-      "dev": true,
-      "dependencies": {
-        "remark-gfm": "^4.0.0",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.4.6"
-      }
-    },
     "node_modules/@storybook/addon-measure": {
       "version": "8.4.6",
       "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-8.4.6.tgz",
@@ -28144,7 +28127,6 @@
         "@storybook/addon-essentials": "^8.4.3",
         "@storybook/addon-interactions": "^8.4.3",
         "@storybook/addon-links": "^8.4.3",
-        "@storybook/addon-mdx-gfm": "^8.4.3",
         "@storybook/addon-webpack5-compiler-swc": "^1.0.5",
         "@storybook/cli": "^8.4.3",
         "@storybook/csf": "^0.1.11",

--- a/packages/nimble-components/src/combobox/index.ts
+++ b/packages/nimble-components/src/combobox/index.ts
@@ -41,6 +41,7 @@ import type { AnchoredRegion } from '../anchored-region';
 import { template } from './template';
 import { FormAssociatedCombobox } from './models/combobox-form-associated';
 import type { ListOption } from '../list-option';
+import { mixinRequiredVisiblePattern } from '../patterns/required-visible/types';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -52,7 +53,7 @@ declare global {
  * A nimble-styed HTML combobox
  */
 export class Combobox
-    extends mixinErrorPattern(FormAssociatedCombobox)
+    extends mixinErrorPattern(mixinRequiredVisiblePattern(FormAssociatedCombobox))
     implements DropdownPattern {
     @attr
     public appearance: DropdownAppearance = DropdownAppearance.underline;

--- a/packages/nimble-components/src/combobox/index.ts
+++ b/packages/nimble-components/src/combobox/index.ts
@@ -53,7 +53,9 @@ declare global {
  * A nimble-styed HTML combobox
  */
 export class Combobox
-    extends mixinErrorPattern(mixinRequiredVisiblePattern(FormAssociatedCombobox))
+    extends mixinErrorPattern(
+        mixinRequiredVisiblePattern(FormAssociatedCombobox)
+    )
     implements DropdownPattern {
     @attr
     public appearance: DropdownAppearance = DropdownAppearance.underline;

--- a/packages/nimble-components/src/combobox/styles.ts
+++ b/packages/nimble-components/src/combobox/styles.ts
@@ -10,6 +10,7 @@ import {
 
 import { styles as dropdownStyles } from '../patterns/dropdown/styles';
 import { styles as errorStyles } from '../patterns/error/styles';
+import { styles as requiredVisibleStyles } from '../patterns/required-visible/styles';
 import { focusVisible } from '../utilities/style/focus';
 import { appearanceBehavior } from '../utilities/style/appearance';
 import { DropdownAppearance } from '../select/types';
@@ -18,6 +19,7 @@ import { userSelectNone } from '../utilities/style/user-select';
 export const styles = css`
     ${dropdownStyles}
     ${errorStyles}
+    ${requiredVisibleStyles}
 
     :host {
         --ni-private-hover-bottom-border-width: 2px;

--- a/packages/nimble-components/src/combobox/template.ts
+++ b/packages/nimble-components/src/combobox/template.ts
@@ -17,6 +17,13 @@ import { anchoredRegionTag } from '../anchored-region';
 import { DropdownPosition } from '../patterns/dropdown/types';
 import { overflow } from '../utilities/directive/overflow';
 import { filterNoResultsLabel } from '../label-provider/core/label-tokens';
+import { getLabelTemplate } from '../patterns/required-visible/template';
+
+const labelTemplate = getLabelTemplate(html<Combobox>`
+    <label part="label" class="label">
+        <slot></slot>
+    </label>
+`);
 
 /* eslint-disable @typescript-eslint/indent */
 // prettier-ignore
@@ -34,9 +41,7 @@ ComboboxOptions
         @focusout="${(x, c) => x.focusoutHandler(c.event as FocusEvent)}"
         @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
     >
-        <label part="label" class="label">
-            <slot></slot>
-        </label>
+        ${labelTemplate}
         <div class="control" part="control" ${ref('controlWrapper')}>
             ${startSlotTemplate(context, definition)}
             <slot name="control">
@@ -46,6 +51,7 @@ ComboboxOptions
                     aria-controls="${x => x.ariaControls}"
                     aria-disabled="${x => x.ariaDisabled}"
                     aria-expanded="${x => x.ariaExpanded}"
+                    aria-required=${x => x.requiredVisible}
                     aria-haspopup="listbox"
                     class="selected-value"
                     part="selected-value"

--- a/packages/nimble-components/src/combobox/template.ts
+++ b/packages/nimble-components/src/combobox/template.ts
@@ -17,9 +17,9 @@ import { anchoredRegionTag } from '../anchored-region';
 import { DropdownPosition } from '../patterns/dropdown/types';
 import { overflow } from '../utilities/directive/overflow';
 import { filterNoResultsLabel } from '../label-provider/core/label-tokens';
-import { getLabelTemplate } from '../patterns/required-visible/template';
+import { getRequiredVisibleLabelTemplate } from '../patterns/required-visible/template';
 
-const labelTemplate = getLabelTemplate(html<Combobox>`
+const labelTemplate = getRequiredVisibleLabelTemplate(html<Combobox>`
     <label part="label" class="label">
         <slot></slot>
     </label>

--- a/packages/nimble-components/src/combobox/template.ts
+++ b/packages/nimble-components/src/combobox/template.ts
@@ -51,7 +51,7 @@ ComboboxOptions
                     aria-controls="${x => x.ariaControls}"
                     aria-disabled="${x => x.ariaDisabled}"
                     aria-expanded="${x => x.ariaExpanded}"
-                    aria-required=${x => x.requiredVisible}
+                    aria-required="${x => x.requiredVisible}"
                     aria-haspopup="listbox"
                     class="selected-value"
                     part="selected-value"

--- a/packages/nimble-components/src/combobox/template.ts
+++ b/packages/nimble-components/src/combobox/template.ts
@@ -17,9 +17,9 @@ import { anchoredRegionTag } from '../anchored-region';
 import { DropdownPosition } from '../patterns/dropdown/types';
 import { overflow } from '../utilities/directive/overflow';
 import { filterNoResultsLabel } from '../label-provider/core/label-tokens';
-import { getRequiredVisibleLabelTemplate } from '../patterns/required-visible/template';
+import { createRequiredVisibleLabelTemplate } from '../patterns/required-visible/template';
 
-const labelTemplate = getRequiredVisibleLabelTemplate(html<Combobox>`
+const labelTemplate = createRequiredVisibleLabelTemplate(html<Combobox>`
     <label part="label" class="label">
         <slot></slot>
     </label>

--- a/packages/nimble-components/src/combobox/tests/combobox.spec.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox.spec.ts
@@ -3,7 +3,10 @@ import { parameterizeSpec, parameterizeSuite } from '@ni/jasmine-parameterized';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Combobox, comboboxTag } from '..';
 import { ComboboxAutocomplete } from '../types';
-import { processUpdates, waitForUpdatesAsync } from '../../testing/async-helpers';
+import {
+    processUpdates,
+    waitForUpdatesAsync
+} from '../../testing/async-helpers';
 import { checkFullyInViewport } from '../../utilities/tests/intersection-observer';
 import { listOptionTag } from '../../list-option';
 import { ComboboxPageObject } from '../testing/combobox.pageobject';

--- a/packages/nimble-components/src/combobox/tests/combobox.spec.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox.spec.ts
@@ -109,15 +109,13 @@ describe('Combobox', () => {
             expect(element.control.getAttribute('disabled')).not.toBeNull();
         });
 
-        it('should set "aria-required" to true when "required-visible" is true', async () => {
-            await connect();
+        it('should set "aria-required" to true when "required-visible" is true', () => {
             element.requiredVisible = true;
             processUpdates();
             expect(element.control.getAttribute('aria-required')).toBe('true');
         });
 
-        it('should set "aria-required" to false when "required-visible" is false', async () => {
-            await connect();
+        it('should set "aria-required" to false when "required-visible" is false', () => {
             element.requiredVisible = false;
             processUpdates();
             expect(element.control.getAttribute('aria-required')).toBe('false');

--- a/packages/nimble-components/src/combobox/tests/combobox.spec.ts
+++ b/packages/nimble-components/src/combobox/tests/combobox.spec.ts
@@ -3,7 +3,7 @@ import { parameterizeSpec, parameterizeSuite } from '@ni/jasmine-parameterized';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Combobox, comboboxTag } from '..';
 import { ComboboxAutocomplete } from '../types';
-import { waitForUpdatesAsync } from '../../testing/async-helpers';
+import { processUpdates, waitForUpdatesAsync } from '../../testing/async-helpers';
 import { checkFullyInViewport } from '../../utilities/tests/intersection-observer';
 import { listOptionTag } from '../../list-option';
 import { ComboboxPageObject } from '../testing/combobox.pageobject';
@@ -104,6 +104,20 @@ describe('Combobox', () => {
             element.disabled = true;
             await waitForUpdatesAsync();
             expect(element.control.getAttribute('disabled')).not.toBeNull();
+        });
+
+        it('should set "aria-required" to true when "required-visible" is true', async () => {
+            await connect();
+            element.requiredVisible = true;
+            processUpdates();
+            expect(element.control.getAttribute('aria-required')).toBe('true');
+        });
+
+        it('should set "aria-required" to false when "required-visible" is false', async () => {
+            await connect();
+            element.requiredVisible = false;
+            processUpdates();
+            expect(element.control.getAttribute('aria-required')).toBe('false');
         });
 
         it('should forward value property to inner control', async () => {

--- a/packages/nimble-components/src/icon-base/styles.ts
+++ b/packages/nimble-components/src/icon-base/styles.ts
@@ -21,6 +21,7 @@ export const styles = css`
     }
 
     .icon {
+        display: contents;
         width: 100%;
         height: 100%;
     }
@@ -42,7 +43,7 @@ export const styles = css`
     }
 
     .icon svg {
-        display: block;
+        display: inline-flex;
         fill: ${iconColor};
         width: 100%;
         height: 100%;

--- a/packages/nimble-components/src/icon-base/styles.ts
+++ b/packages/nimble-components/src/icon-base/styles.ts
@@ -42,6 +42,7 @@ export const styles = css`
     }
 
     .icon svg {
+        display: block;
         fill: ${iconColor};
         width: 100%;
         height: 100%;

--- a/packages/nimble-components/src/icon-base/styles.ts
+++ b/packages/nimble-components/src/icon-base/styles.ts
@@ -22,8 +22,6 @@ export const styles = css`
 
     .icon {
         display: contents;
-        width: 100%;
-        height: 100%;
     }
 
     :host([severity='error']) {

--- a/packages/nimble-components/src/patterns/required-visible/styles.ts
+++ b/packages/nimble-components/src/patterns/required-visible/styles.ts
@@ -1,0 +1,19 @@
+import { css } from '@microsoft/fast-element';
+import {
+    smallPadding
+} from '../../theme-provider/design-tokens';
+
+export const styles = css`
+    .annotated-label {
+        display: flex;
+        flex-direction: row;
+    }
+
+    .required-icon {
+        flex: none;
+        width: 5px;
+        height: 5px;
+        margin-top: 3px;
+        margin-left: ${smallPadding};
+    }
+`;

--- a/packages/nimble-components/src/patterns/required-visible/styles.ts
+++ b/packages/nimble-components/src/patterns/required-visible/styles.ts
@@ -1,7 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import {
-    smallPadding
-} from '../../theme-provider/design-tokens';
+import { smallPadding } from '../../theme-provider/design-tokens';
 
 export const styles = css`
     .annotated-label {

--- a/packages/nimble-components/src/patterns/required-visible/template.ts
+++ b/packages/nimble-components/src/patterns/required-visible/template.ts
@@ -3,7 +3,7 @@ import { iconAsteriskTag } from '../../icons/asterisk';
 import type { RequiredVisiblePattern } from './types';
 
 /* eslint-disable @typescript-eslint/indent */
-export function getLabelTemplate(
+export function getRequiredVisibleLabelTemplate(
     labelTemplate: ViewTemplate<RequiredVisiblePattern>
 ): ViewTemplate<RequiredVisiblePattern> {
     return html`

--- a/packages/nimble-components/src/patterns/required-visible/template.ts
+++ b/packages/nimble-components/src/patterns/required-visible/template.ts
@@ -3,7 +3,7 @@ import { iconAsteriskTag } from '../../icons/asterisk';
 import type { RequiredVisiblePattern } from './types';
 
 /* eslint-disable @typescript-eslint/indent */
-export function getRequiredVisibleLabelTemplate(
+export function createRequiredVisibleLabelTemplate(
     labelTemplate: ViewTemplate<RequiredVisiblePattern>
 ): ViewTemplate<RequiredVisiblePattern> {
     return html`

--- a/packages/nimble-components/src/patterns/required-visible/template.ts
+++ b/packages/nimble-components/src/patterns/required-visible/template.ts
@@ -2,18 +2,16 @@ import { ViewTemplate, html, when } from '@microsoft/fast-element';
 import { iconAsteriskTag } from '../../icons/asterisk';
 import type { RequiredVisiblePattern } from './types';
 
+/* eslint-disable @typescript-eslint/indent */
 export function getLabelTemplate(
     labelTemplate: ViewTemplate<RequiredVisiblePattern>
 ): ViewTemplate<RequiredVisiblePattern> {
     return html`
         <div class="annotated-label">
             ${labelTemplate}
-            ${when(
-        x => x.requiredVisible,
-        html`
+            ${when(x => x.requiredVisible, html`
                 <${iconAsteriskTag} class="required-icon" severity="error"></${iconAsteriskTag}>
-            `
-    )}
+            `)}
         </div>
     `;
 }

--- a/packages/nimble-components/src/patterns/required-visible/template.ts
+++ b/packages/nimble-components/src/patterns/required-visible/template.ts
@@ -2,6 +2,12 @@ import { ViewTemplate, html, when } from '@microsoft/fast-element';
 import { iconAsteriskTag } from '../../icons/asterisk';
 import type { RequiredVisiblePattern } from './types';
 
+/**
+ * Given the template for a control label, creates a new template that includes
+ * an icon next to the label to indicate whether or not the control is required.
+ *
+ * This function is intended to be used with components leveraging `mixinRequiredVisiblePattern`.
+ */
 /* eslint-disable @typescript-eslint/indent */
 export function createRequiredVisibleLabelTemplate(
     labelTemplate: ViewTemplate<RequiredVisiblePattern>

--- a/packages/nimble-components/src/patterns/required-visible/template.ts
+++ b/packages/nimble-components/src/patterns/required-visible/template.ts
@@ -9,9 +9,12 @@ export function getRequiredVisibleLabelTemplate(
     return html`
         <div class="annotated-label">
             ${labelTemplate}
-            ${when(x => x.requiredVisible, html`
+            ${when(
+                x => x.requiredVisible,
+                html`
                 <${iconAsteriskTag} class="required-icon" severity="error"></${iconAsteriskTag}>
-            `)}
+            `
+            )}
         </div>
     `;
 }

--- a/packages/nimble-components/src/patterns/required-visible/template.ts
+++ b/packages/nimble-components/src/patterns/required-visible/template.ts
@@ -1,0 +1,14 @@
+import { ViewTemplate, html, when } from '@microsoft/fast-element';
+import { iconAsteriskTag } from '../../icons/asterisk';
+import type { RequiredVisiblePattern } from './types';
+
+export function getLabelTemplate(labelTemplate: ViewTemplate<RequiredVisiblePattern>): ViewTemplate<RequiredVisiblePattern> {
+    return html`
+        <div class="annotated-label">
+            ${labelTemplate}
+            ${when(x => x.requiredVisible, html`
+                <${iconAsteriskTag} class="required-icon" severity="error"></${iconAsteriskTag}>
+            `)}
+        </div>
+    `;
+}

--- a/packages/nimble-components/src/patterns/required-visible/template.ts
+++ b/packages/nimble-components/src/patterns/required-visible/template.ts
@@ -2,13 +2,18 @@ import { ViewTemplate, html, when } from '@microsoft/fast-element';
 import { iconAsteriskTag } from '../../icons/asterisk';
 import type { RequiredVisiblePattern } from './types';
 
-export function getLabelTemplate(labelTemplate: ViewTemplate<RequiredVisiblePattern>): ViewTemplate<RequiredVisiblePattern> {
+export function getLabelTemplate(
+    labelTemplate: ViewTemplate<RequiredVisiblePattern>
+): ViewTemplate<RequiredVisiblePattern> {
     return html`
         <div class="annotated-label">
             ${labelTemplate}
-            ${when(x => x.requiredVisible, html`
+            ${when(
+        x => x.requiredVisible,
+        html`
                 <${iconAsteriskTag} class="required-icon" severity="error"></${iconAsteriskTag}>
-            `)}
+            `
+    )}
         </div>
     `;
 }

--- a/packages/nimble-components/src/patterns/required-visible/testing/required-visible-pattern.pageobject.ts
+++ b/packages/nimble-components/src/patterns/required-visible/testing/required-visible-pattern.pageobject.ts
@@ -1,0 +1,21 @@
+import type { FoundationElement } from '@microsoft/fast-foundation';
+import { processUpdates } from '../../../testing/async-helpers';
+
+/**
+ * A page object for the elements that use the required-visible mixin.
+ */
+export class RequiredVisiblePatternPageObject {
+    public constructor(private readonly element: FoundationElement) {}
+
+    public isRequiredVisibleIconVisible(): boolean {
+        const icon = this.getRequiredVisibleIcon();
+        if (!icon) {
+            return false;
+        }
+        return getComputedStyle(icon).display !== 'none';
+    }
+
+    private getRequiredVisibleIcon(): HTMLElement | null {
+        return this.element.shadowRoot!.querySelector('.required-icon');
+    }
+}

--- a/packages/nimble-components/src/patterns/required-visible/testing/required-visible-pattern.pageobject.ts
+++ b/packages/nimble-components/src/patterns/required-visible/testing/required-visible-pattern.pageobject.ts
@@ -1,5 +1,4 @@
 import type { FoundationElement } from '@microsoft/fast-foundation';
-import { processUpdates } from '../../../testing/async-helpers';
 
 /**
  * A page object for the elements that use the required-visible mixin.

--- a/packages/nimble-components/src/patterns/required-visible/tests/required-visible-pattern-mixin.spec.ts
+++ b/packages/nimble-components/src/patterns/required-visible/tests/required-visible-pattern-mixin.spec.ts
@@ -1,0 +1,64 @@
+import { customElement, html } from '@microsoft/fast-element';
+import { FoundationElement } from '@microsoft/fast-foundation';
+import {
+    Fixture,
+    fixture,
+    uniqueElementName
+} from '../../../utilities/tests/fixture';
+import { mixinRequiredVisiblePattern } from '../types';
+import { styles } from '../styles';
+import { getRequiredVisibleLabelTemplate } from '../template';
+import { processUpdates } from '../../../testing/async-helpers';
+import { RequiredVisiblePatternPageObject } from '../testing/required-visible-pattern.pageobject';
+
+const labelTemplate = getRequiredVisibleLabelTemplate(html`<slot name="label"></slot>`);
+const elementName = uniqueElementName();
+@customElement({
+    name: elementName,
+    template: html`${labelTemplate}`,
+    styles
+})
+class TestErrorPatternElement extends mixinRequiredVisiblePattern(FoundationElement) {}
+
+async function setup(): Promise<Fixture<TestErrorPatternElement>> {
+    return await fixture(elementName);
+}
+
+describe('RequiredVisiblePatternMixin', () => {
+    let element: TestErrorPatternElement;
+    let connect: () => Promise<void>;
+    let disconnect: () => Promise<void>;
+    let pageObject: RequiredVisiblePatternPageObject;
+
+    beforeEach(async () => {
+        ({ element, connect, disconnect } = await setup());
+        await connect();
+        pageObject = new RequiredVisiblePatternPageObject(element);
+    });
+
+    afterEach(async () => {
+        await disconnect();
+    });
+
+    it('defaults requiredVisible to false', () => {
+        expect(element.requiredVisible).toBeFalse();
+    });
+
+    it('shows icon when requiredVisible is true', () => {
+        element.requiredVisible = true;
+        processUpdates();
+        expect(pageObject.isRequiredVisibleIconVisible()).toBeTrue();
+    });
+
+    it('does not show icon when requiredVisible is false', () => {
+        element.requiredVisible = false;
+        processUpdates();
+        expect(pageObject.isRequiredVisibleIconVisible()).toBeFalse();
+    });
+
+    it('uses boolean "required-visible" attribute to set requiredVisible', () => {
+        element.setAttribute('required-visible', '');
+        processUpdates();
+        expect(element.requiredVisible).toBeTrue();
+    });
+});

--- a/packages/nimble-components/src/patterns/required-visible/tests/required-visible-pattern-mixin.spec.ts
+++ b/packages/nimble-components/src/patterns/required-visible/tests/required-visible-pattern-mixin.spec.ts
@@ -11,14 +11,18 @@ import { getRequiredVisibleLabelTemplate } from '../template';
 import { processUpdates } from '../../../testing/async-helpers';
 import { RequiredVisiblePatternPageObject } from '../testing/required-visible-pattern.pageobject';
 
-const labelTemplate = getRequiredVisibleLabelTemplate(html`<slot name="label"></slot>`);
+const labelTemplate = getRequiredVisibleLabelTemplate(
+    html`<slot name="label"></slot>`
+);
 const elementName = uniqueElementName();
 @customElement({
     name: elementName,
     template: html`${labelTemplate}`,
     styles
 })
-class TestErrorPatternElement extends mixinRequiredVisiblePattern(FoundationElement) {}
+class TestErrorPatternElement extends mixinRequiredVisiblePattern(
+        FoundationElement
+    ) {}
 
 async function setup(): Promise<Fixture<TestErrorPatternElement>> {
     return await fixture(elementName);

--- a/packages/nimble-components/src/patterns/required-visible/tests/required-visible-pattern-mixin.spec.ts
+++ b/packages/nimble-components/src/patterns/required-visible/tests/required-visible-pattern-mixin.spec.ts
@@ -7,11 +7,11 @@ import {
 } from '../../../utilities/tests/fixture';
 import { mixinRequiredVisiblePattern } from '../types';
 import { styles } from '../styles';
-import { getRequiredVisibleLabelTemplate } from '../template';
+import { createRequiredVisibleLabelTemplate } from '../template';
 import { processUpdates } from '../../../testing/async-helpers';
 import { RequiredVisiblePatternPageObject } from '../testing/required-visible-pattern.pageobject';
 
-const labelTemplate = getRequiredVisibleLabelTemplate(
+const labelTemplate = createRequiredVisibleLabelTemplate(
     html`<slot name="label"></slot>`
 );
 const elementName = uniqueElementName();

--- a/packages/nimble-components/src/patterns/required-visible/types.ts
+++ b/packages/nimble-components/src/patterns/required-visible/types.ts
@@ -12,14 +12,16 @@ type FASTElementConstructor = abstract new (...args: any[]) => FASTElement;
 
 // As the returned class is internal to the function, we can't write a signature that uses is directly, so rely on inference
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type
-export function mixinRequiredVisiblePattern<TBase extends FASTElementConstructor>(
-    base: TBase
-) {
+export function mixinRequiredVisiblePattern<
+    TBase extends FASTElementConstructor
+>(base: TBase) {
     /**
      * The Mixin that provides the requiredVisible property and required-visible attribute
      * to a component.
      */
-    abstract class RequiredVisibleElement extends base implements RequiredVisiblePattern {
+    abstract class RequiredVisibleElement
+        extends base
+        implements RequiredVisiblePattern {
         /*
          * Show the required appearance of the control
          */

--- a/packages/nimble-components/src/patterns/required-visible/types.ts
+++ b/packages/nimble-components/src/patterns/required-visible/types.ts
@@ -1,0 +1,34 @@
+import { attr, FASTElement } from '@microsoft/fast-element';
+
+export interface RequiredVisiblePattern {
+    /**
+     * Whether or not to show the required appearance of the control
+     */
+    requiredVisible: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type FASTElementConstructor = abstract new (...args: any[]) => FASTElement;
+
+// As the returned class is internal to the function, we can't write a signature that uses is directly, so rely on inference
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type
+export function mixinRequiredVisiblePattern<TBase extends FASTElementConstructor>(
+    base: TBase
+) {
+    /**
+     * The Mixin that provides the requiredVisible property and required-visible attribute
+     * to a component.
+     */
+    abstract class RequiredVisibleElement extends base implements RequiredVisiblePattern {
+        /*
+         * Show the required appearance of the control
+         */
+        public requiredVisible = false;
+    }
+
+    attr({ attribute: 'required-visible', mode: 'boolean' })(
+        RequiredVisibleElement.prototype,
+        'requiredVisible'
+    );
+    return RequiredVisibleElement;
+}

--- a/packages/nimble-components/src/radio-group/index.ts
+++ b/packages/nimble-components/src/radio-group/index.ts
@@ -19,7 +19,9 @@ export { Orientation };
 /**
  * A nimble-styled grouping element for radio buttons
  */
-export class RadioGroup extends mixinErrorPattern(mixinRequiredVisiblePattern(FoundationRadioGroup)) {}
+export class RadioGroup extends mixinErrorPattern(
+    mixinRequiredVisiblePattern(FoundationRadioGroup)
+) {}
 
 const nimbleRadioGroup = RadioGroup.compose({
     baseName: 'radio-group',

--- a/packages/nimble-components/src/radio-group/index.ts
+++ b/packages/nimble-components/src/radio-group/index.ts
@@ -6,6 +6,7 @@ import { Orientation } from '@microsoft/fast-web-utilities';
 import { styles } from './styles';
 import { template } from './template';
 import { mixinErrorPattern } from '../patterns/error/types';
+import { mixinRequiredVisiblePattern } from '../patterns/required-visible/types';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -18,7 +19,7 @@ export { Orientation };
 /**
  * A nimble-styled grouping element for radio buttons
  */
-export class RadioGroup extends mixinErrorPattern(FoundationRadioGroup) {}
+export class RadioGroup extends mixinErrorPattern(mixinRequiredVisiblePattern(FoundationRadioGroup)) {}
 
 const nimbleRadioGroup = RadioGroup.compose({
     baseName: 'radio-group',

--- a/packages/nimble-components/src/radio-group/styles.ts
+++ b/packages/nimble-components/src/radio-group/styles.ts
@@ -46,10 +46,6 @@ export const styles = css`
         color: ${controlLabelDisabledFontColor};
     }
 
-    .required-icon {
-        margin-left: 0px;
-    }
-
     .error-icon {
         margin-left: auto;
         margin-right: ${smallPadding};

--- a/packages/nimble-components/src/radio-group/styles.ts
+++ b/packages/nimble-components/src/radio-group/styles.ts
@@ -32,7 +32,7 @@ export const styles = css`
 
     .label-container {
         display: flex;
-        height: ${controlLabelFontLineHeight};
+        min-height: ${controlLabelFontLineHeight};
         gap: ${smallPadding};
         margin-bottom: ${smallPadding};
     }

--- a/packages/nimble-components/src/radio-group/styles.ts
+++ b/packages/nimble-components/src/radio-group/styles.ts
@@ -9,10 +9,12 @@ import {
     standardPadding
 } from '../theme-provider/design-tokens';
 import { styles as errorStyles } from '../patterns/error/styles';
+import { styles as requiredVisibleStyles } from '../patterns/required-visible/styles';
 
 export const styles = css`
     ${display('inline-block')}
     ${errorStyles}
+    ${requiredVisibleStyles}
 
     .positioning-region {
         display: flex;
@@ -42,6 +44,10 @@ export const styles = css`
 
     :host([disabled]) slot[name='label'] {
         color: ${controlLabelDisabledFontColor};
+    }
+
+    .required-icon {
+        margin-left: 0px;
     }
 
     .error-icon {

--- a/packages/nimble-components/src/radio-group/template.ts
+++ b/packages/nimble-components/src/radio-group/template.ts
@@ -5,7 +5,9 @@ import { errorTextTemplate } from '../patterns/error/template';
 import { iconExclamationMarkTag } from '../icons/exclamation-mark';
 import { getRequiredVisibleLabelTemplate } from '../patterns/required-visible/template';
 
-const labelTemplate = getRequiredVisibleLabelTemplate(html<RadioGroup>`<slot name="label"></slot>`);
+const labelTemplate = getRequiredVisibleLabelTemplate(
+    html<RadioGroup>`<slot name="label"></slot>`
+);
 
 /* eslint-disable @typescript-eslint/indent */
 export const template = html<RadioGroup>`

--- a/packages/nimble-components/src/radio-group/template.ts
+++ b/packages/nimble-components/src/radio-group/template.ts
@@ -13,6 +13,7 @@ export const template = html<RadioGroup>`
         role="radiogroup"
         aria-disabled="${x => x.disabled}"
         aria-readonly="${x => x.readOnly}"
+        aria-required="${x => x.requiredVisible}"
         @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
         @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
         @focusout="${(x, c) => x.focusOutHandler(c.event as FocusEvent)}"

--- a/packages/nimble-components/src/radio-group/template.ts
+++ b/packages/nimble-components/src/radio-group/template.ts
@@ -1,9 +1,11 @@
-import { elements, html, slotted, when } from '@microsoft/fast-element';
+import { elements, html, slotted } from '@microsoft/fast-element';
 import { Orientation } from '@microsoft/fast-web-utilities';
 import type { RadioGroup } from '.';
 import { errorTextTemplate } from '../patterns/error/template';
 import { iconExclamationMarkTag } from '../icons/exclamation-mark';
-import { iconAsteriskTag } from '../icons/asterisk';
+import { getLabelTemplate } from '../patterns/required-visible/template';
+
+const labelTemplate = getLabelTemplate(html<RadioGroup>`<slot name="label"></slot>`);
 
 /* eslint-disable @typescript-eslint/indent */
 export const template = html<RadioGroup>`
@@ -15,16 +17,8 @@ export const template = html<RadioGroup>`
         @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
         @focusout="${(x, c) => x.focusOutHandler(c.event as FocusEvent)}"
     >
-        ${''
-        /**
-         * Don't use the shared label required-visible label template here because the error icon
-         * needs to be positioned within the label as well.
-         */}
         <div class="label-container">
-            <slot name="label"></slot>
-            ${when(x => x.requiredVisible, html`
-                <${iconAsteriskTag} class="required-icon" severity="error"></${iconAsteriskTag}>
-            `)}
+            ${labelTemplate}
             <${iconExclamationMarkTag}
                 severity="error"
                 class="error-icon"

--- a/packages/nimble-components/src/radio-group/template.ts
+++ b/packages/nimble-components/src/radio-group/template.ts
@@ -3,9 +3,9 @@ import { Orientation } from '@microsoft/fast-web-utilities';
 import type { RadioGroup } from '.';
 import { errorTextTemplate } from '../patterns/error/template';
 import { iconExclamationMarkTag } from '../icons/exclamation-mark';
-import { getRequiredVisibleLabelTemplate } from '../patterns/required-visible/template';
+import { createRequiredVisibleLabelTemplate } from '../patterns/required-visible/template';
 
-const labelTemplate = getRequiredVisibleLabelTemplate(
+const labelTemplate = createRequiredVisibleLabelTemplate(
     html<RadioGroup>`<slot name="label"></slot>`
 );
 

--- a/packages/nimble-components/src/radio-group/template.ts
+++ b/packages/nimble-components/src/radio-group/template.ts
@@ -3,9 +3,9 @@ import { Orientation } from '@microsoft/fast-web-utilities';
 import type { RadioGroup } from '.';
 import { errorTextTemplate } from '../patterns/error/template';
 import { iconExclamationMarkTag } from '../icons/exclamation-mark';
-import { getLabelTemplate } from '../patterns/required-visible/template';
+import { getRequiredVisibleLabelTemplate } from '../patterns/required-visible/template';
 
-const labelTemplate = getLabelTemplate(html<RadioGroup>`<slot name="label"></slot>`);
+const labelTemplate = getRequiredVisibleLabelTemplate(html<RadioGroup>`<slot name="label"></slot>`);
 
 /* eslint-disable @typescript-eslint/indent */
 export const template = html<RadioGroup>`

--- a/packages/nimble-components/src/radio-group/template.ts
+++ b/packages/nimble-components/src/radio-group/template.ts
@@ -1,8 +1,9 @@
-import { elements, html, slotted } from '@microsoft/fast-element';
+import { elements, html, slotted, when } from '@microsoft/fast-element';
 import { Orientation } from '@microsoft/fast-web-utilities';
 import type { RadioGroup } from '.';
 import { errorTextTemplate } from '../patterns/error/template';
 import { iconExclamationMarkTag } from '../icons/exclamation-mark';
+import { iconAsteriskTag } from '../icons/asterisk';
 
 /* eslint-disable @typescript-eslint/indent */
 export const template = html<RadioGroup>`
@@ -14,8 +15,16 @@ export const template = html<RadioGroup>`
         @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
         @focusout="${(x, c) => x.focusOutHandler(c.event as FocusEvent)}"
     >
+        ${''
+        /**
+         * Don't use the shared label required-visible label template here because the error icon
+         * needs to be positioned within the label as well.
+         */}
         <div class="label-container">
-            <slot name="label"></slot>            
+            <slot name="label"></slot>
+            ${when(x => x.requiredVisible, html`
+                <${iconAsteriskTag} class="required-icon" severity="error"></${iconAsteriskTag}>
+            `)}
             <${iconExclamationMarkTag}
                 severity="error"
                 class="error-icon"

--- a/packages/nimble-components/src/radio-group/tests/radio-group.spec.ts
+++ b/packages/nimble-components/src/radio-group/tests/radio-group.spec.ts
@@ -4,7 +4,9 @@ import { Fixture, fixture } from '../../utilities/tests/fixture';
 import { processUpdates } from '../../testing/async-helpers';
 
 async function setup(): Promise<Fixture<RadioGroup>> {
-    return await fixture<RadioGroup>(html`<${radioGroupTag}></${radioGroupTag}>`);
+    return await fixture<RadioGroup>(
+        html`<${radioGroupTag}></${radioGroupTag}>`
+    );
 }
 
 describe('Radio Group', () => {

--- a/packages/nimble-components/src/radio-group/tests/radio-group.spec.ts
+++ b/packages/nimble-components/src/radio-group/tests/radio-group.spec.ts
@@ -16,6 +16,7 @@ describe('Radio Group', () => {
 
     beforeEach(async () => {
         ({ element, connect, disconnect } = await setup());
+        await connect();
     });
 
     afterEach(async () => {
@@ -28,15 +29,13 @@ describe('Radio Group', () => {
         );
     });
 
-    it('should set "aria-required" to true when "required-visible" is true', async () => {
-        await connect();
+    it('should set "aria-required" to true when "required-visible" is true', () => {
         element.requiredVisible = true;
         processUpdates();
         expect(element.getAttribute('aria-required')).toBe('true');
     });
 
-    it('should set "aria-required" to false when "required-visible" is false', async () => {
-        await connect();
+    it('should set "aria-required" to false when "required-visible" is false', () => {
         element.requiredVisible = false;
         processUpdates();
         expect(element.getAttribute('aria-required')).toBe('false');

--- a/packages/nimble-components/src/radio-group/tests/radio-group.spec.ts
+++ b/packages/nimble-components/src/radio-group/tests/radio-group.spec.ts
@@ -1,9 +1,42 @@
+import { html } from '@microsoft/fast-element';
 import { RadioGroup, radioGroupTag } from '..';
+import { Fixture, fixture } from '../../utilities/tests/fixture';
+import { processUpdates } from '../../testing/async-helpers';
+
+async function setup(): Promise<Fixture<RadioGroup>> {
+    return await fixture<RadioGroup>(html`<${radioGroupTag}></${radioGroupTag}>`);
+}
 
 describe('Radio Group', () => {
+    let element: RadioGroup;
+    let connect: () => Promise<void>;
+    let disconnect: () => Promise<void>;
+
+    beforeEach(async () => {
+        ({ element, connect, disconnect } = await setup());
+    });
+
+    afterEach(async () => {
+        await disconnect();
+    });
+
     it('can construct an element instance', () => {
         expect(document.createElement(radioGroupTag)).toBeInstanceOf(
             RadioGroup
         );
+    });
+
+    it('should set "aria-required" to true when "required-visible" is true', async () => {
+        await connect();
+        element.requiredVisible = true;
+        processUpdates();
+        expect(element.getAttribute('aria-required')).toBe('true');
+    });
+
+    it('should set "aria-required" to false when "required-visible" is false', async () => {
+        await connect();
+        element.requiredVisible = false;
+        processUpdates();
+        expect(element.getAttribute('aria-required')).toBe('false');
     });
 });

--- a/packages/nimble-components/src/select/index.ts
+++ b/packages/nimble-components/src/select/index.ts
@@ -44,6 +44,7 @@ import { diacriticInsensitiveStringNormalizer } from '../utilities/models/string
 import { FormAssociatedSelect } from './models/select-form-associated';
 import type { ListOptionGroup } from '../list-option-group';
 import { slotTextContent } from '../utilities/models/slot-text-content';
+import { mixinRequiredVisiblePattern } from '../patterns/required-visible/types';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -71,7 +72,7 @@ const isOptionOrGroupVisible = (el: ListOption | ListOptionGroup): boolean => {
  * A nimble-styled HTML select.
  */
 export class Select
-    extends mixinErrorPattern(FormAssociatedSelect)
+    extends mixinErrorPattern(mixinRequiredVisiblePattern(FormAssociatedSelect))
     implements ListOptionOwner {
     @attr
     public appearance: DropdownAppearance = DropdownAppearance.underline;

--- a/packages/nimble-components/src/select/styles.ts
+++ b/packages/nimble-components/src/select/styles.ts
@@ -2,6 +2,7 @@ import { css } from '@microsoft/fast-element';
 import { White } from '@ni/nimble-tokens/dist/styledictionary/js/tokens';
 import { styles as dropdownStyles } from '../patterns/dropdown/styles';
 import { styles as errorStyles } from '../patterns/error/styles';
+import { styles as requiredVisibleStyles } from '../patterns/required-visible/styles';
 import {
     borderRgbPartialColor,
     borderWidth,
@@ -25,6 +26,7 @@ import { hexToRgbaCssColor } from '../utilities/style/colors';
 export const styles = css`
     ${dropdownStyles}
     ${errorStyles}
+    ${requiredVisibleStyles}
 
     ${
         /* We are using flex `order` to define the visual ordering of the selected value,

--- a/packages/nimble-components/src/select/template.ts
+++ b/packages/nimble-components/src/select/template.ts
@@ -27,7 +27,7 @@ import { buttonTag } from '../button';
 import { iconTimesTag } from '../icons/times';
 import { ListOption } from '../list-option';
 import { spinnerTag } from '../spinner';
-import { getLabelTemplate } from '../patterns/required-visible/template';
+import { getRequiredVisibleLabelTemplate } from '../patterns/required-visible/template';
 
 export const isListOption = (
     el: Element | undefined | null
@@ -41,7 +41,7 @@ export const isListOptionGroup = (
     return n instanceof ListOptionGroup;
 };
 
-const labelTemplate = getLabelTemplate(html<Select>`
+const labelTemplate = getRequiredVisibleLabelTemplate(html<Select>`
     <label part="label" class="label" aria-hidden="true">
         <slot ${ref('labelSlot')}></slot>
     </label>

--- a/packages/nimble-components/src/select/template.ts
+++ b/packages/nimble-components/src/select/template.ts
@@ -27,7 +27,7 @@ import { buttonTag } from '../button';
 import { iconTimesTag } from '../icons/times';
 import { ListOption } from '../list-option';
 import { spinnerTag } from '../spinner';
-import { getRequiredVisibleLabelTemplate } from '../patterns/required-visible/template';
+import { createRequiredVisibleLabelTemplate } from '../patterns/required-visible/template';
 
 export const isListOption = (
     el: Element | undefined | null
@@ -41,7 +41,7 @@ export const isListOptionGroup = (
     return n instanceof ListOptionGroup;
 };
 
-const labelTemplate = getRequiredVisibleLabelTemplate(html<Select>`
+const labelTemplate = createRequiredVisibleLabelTemplate(html<Select>`
     <label part="label" class="label" aria-hidden="true">
         <slot ${ref('labelSlot')}></slot>
     </label>

--- a/packages/nimble-components/src/select/template.ts
+++ b/packages/nimble-components/src/select/template.ts
@@ -27,6 +27,7 @@ import { buttonTag } from '../button';
 import { iconTimesTag } from '../icons/times';
 import { ListOption } from '../list-option';
 import { spinnerTag } from '../spinner';
+import { getLabelTemplate } from '../patterns/required-visible/template';
 
 export const isListOption = (
     el: Element | undefined | null
@@ -39,6 +40,12 @@ export const isListOptionGroup = (
 ): n is ListOptionGroup => {
     return n instanceof ListOptionGroup;
 };
+
+const labelTemplate = getLabelTemplate(html<Select>`
+    <label part="label" class="label" aria-hidden="true">
+        <slot ${ref('labelSlot')}></slot>
+    </label>
+`);
 
 /* eslint-disable @typescript-eslint/indent */
 // prettier-ignore
@@ -60,6 +67,7 @@ SelectOptions
         aria-haspopup="${x => (x.collapsible ? 'listbox' : null)}"
         aria-label="${x => x.labelContent}"
         aria-multiselectable="${x => x.ariaMultiSelectable}"
+        aria-required="${x => x.requiredVisible}"
         ?open="${x => x.open}"
         role="combobox"
         tabindex="${x => (!x.disabled ? '0' : null)}"
@@ -70,9 +78,7 @@ SelectOptions
         @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
         @mousedown="${(x, c) => x.mousedownHandler(c.event as MouseEvent)}"
     >
-        <label part="label" class="label" aria-hidden="true">
-            <slot ${ref('labelSlot')}></slot>
-        </label>
+        ${labelTemplate}
         ${when(x => x.collapsible, html<Select>`
             <div
                 class="control"

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -4,7 +4,7 @@ import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Select, selectTag } from '..';
 import { SelectPageObjectInternal as SelectPageObject } from './select.pageobject.internal';
 import { ListOption, listOptionTag } from '../../list-option';
-import { waitForUpdatesAsync } from '../../testing/async-helpers';
+import { processUpdates, waitForUpdatesAsync } from '../../testing/async-helpers';
 import { checkFullyInViewport } from '../../utilities/tests/intersection-observer';
 import { FilterMode, SelectFilterInputEventDetail } from '../types';
 import {
@@ -166,6 +166,24 @@ describe('Select', () => {
 
             await disconnect();
         });
+    });
+
+    it('should set "aria-required" to true when "required-visible" is true', async () => {
+        const { element, connect, disconnect } = await setup('above', true);
+        await connect();
+        element.requiredVisible = true;
+        processUpdates();
+        expect(element.getAttribute('aria-required')).toBe('true');
+        await disconnect();
+    });
+
+    it('should set "aria-required" to false when "required-visible" is false', async () => {
+        const { element, connect, disconnect } = await setup('above', true);
+        await connect();
+        element.requiredVisible = false;
+        processUpdates();
+        expect(element.getAttribute('aria-required')).toBe('false');
+        await disconnect();
     });
 
     it('should respect value set before connect is completed', async () => {

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -4,7 +4,10 @@ import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { Select, selectTag } from '..';
 import { SelectPageObjectInternal as SelectPageObject } from './select.pageobject.internal';
 import { ListOption, listOptionTag } from '../../list-option';
-import { processUpdates, waitForUpdatesAsync } from '../../testing/async-helpers';
+import {
+    processUpdates,
+    waitForUpdatesAsync
+} from '../../testing/async-helpers';
 import { checkFullyInViewport } from '../../utilities/tests/intersection-observer';
 import { FilterMode, SelectFilterInputEventDetail } from '../types';
 import {

--- a/packages/nimble-components/src/text-area/index.ts
+++ b/packages/nimble-components/src/text-area/index.ts
@@ -7,6 +7,7 @@ import { mixinErrorPattern } from '../patterns/error/types';
 import { styles } from './styles';
 import { template } from './template';
 import { TextAreaAppearance } from './types';
+import { mixinRequiredVisiblePattern } from '../patterns/required-visible/types';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -17,7 +18,7 @@ declare global {
 /**
  * A nimble-styed HTML text area
  */
-export class TextArea extends mixinErrorPattern(FoundationTextArea) {
+export class TextArea extends mixinErrorPattern(mixinRequiredVisiblePattern(FoundationTextArea)) {
     /**
      * The appearance the text area should have.
      *

--- a/packages/nimble-components/src/text-area/index.ts
+++ b/packages/nimble-components/src/text-area/index.ts
@@ -18,7 +18,9 @@ declare global {
 /**
  * A nimble-styed HTML text area
  */
-export class TextArea extends mixinErrorPattern(mixinRequiredVisiblePattern(FoundationTextArea)) {
+export class TextArea extends mixinErrorPattern(
+    mixinRequiredVisiblePattern(FoundationTextArea)
+) {
     /**
      * The appearance the text area should have.
      *

--- a/packages/nimble-components/src/text-area/styles.ts
+++ b/packages/nimble-components/src/text-area/styles.ts
@@ -19,11 +19,13 @@ import {
 import { appearanceBehavior } from '../utilities/style/appearance';
 import { TextAreaAppearance } from './types';
 import { styles as errorStyles } from '../patterns/error/styles';
+import { styles as requiredVisibleStyles } from '../patterns/required-visible/styles';
 import { userSelectNone } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('inline-flex')}
     ${errorStyles}
+    ${requiredVisibleStyles}
 
     :host {
         font: ${bodyFont};

--- a/packages/nimble-components/src/text-area/template.ts
+++ b/packages/nimble-components/src/text-area/template.ts
@@ -3,9 +3,9 @@ import type { FoundationElementTemplate } from '@microsoft/fast-foundation';
 import type { TextArea } from '.';
 import { iconExclamationMarkTag } from '../icons/exclamation-mark';
 import { errorTextTemplate } from '../patterns/error/template';
-import { getLabelTemplate } from '../patterns/required-visible/template';
+import { getRequiredVisibleLabelTemplate } from '../patterns/required-visible/template';
 
-const labelTemplate = getLabelTemplate(html<TextArea>`
+const labelTemplate = getRequiredVisibleLabelTemplate(html<TextArea>`
     <label
         part="label"
         for="control"

--- a/packages/nimble-components/src/text-area/template.ts
+++ b/packages/nimble-components/src/text-area/template.ts
@@ -3,10 +3,9 @@ import type { FoundationElementTemplate } from '@microsoft/fast-foundation';
 import type { TextArea } from '.';
 import { iconExclamationMarkTag } from '../icons/exclamation-mark';
 import { errorTextTemplate } from '../patterns/error/template';
+import { getLabelTemplate } from '../patterns/required-visible/template';
 
-export const template: FoundationElementTemplate<
-ViewTemplate<TextArea>
-> = () => html<TextArea>`
+const labelTemplate = getLabelTemplate(html<TextArea>`
     <label
         part="label"
         for="control"
@@ -14,6 +13,12 @@ ViewTemplate<TextArea>
     >
         <slot ${slotted('defaultSlottedNodes')}></slot>
     </label>
+`);
+
+export const template: FoundationElementTemplate<
+ViewTemplate<TextArea>
+> = () => html<TextArea>`
+    ${labelTemplate}
     <div class="container">
         <textarea
             part="control"
@@ -52,6 +57,7 @@ ViewTemplate<TextArea>
             aria-owns="${x => x.ariaOwns}"
             aria-relevant="${x => x.ariaRelevant}"
             aria-roledescription="${x => x.ariaRoledescription}"
+            aria-required="${x => x.requiredVisible}"
             @input="${x => x.onTextAreaInput()}"
             @change="${x => x.handleChange()}"
             ${ref('control')}

--- a/packages/nimble-components/src/text-area/template.ts
+++ b/packages/nimble-components/src/text-area/template.ts
@@ -3,9 +3,9 @@ import type { FoundationElementTemplate } from '@microsoft/fast-foundation';
 import type { TextArea } from '.';
 import { iconExclamationMarkTag } from '../icons/exclamation-mark';
 import { errorTextTemplate } from '../patterns/error/template';
-import { getRequiredVisibleLabelTemplate } from '../patterns/required-visible/template';
+import { createRequiredVisibleLabelTemplate } from '../patterns/required-visible/template';
 
-const labelTemplate = getRequiredVisibleLabelTemplate(html<TextArea>`
+const labelTemplate = createRequiredVisibleLabelTemplate(html<TextArea>`
     <label
         part="label"
         for="control"

--- a/packages/nimble-components/src/text-area/tests/text-area.spec.ts
+++ b/packages/nimble-components/src/text-area/tests/text-area.spec.ts
@@ -1,7 +1,10 @@
 import { html } from '@microsoft/fast-element';
 import { parameterizeSpec } from '@ni/jasmine-parameterized';
 import { TextArea, textAreaTag } from '..';
-import { processUpdates, waitForUpdatesAsync } from '../../testing/async-helpers';
+import {
+    processUpdates,
+    waitForUpdatesAsync
+} from '../../testing/async-helpers';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 
 async function setup(): Promise<Fixture<TextArea>> {

--- a/packages/nimble-components/src/text-area/tests/text-area.spec.ts
+++ b/packages/nimble-components/src/text-area/tests/text-area.spec.ts
@@ -1,7 +1,7 @@
 import { html } from '@microsoft/fast-element';
 import { parameterizeSpec } from '@ni/jasmine-parameterized';
 import { TextArea, textAreaTag } from '..';
-import { waitForUpdatesAsync } from '../../testing/async-helpers';
+import { processUpdates, waitForUpdatesAsync } from '../../testing/async-helpers';
 import { fixture, Fixture } from '../../utilities/tests/fixture';
 
 async function setup(): Promise<Fixture<TextArea>> {
@@ -33,6 +33,20 @@ describe('Text Area', () => {
     it('should set the `part` attribute to "control" on the internal control', async () => {
         await connect();
         expect(element.control.part.contains('control')).toBe(true);
+    });
+
+    it('should set "aria-required" to true when "required-visible" is true', async () => {
+        await connect();
+        element.requiredVisible = true;
+        processUpdates();
+        expect(element.control.getAttribute('aria-required')).toBe('true');
+    });
+
+    it('should set "aria-required" to false when "required-visible" is false', async () => {
+        await connect();
+        element.requiredVisible = false;
+        processUpdates();
+        expect(element.control.getAttribute('aria-required')).toBe('false');
     });
 
     const attributeNames: readonly {

--- a/packages/storybook/.storybook/main.js
+++ b/packages/storybook/.storybook/main.js
@@ -31,8 +31,7 @@ export const addons = [
     getAbsolutePath('@storybook/addon-interactions'),
     getAbsolutePath('@chromatic-com/storybook'),
     getAbsolutePath('@storybook/addon-webpack5-compiler-swc'),
-    getAbsolutePath('storybook-addon-pseudo-states'),
-    getAbsolutePath('@storybook/addon-mdx-gfm')
+    getAbsolutePath('storybook-addon-pseudo-states')
 ];
 
 export function webpackFinal(config) {

--- a/packages/storybook/.storybook/main.js
+++ b/packages/storybook/.storybook/main.js
@@ -1,4 +1,3 @@
-import { dirname, join } from 'path';
 import remarkGfm from 'remark-gfm';
 import CircularDependencyPlugin from 'circular-dependency-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
@@ -12,13 +11,13 @@ export const stories = [
 ];
 export const addons = [
     {
-        name: getAbsolutePath('@storybook/addon-essentials'),
+        name: '@storybook/addon-essentials',
         options: {
             outline: false,
             docs: false
         }
     }, {
-        name: getAbsolutePath('@storybook/addon-docs'),
+        name: '@storybook/addon-docs',
         options: {
             mdxPluginOptions: {
                 mdxCompileOptions: {
@@ -27,11 +26,11 @@ export const addons = [
             }
         }
     },
-    getAbsolutePath('@storybook/addon-a11y'),
-    getAbsolutePath('@storybook/addon-interactions'),
-    getAbsolutePath('@chromatic-com/storybook'),
-    getAbsolutePath('@storybook/addon-webpack5-compiler-swc'),
-    getAbsolutePath('storybook-addon-pseudo-states')
+    '@storybook/addon-a11y',
+    '@storybook/addon-interactions',
+    '@chromatic-com/storybook',
+    '@storybook/addon-webpack5-compiler-swc',
+    'storybook-addon-pseudo-states'
 ];
 
 export function webpackFinal(config) {
@@ -64,9 +63,5 @@ export function webpackFinal(config) {
 }
 export const staticDirs = ['public'];
 export const framework = {
-    name: getAbsolutePath('@storybook/html-webpack5')
+    name: '@storybook/html-webpack5'
 };
-
-function getAbsolutePath(value) {
-    return dirname(require.resolve(join(value, 'package.json')));
-}

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -105,5 +105,5 @@ configureActions({
     depth: 1
 });
 
-// Update the GUID on this line to trigger a turbosnap full rebuild: d3f8a1b2-4c5d-4e7f-8a9e-1b2c3d4e5f6a
+// Update the GUID on this line to trigger a turbosnap full rebuild: cc80e377-cf05-45d2-b36b-a9139f053fe2
 // See https://www.chromatic.com/docs/turbosnap/#full-rebuilds

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -105,5 +105,5 @@ configureActions({
     depth: 1
 });
 
-// Update the GUID on this line to trigger a turbosnap full rebuild: cc80e377-cf05-45d2-b36b-a9139f053fe2
+// Update the GUID on this line to trigger a turbosnap full rebuild: 870f48a2-7101-46f3-b0e1-57c16e7c3313
 // See https://www.chromatic.com/docs/turbosnap/#full-rebuilds

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -33,7 +33,6 @@
     "@storybook/addon-essentials": "^8.4.3",
     "@storybook/addon-interactions": "^8.4.3",
     "@storybook/addon-links": "^8.4.3",
-    "@storybook/addon-mdx-gfm": "^8.4.3",
     "@storybook/addon-webpack5-compiler-swc": "^1.0.5",
     "@storybook/cli": "^8.4.3",
     "@storybook/csf": "^0.1.11",

--- a/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
@@ -14,7 +14,9 @@ import {
     disabledStates,
     DisabledState,
     errorStates,
-    ErrorState
+    ErrorState,
+    RequiredVisibleState,
+    requiredVisibleStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { loremIpsum } from '../../utilities/lorem-ipsum';
@@ -47,7 +49,8 @@ const component = (
     [disabledName, disabled]: DisabledState,
     [appearanceName, appearance]: AppearanceState,
     [errorName, errorVisible, errorText]: ErrorState,
-    [valueName, value, placeholder]: ValueState
+    [valueName, value, placeholder]: ValueState,
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState
 ): ViewTemplate => html`
     <${comboboxTag} 
         ?disabled="${() => disabled}"
@@ -56,12 +59,14 @@ const component = (
         error-text="${() => errorText}"
         value="${() => value}"
         placeholder="${() => placeholder}"
+        ?required-visible="${() => requiredVisible}"
         style="width: 250px; margin: var(${standardPadding.cssCustomProperty});"
     >
         ${() => disabledName}
         ${() => appearanceName}
         ${() => errorName}
         ${() => valueName}
+        ${() => requiredVisibleName}
         <${listOptionTag} value="1">Option 1</${listOptionTag}>
         <${listOptionTag} value="2" disabled>Option 2</${listOptionTag}>
         <${listOptionTag} value="3">Option 3</${listOptionTag}>
@@ -74,7 +79,8 @@ export const comboboxThemeMatrix: StoryFn = createMatrixThemeStory(
         disabledStates,
         appearanceStates,
         errorStates,
-        valueStates
+        valueStates,
+        requiredVisibleStates
     ])
 );
 

--- a/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
@@ -46,11 +46,11 @@ export default metadata;
 
 // prettier-ignore
 const component = (
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [disabledName, disabled]: DisabledState,
     [appearanceName, appearance]: AppearanceState,
     [errorName, errorVisible, errorText]: ErrorState,
-    [valueName, value, placeholder]: ValueState,
-    [requiredVisibleName, requiredVisible]: RequiredVisibleState
+    [valueName, value, placeholder]: ValueState
 ): ViewTemplate => html`
     <${comboboxTag} 
         ?disabled="${() => disabled}"
@@ -76,11 +76,11 @@ const component = (
 
 export const comboboxThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         disabledStates,
         appearanceStates,
         errorStates,
-        valueStates,
-        requiredVisibleStates
+        valueStates
     ])
 );
 

--- a/packages/storybook/src/nimble/combobox/combobox.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox.stories.ts
@@ -31,6 +31,7 @@ interface ComboboxArgs {
     optionsType: ExampleOptionsType;
     errorVisible: boolean;
     errorText: string;
+    requiredVisible: boolean;
     currentValue: string;
     appearance: string;
     placeholder: string;
@@ -108,6 +109,7 @@ const metadata: Meta<ComboboxArgs> = {
             appearance="${x => x.appearance}"
             value="${x => x.currentValue}"
             placeholder="${x => x.placeholder}"
+            ?required-visible="${x => x.requiredVisible}"
             style="min-width: 250px;"
         >
             ${x => x.label}
@@ -164,6 +166,11 @@ const metadata: Meta<ComboboxArgs> = {
             description: placeholderDescription({ componentName: 'combobox' }),
             table: { category: apiCategory.attributes }
         },
+        requiredVisible: {
+            name: 'required-visible',
+            description: 'foo bar',
+            table: { category: apiCategory.attributes }
+        },
         optionsType: {
             name: 'default',
             description: optionsDescription({ includeGrouping: false }),
@@ -200,7 +207,8 @@ const metadata: Meta<ComboboxArgs> = {
         errorText: 'Value is invalid',
         appearance: DropdownAppearance.underline,
         placeholder: 'Select value...',
-        optionsType: ExampleOptionsType.simpleOptions
+        optionsType: ExampleOptionsType.simpleOptions,
+        requiredVisible: false
     }
 };
 

--- a/packages/storybook/src/nimble/combobox/combobox.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox.stories.ts
@@ -20,6 +20,7 @@ import {
     errorVisibleDescription,
     optionsDescription,
     placeholderDescription,
+    requiredVisibleDescription,
     slottedLabelDescription
 } from '../../utilities/storybook';
 
@@ -168,7 +169,7 @@ const metadata: Meta<ComboboxArgs> = {
         },
         requiredVisible: {
             name: 'required-visible',
-            description: 'foo bar',
+            description: requiredVisibleDescription,
             table: { category: apiCategory.attributes }
         },
         optionsType: {

--- a/packages/storybook/src/nimble/patterns/required-visible/required-visible.stories.ts
+++ b/packages/storybook/src/nimble/patterns/required-visible/required-visible.stories.ts
@@ -10,7 +10,10 @@ import { comboboxTag } from '../../../../../nimble-components/src/combobox';
 import { selectTag } from '../../../../../nimble-components/src/select';
 import { textAreaTag } from '../../../../../nimble-components/src/text-area';
 import { createUserSelectedThemeStory } from '../../../utilities/storybook';
-import { Orientation, radioGroupTag } from '../../../../../nimble-components/src/radio-group';
+import {
+    Orientation,
+    radioGroupTag
+} from '../../../../../nimble-components/src/radio-group';
 import { radioTag } from '../../../../../nimble-components/src/radio';
 
 interface RequiredVisiblePatternArgs {

--- a/packages/storybook/src/nimble/patterns/required-visible/required-visible.stories.ts
+++ b/packages/storybook/src/nimble/patterns/required-visible/required-visible.stories.ts
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import { html } from '@microsoft/fast-element';
+import {
+    groupHeaderFont,
+    groupHeaderFontColor,
+    largePadding,
+    standardPadding
+} from '../../../../../nimble-components/src/theme-provider/design-tokens';
+import { comboboxTag } from '../../../../../nimble-components/src/combobox';
+import { selectTag } from '../../../../../nimble-components/src/select';
+import { textAreaTag } from '../../../../../nimble-components/src/text-area';
+import { createUserSelectedThemeStory } from '../../../utilities/storybook';
+import { Orientation, radioGroupTag } from '../../../../../nimble-components/src/radio-group';
+import { radioTag } from '../../../../../nimble-components/src/radio';
+
+interface RequiredVisiblePatternArgs {
+    shortLabel: string;
+    longLabel: string;
+}
+
+const metadata: Meta<RequiredVisiblePatternArgs> = {
+    title: 'Tests/Required Visible',
+    parameters: {
+        actions: {}
+    },
+    // prettier-ignore
+    render: createUserSelectedThemeStory(html`
+        <style class='code-hide'>
+            .control-container {
+                margin: var(${largePadding.cssCustomProperty});
+                display: flex;
+                flex-direction: column;
+                gap: var(${standardPadding.cssCustomProperty});
+            }
+
+            .label {
+                font: var(${groupHeaderFont.cssCustomProperty});
+                color: var(${groupHeaderFontColor.cssCustomProperty});
+            }
+
+            .fixed-width {
+                width: 200px;
+            }
+        </style>
+        <div class="control-container">
+            <div class="label">Combobox</div>
+            <${comboboxTag} class="fixed-width" required-visible>${x => x.shortLabel}</${comboboxTag}>
+            <${comboboxTag} class="fixed-width" required-visible>${x => x.longLabel}</${comboboxTag}>
+        </div>
+        <div class="control-container">
+            <div class="label">Radio group</div>
+            <${radioGroupTag} class="fixed-width" orientation=${Orientation.horizontal} required-visible>
+                <span slot="label">${x => x.shortLabel}</span>
+                <${radioTag} value="1">Option 1</${radioTag}>
+                <${radioTag} value="2">Option 2</${radioTag}>
+            </${radioGroupTag}>
+            <${radioGroupTag} class="fixed-width" orientation=${Orientation.horizontal}  required-visible>
+                <span slot="label">${x => x.longLabel}</span>
+                <${radioTag} value="1">Option 1</${radioTag}>
+                <${radioTag} value="2">Option 2</${radioTag}>
+            </${radioGroupTag}>
+            <${radioGroupTag} class="fixed-width" orientation=${Orientation.vertical} required-visible>
+                <span slot="label">${x => x.shortLabel}</span>
+                <${radioTag} value="1">Option 1</${radioTag}>
+                <${radioTag} value="2">Option 2</${radioTag}>
+            </${radioGroupTag}>
+            <${radioGroupTag} class="fixed-width" orientation=${Orientation.vertical}  required-visible>
+                <span slot="label">${x => x.longLabel}</span>
+                <${radioTag} value="1">Option 1</${radioTag}>
+                <${radioTag} value="2">Option 2</${radioTag}>
+            </${radioGroupTag}>
+        </div>
+        <div class="control-container">
+            <div class="label">Select</div>
+            <${selectTag} class="fixed-width" required-visible>${x => x.shortLabel}</${selectTag}>
+            <${selectTag} class="fixed-width" required-visible>${x => x.longLabel}</${selectTag}>
+        </div>
+        <div class="control-container">
+            <div class="label">Text area</div>
+            <${textAreaTag} class="fixed-width" required-visible>${x => x.shortLabel}</${textAreaTag}>
+            <${textAreaTag} class="fixed-width" required-visible>${x => x.longLabel}</${textAreaTag}>
+        </div>
+    `),
+    args: {
+        shortLabel: 'Short label',
+        longLabel: 'This is a long label that will wrap to the next line'
+    }
+};
+
+export default metadata;
+
+export const requiredVisiblePattern: StoryObj<RequiredVisiblePatternArgs> = {};

--- a/packages/storybook/src/nimble/radio-group/radio-group-matrix.stories.ts
+++ b/packages/storybook/src/nimble/radio-group/radio-group-matrix.stories.ts
@@ -13,7 +13,9 @@ import {
     disabledStates,
     DisabledState,
     errorStates,
-    ErrorState
+    ErrorState,
+    requiredVisibleStates,
+    RequiredVisibleState
 } from '../../utilities/states';
 import { createStory } from '../../utilities/storybook';
 import { hiddenWrapper } from '../../utilities/hidden';
@@ -37,22 +39,24 @@ export default metadata;
 const component = (
     [disabledName, disabled]: DisabledState,
     [orientationName, orientation]: OrientationState,
-    [errorName, errorVisible, errorText]: ErrorState
+    [errorName, errorVisible, errorText]: ErrorState,
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState
 ): ViewTemplate => html`<${radioGroupTag}
     orientation="${() => orientation}"
     ?disabled="${() => disabled}"
     ?error-visible="${() => errorVisible}"
     error-text="${() => errorText}"
+    ?required-visible="${() => requiredVisible}"
     value="1"
     style="width: 250px; margin: var(${standardPadding.cssCustomProperty});"
 >
-    <label slot="label">${orientationName} ${disabledName} ${errorName}</label>
+    <label slot="label">${orientationName} ${disabledName} ${errorName} ${requiredVisibleName}</label>
     <${radioTag} value="1">Option 1</${radioTag}>
     <${radioTag} value="2">Option 2</${radioTag}>
 </${radioGroupTag}>`;
 
 export const radioGroupThemeMatrix: StoryFn = createMatrixThemeStory(
-    createMatrix(component, [disabledStates, orientationStates, errorStates])
+    createMatrix(component, [disabledStates, orientationStates, errorStates, requiredVisibleStates])
 );
 
 export const hiddenRadioGroup: StoryFn = createStory(

--- a/packages/storybook/src/nimble/radio-group/radio-group-matrix.stories.ts
+++ b/packages/storybook/src/nimble/radio-group/radio-group-matrix.stories.ts
@@ -37,10 +37,10 @@ const metadata: Meta = {
 export default metadata;
 
 const component = (
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [disabledName, disabled]: DisabledState,
     [orientationName, orientation]: OrientationState,
-    [errorName, errorVisible, errorText]: ErrorState,
-    [requiredVisibleName, requiredVisible]: RequiredVisibleState
+    [errorName, errorVisible, errorText]: ErrorState
 ): ViewTemplate => html`<${radioGroupTag}
     orientation="${() => orientation}"
     ?disabled="${() => disabled}"
@@ -57,10 +57,10 @@ const component = (
 
 export const radioGroupThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         disabledStates,
         orientationStates,
-        errorStates,
-        requiredVisibleStates
+        errorStates
     ])
 );
 

--- a/packages/storybook/src/nimble/radio-group/radio-group-matrix.stories.ts
+++ b/packages/storybook/src/nimble/radio-group/radio-group-matrix.stories.ts
@@ -56,7 +56,12 @@ const component = (
 </${radioGroupTag}>`;
 
 export const radioGroupThemeMatrix: StoryFn = createMatrixThemeStory(
-    createMatrix(component, [disabledStates, orientationStates, errorStates, requiredVisibleStates])
+    createMatrix(component, [
+        disabledStates,
+        orientationStates,
+        errorStates,
+        requiredVisibleStates
+    ])
 );
 
 export const hiddenRadioGroup: StoryFn = createStory(

--- a/packages/storybook/src/nimble/radio-group/radio-group.stories.ts
+++ b/packages/storybook/src/nimble/radio-group/radio-group.stories.ts
@@ -130,6 +130,7 @@ export const radioGroup: StoryObj<RadioGroupArgs> = {
             table: { category: apiCategory.attributes }
         },
         requiredVisible: {
+            name: 'required-visible',
             description: requiredVisibleDescription,
             table: { category: apiCategory.attributes }
         }

--- a/packages/storybook/src/nimble/radio-group/radio-group.stories.ts
+++ b/packages/storybook/src/nimble/radio-group/radio-group.stories.ts
@@ -10,6 +10,7 @@ import {
     disabledDescription,
     errorTextDescription,
     errorVisibleDescription,
+    requiredVisibleDescription,
     slottedLabelDescription
 } from '../../utilities/storybook';
 
@@ -23,6 +24,7 @@ interface RadioGroupArgs {
     change: undefined;
     errorVisible: boolean;
     errorText: string;
+    requiredVisible: boolean;
 }
 
 interface RadioArgs {
@@ -55,6 +57,7 @@ export const radioGroup: StoryObj<RadioGroupArgs> = {
             value="${x => (x.value === 'none' ? undefined : x.value)}"
             ?error-visible="${x => x.errorVisible}"
             error-text="${x => x.errorText}"
+            ?required-visible="${x => x.requiredVisible}"
             style="min-width: 200px;"
         >
             <label slot="label">${x => x.label}</label>
@@ -70,7 +73,8 @@ export const radioGroup: StoryObj<RadioGroupArgs> = {
         name: 'fruit',
         value: 'none',
         errorVisible: false,
-        errorText: 'Value is invalid'
+        errorText: 'Value is invalid',
+        requiredVisible: false
     },
     argTypes: {
         value: {
@@ -123,6 +127,10 @@ export const radioGroup: StoryObj<RadioGroupArgs> = {
         errorVisible: {
             name: 'error-visible',
             description: errorVisibleDescription,
+            table: { category: apiCategory.attributes }
+        },
+        requiredVisible: {
+            description: requiredVisibleDescription,
             table: { category: apiCategory.attributes }
         }
     }

--- a/packages/storybook/src/nimble/select/select-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-matrix.stories.ts
@@ -55,7 +55,7 @@ export default metadata;
 
 // prettier-ignore
 const component = (
-    [requiredVisibleName, requiredVisible]: RequiredVisibleState
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [disabledName, disabled]: DisabledState,
     [appearanceName, appearance]: AppearanceState,
     [errorName, errorVisible, errorText]: ErrorState,

--- a/packages/storybook/src/nimble/select/select-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-matrix.stories.ts
@@ -55,12 +55,12 @@ export default metadata;
 
 // prettier-ignore
 const component = (
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState
     [disabledName, disabled]: DisabledState,
     [appearanceName, appearance]: AppearanceState,
     [errorName, errorVisible, errorText]: ErrorState,
     [valueName, valueValue]: ValueState,
-    [clearableName, clearable]: ClearableState,
-    [requiredVisibleName, requiredVisible]: RequiredVisibleState
+    [clearableName, clearable]: ClearableState
 ): ViewTemplate => html`
     <${selectTag}
         ?error-visible="${() => errorVisible}"
@@ -81,12 +81,12 @@ const component = (
 
 export const selectThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         disabledStates,
         appearanceStates,
         errorStates,
         valueStates,
-        clearableStates,
-        requiredVisibleStates
+        clearableStates
     ])
 );
 

--- a/packages/storybook/src/nimble/select/select-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-matrix.stories.ts
@@ -17,7 +17,9 @@ import {
     disabledStates,
     DisabledState,
     ErrorState,
-    errorStates
+    errorStates,
+    requiredVisibleStates,
+    RequiredVisibleState
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -57,7 +59,8 @@ const component = (
     [appearanceName, appearance]: AppearanceState,
     [errorName, errorVisible, errorText]: ErrorState,
     [valueName, valueValue]: ValueState,
-    [clearableName, clearable]: ClearableState
+    [clearableName, clearable]: ClearableState,
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState
 ): ViewTemplate => html`
     <${selectTag}
         ?error-visible="${() => errorVisible}"
@@ -65,9 +68,10 @@ const component = (
         ?disabled="${() => disabled}"
         ?clearable="${() => clearable}"
         appearance="${() => appearance}"
+        ?required-visible="${() => requiredVisible}"
         style="width: 250px; margin: var(${standardPadding.cssCustomProperty});"
     >
-        ${() => errorName} ${() => disabledName} ${() => appearanceName} ${() => valueName} ${() => clearableName}
+        ${() => errorName} ${() => disabledName} ${() => appearanceName} ${() => valueName} ${() => clearableName} ${() => requiredVisibleName}
         <${listOptionTag} value="1">${valueValue}</${listOptionTag}>
         <${listOptionTag} value="2" disabled>Option 2</${listOptionTag}>
         <${listOptionTag} value="3">Option 3</${listOptionTag}>
@@ -81,7 +85,8 @@ export const selectThemeMatrix: StoryFn = createMatrixThemeStory(
         appearanceStates,
         errorStates,
         valueStates,
-        clearableStates
+        clearableStates,
+        requiredVisibleStates
     ])
 );
 

--- a/packages/storybook/src/nimble/select/select.stories.ts
+++ b/packages/storybook/src/nimble/select/select.stories.ts
@@ -17,6 +17,7 @@ import {
     errorTextDescription,
     errorVisibleDescription,
     optionsDescription,
+    requiredVisibleDescription,
     slottedLabelDescription
 } from '../../utilities/storybook';
 import { ExampleOptionsType } from './types';
@@ -230,7 +231,7 @@ const metadata: Meta<SelectArgs> = {
         },
         requiredVisible: {
             name: 'required-visible',
-            description: 'foo bar',
+            description: requiredVisibleDescription,
             table: { category: apiCategory.attributes }
         },
         value: {

--- a/packages/storybook/src/nimble/select/select.stories.ts
+++ b/packages/storybook/src/nimble/select/select.stories.ts
@@ -26,6 +26,7 @@ interface SelectArgs {
     disabled: boolean;
     errorVisible: boolean;
     errorText: string;
+    requiredVisible: boolean;
     dropDownPosition: string;
     optionsType: ExampleOptionsType;
     appearance: string;
@@ -144,6 +145,7 @@ const metadata: Meta<SelectArgs> = {
             appearance="${x => x.appearance}"
             filter-mode="${x => (x.filterMode === 'none' ? undefined : x.filterMode)}"
             ?loading-visible="${x => x.loadingVisible}"
+            ?required-visible="${x => x.requiredVisible}"
             style="width:250px;"
         >
             ${x => x.label}
@@ -226,6 +228,11 @@ const metadata: Meta<SelectArgs> = {
             description: loadingVisibleDescription,
             table: { category: apiCategory.attributes }
         },
+        requiredVisible: {
+            name: 'required-visible',
+            description: 'foo bar',
+            table: { category: apiCategory.attributes }
+        },
         value: {
             name: 'value',
             description:
@@ -272,7 +279,8 @@ const metadata: Meta<SelectArgs> = {
         appearance: DropdownAppearance.underline,
         optionsType: ExampleOptionsType.simpleOptions,
         clearable: false,
-        loadingVisible: false
+        loadingVisible: false,
+        requiredVisible: false
     }
 };
 

--- a/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
@@ -14,7 +14,9 @@ import {
     ReadOnlyState,
     readOnlyStates,
     ErrorState,
-    errorStates
+    errorStates,
+    RequiredVisibleState,
+    requiredVisibleStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -47,7 +49,8 @@ const component = (
     [disabledName, disabled]: DisabledState,
     [appearanceName, appearance]: AppearanceState,
     [valueName, valueValue, placeholderValue]: ValueState,
-    [errorStateName, isError, errorText]: ErrorState
+    [errorStateName, isError, errorText]: ErrorState,
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState
 ): ViewTemplate => html`
     <${textAreaTag}
         style="width: 250px; margin: 15px;"
@@ -56,11 +59,12 @@ const component = (
         value="${() => valueValue}"
         placeholder="${() => placeholderValue}"
         ?readonly="${() => readonly}"
-        error-visible="${() => isError}"
+        ?error-visible="${() => isError}"
         error-text="${() => errorText}"
+        ?required-visible="${() => requiredVisible}"
     >
         ${() => disabledName} ${() => appearanceName} ${() => valueName}
-        ${() => readOnlyName} ${() => errorStateName}
+        ${() => readOnlyName} ${() => errorStateName} ${() => requiredVisibleName}
     </${textAreaTag}>
 `;
 
@@ -70,7 +74,8 @@ export const textAreaThemeMatrix: StoryFn = createMatrixThemeStory(
         disabledStates,
         appearanceStates,
         valueStates,
-        errorStates
+        errorStates,
+        requiredVisibleStates
     ])
 );
 

--- a/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
@@ -45,12 +45,12 @@ const metadata: Meta = {
 export default metadata;
 
 const component = (
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [readOnlyName, readonly]: ReadOnlyState,
     [disabledName, disabled]: DisabledState,
     [appearanceName, appearance]: AppearanceState,
     [valueName, valueValue, placeholderValue]: ValueState,
-    [errorStateName, isError, errorText]: ErrorState,
-    [requiredVisibleName, requiredVisible]: RequiredVisibleState
+    [errorStateName, isError, errorText]: ErrorState
 ): ViewTemplate => html`
     <${textAreaTag}
         style="width: 250px; margin: 15px;"
@@ -70,12 +70,12 @@ const component = (
 
 export const textAreaThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         readOnlyStates,
         disabledStates,
         appearanceStates,
         valueStates,
-        errorStates,
-        requiredVisibleStates
+        errorStates
     ])
 );
 

--- a/packages/storybook/src/nimble/text-area/text-area.stories.ts
+++ b/packages/storybook/src/nimble/text-area/text-area.stories.ts
@@ -33,6 +33,7 @@ interface TextAreaArgs {
     cols: number;
     maxlength: number;
     change: undefined;
+    requiredVisible: boolean;
 }
 
 const metadata: Meta<TextAreaArgs> = {
@@ -57,6 +58,7 @@ const metadata: Meta<TextAreaArgs> = {
             rows="${x => x.rows}"
             cols="${x => x.cols}"
             maxlength="${x => x.maxlength}"
+            ?required-visible="${x => x.requiredVisible}"
         >
             ${x => x.label}
         </${textAreaTag}>
@@ -127,6 +129,11 @@ const metadata: Meta<TextAreaArgs> = {
                 'Maximum number of characters that may be entered by the user',
             table: { category: apiCategory.attributes }
         },
+        requiredVisible: {
+            name: 'required-visible',
+            description: 'Whether to display the required state.',
+            table: { category: apiCategory.attributes }
+        },
         change: {
             description:
                 'Event emitted when the user commits a new value to the text area.',
@@ -147,7 +154,8 @@ const metadata: Meta<TextAreaArgs> = {
         resize: TextAreaResize.both,
         rows: 3,
         cols: 20,
-        maxlength: 500
+        maxlength: 500,
+        requiredVisible: false
     }
 };
 

--- a/packages/storybook/src/nimble/text-area/text-area.stories.ts
+++ b/packages/storybook/src/nimble/text-area/text-area.stories.ts
@@ -14,6 +14,7 @@ import {
     errorTextDescription,
     errorVisibleDescription,
     placeholderDescription,
+    requiredVisibleDescription,
     slottedLabelDescription
 } from '../../utilities/storybook';
 import { loremIpsum } from '../../utilities/lorem-ipsum';
@@ -131,7 +132,7 @@ const metadata: Meta<TextAreaArgs> = {
         },
         requiredVisible: {
             name: 'required-visible',
-            description: 'Whether to display the required state.',
+            description: requiredVisibleDescription,
             table: { category: apiCategory.attributes }
         },
         change: {

--- a/packages/storybook/src/utilities/states.ts
+++ b/packages/storybook/src/utilities/states.ts
@@ -51,3 +51,9 @@ export const placeholderStates = [
     ['', undefined]
 ] as const;
 export type PlaceholderState = (typeof placeholderStates)[number];
+
+export const requiredVisibleStates = [
+    ['', false],
+    ['Required', true]
+] as const;
+export type RequiredVisibleState = (typeof requiredVisibleStates)[number];

--- a/packages/storybook/src/utilities/storybook.ts
+++ b/packages/storybook/src/utilities/storybook.ts
@@ -197,6 +197,8 @@ export const placeholderDescription = (options: {
 export const errorTextDescription = 'A message to be displayed explaining why the value is invalid. Only visible when `error-visible` is set.';
 export const errorVisibleDescription = 'When set to `true`, an error indicator will be displayed within the control and the `error-text` message will be displayed.';
 
+export const requiredVisibleDescription = 'When set to `true`, an indicator will be displayed within the control to indicate that the field is required. A control should not set `required-visible` on disabled or readonly controls.';
+
 export const dropdownPositionDescription = (options: {
     componentName: string
 }): string => `Controls the position of the dropdown relative to the ${options.componentName}.`;

--- a/packages/storybook/src/utilities/storybook.ts
+++ b/packages/storybook/src/utilities/storybook.ts
@@ -197,7 +197,7 @@ export const placeholderDescription = (options: {
 export const errorTextDescription = 'A message to be displayed explaining why the value is invalid. Only visible when `error-visible` is set.';
 export const errorVisibleDescription = 'When set to `true`, an error indicator will be displayed within the control and the `error-text` message will be displayed.';
 
-export const requiredVisibleDescription = 'When set to `true`, an indicator will be displayed within the control to indicate that the field is required. A control should not set `required-visible` on disabled or readonly controls.';
+export const requiredVisibleDescription = 'When set to `true`, an indicator will be displayed within the control to indicate that the field is required. A disabled or readonly control should not also be marked as `required-visible`.';
 
 export const dropdownPositionDescription = (options: {
     componentName: string


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Add `required-visible` attributes to the radio-group, select, combobox, and text-area components as part of #2100.

There is still a need to add this attribute to the text-field and number-field. That will be done once the templates for those components have been forked (#2495).

## 👩‍💻 Implementation

Within the `patterns` directory, I created a mixin that can be used on elements that should have a `requiredVisible` property and `required-visible` attribute. Additionally, shared styling was added for the `requiredVisible` state and a function was created to generate the template for an element's label. This is a function rather than a constant template because each element already had an existing label structure that I didn't want to change as part of this PR.

The template of each element included in this PR was also updated to set `aria-required` based on the value of `requiredVisible`.

I also updated the styling of icons to solve a problem I encountered when shrinking the asterisk icon down to 5x5.

## 🧪 Testing

- Manually tested
- New matrix tests
- Unit tests for the new mixin
- New unit tests for the ARIA behavior of each element

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
