### PR TITLE
Update to latest .net sdk 8.0.405

### DIFF
--- a/packages/blazor-workspace/Examples/Demo.Client/packages.lock.json
+++ b/packages/blazor-workspace/Examples/Demo.Client/packages.lock.json
@@ -23,15 +23,15 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.11, )",
-        "resolved": "8.0.11",
-        "contentHash": "zk5lnZrYJgtuJG8L4v17Ej8rZ3PUcR2iweNV08BaO5LbYHIi2wNaVNcJoLxvqgQdnjLlKnCCfVGLDr6QHeAarQ=="
+        "requested": "[8.0.12, )",
+        "resolved": "8.0.12",
+        "contentHash": "FV4HnQ3JI15PHnJ5PGTbz+rYvrih42oLi/7UMIshNwCwUZhTq13UzrggtXk4ygrcMcN+4jsS6hhshx2p/Zd0ig=="
       },
       "Microsoft.NET.Sdk.WebAssembly.Pack": {
         "type": "Direct",
-        "requested": "[8.0.11, )",
-        "resolved": "8.0.11",
-        "contentHash": "apyq1nlpnHG64NVs1RpgUJAxM73bu5fLFB/SsIcYYiLKdUxiIMPQQWr9ysRxfJRLlKwLSoJo6LmjhjS9sxC8eg=="
+        "requested": "[8.0.12, )",
+        "resolved": "8.0.12",
+        "contentHash": "JS5B7ZJVqaBOjlbjDgOkg+COEy24CB6IdGiwNeZnPJMoIZFdxehGFUmlxl4Mz3GZaoIduOtMtwkEdy6jh+NUpg=="
       },
       "NI.CSharp.Analyzers": {
         "type": "Direct",

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests.Acceptance.Client/packages.lock.json
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests.Acceptance.Client/packages.lock.json
@@ -17,15 +17,15 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.11, )",
-        "resolved": "8.0.11",
-        "contentHash": "zk5lnZrYJgtuJG8L4v17Ej8rZ3PUcR2iweNV08BaO5LbYHIi2wNaVNcJoLxvqgQdnjLlKnCCfVGLDr6QHeAarQ=="
+        "requested": "[8.0.12, )",
+        "resolved": "8.0.12",
+        "contentHash": "FV4HnQ3JI15PHnJ5PGTbz+rYvrih42oLi/7UMIshNwCwUZhTq13UzrggtXk4ygrcMcN+4jsS6hhshx2p/Zd0ig=="
       },
       "Microsoft.NET.Sdk.WebAssembly.Pack": {
         "type": "Direct",
-        "requested": "[8.0.11, )",
-        "resolved": "8.0.11",
-        "contentHash": "apyq1nlpnHG64NVs1RpgUJAxM73bu5fLFB/SsIcYYiLKdUxiIMPQQWr9ysRxfJRLlKwLSoJo6LmjhjS9sxC8eg=="
+        "requested": "[8.0.12, )",
+        "resolved": "8.0.12",
+        "contentHash": "JS5B7ZJVqaBOjlbjDgOkg+COEy24CB6IdGiwNeZnPJMoIZFdxehGFUmlxl4Mz3GZaoIduOtMtwkEdy6jh+NUpg=="
       },
       "NI.CSharp.Analyzers": {
         "type": "Direct",

--- a/packages/blazor-workspace/global.json
+++ b/packages/blazor-workspace/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.404",
+    "version": "8.0.405",
     "allowPrelease": "false",
     "rollForward": "disable"
   }

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -105,5 +105,5 @@ configureActions({
     depth: 1
 });
 
-// Update the GUID on this line to trigger a turbosnap full rebuild: 3076af9e-b6b1-4315-a870-28b64a1e9cda
+// Update the GUID on this line to trigger a turbosnap full rebuild: 3076af9e-b6b1-4315-a870-28b64a1e9cdb
 // See https://www.chromatic.com/docs/turbosnap/#full-rebuilds


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Builds on main started failing with messages like:

> /home/runner/work/nimble/nimble/packages/blazor-workspace/Examples/Demo.Client/Demo.Client.csproj : error NU1004: The package reference Microsoft.NET.Sdk.WebAssembly.Pack version has changed from [8.0.11, ) to [8.0.12, ).The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode. Disable the RestoreLockedMode MSBuild property or pass an explicit --force-evaluate option to run restore to update the lock file. [/home/runner/work/nimble/nimble/packages/blazor-workspace/BlazorWorkspace.sln]


But if you check for references to 8.0.12 assemblies you won't find them. I think what is happening is that the GitHub agents have the latest v8 dotnet installed (v8.0.405) which supersedes the older (v8.0.404) we try to install. So the newer assemblies (v8.0.12) seem to completely replace what the lockfile targets (v8.0.11).

You can reproduce the above errors by just having the newer dotnet sdk (v8.0.405) installed and running a nimble build prior to this PR.

## 👩‍💻 Implementation

Updated to the latest dotnet sdk and ran `npm run update-lock-filesupdate-lock-files`.

## 🧪 Testing

Rely on CI.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
