### PR TITLE
Allow an item in the toolbar to lose focus by clicking the toolbar itself

### DIFF
--- a/change/@ni-nimble-components-66a1a299-08a4-495c-9750-85902fe5413f.json
+++ b/change/@ni-nimble-components-66a1a299-08a4-495c-9750-85902fe5413f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow an item in the toolbar to lose focus by clicking the toolbar itself",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/toolbar/index.ts
+++ b/packages/nimble-components/src/toolbar/index.ts
@@ -21,10 +21,7 @@ const nimbleToolbar = Toolbar.compose<ToolbarOptions>({
     baseName: 'toolbar',
     baseClass: FoundationToolbar,
     template,
-    styles,
-    shadowOptions: {
-        delegatesFocus: true
-    }
+    styles
 });
 
 DesignSystem.getOrCreate().withPrefix('nimble').register(nimbleToolbar());


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #2494

## 👩‍💻 Implementation

Removed `delgatesFocus: true` on the toolbar so that clicking on an empty space within the toolbar will cause the currently focused item to lose focus.

Note: The use case described in the referenced issue may still be a bit problematic given all the editable fields (date pickers, numerics, etc) because the user may expect to use the left/right arrow keys to navigate within that component, but the toolbar will handle the key event first and move focus to a different item in the keyboard. That behavior is not affected in any way by this change.

## 🧪 Testing

Manually tested with a numeric field and text field in the toolbar.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
