### PR TITLE
Changes required to adopt FAST fork

### DIFF
--- a/change/@ni-nimble-components-512b7957-0ae3-47ed-8825-ec0e4378a614.json
+++ b/change/@ni-nimble-components-512b7957-0ae3-47ed-8825-ec0e4378a614.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Inline constant from external library for table pageobject",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/testing/table.pageobject.ts
+++ b/packages/nimble-components/src/table/testing/table.pageobject.ts
@@ -1,5 +1,4 @@
 import type { Checkbox } from '@microsoft/fast-foundation';
-import { keyShift } from '@microsoft/fast-web-utilities';
 import { parseColor } from '@microsoft/fast-colors';
 import type { Table } from '..';
 import { tableHeaderTag, type TableHeader } from '../components/header';
@@ -482,7 +481,7 @@ export class TablePageObject<T extends TableRecord> {
     public clickRowSelectionCheckbox(rowIndex: number, shiftKey = false): void {
         if (shiftKey) {
             const shiftKeyDownEvent = new KeyboardEvent('keydown', {
-                key: keyShift,
+                key: 'Shift',
                 shiftKey: true,
                 bubbles: true
             } as KeyboardEventInit);
@@ -494,7 +493,7 @@ export class TablePageObject<T extends TableRecord> {
 
         if (shiftKey) {
             const shiftKeyUpEvent = new KeyboardEvent('keyup', {
-                key: keyShift,
+                key: 'Shift',
                 bubbles: true
             } as KeyboardEventInit);
             document.dispatchEvent(shiftKeyUpEvent);
@@ -514,7 +513,7 @@ export class TablePageObject<T extends TableRecord> {
     ): void {
         if (shiftKey) {
             const shiftKeyDownEvent = new KeyboardEvent('keydown', {
-                key: keyShift,
+                key: 'Shift',
                 shiftKey: true,
                 bubbles: true
             } as KeyboardEventInit);
@@ -526,7 +525,7 @@ export class TablePageObject<T extends TableRecord> {
 
         if (shiftKey) {
             const shiftKeyUpEvent = new KeyboardEvent('keyup', {
-                key: keyShift,
+                key: 'Shift',
                 bubbles: true
             } as KeyboardEventInit);
             document.dispatchEvent(shiftKeyUpEvent);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This PR covers changes needed in Nimble beyond mechanical scope changes (i.e. `@microsoft` to `@ni`) to adopt the https://github.com/ni/fast fork. The change is very minor to just inline a constant exposed from `fast-web-utilities`. 

Nimble (unfortunately) depends on both `@microsoft/fast-web-utilities` v5.4.1 transitively from [`archives/fast-element-1`](https://github.com/microsoft/fast/tree/archives/fast-element-1/packages/utilities/fast-web-utilities) and v6 directly from [`archives/fast-foundation-3`](https://github.com/microsoft/fast/tree/archives/fast-foundation-3/packages/utilities/fast-web-utilities).

The `archives/fast-element-1` v5.4.1 is what is in the `ni/fast` fork so this PR resolves the difference for that upcoming change.

Alternatively we could try and merge up the changes from the [`archives/fast-foundation-3` history](https://github.com/microsoft/fast/commits/archives/fast-foundation-3/packages/utilities/fast-web-utilities) into our fork (i.e. commits from May 3, 2022 to June 20, 2024) but that seemed low value as it's lots of noise from tsconfig, style rule, and package structure changes with almost no feature changes (addition of some constants).

Also [doesn't seem like clients are directly relying on the package](https://dev.azure.com/ni/_search?action=contents&text=fast-web-utilities%20NOT%20file%3Apackage-lock.json&type=code&lp=custom-Collection&filters=&pageSize=25) so reverting to the older package is up to Nimble's discretion. Ultimately this is a low value and poorly scoped package I expect we will remove over time.

## 👩‍💻 Implementation

Inlined the constant from `fast-web-utilities` that is not in the package from the time of our fork.

## 🧪 Testing

Rely on CI.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
