### PR TITLE
Export DiacriticInsensitivePipe, Icon base, and Table SortedColumn types

### DIFF
--- a/change/@ni-nimble-angular-127e0e6a-d1e2-424f-811b-21791d0fe443.json
+++ b/change/@ni-nimble-angular-127e0e6a-d1e2-424f-811b-21791d0fe443.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Export DiacriticInsensitivePipe, Icon base, and Table SortedColumn types",
+  "packageName": "@ni/nimble-angular",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/angular-workspace/nimble-angular/pipes/diacritic-insensitive.pipe.ts
+++ b/packages/angular-workspace/nimble-angular/pipes/diacritic-insensitive.pipe.ts
@@ -10,10 +10,7 @@ import { diacriticInsensitiveStringNormalizer } from '@ni/nimble-components/dist
     standalone: true
 })
 export class DiacriticInsensitivePipe implements PipeTransform {
-    public transform(value: string | null | undefined): string {
-        if (typeof value !== 'string') {
-            return '';
-        }
+    public transform(value: string): string {
         return diacriticInsensitiveStringNormalizer(value);
     }
 }

--- a/packages/angular-workspace/nimble-angular/pipes/diacritic-insensitive.pipe.ts
+++ b/packages/angular-workspace/nimble-angular/pipes/diacritic-insensitive.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, type PipeTransform } from '@angular/core';
+import { diacriticInsensitiveStringNormalizer } from '@ni/nimble-components/dist/esm/utilities/models/string-normalizers';
+
+/**
+ * Generic normalize pipe that removes the accents and special characters.
+ * This pipe can be used to normalize a string before performing diacritic-insensitive string comparisons.
+ */
+@Pipe({
+    name: 'diacritic-insensitive',
+    standalone: true
+})
+export class DiacriticInsensitivePipe implements PipeTransform {
+    public transform(value: string | null | undefined): string {
+        if (typeof value !== 'string') {
+            return '';
+        }
+        return diacriticInsensitiveStringNormalizer(value);
+    }
+}

--- a/packages/angular-workspace/nimble-angular/pipes/public-api.ts
+++ b/packages/angular-workspace/nimble-angular/pipes/public-api.ts
@@ -1,3 +1,4 @@
+export * from './diacritic-insensitive.pipe';
 export * from './duration.pipe';
 export * from './number-text.pipe';
 export { byteUnitScale } from '@ni/nimble-components/dist/esm/utilities/unit-format/unit-scale/byte-unit-scale';

--- a/packages/angular-workspace/nimble-angular/pipes/tests/diacritic-insensitive.pipe.spec.ts
+++ b/packages/angular-workspace/nimble-angular/pipes/tests/diacritic-insensitive.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { DiacriticInsensitivePipe } from '../diacritic-insensitive.pipe';
+
+describe('DiacriticInsensitivePipe', () => {
+    it('can be constructed and used', () => {
+        const pipe = new DiacriticInsensitivePipe();
+        expect(pipe.transform('Français é, è, ê and ë (French characters)')).toBe('francais e, e, e and e (french characters)');
+    });
+});

--- a/packages/angular-workspace/nimble-angular/src/directives/icon-base/nimble-icon-base.directive.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/icon-base/nimble-icon-base.directive.ts
@@ -1,6 +1,8 @@
 import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
-import type { Icon } from '@ni/nimble-components/dist/esm/icon-base';
+import { Icon } from '@ni/nimble-components/dist/esm/icon-base';
 import type { IconSeverity } from '@ni/nimble-components/dist/esm/icon-base/types';
+
+export { Icon };
 
 /**
  * Base class for the nimble icon directives

--- a/packages/angular-workspace/nimble-angular/table/testing/table.pageobject.ts
+++ b/packages/angular-workspace/nimble-angular/table/testing/table.pageobject.ts
@@ -1,6 +1,8 @@
-import { TablePageObject as NimbleComponentsTablePageObject } from '@ni/nimble-components/dist/esm/table/testing/table.pageobject';
+import { TablePageObject as NimbleComponentsTablePageObject, type SortedColumn } from '@ni/nimble-components/dist/esm/table/testing/table.pageobject';
 import { waitForUpdatesAsync } from '@ni/nimble-angular';
 import type { Table, TableRecord } from '@ni/nimble-angular/table';
+
+export type { SortedColumn };
 
 /**
  * The page object for the `nimble-table` component to provide consistent ways of querying


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Found many instances of direct imports to `@ni/nimble-components` in Angular apps because there was not a direct export of `diacriticInsensitiveStringNormalizer` and a few other types.

## 👩‍💻 Implementation

- Exposed `diacriticInsensitiveStringNormalizer` from nimble-angular as a pipe named `DiacriticInsensitivePipe`
- Passed through the table page object export of `SortedColumn`
- Exported the Icon base class

## 🧪 Testing

Rely on CI.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
