### PR TITLE
Fix Storybook build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7307,23 +7307,6 @@
         }
       }
     },
-    "node_modules/@storybook/addon-mdx-gfm": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-mdx-gfm/-/addon-mdx-gfm-8.4.6.tgz",
-      "integrity": "sha512-wagsSBUN6pwcSZSWxp/aOhE16ZKI8ZW4XeRT6QivySmkJaLcbva+HNvQOijdXIM28W8PprKjqtyVa8nu4YQxsw==",
-      "dev": true,
-      "dependencies": {
-        "remark-gfm": "^4.0.0",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.4.6"
-      }
-    },
     "node_modules/@storybook/addon-measure": {
       "version": "8.4.6",
       "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-8.4.6.tgz",
@@ -28144,7 +28127,6 @@
         "@storybook/addon-essentials": "^8.4.3",
         "@storybook/addon-interactions": "^8.4.3",
         "@storybook/addon-links": "^8.4.3",
-        "@storybook/addon-mdx-gfm": "^8.4.3",
         "@storybook/addon-webpack5-compiler-swc": "^1.0.5",
         "@storybook/cli": "^8.4.3",
         "@storybook/csf": "^0.1.11",

--- a/packages/storybook/.storybook/main.js
+++ b/packages/storybook/.storybook/main.js
@@ -1,4 +1,3 @@
-import { dirname, join } from 'path';
 import remarkGfm from 'remark-gfm';
 import CircularDependencyPlugin from 'circular-dependency-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
@@ -12,13 +11,13 @@ export const stories = [
 ];
 export const addons = [
     {
-        name: getAbsolutePath('@storybook/addon-essentials'),
+        name: '@storybook/addon-essentials',
         options: {
             outline: false,
             docs: false
         }
     }, {
-        name: getAbsolutePath('@storybook/addon-docs'),
+        name: '@storybook/addon-docs',
         options: {
             mdxPluginOptions: {
                 mdxCompileOptions: {
@@ -27,12 +26,11 @@ export const addons = [
             }
         }
     },
-    getAbsolutePath('@storybook/addon-a11y'),
-    getAbsolutePath('@storybook/addon-interactions'),
-    getAbsolutePath('@chromatic-com/storybook'),
-    getAbsolutePath('@storybook/addon-webpack5-compiler-swc'),
-    getAbsolutePath('storybook-addon-pseudo-states'),
-    getAbsolutePath('@storybook/addon-mdx-gfm')
+    '@storybook/addon-a11y',
+    '@storybook/addon-interactions',
+    '@chromatic-com/storybook',
+    '@storybook/addon-webpack5-compiler-swc',
+    'storybook-addon-pseudo-states'
 ];
 
 export function webpackFinal(config) {
@@ -65,9 +63,5 @@ export function webpackFinal(config) {
 }
 export const staticDirs = ['public'];
 export const framework = {
-    name: getAbsolutePath('@storybook/html-webpack5')
+    name: '@storybook/html-webpack5'
 };
-
-function getAbsolutePath(value) {
-    return dirname(require.resolve(join(value, 'package.json')));
-}

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -33,7 +33,6 @@
     "@storybook/addon-essentials": "^8.4.3",
     "@storybook/addon-interactions": "^8.4.3",
     "@storybook/addon-links": "^8.4.3",
-    "@storybook/addon-mdx-gfm": "^8.4.3",
     "@storybook/addon-webpack5-compiler-swc": "^1.0.5",
     "@storybook/cli": "^8.4.3",
     "@storybook/csf": "^0.1.11",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

A combination of node 22.12.0 and our Storybook configuration fails. See https://github.com/nodejs/node/issues/56127 for more information. 

A quick fix is to remove some [unnecessary](https://storybook.js.org/docs/faq#how-do-i-fix-module-resolution-in-special-environments) code that the Storybook migration tools added to our configuration a few releases ago. 

## 👩‍💻 Implementation

- Removed uses of the `getAbsolutePath()` macro
- Removed the @storybook/addon-mdx-gfm Storybook add-on which, per the build logs, isn't necessary to have installed to support GitHub flavored markdown

## 🧪 Testing

- Verified that markdown tables still render in Storybook (GFM feature)
- The build no longer breaks

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
