### PR TITLE
Required indicator on text-field and number-field

### DIFF
--- a/change/@ni-nimble-components-359b74e4-1ec1-4053-ae16-bff4746467ea.json
+++ b/change/@ni-nimble-components-359b74e4-1ec1-4053-ae16-bff4746467ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add `required-visible` attribute to number-field and text-field",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/number-field/index.ts
+++ b/packages/nimble-components/src/number-field/index.ts
@@ -17,6 +17,7 @@ import {
     numericIncrementLabel
 } from '../label-provider/core/label-tokens';
 import { template } from './template';
+import { mixinRequiredVisiblePattern } from '../patterns/required-visible/types';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -27,7 +28,9 @@ declare global {
 /**
  * A nimble-styled HTML number input
  */
-export class NumberField extends mixinErrorPattern(FoundationNumberField) {
+export class NumberField extends mixinErrorPattern(
+    mixinRequiredVisiblePattern(FoundationNumberField)
+) {
     @attr
     public appearance: NumberFieldAppearance = NumberFieldAppearance.underline;
 

--- a/packages/nimble-components/src/number-field/styles.ts
+++ b/packages/nimble-components/src/number-field/styles.ts
@@ -19,11 +19,13 @@ import {
 import { appearanceBehavior } from '../utilities/style/appearance';
 import { NumberFieldAppearance } from './types';
 import { styles as errorStyles } from '../patterns/error/styles';
+import { styles as requiredVisibleStyles } from '../patterns/required-visible/styles';
 import { userSelectNone } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('inline-block')}
     ${errorStyles}
+    ${requiredVisibleStyles}
 
     :host {
         font: ${bodyFont};

--- a/packages/nimble-components/src/number-field/template.ts
+++ b/packages/nimble-components/src/number-field/template.ts
@@ -13,9 +13,7 @@ const labelTemplate = createRequiredVisibleLabelTemplate(
     html<NumberField>`<label
         part="label"
         for="control"
-        class="${x => (x.defaultSlottedNodes?.length
-        ? 'label'
-        : 'label label__hidden')}"
+        class="${x => (x.defaultSlottedNodes?.length ? 'label' : 'label label__hidden')}"
     >
         <slot ${slotted('defaultSlottedNodes')}></slot>
     </label>`

--- a/packages/nimble-components/src/number-field/template.ts
+++ b/packages/nimble-components/src/number-field/template.ts
@@ -7,6 +7,19 @@ import {
     startSlotTemplate
 } from '@microsoft/fast-foundation';
 import type { NumberField } from '.';
+import { createRequiredVisibleLabelTemplate } from '../patterns/required-visible/template';
+
+const labelTemplate = createRequiredVisibleLabelTemplate(
+    html<NumberField>`<label
+        part="label"
+        for="control"
+        class="${x => (x.defaultSlottedNodes?.length
+        ? 'label'
+        : 'label label__hidden')}"
+    >
+        <slot ${slotted('defaultSlottedNodes')}></slot>
+    </label>`
+);
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(NumberField:class)} component.
@@ -17,15 +30,7 @@ ViewTemplate<NumberField>,
 NumberFieldOptions
 > = (context, definition) => html`
     <template class="${x => (x.readOnly ? 'readonly' : '')}">
-        <label
-            part="label"
-            for="control"
-            class="${x => (x.defaultSlottedNodes?.length
-        ? 'label'
-        : 'label label__hidden')}"
-        >
-            <slot ${slotted('defaultSlottedNodes')}></slot>
-        </label>
+        ${labelTemplate}
         <div class="root" part="root">
             ${startSlotTemplate(context, definition)}
             <input
@@ -69,6 +74,7 @@ NumberFieldOptions
                 aria-owns="${x => x.ariaOwns}"
                 aria-relevant="${x => x.ariaRelevant}"
                 aria-roledescription="${x => x.ariaRoledescription}"
+                aria-required="${x => x.requiredVisible}"
                 ${ref('control')}
             />
             ${when(

--- a/packages/nimble-components/src/number-field/tests/number-field.spec.ts
+++ b/packages/nimble-components/src/number-field/tests/number-field.spec.ts
@@ -4,7 +4,10 @@ import {
     LabelProviderCore,
     labelProviderCoreTag
 } from '../../label-provider/core';
-import { processUpdates, waitForUpdatesAsync } from '../../testing/async-helpers';
+import {
+    processUpdates,
+    waitForUpdatesAsync
+} from '../../testing/async-helpers';
 import { ThemeProvider, themeProviderTag } from '../../theme-provider';
 import { fixture, type Fixture } from '../../utilities/tests/fixture';
 
@@ -45,8 +48,7 @@ describe('NumberField', () => {
 
     it('prevents inc/dec buttons from being focusable', () => {
         const buttons = Array.from(
-            element
-                .shadowRoot!.querySelectorAll('.step-up-down-button')
+            element.shadowRoot!.querySelectorAll('.step-up-down-button')
         );
         expect(
             buttons.every(x => (x as HTMLElement).tabIndex === -1)
@@ -55,8 +57,7 @@ describe('NumberField', () => {
 
     it('hides inc/dec buttons from a11y tree', () => {
         const buttons = Array.from(
-            element
-                .shadowRoot!.querySelectorAll('.step-up-down-button')
+            element.shadowRoot!.querySelectorAll('.step-up-down-button')
         );
         expect(
             buttons.every(x => (x as HTMLElement).ariaHidden === 'true')

--- a/packages/nimble-components/src/number-field/tests/number-field.spec.ts
+++ b/packages/nimble-components/src/number-field/tests/number-field.spec.ts
@@ -4,9 +4,15 @@ import {
     LabelProviderCore,
     labelProviderCoreTag
 } from '../../label-provider/core';
-import { waitForUpdatesAsync } from '../../testing/async-helpers';
+import { processUpdates, waitForUpdatesAsync } from '../../testing/async-helpers';
 import { ThemeProvider, themeProviderTag } from '../../theme-provider';
 import { fixture, type Fixture } from '../../utilities/tests/fixture';
+
+async function setup(): Promise<Fixture<NumberField>> {
+    return await fixture<NumberField>(
+        html`<${numberFieldTag}></${numberFieldTag}>`
+    );
+}
 
 async function setupWithLabelProvider(): Promise<Fixture<ThemeProvider>> {
     return await fixture<ThemeProvider>(html`
@@ -18,6 +24,19 @@ async function setupWithLabelProvider(): Promise<Fixture<ThemeProvider>> {
 }
 
 describe('NumberField', () => {
+    let element: NumberField;
+    let connect: () => Promise<void>;
+    let disconnect: () => Promise<void>;
+
+    beforeEach(async () => {
+        ({ element, connect, disconnect } = await setup());
+        await connect();
+    });
+
+    afterEach(async () => {
+        await disconnect();
+    });
+
     it('can construct an element instance', () => {
         expect(document.createElement(numberFieldTag)).toBeInstanceOf(
             NumberField
@@ -26,8 +45,7 @@ describe('NumberField', () => {
 
     it('prevents inc/dec buttons from being focusable', () => {
         const buttons = Array.from(
-            document
-                .createElement(numberFieldTag)
+            element
                 .shadowRoot!.querySelectorAll('.step-up-down-button')
         );
         expect(
@@ -37,13 +55,24 @@ describe('NumberField', () => {
 
     it('hides inc/dec buttons from a11y tree', () => {
         const buttons = Array.from(
-            document
-                .createElement(numberFieldTag)
+            element
                 .shadowRoot!.querySelectorAll('.step-up-down-button')
         );
         expect(
             buttons.every(x => (x as HTMLElement).ariaHidden === 'true')
         ).toBeTrue();
+    });
+
+    it('should set "aria-required" to true when "required-visible" is true', () => {
+        element.requiredVisible = true;
+        processUpdates();
+        expect(element.control.getAttribute('aria-required')).toBe('true');
+    });
+
+    it('should set "aria-required" to false when "required-visible" is false', () => {
+        element.requiredVisible = false;
+        processUpdates();
+        expect(element.control.getAttribute('aria-required')).toBe('false');
     });
 });
 

--- a/packages/nimble-components/src/text-field/index.ts
+++ b/packages/nimble-components/src/text-field/index.ts
@@ -10,6 +10,7 @@ import { errorTextTemplate } from '../patterns/error/template';
 import { mixinErrorPattern } from '../patterns/error/types';
 import { iconExclamationMarkTag } from '../icons/exclamation-mark';
 import { template } from './template';
+import { mixinRequiredVisiblePattern } from '../patterns/required-visible/types';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -20,7 +21,9 @@ declare global {
 /**
  * A nimble-styed HTML text input
  */
-export class TextField extends mixinErrorPattern(FoundationTextField) {
+export class TextField extends mixinErrorPattern(
+    mixinRequiredVisiblePattern(FoundationTextField)
+) {
     /**
      * The appearance the text field should have.
      *

--- a/packages/nimble-components/src/text-field/styles.ts
+++ b/packages/nimble-components/src/text-field/styles.ts
@@ -21,11 +21,13 @@ import { TextFieldAppearance } from './types';
 import { Theme } from '../theme-provider/types';
 import { themeBehavior } from '../utilities/style/theme';
 import { styles as errorStyles } from '../patterns/error/styles';
+import { styles as requiredVisibleStyles } from '../patterns/required-visible/styles';
 import { userSelectNone } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('inline-block')}
     ${errorStyles}
+    ${requiredVisibleStyles}
 
     :host {
         font: ${bodyFont};

--- a/packages/nimble-components/src/text-field/template.ts
+++ b/packages/nimble-components/src/text-field/template.ts
@@ -14,9 +14,7 @@ const labelTemplate = createRequiredVisibleLabelTemplate(
     html<TextField>`<label
         part="label"
         for="control"
-        class="${x => (x.defaultSlottedNodes?.length
-        ? 'label'
-        : 'label label__hidden')}"
+        class="${x => (x.defaultSlottedNodes?.length ? 'label' : 'label label__hidden')}"
     >
         <slot
             ${slotted({

--- a/packages/nimble-components/src/text-field/template.ts
+++ b/packages/nimble-components/src/text-field/template.ts
@@ -8,6 +8,24 @@ import {
     endSlotTemplate
 } from '@microsoft/fast-foundation';
 import type { TextField } from '.';
+import { createRequiredVisibleLabelTemplate } from '../patterns/required-visible/template';
+
+const labelTemplate = createRequiredVisibleLabelTemplate(
+    html<TextField>`<label
+    part="label"
+    for="control"
+    class="${x => (x.defaultSlottedNodes?.length
+        ? 'label'
+        : 'label label__hidden')}"
+>
+    <slot
+        ${slotted({
+        property: 'defaultSlottedNodes',
+        filter: whitespaceFilter
+    })}
+    ></slot>
+</label>`
+);
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(TextField:class)} component.
@@ -22,20 +40,7 @@ TextFieldOptions
             ${x => (x.readOnly ? 'readonly' : '')}
         "
     >
-        <label
-            part="label"
-            for="control"
-            class="${x => (x.defaultSlottedNodes?.length
-        ? 'label'
-        : 'label label__hidden')}"
-        >
-            <slot
-                ${slotted({
-        property: 'defaultSlottedNodes',
-        filter: whitespaceFilter
-    })}
-            ></slot>
-        </label>
+        ${labelTemplate}
         <div class="root" part="root">
             ${startSlotTemplate(context, definition)}
             <input
@@ -76,6 +81,7 @@ TextFieldOptions
                 aria-owns="${x => x.ariaOwns}"
                 aria-relevant="${x => x.ariaRelevant}"
                 aria-roledescription="${x => x.ariaRoledescription}"
+                aria-required="${x => x.requiredVisible}"
                 ${ref('control')}
             />
             ${endSlotTemplate(context, definition)}

--- a/packages/nimble-components/src/text-field/template.ts
+++ b/packages/nimble-components/src/text-field/template.ts
@@ -12,19 +12,19 @@ import { createRequiredVisibleLabelTemplate } from '../patterns/required-visible
 
 const labelTemplate = createRequiredVisibleLabelTemplate(
     html<TextField>`<label
-    part="label"
-    for="control"
-    class="${x => (x.defaultSlottedNodes?.length
+        part="label"
+        for="control"
+        class="${x => (x.defaultSlottedNodes?.length
         ? 'label'
         : 'label label__hidden')}"
->
-    <slot
-        ${slotted({
+    >
+        <slot
+            ${slotted({
         property: 'defaultSlottedNodes',
         filter: whitespaceFilter
     })}
-    ></slot>
-</label>`
+        ></slot>
+    </label>`
 );
 
 /**

--- a/packages/nimble-components/src/text-field/tests/text-field.spec.ts
+++ b/packages/nimble-components/src/text-field/tests/text-field.spec.ts
@@ -1,7 +1,41 @@
+import { html } from '@microsoft/fast-element';
 import { TextField, textFieldTag } from '..';
+import { fixture, Fixture } from '../../utilities/tests/fixture';
+import { processUpdates } from '../../testing/async-helpers';
+
+async function setup(): Promise<Fixture<TextField>> {
+    return await fixture<TextField>(
+        html`<${textFieldTag}></${textFieldTag}>`
+    );
+}
 
 describe('TextField', () => {
+    let element: TextField;
+    let connect: () => Promise<void>;
+    let disconnect: () => Promise<void>;
+
+    beforeEach(async () => {
+        ({ element, connect, disconnect } = await setup());
+        await connect();
+    });
+
+    afterEach(async () => {
+        await disconnect();
+    });
+
     it('can construct an element instance', () => {
         expect(document.createElement(textFieldTag)).toBeInstanceOf(TextField);
+    });
+
+    it('should set "aria-required" to true when "required-visible" is true', () => {
+        element.requiredVisible = true;
+        processUpdates();
+        expect(element.control.getAttribute('aria-required')).toBe('true');
+    });
+
+    it('should set "aria-required" to false when "required-visible" is false', () => {
+        element.requiredVisible = false;
+        processUpdates();
+        expect(element.control.getAttribute('aria-required')).toBe('false');
     });
 });

--- a/packages/nimble-components/src/text-field/tests/text-field.spec.ts
+++ b/packages/nimble-components/src/text-field/tests/text-field.spec.ts
@@ -4,9 +4,7 @@ import { fixture, Fixture } from '../../utilities/tests/fixture';
 import { processUpdates } from '../../testing/async-helpers';
 
 async function setup(): Promise<Fixture<TextField>> {
-    return await fixture<TextField>(
-        html`<${textFieldTag}></${textFieldTag}>`
-    );
+    return await fixture<TextField>(html`<${textFieldTag}></${textFieldTag}>`);
 }
 
 describe('TextField', () => {

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -19,7 +19,9 @@ import {
     errorStatesNoError,
     errorStatesErrorWithMessage,
     ReadOnlyState,
-    readOnlyStates
+    readOnlyStates,
+    RequiredVisibleState,
+    requiredVisibleStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -55,6 +57,7 @@ const metadata: Meta = {
 export default metadata;
 
 const component = (
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [readOnlyName, readonly]: ReadOnlyState,
     [disabledName, disabled]: DisabledState,
     [hideStepName, hideStep]: HideStepState,
@@ -72,14 +75,17 @@ const component = (
         ?disabled="${() => disabled}"
         error-text="${() => errorText}"
         ?error-visible="${() => errorVisible}"
+        ?required-visible="${() => requiredVisible}"
     >
         ${() => errorName} ${() => appearanceName} ${() => valueName}
         ${() => hideStepName} ${() => disabledName} ${() => readOnlyName}
+        ${() => requiredVisibleName}
     </${numberFieldTag}>
 `;
 
 export const numberFieldThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         readOnlyStates,
         disabledStates,
         hideStepStates,
@@ -89,7 +95,10 @@ export const numberFieldThemeMatrix: StoryFn = createMatrixThemeStory(
     ])
 );
 
+const notRequiredState = requiredVisibleStates[0];
+
 const interactionStatesHover = cartesianProduct([
+    [notRequiredState],
     readOnlyStates,
     disabledStates,
     [hideStepStateStepVisible],
@@ -99,6 +108,7 @@ const interactionStatesHover = cartesianProduct([
 ] as const);
 
 const interactionStates = cartesianProduct([
+    [notRequiredState],
     readOnlyStates,
     [disabledStateIsEnabled],
     [hideStepStateStepVisible],

--- a/packages/storybook/src/nimble/number-field/number-field.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field.stories.ts
@@ -20,7 +20,8 @@ import {
     readonlyDescription,
     errorTextDescription,
     errorVisibleDescription,
-    slottedLabelDescription
+    slottedLabelDescription,
+    requiredVisibleDescription
 } from '../../utilities/storybook';
 
 interface NumberFieldArgs extends LabelUserArgs {
@@ -37,6 +38,7 @@ interface NumberFieldArgs extends LabelUserArgs {
     errorText: string;
     change: undefined;
     input: undefined;
+    requiredVisible: boolean;
 }
 
 const metadata: Meta<NumberFieldArgs> = {
@@ -60,6 +62,7 @@ const metadata: Meta<NumberFieldArgs> = {
             ?disabled="${x => x.disabled}"
             ?error-visible="${x => x.errorVisible}"
             error-text="${x => x.errorText}"
+            ?required-visible="${x => x.requiredVisible}"
         >
             ${x => x.label}
         </${numberFieldTag}>
@@ -120,6 +123,11 @@ const metadata: Meta<NumberFieldArgs> = {
             description: errorTextDescription,
             table: { category: apiCategory.attributes }
         },
+        requiredVisible: {
+            name: 'required-visible',
+            description: requiredVisibleDescription,
+            table: { category: apiCategory.attributes }
+        },
         change: {
             description:
                 'Event emitted when the user commits a new value to the number field.',
@@ -144,7 +152,8 @@ const metadata: Meta<NumberFieldArgs> = {
         readonly: false,
         disabled: false,
         errorVisible: false,
-        errorText: 'Value is invalid'
+        errorText: 'Value is invalid',
+        requiredVisible: false
     }
 };
 addLabelUseMetadata(

--- a/packages/storybook/src/nimble/patterns/required-visible/required-visible.stories.ts
+++ b/packages/storybook/src/nimble/patterns/required-visible/required-visible.stories.ts
@@ -15,6 +15,8 @@ import {
     radioGroupTag
 } from '../../../../../nimble-components/src/radio-group';
 import { radioTag } from '../../../../../nimble-components/src/radio';
+import { textFieldTag } from '../../../../../nimble-components/src/text-field';
+import { numberFieldTag } from '../../../../../nimble-components/src/number-field';
 
 interface RequiredVisiblePatternArgs {
     shortLabel: string;
@@ -51,6 +53,11 @@ const metadata: Meta<RequiredVisiblePatternArgs> = {
             <${comboboxTag} class="fixed-width" required-visible>${x => x.longLabel}</${comboboxTag}>
         </div>
         <div class="control-container">
+            <div class="label">Number field</div>
+            <${numberFieldTag} class="fixed-width" required-visible>${x => x.shortLabel}</${numberFieldTag}>
+            <${numberFieldTag} class="fixed-width" required-visible>${x => x.longLabel}</${numberFieldTag}>
+        </div>
+        <div class="control-container">
             <div class="label">Radio group</div>
             <${radioGroupTag} class="fixed-width" orientation=${Orientation.horizontal} required-visible>
                 <span slot="label">${x => x.shortLabel}</span>
@@ -82,6 +89,11 @@ const metadata: Meta<RequiredVisiblePatternArgs> = {
             <div class="label">Text area</div>
             <${textAreaTag} class="fixed-width" required-visible>${x => x.shortLabel}</${textAreaTag}>
             <${textAreaTag} class="fixed-width" required-visible>${x => x.longLabel}</${textAreaTag}>
+        </div>
+        <div class="control-container">
+            <div class="label">Text field</div>
+            <${textFieldTag} class="fixed-width" required-visible>${x => x.shortLabel}</${textFieldTag}>
+            <${textFieldTag} class="fixed-width" required-visible>${x => x.longLabel}</${textFieldTag}>
         </div>
     `),
     args: {

--- a/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
@@ -137,9 +137,9 @@ const component = (
     </${textFieldTag}>
 `;
 
-export const lightThemeEditableEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const lightThemeNotRequiredEditableEnabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[0]],
         [disabledStates[0]],
         [actionButtonStates[0]],
@@ -153,9 +153,9 @@ export const lightThemeEditableEnabledWithoutButtons: StoryFn = createFixedTheme
     lightThemeWhiteBackground
 );
 
-export const lightThemeEditableEnabledWithButtons: StoryFn = createFixedThemeStory(
+export const lightThemeNotRequiredEditableEnabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[0]],
         [disabledStates[0]],
         [actionButtonStates[1]],
@@ -169,9 +169,9 @@ export const lightThemeEditableEnabledWithButtons: StoryFn = createFixedThemeSto
     lightThemeWhiteBackground
 );
 
-export const lightThemeEditableDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const lightThemeNotRequiredEditableDisabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[0]],
         [disabledStates[1]],
         [actionButtonStates[0]],
@@ -185,9 +185,9 @@ export const lightThemeEditableDisabledWithoutButtons: StoryFn = createFixedThem
     lightThemeWhiteBackground
 );
 
-export const lightThemeEditableDisabledWithButtons: StoryFn = createFixedThemeStory(
+export const lightThemeNotRequiredEditableDisabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[0]],
         [disabledStates[1]],
         [actionButtonStates[1]],
@@ -201,9 +201,9 @@ export const lightThemeEditableDisabledWithButtons: StoryFn = createFixedThemeSt
     lightThemeWhiteBackground
 );
 
-export const lightThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const lightThemeNotRequiredReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[1]],
         [disabledStates[0]],
         [actionButtonStates[0]],
@@ -217,9 +217,9 @@ export const lightThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedTheme
     lightThemeWhiteBackground
 );
 
-export const lightThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStory(
+export const lightThemeNotRequiredReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[1]],
         [disabledStates[0]],
         [actionButtonStates[1]],
@@ -233,9 +233,9 @@ export const lightThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeSto
     lightThemeWhiteBackground
 );
 
-export const lightThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const lightThemeNotRequiredReadOnlyDisabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[1]],
         [disabledStates[1]],
         [actionButtonStates[0]],
@@ -249,9 +249,9 @@ export const lightThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedThem
     lightThemeWhiteBackground
 );
 
-export const lightThemeReadOnlyDisabledWithButtons: StoryFn = createFixedThemeStory(
+export const lightThemeNotRequiredReadOnlyDisabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[1]],
         [disabledStates[1]],
         [actionButtonStates[1]],
@@ -265,9 +265,9 @@ export const lightThemeReadOnlyDisabledWithButtons: StoryFn = createFixedThemeSt
     lightThemeWhiteBackground
 );
 
-export const darkThemeEditableEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const darkThemeNotRequiredEditableEnabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[0]],
         [disabledStates[0]],
         [actionButtonStates[0]],
@@ -281,9 +281,9 @@ export const darkThemeEditableEnabledWithoutButtons: StoryFn = createFixedThemeS
     darkThemeBlackBackground
 );
 
-export const darkThemeEditableEnabledWithButtons: StoryFn = createFixedThemeStory(
+export const darkThemeNotRequiredEditableEnabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[0]],
         [disabledStates[0]],
         [actionButtonStates[1]],
@@ -297,9 +297,9 @@ export const darkThemeEditableEnabledWithButtons: StoryFn = createFixedThemeStor
     darkThemeBlackBackground
 );
 
-export const darkThemeEditableDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const darkThemeNotRequiredEditableDisabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[0]],
         [disabledStates[1]],
         [actionButtonStates[0]],
@@ -313,9 +313,9 @@ export const darkThemeEditableDisabledWithoutButtons: StoryFn = createFixedTheme
     darkThemeBlackBackground
 );
 
-export const darkThemeEditableDisabledWithButtons: StoryFn = createFixedThemeStory(
+export const darkThemeNotRequiredEditableDisabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[0]],
         [disabledStates[1]],
         [actionButtonStates[1]],
@@ -329,9 +329,9 @@ export const darkThemeEditableDisabledWithButtons: StoryFn = createFixedThemeSto
     darkThemeBlackBackground
 );
 
-export const darkThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const darkThemeNotRequiredReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[1]],
         [disabledStates[0]],
         [actionButtonStates[0]],
@@ -345,9 +345,9 @@ export const darkThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeS
     darkThemeBlackBackground
 );
 
-export const darkThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStory(
+export const darkThemeNotRequiredReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[1]],
         [disabledStates[0]],
         [actionButtonStates[1]],
@@ -361,9 +361,9 @@ export const darkThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStor
     darkThemeBlackBackground
 );
 
-export const darkThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const darkThemeNotRequiredReadOnlyDisabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[1]],
         [disabledStates[1]],
         [actionButtonStates[0]],
@@ -377,9 +377,9 @@ export const darkThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedTheme
     darkThemeBlackBackground
 );
 
-export const darkThemeReadOnlyDisabledWithButtons: StoryFn = createFixedThemeStory(
+export const darkThemeNotRequiredReadOnlyDisabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[1]],
         [disabledStates[1]],
         [actionButtonStates[1]],
@@ -393,9 +393,9 @@ export const darkThemeReadOnlyDisabledWithButtons: StoryFn = createFixedThemeSto
     darkThemeBlackBackground
 );
 
-export const colorThemeEditableEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const colorThemeNotRequiredEditableEnabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[0]],
         [disabledStates[0]],
         [actionButtonStates[0]],
@@ -409,9 +409,9 @@ export const colorThemeEditableEnabledWithoutButtons: StoryFn = createFixedTheme
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeEditableEnabledWithButtons: StoryFn = createFixedThemeStory(
+export const colorThemeNotRequiredEditableEnabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[0]],
         [disabledStates[0]],
         [actionButtonStates[1]],
@@ -425,9 +425,9 @@ export const colorThemeEditableEnabledWithButtons: StoryFn = createFixedThemeSto
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeEditableDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const colorThemeNotRequiredEditableDisabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[0]],
         [disabledStates[1]],
         [actionButtonStates[0]],
@@ -441,9 +441,9 @@ export const colorThemeEditableDisabledWithoutButtons: StoryFn = createFixedThem
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeEditableDisabledWithButtons: StoryFn = createFixedThemeStory(
+export const colorThemeNotRequiredEditableDisabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[0]],
         [disabledStates[1]],
         [actionButtonStates[1]],
@@ -457,9 +457,9 @@ export const colorThemeEditableDisabledWithButtons: StoryFn = createFixedThemeSt
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const colorThemeNotRequiredReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[1]],
         [disabledStates[0]],
         [actionButtonStates[0]],
@@ -473,9 +473,9 @@ export const colorThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedTheme
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStory(
+export const colorThemeNotRequiredReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[1]],
         [disabledStates[0]],
         [actionButtonStates[1]],
@@ -489,9 +489,9 @@ export const colorThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeSto
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const colorThemeNotRequiredReadOnlyDisabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
         [readOnlyStates[1]],
         [disabledStates[1]],
         [actionButtonStates[0]],
@@ -505,9 +505,393 @@ export const colorThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedThem
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeReadOnlyDisabledWithButtons: StoryFn = createFixedThemeStory(
+export const colorThemeNotRequiredReadOnlyDisabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        [requiredVisibleStates[0]],
+        [readOnlyStates[1]],
+        [disabledStates[1]],
+        [actionButtonStates[1]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    colorThemeDarkGreenBackground
+);
+
+export const lightThemeRequiredEditableEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[0]],
+        [disabledStates[0]],
+        [actionButtonStates[0]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    lightThemeWhiteBackground
+);
+
+export const lightThemeRequiredEditableEnabledWithButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[0]],
+        [disabledStates[0]],
+        [actionButtonStates[1]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    lightThemeWhiteBackground
+);
+
+export const lightThemeRequiredEditableDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[0]],
+        [disabledStates[1]],
+        [actionButtonStates[0]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    lightThemeWhiteBackground
+);
+
+export const lightThemeRequiredEditableDisabledWithButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[0]],
+        [disabledStates[1]],
+        [actionButtonStates[1]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    lightThemeWhiteBackground
+);
+
+export const lightThemeRequiredReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[1]],
+        [disabledStates[0]],
+        [actionButtonStates[0]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    lightThemeWhiteBackground
+);
+
+export const lightThemeRequiredReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[1]],
+        [disabledStates[0]],
+        [actionButtonStates[1]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    lightThemeWhiteBackground
+);
+
+export const lightThemeRequiredReadOnlyDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[1]],
+        [disabledStates[1]],
+        [actionButtonStates[0]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    lightThemeWhiteBackground
+);
+
+export const lightThemeRequiredReadOnlyDisabledWithButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[1]],
+        [disabledStates[1]],
+        [actionButtonStates[1]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    lightThemeWhiteBackground
+);
+
+export const darkThemeRequiredEditableEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[0]],
+        [disabledStates[0]],
+        [actionButtonStates[0]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    darkThemeBlackBackground
+);
+
+export const darkThemeRequiredEditableEnabledWithButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[0]],
+        [disabledStates[0]],
+        [actionButtonStates[1]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    darkThemeBlackBackground
+);
+
+export const darkThemeRequiredEditableDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[0]],
+        [disabledStates[1]],
+        [actionButtonStates[0]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    darkThemeBlackBackground
+);
+
+export const darkThemeRequiredEditableDisabledWithButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[0]],
+        [disabledStates[1]],
+        [actionButtonStates[1]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    darkThemeBlackBackground
+);
+
+export const darkThemeRequiredReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[1]],
+        [disabledStates[0]],
+        [actionButtonStates[0]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    darkThemeBlackBackground
+);
+
+export const darkThemeRequiredReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[1]],
+        [disabledStates[0]],
+        [actionButtonStates[1]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    darkThemeBlackBackground
+);
+
+export const darkThemeRequiredReadOnlyDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[1]],
+        [disabledStates[1]],
+        [actionButtonStates[0]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    darkThemeBlackBackground
+);
+
+export const darkThemeRequiredReadOnlyDisabledWithButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[1]],
+        [disabledStates[1]],
+        [actionButtonStates[1]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    darkThemeBlackBackground
+);
+
+export const colorThemeRequiredEditableEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[0]],
+        [disabledStates[0]],
+        [actionButtonStates[0]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    colorThemeDarkGreenBackground
+);
+
+export const colorThemeRequiredEditableEnabledWithButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[0]],
+        [disabledStates[0]],
+        [actionButtonStates[1]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    colorThemeDarkGreenBackground
+);
+
+export const colorThemeRequiredEditableDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[0]],
+        [disabledStates[1]],
+        [actionButtonStates[0]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    colorThemeDarkGreenBackground
+);
+
+export const colorThemeRequiredEditableDisabledWithButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[0]],
+        [disabledStates[1]],
+        [actionButtonStates[1]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    colorThemeDarkGreenBackground
+);
+
+export const colorThemeRequiredReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[1]],
+        [disabledStates[0]],
+        [actionButtonStates[0]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    colorThemeDarkGreenBackground
+);
+
+export const colorThemeRequiredReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[1]],
+        [disabledStates[0]],
+        [actionButtonStates[1]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    colorThemeDarkGreenBackground
+);
+
+export const colorThemeRequiredReadOnlyDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
+        [readOnlyStates[1]],
+        [disabledStates[1]],
+        [actionButtonStates[0]],
+        leftIconStates,
+        errorStates,
+        typeStates,
+        appearanceStates,
+        fullBleedStates,
+        valueStates
+    ]),
+    colorThemeDarkGreenBackground
+);
+
+export const colorThemeRequiredReadOnlyDisabledWithButtons: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        [requiredVisibleStates[1]],
         [readOnlyStates[1]],
         [disabledStates[1]],
         [actionButtonStates[1]],

--- a/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
@@ -22,7 +22,9 @@ import {
     readOnlyStates,
     backgroundStates,
     errorStates,
-    ErrorState
+    ErrorState,
+    RequiredVisibleState,
+    requiredVisibleStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -88,6 +90,7 @@ export default metadata;
 
 // prettier-ignore
 const component = (
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [_readOnlyName, readonly]: ReadOnlyState,
     [_disabledName, disabled]: DisabledState,
     [_showActionButtonsName, showActionButtons]: ActionButtonState,
@@ -109,6 +112,7 @@ const component = (
         ?readonly="${() => readonly}"
         ?error-visible="${() => errorVisible}"
         error-text="${() => errorText}"
+        ?required-visible="${() => requiredVisible}"
     >
         ${when(() => showLeftIcon, html`<${iconTagTag} slot="start"></${iconTagTag}>`)}
 
@@ -119,6 +123,7 @@ const component = (
         ${() => appearanceName}
         ${() => fullBleedName}
         ${() => valueName}
+        ${() => requiredVisibleName}
 
         ${when(() => showActionButtons, html`
             <${buttonTag} slot="actions" appearance="outline" content-hidden>
@@ -134,6 +139,7 @@ const component = (
 
 export const lightThemeEditableEnabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[0]],
         [disabledStates[0]],
         [actionButtonStates[0]],
@@ -149,6 +155,7 @@ export const lightThemeEditableEnabledWithoutButtons: StoryFn = createFixedTheme
 
 export const lightThemeEditableEnabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[0]],
         [disabledStates[0]],
         [actionButtonStates[1]],
@@ -164,6 +171,7 @@ export const lightThemeEditableEnabledWithButtons: StoryFn = createFixedThemeSto
 
 export const lightThemeEditableDisabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[0]],
         [disabledStates[1]],
         [actionButtonStates[0]],
@@ -179,6 +187,7 @@ export const lightThemeEditableDisabledWithoutButtons: StoryFn = createFixedThem
 
 export const lightThemeEditableDisabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[0]],
         [disabledStates[1]],
         [actionButtonStates[1]],
@@ -194,6 +203,7 @@ export const lightThemeEditableDisabledWithButtons: StoryFn = createFixedThemeSt
 
 export const lightThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[1]],
         [disabledStates[0]],
         [actionButtonStates[0]],
@@ -209,6 +219,7 @@ export const lightThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedTheme
 
 export const lightThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[1]],
         [disabledStates[0]],
         [actionButtonStates[1]],
@@ -224,6 +235,7 @@ export const lightThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeSto
 
 export const lightThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[1]],
         [disabledStates[1]],
         [actionButtonStates[0]],
@@ -239,6 +251,7 @@ export const lightThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedThem
 
 export const lightThemeReadOnlyDisabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[1]],
         [disabledStates[1]],
         [actionButtonStates[1]],
@@ -254,6 +267,7 @@ export const lightThemeReadOnlyDisabledWithButtons: StoryFn = createFixedThemeSt
 
 export const darkThemeEditableEnabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[0]],
         [disabledStates[0]],
         [actionButtonStates[0]],
@@ -269,6 +283,7 @@ export const darkThemeEditableEnabledWithoutButtons: StoryFn = createFixedThemeS
 
 export const darkThemeEditableEnabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[0]],
         [disabledStates[0]],
         [actionButtonStates[1]],
@@ -284,6 +299,7 @@ export const darkThemeEditableEnabledWithButtons: StoryFn = createFixedThemeStor
 
 export const darkThemeEditableDisabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[0]],
         [disabledStates[1]],
         [actionButtonStates[0]],
@@ -299,6 +315,7 @@ export const darkThemeEditableDisabledWithoutButtons: StoryFn = createFixedTheme
 
 export const darkThemeEditableDisabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[0]],
         [disabledStates[1]],
         [actionButtonStates[1]],
@@ -314,6 +331,7 @@ export const darkThemeEditableDisabledWithButtons: StoryFn = createFixedThemeSto
 
 export const darkThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[1]],
         [disabledStates[0]],
         [actionButtonStates[0]],
@@ -329,6 +347,7 @@ export const darkThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeS
 
 export const darkThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[1]],
         [disabledStates[0]],
         [actionButtonStates[1]],
@@ -344,6 +363,7 @@ export const darkThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStor
 
 export const darkThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[1]],
         [disabledStates[1]],
         [actionButtonStates[0]],
@@ -359,6 +379,7 @@ export const darkThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedTheme
 
 export const darkThemeReadOnlyDisabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[1]],
         [disabledStates[1]],
         [actionButtonStates[1]],
@@ -374,6 +395,7 @@ export const darkThemeReadOnlyDisabledWithButtons: StoryFn = createFixedThemeSto
 
 export const colorThemeEditableEnabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[0]],
         [disabledStates[0]],
         [actionButtonStates[0]],
@@ -389,6 +411,7 @@ export const colorThemeEditableEnabledWithoutButtons: StoryFn = createFixedTheme
 
 export const colorThemeEditableEnabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[0]],
         [disabledStates[0]],
         [actionButtonStates[1]],
@@ -404,6 +427,7 @@ export const colorThemeEditableEnabledWithButtons: StoryFn = createFixedThemeSto
 
 export const colorThemeEditableDisabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[0]],
         [disabledStates[1]],
         [actionButtonStates[0]],
@@ -419,6 +443,7 @@ export const colorThemeEditableDisabledWithoutButtons: StoryFn = createFixedThem
 
 export const colorThemeEditableDisabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[0]],
         [disabledStates[1]],
         [actionButtonStates[1]],
@@ -434,6 +459,7 @@ export const colorThemeEditableDisabledWithButtons: StoryFn = createFixedThemeSt
 
 export const colorThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[1]],
         [disabledStates[0]],
         [actionButtonStates[0]],
@@ -449,6 +475,7 @@ export const colorThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedTheme
 
 export const colorThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[1]],
         [disabledStates[0]],
         [actionButtonStates[1]],
@@ -464,6 +491,7 @@ export const colorThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeSto
 
 export const colorThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[1]],
         [disabledStates[1]],
         [actionButtonStates[0]],
@@ -479,6 +507,7 @@ export const colorThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedThem
 
 export const colorThemeReadOnlyDisabledWithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         [readOnlyStates[1]],
         [disabledStates[1]],
         [actionButtonStates[1]],

--- a/packages/storybook/src/nimble/text-field/text-field.stories.ts
+++ b/packages/storybook/src/nimble/text-field/text-field.stories.ts
@@ -18,7 +18,8 @@ import {
     errorTextDescription,
     errorVisibleDescription,
     placeholderDescription,
-    slottedLabelDescription
+    slottedLabelDescription,
+    requiredVisibleDescription
 } from '../../utilities/storybook';
 
 interface TextFieldArgs {
@@ -37,6 +38,7 @@ interface TextFieldArgs {
     leftIcon: boolean;
     change: undefined;
     input: undefined;
+    requiredVisible: boolean;
 }
 
 const leftIconDescription = 'An icon to display at the start of the text field.';
@@ -68,6 +70,7 @@ const metadata: Meta<TextFieldArgs> = {
             error-text="${x => x.errorText}"
             ?error-visible="${x => x.errorVisible}"
             ?full-bleed="${x => x.fullBleed}"
+            ?required-visible="${x => x.requiredVisible}"
         >
             ${when(x => x.leftIcon, html`
                 <${iconTagTag} slot="start"></${iconTagTag}>`)}
@@ -141,6 +144,11 @@ const metadata: Meta<TextFieldArgs> = {
             description: errorTextDescription,
             table: { category: apiCategory.attributes }
         },
+        requiredVisible: {
+            name: 'required-visible',
+            description: requiredVisibleDescription,
+            table: { category: apiCategory.attributes }
+        },
         actionButton: {
             name: 'actions',
             description: actionButtonDescription,
@@ -176,7 +184,8 @@ const metadata: Meta<TextFieldArgs> = {
         errorVisible: false,
         errorText: 'Value is invalid',
         actionButton: false,
-        leftIcon: false
+        leftIcon: false,
+        requiredVisible: false
     }
 };
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Add required-visible attributes to the text-field and number-field as part of https://github.com/ni/nimble/issues/2100.

## 👩‍💻 Implementation

Used the newly established pattern for required-visible to add `required-visible` to the text-field and number-field.

## 🧪 Testing

- New unit tests for `aria-required` on both components
- Manually tested both components in storybook
- Storybook updates
- Matrix test updates
- Updated required-visible story

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
