### PR TITLE
Required indicator on text-field and number-field

### DIFF
--- a/change/@ni-nimble-components-ffa804bd-55ba-4a11-9bc0-7cc6f4b48236.json
+++ b/change/@ni-nimble-components-ffa804bd-55ba-4a11-9bc0-7cc6f4b48236.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add `required-visible` attribute to number-field and text-field",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/number-field/index.ts
+++ b/packages/nimble-components/src/number-field/index.ts
@@ -17,6 +17,7 @@ import {
     numericIncrementLabel
 } from '../label-provider/core/label-tokens';
 import { template } from './template';
+import { mixinRequiredVisiblePattern } from '../patterns/required-visible/types';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -27,7 +28,9 @@ declare global {
 /**
  * A nimble-styled HTML number input
  */
-export class NumberField extends mixinErrorPattern(FoundationNumberField) {
+export class NumberField extends mixinErrorPattern(
+    mixinRequiredVisiblePattern(FoundationNumberField)
+) {
     @attr
     public appearance: NumberFieldAppearance = NumberFieldAppearance.underline;
 

--- a/packages/nimble-components/src/number-field/styles.ts
+++ b/packages/nimble-components/src/number-field/styles.ts
@@ -19,11 +19,13 @@ import {
 import { appearanceBehavior } from '../utilities/style/appearance';
 import { NumberFieldAppearance } from './types';
 import { styles as errorStyles } from '../patterns/error/styles';
+import { styles as requiredVisibleStyles } from '../patterns/required-visible/styles';
 import { userSelectNone } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('inline-block')}
     ${errorStyles}
+    ${requiredVisibleStyles}
 
     :host {
         font: ${bodyFont};

--- a/packages/nimble-components/src/number-field/template.ts
+++ b/packages/nimble-components/src/number-field/template.ts
@@ -7,6 +7,17 @@ import {
     startSlotTemplate
 } from '@microsoft/fast-foundation';
 import type { NumberField } from '.';
+import { createRequiredVisibleLabelTemplate } from '../patterns/required-visible/template';
+
+const labelTemplate = createRequiredVisibleLabelTemplate(
+    html<NumberField>`<label
+        part="label"
+        for="control"
+        class="${x => (x.defaultSlottedNodes?.length ? 'label' : 'label label__hidden')}"
+    >
+        <slot ${slotted('defaultSlottedNodes')}></slot>
+    </label>`
+);
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(NumberField:class)} component.
@@ -17,15 +28,7 @@ ViewTemplate<NumberField>,
 NumberFieldOptions
 > = (context, definition) => html`
     <template class="${x => (x.readOnly ? 'readonly' : '')}">
-        <label
-            part="label"
-            for="control"
-            class="${x => (x.defaultSlottedNodes?.length
-        ? 'label'
-        : 'label label__hidden')}"
-        >
-            <slot ${slotted('defaultSlottedNodes')}></slot>
-        </label>
+        ${labelTemplate}
         <div class="root" part="root">
             ${startSlotTemplate(context, definition)}
             <input
@@ -69,6 +72,7 @@ NumberFieldOptions
                 aria-owns="${x => x.ariaOwns}"
                 aria-relevant="${x => x.ariaRelevant}"
                 aria-roledescription="${x => x.ariaRoledescription}"
+                aria-required="${x => x.requiredVisible}"
                 ${ref('control')}
             />
             ${when(

--- a/packages/nimble-components/src/number-field/tests/number-field.spec.ts
+++ b/packages/nimble-components/src/number-field/tests/number-field.spec.ts
@@ -4,9 +4,18 @@ import {
     LabelProviderCore,
     labelProviderCoreTag
 } from '../../label-provider/core';
-import { waitForUpdatesAsync } from '../../testing/async-helpers';
+import {
+    processUpdates,
+    waitForUpdatesAsync
+} from '../../testing/async-helpers';
 import { ThemeProvider, themeProviderTag } from '../../theme-provider';
 import { fixture, type Fixture } from '../../utilities/tests/fixture';
+
+async function setup(): Promise<Fixture<NumberField>> {
+    return await fixture<NumberField>(
+        html`<${numberFieldTag}></${numberFieldTag}>`
+    );
+}
 
 async function setupWithLabelProvider(): Promise<Fixture<ThemeProvider>> {
     return await fixture<ThemeProvider>(html`
@@ -18,6 +27,19 @@ async function setupWithLabelProvider(): Promise<Fixture<ThemeProvider>> {
 }
 
 describe('NumberField', () => {
+    let element: NumberField;
+    let connect: () => Promise<void>;
+    let disconnect: () => Promise<void>;
+
+    beforeEach(async () => {
+        ({ element, connect, disconnect } = await setup());
+        await connect();
+    });
+
+    afterEach(async () => {
+        await disconnect();
+    });
+
     it('can construct an element instance', () => {
         expect(document.createElement(numberFieldTag)).toBeInstanceOf(
             NumberField
@@ -26,9 +48,7 @@ describe('NumberField', () => {
 
     it('prevents inc/dec buttons from being focusable', () => {
         const buttons = Array.from(
-            document
-                .createElement(numberFieldTag)
-                .shadowRoot!.querySelectorAll('.step-up-down-button')
+            element.shadowRoot!.querySelectorAll('.step-up-down-button')
         );
         expect(
             buttons.every(x => (x as HTMLElement).tabIndex === -1)
@@ -37,13 +57,23 @@ describe('NumberField', () => {
 
     it('hides inc/dec buttons from a11y tree', () => {
         const buttons = Array.from(
-            document
-                .createElement(numberFieldTag)
-                .shadowRoot!.querySelectorAll('.step-up-down-button')
+            element.shadowRoot!.querySelectorAll('.step-up-down-button')
         );
         expect(
             buttons.every(x => (x as HTMLElement).ariaHidden === 'true')
         ).toBeTrue();
+    });
+
+    it('should set "aria-required" to true when "required-visible" is true', () => {
+        element.requiredVisible = true;
+        processUpdates();
+        expect(element.control.getAttribute('aria-required')).toBe('true');
+    });
+
+    it('should set "aria-required" to false when "required-visible" is false', () => {
+        element.requiredVisible = false;
+        processUpdates();
+        expect(element.control.getAttribute('aria-required')).toBe('false');
     });
 });
 

--- a/packages/nimble-components/src/text-field/index.ts
+++ b/packages/nimble-components/src/text-field/index.ts
@@ -10,6 +10,7 @@ import { errorTextTemplate } from '../patterns/error/template';
 import { mixinErrorPattern } from '../patterns/error/types';
 import { iconExclamationMarkTag } from '../icons/exclamation-mark';
 import { template } from './template';
+import { mixinRequiredVisiblePattern } from '../patterns/required-visible/types';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -20,7 +21,9 @@ declare global {
 /**
  * A nimble-styed HTML text input
  */
-export class TextField extends mixinErrorPattern(FoundationTextField) {
+export class TextField extends mixinErrorPattern(
+    mixinRequiredVisiblePattern(FoundationTextField)
+) {
     /**
      * The appearance the text field should have.
      *

--- a/packages/nimble-components/src/text-field/styles.ts
+++ b/packages/nimble-components/src/text-field/styles.ts
@@ -21,11 +21,13 @@ import { TextFieldAppearance } from './types';
 import { Theme } from '../theme-provider/types';
 import { themeBehavior } from '../utilities/style/theme';
 import { styles as errorStyles } from '../patterns/error/styles';
+import { styles as requiredVisibleStyles } from '../patterns/required-visible/styles';
 import { userSelectNone } from '../utilities/style/user-select';
 
 export const styles = css`
     ${display('inline-block')}
     ${errorStyles}
+    ${requiredVisibleStyles}
 
     :host {
         font: ${bodyFont};

--- a/packages/nimble-components/src/text-field/template.ts
+++ b/packages/nimble-components/src/text-field/template.ts
@@ -8,6 +8,22 @@ import {
     endSlotTemplate
 } from '@microsoft/fast-foundation';
 import type { TextField } from '.';
+import { createRequiredVisibleLabelTemplate } from '../patterns/required-visible/template';
+
+const labelTemplate = createRequiredVisibleLabelTemplate(
+    html<TextField>`<label
+        part="label"
+        for="control"
+        class="${x => (x.defaultSlottedNodes?.length ? 'label' : 'label label__hidden')}"
+    >
+        <slot
+            ${slotted({
+        property: 'defaultSlottedNodes',
+        filter: whitespaceFilter
+    })}
+        ></slot>
+    </label>`
+);
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(TextField:class)} component.
@@ -22,20 +38,7 @@ TextFieldOptions
             ${x => (x.readOnly ? 'readonly' : '')}
         "
     >
-        <label
-            part="label"
-            for="control"
-            class="${x => (x.defaultSlottedNodes?.length
-        ? 'label'
-        : 'label label__hidden')}"
-        >
-            <slot
-                ${slotted({
-        property: 'defaultSlottedNodes',
-        filter: whitespaceFilter
-    })}
-            ></slot>
-        </label>
+        ${labelTemplate}
         <div class="root" part="root">
             ${startSlotTemplate(context, definition)}
             <input
@@ -76,6 +79,7 @@ TextFieldOptions
                 aria-owns="${x => x.ariaOwns}"
                 aria-relevant="${x => x.ariaRelevant}"
                 aria-roledescription="${x => x.ariaRoledescription}"
+                aria-required="${x => x.requiredVisible}"
                 ${ref('control')}
             />
             ${endSlotTemplate(context, definition)}

--- a/packages/nimble-components/src/text-field/tests/text-field.spec.ts
+++ b/packages/nimble-components/src/text-field/tests/text-field.spec.ts
@@ -1,7 +1,39 @@
+import { html } from '@microsoft/fast-element';
 import { TextField, textFieldTag } from '..';
+import { fixture, Fixture } from '../../utilities/tests/fixture';
+import { processUpdates } from '../../testing/async-helpers';
+
+async function setup(): Promise<Fixture<TextField>> {
+    return await fixture<TextField>(html`<${textFieldTag}></${textFieldTag}>`);
+}
 
 describe('TextField', () => {
+    let element: TextField;
+    let connect: () => Promise<void>;
+    let disconnect: () => Promise<void>;
+
+    beforeEach(async () => {
+        ({ element, connect, disconnect } = await setup());
+        await connect();
+    });
+
+    afterEach(async () => {
+        await disconnect();
+    });
+
     it('can construct an element instance', () => {
         expect(document.createElement(textFieldTag)).toBeInstanceOf(TextField);
+    });
+
+    it('should set "aria-required" to true when "required-visible" is true', () => {
+        element.requiredVisible = true;
+        processUpdates();
+        expect(element.control.getAttribute('aria-required')).toBe('true');
+    });
+
+    it('should set "aria-required" to false when "required-visible" is false', () => {
+        element.requiredVisible = false;
+        processUpdates();
+        expect(element.control.getAttribute('aria-required')).toBe('false');
     });
 });

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -19,7 +19,9 @@ import {
     errorStatesNoError,
     errorStatesErrorWithMessage,
     ReadOnlyState,
-    readOnlyStates
+    readOnlyStates,
+    RequiredVisibleState,
+    requiredVisibleStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -55,6 +57,7 @@ const metadata: Meta = {
 export default metadata;
 
 const component = (
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [readOnlyName, readonly]: ReadOnlyState,
     [disabledName, disabled]: DisabledState,
     [hideStepName, hideStep]: HideStepState,
@@ -72,14 +75,17 @@ const component = (
         ?disabled="${() => disabled}"
         error-text="${() => errorText}"
         ?error-visible="${() => errorVisible}"
+        ?required-visible="${() => requiredVisible}"
     >
         ${() => errorName} ${() => appearanceName} ${() => valueName}
         ${() => hideStepName} ${() => disabledName} ${() => readOnlyName}
+        ${() => requiredVisibleName}
     </${numberFieldTag}>
 `;
 
 export const numberFieldThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         readOnlyStates,
         disabledStates,
         hideStepStates,
@@ -89,7 +95,10 @@ export const numberFieldThemeMatrix: StoryFn = createMatrixThemeStory(
     ])
 );
 
+const notRequiredState = requiredVisibleStates[0];
+
 const interactionStatesHover = cartesianProduct([
+    [notRequiredState],
     readOnlyStates,
     disabledStates,
     [hideStepStateStepVisible],
@@ -99,6 +108,7 @@ const interactionStatesHover = cartesianProduct([
 ] as const);
 
 const interactionStates = cartesianProduct([
+    [notRequiredState],
     readOnlyStates,
     [disabledStateIsEnabled],
     [hideStepStateStepVisible],

--- a/packages/storybook/src/nimble/number-field/number-field.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field.stories.ts
@@ -20,7 +20,8 @@ import {
     readonlyDescription,
     errorTextDescription,
     errorVisibleDescription,
-    slottedLabelDescription
+    slottedLabelDescription,
+    requiredVisibleDescription
 } from '../../utilities/storybook';
 
 interface NumberFieldArgs extends LabelUserArgs {
@@ -37,6 +38,7 @@ interface NumberFieldArgs extends LabelUserArgs {
     errorText: string;
     change: undefined;
     input: undefined;
+    requiredVisible: boolean;
 }
 
 const metadata: Meta<NumberFieldArgs> = {
@@ -60,6 +62,7 @@ const metadata: Meta<NumberFieldArgs> = {
             ?disabled="${x => x.disabled}"
             ?error-visible="${x => x.errorVisible}"
             error-text="${x => x.errorText}"
+            ?required-visible="${x => x.requiredVisible}"
         >
             ${x => x.label}
         </${numberFieldTag}>
@@ -120,6 +123,11 @@ const metadata: Meta<NumberFieldArgs> = {
             description: errorTextDescription,
             table: { category: apiCategory.attributes }
         },
+        requiredVisible: {
+            name: 'required-visible',
+            description: requiredVisibleDescription,
+            table: { category: apiCategory.attributes }
+        },
         change: {
             description:
                 'Event emitted when the user commits a new value to the number field.',
@@ -144,7 +152,8 @@ const metadata: Meta<NumberFieldArgs> = {
         readonly: false,
         disabled: false,
         errorVisible: false,
-        errorText: 'Value is invalid'
+        errorText: 'Value is invalid',
+        requiredVisible: false
     }
 };
 addLabelUseMetadata(

--- a/packages/storybook/src/nimble/patterns/required-visible/required-visible.stories.ts
+++ b/packages/storybook/src/nimble/patterns/required-visible/required-visible.stories.ts
@@ -15,6 +15,8 @@ import {
     radioGroupTag
 } from '../../../../../nimble-components/src/radio-group';
 import { radioTag } from '../../../../../nimble-components/src/radio';
+import { textFieldTag } from '../../../../../nimble-components/src/text-field';
+import { numberFieldTag } from '../../../../../nimble-components/src/number-field';
 
 interface RequiredVisiblePatternArgs {
     shortLabel: string;
@@ -51,6 +53,11 @@ const metadata: Meta<RequiredVisiblePatternArgs> = {
             <${comboboxTag} class="fixed-width" required-visible>${x => x.longLabel}</${comboboxTag}>
         </div>
         <div class="control-container">
+            <div class="label">Number field</div>
+            <${numberFieldTag} class="fixed-width" required-visible>${x => x.shortLabel}</${numberFieldTag}>
+            <${numberFieldTag} class="fixed-width" required-visible>${x => x.longLabel}</${numberFieldTag}>
+        </div>
+        <div class="control-container">
             <div class="label">Radio group</div>
             <${radioGroupTag} class="fixed-width" orientation=${Orientation.horizontal} required-visible>
                 <span slot="label">${x => x.shortLabel}</span>
@@ -82,6 +89,11 @@ const metadata: Meta<RequiredVisiblePatternArgs> = {
             <div class="label">Text area</div>
             <${textAreaTag} class="fixed-width" required-visible>${x => x.shortLabel}</${textAreaTag}>
             <${textAreaTag} class="fixed-width" required-visible>${x => x.longLabel}</${textAreaTag}>
+        </div>
+        <div class="control-container">
+            <div class="label">Text field</div>
+            <${textFieldTag} class="fixed-width" required-visible>${x => x.shortLabel}</${textFieldTag}>
+            <${textFieldTag} class="fixed-width" required-visible>${x => x.longLabel}</${textFieldTag}>
         </div>
     `),
     args: {

--- a/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
@@ -22,7 +22,9 @@ import {
     readOnlyStates,
     backgroundStates,
     errorStates,
-    ErrorState
+    ErrorState,
+    RequiredVisibleState,
+    requiredVisibleStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -129,6 +131,31 @@ const component = (
                 <${iconXmarkTag} slot="start"></${iconXmarkTag}>
                 Clear
             </${buttonTag}>`)}
+    </${textFieldTag}>
+`;
+
+// prettier-ignore
+const requiredVisibleStatesComponent = (
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
+    [appearanceName, appearance]: AppearanceState,
+    [readOnlyName, readonly]: ReadOnlyState,
+    [disabledName, disabled]: DisabledState,
+    [errorName, errorVisible, errorText]: ErrorState
+): ViewTemplate => html`
+    <${textFieldTag}
+        style="width: 350px; margin: 8px;"
+        ?disabled="${() => disabled}"
+        appearance="${() => appearance}"
+        ?readonly="${() => readonly}"
+        ?error-visible="${() => errorVisible}"
+        error-text="${() => errorText}"
+        ?required-visible="${() => requiredVisible}"
+    >
+        ${() => readOnlyName}
+        ${() => disabledName}
+        ${() => errorName}
+        ${() => appearanceName}
+        ${() => requiredVisibleName}
     </${textFieldTag}>
 `;
 
@@ -490,6 +517,16 @@ export const colorThemeReadOnlyDisabledWithButtons: StoryFn = createFixedThemeSt
         valueStates
     ]),
     colorThemeDarkGreenBackground
+);
+
+export const textFieldRequiredVisibleThemeMatrix: StoryFn = createMatrixThemeStory(
+    createMatrix(requiredVisibleStatesComponent, [
+        requiredVisibleStates,
+        appearanceStates,
+        readOnlyStates,
+        disabledStates,
+        errorStates
+    ])
 );
 
 export const hiddenTextField: StoryFn = createStory(

--- a/packages/storybook/src/nimble/text-field/text-field.stories.ts
+++ b/packages/storybook/src/nimble/text-field/text-field.stories.ts
@@ -18,7 +18,8 @@ import {
     errorTextDescription,
     errorVisibleDescription,
     placeholderDescription,
-    slottedLabelDescription
+    slottedLabelDescription,
+    requiredVisibleDescription
 } from '../../utilities/storybook';
 
 interface TextFieldArgs {
@@ -37,6 +38,7 @@ interface TextFieldArgs {
     leftIcon: boolean;
     change: undefined;
     input: undefined;
+    requiredVisible: boolean;
 }
 
 const leftIconDescription = 'An icon to display at the start of the text field.';
@@ -68,6 +70,7 @@ const metadata: Meta<TextFieldArgs> = {
             error-text="${x => x.errorText}"
             ?error-visible="${x => x.errorVisible}"
             ?full-bleed="${x => x.fullBleed}"
+            ?required-visible="${x => x.requiredVisible}"
         >
             ${when(x => x.leftIcon, html`
                 <${iconTagTag} slot="start"></${iconTagTag}>`)}
@@ -141,6 +144,11 @@ const metadata: Meta<TextFieldArgs> = {
             description: errorTextDescription,
             table: { category: apiCategory.attributes }
         },
+        requiredVisible: {
+            name: 'required-visible',
+            description: requiredVisibleDescription,
+            table: { category: apiCategory.attributes }
+        },
         actionButton: {
             name: 'actions',
             description: actionButtonDescription,
@@ -176,7 +184,8 @@ const metadata: Meta<TextFieldArgs> = {
         errorVisible: false,
         errorText: 'Value is invalid',
         actionButton: false,
-        leftIcon: false
+        leftIcon: false,
+        requiredVisible: false
     }
 };
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Add required-visible attributes to the text-field and number-field as part of https://github.com/ni/nimble/issues/2100.

## 👩‍💻 Implementation

Used the newly established pattern for required-visible to add `required-visible` to the text-field and number-field.

## 🧪 Testing

- New unit tests for `aria-required` on both components
- Manually tested both components in storybook
- Storybook updates
- Matrix test updates
- Updated required-visible story

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
