### PR TITLE
Table height does not account for horizontal scrollbar

### DIFF
--- a/change/@ni-nimble-components-bd589a64-2554-4b0e-8b33-edc7b9cef72d.json
+++ b/change/@ni-nimble-components-bd589a64-2554-4b0e-8b33-edc7b9cef72d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Account for horizontal scrollbar when determining value of tableFitRowsHeight token",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/table/models/virtualizer.ts
+++ b/packages/nimble-components/src/table/models/virtualizer.ts
@@ -25,6 +25,9 @@ export class Virtualizer<TData extends TableRecord = TableRecord> {
     public scrollHeight = 0;
 
     @observable
+    public horizontalScrollbarHeight = 0;
+
+    @observable
     public isScrolling = false;
 
     @observable
@@ -58,6 +61,7 @@ export class Virtualizer<TData extends TableRecord = TableRecord> {
                 // by the same margin so the column headers align with the corresponding rendered cells
                 const viewportBoundingWidth = borderBoxSize.inlineSize;
                 this.headerContainerMarginRight = viewportBoundingWidth - this.table.viewport.clientWidth;
+                this.horizontalScrollbarHeight = borderBoxSize.blockSize - this.table.viewport.clientHeight;
             }
         });
     }

--- a/packages/nimble-components/src/table/styles.ts
+++ b/packages/nimble-components/src/table/styles.ts
@@ -28,7 +28,7 @@ export const styles = css`
 
     :host {
         height: 480px;
-        ${tableFitRowsHeight.cssCustomProperty}: calc(var(--ni-private-table-scroll-height) + ${controlHeight});
+        ${tableFitRowsHeight.cssCustomProperty}: calc(var(--ni-private-table-scroll-height) + var(--ni-private-table-horizontal-scrollbar-height) + ${controlHeight});
         ${
             /**
              * Set a default maximum height for the table of 40.5 rows plus the header row so

--- a/packages/nimble-components/src/table/template.ts
+++ b/packages/nimble-components/src/table/template.ts
@@ -41,7 +41,7 @@ export const template = html<Table>`
         aria-multiselectable="${x => x.ariaMultiSelectable}"
         ${children({ property: 'childItems', filter: elements() })}
     >
-        <style>:host{ --ni-private-table-scroll-height: ${x => x.virtualizer.scrollHeight}px; }</style>
+        <style>:host{ --ni-private-table-scroll-height: ${x => x.virtualizer.scrollHeight}px; --ni-private-table-horizontal-scrollbar-height: ${x => x.virtualizer.horizontalScrollbarHeight}px; }</style>
         <div class="table-container ${x => (x.windowShiftKeyDown ? 'disable-select' : '')}"
             style="
             --ni-private-table-scroll-x: -${x => x.scrollX}px;

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -2400,6 +2400,21 @@ describe('Table', () => {
                 expect(tokenValue).toBe(expectedHeight);
             });
 
+            it('adjusts height when horizontal scrollbar is shown', async () => {
+                await element.setData(simpleTableData);
+                await waitForUpdatesAsync();
+
+                await pageObject.sizeTableToGivenRowWidth(100, element);
+                await waitForUpdatesAsync();
+
+                const tokenValue = getTableHeight();
+                const heightWithoutScrollbar = getExpectedHeight(
+                    simpleTableData.length
+                );
+                expect(parseFloat(tokenValue)).toBeGreaterThanOrEqual(parseFloat(heightWithoutScrollbar));
+                expect(element.viewport.scrollHeight).toBe(element.viewport.clientHeight);
+            });
+
             it('has correct height when height changes because of setting data', async () => {
                 await element.setData(simpleTableData);
                 await waitForUpdatesAsync();

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -2411,6 +2411,9 @@ describe('Table', () => {
                 const heightWithoutScrollbar = getExpectedHeight(
                     simpleTableData.length
                 );
+                // Use the `toBeGreaterThanOrEqual` comparison because in browsers with overlay scrollbars,
+                // the heights will match. In other browsers, the token height will be larger than the
+                // calculated height of the rows + header by the width of the scrollbar.
                 expect(parseFloat(tokenValue)).toBeGreaterThanOrEqual(
                     parseFloat(heightWithoutScrollbar)
                 );

--- a/packages/nimble-components/src/table/tests/table.spec.ts
+++ b/packages/nimble-components/src/table/tests/table.spec.ts
@@ -2411,8 +2411,12 @@ describe('Table', () => {
                 const heightWithoutScrollbar = getExpectedHeight(
                     simpleTableData.length
                 );
-                expect(parseFloat(tokenValue)).toBeGreaterThanOrEqual(parseFloat(heightWithoutScrollbar));
-                expect(element.viewport.scrollHeight).toBe(element.viewport.clientHeight);
+                expect(parseFloat(tokenValue)).toBeGreaterThanOrEqual(
+                    parseFloat(heightWithoutScrollbar)
+                );
+                expect(element.viewport.scrollHeight).toBe(
+                    element.viewport.clientHeight
+                );
             });
 
             it('has correct height when height changes because of setting data', async () => {

--- a/packages/storybook/src/nimble/table/table-fit-rows-height-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table/table-fit-rows-height-matrix.stories.ts
@@ -52,6 +52,9 @@ const component = (
     <style>
         ${tableTag} {
             height: var(${tableFitRowsHeight.cssCustomProperty});
+            /** Set a fixed width to guarantee that the large minimum column width
+            will cause the table to scroll horizontally. */
+            width: 600px;
             margin-bottom: 20px;
         }
     </style>

--- a/packages/storybook/src/nimble/table/table-fit-rows-height-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table/table-fit-rows-height-matrix.stories.ts
@@ -29,6 +29,12 @@ const groupingStates = [
 ] as const;
 type GroupingState = (typeof groupingStates)[number];
 
+const minColumnWidthStates = [
+    ['Small Minimum', 100],
+    ['Large Minimum', 500]
+] as const;
+type MinColumnWidthState = (typeof minColumnWidthStates)[number];
+
 const metadata: Meta = {
     title: 'Tests/Table',
     parameters: {
@@ -40,7 +46,8 @@ export default metadata;
 
 // prettier-ignore
 const component = (
-    [_groupingName, groupIndex]: GroupingState
+    [_groupingName, groupIndex]: GroupingState,
+    [_minColumnWidthName, minColumnWidth]: MinColumnWidthState
 ): ViewTemplate => html`
     <style>
         ${tableTag} {
@@ -49,9 +56,9 @@ const component = (
         }
     </style>
     <${tableTag}>
-        <${tableColumnTextTag} field-name="firstName" group-index="${() => groupIndex}">First Name</${tableColumnTextTag}>
-        <${tableColumnTextTag} field-name="lastName">Last Name</${tableColumnTextTag}>
-        <${tableColumnTextTag} field-name="favoriteColor">Favorite Color</${tableColumnTextTag}>
+        <${tableColumnTextTag} field-name="firstName" group-index="${() => groupIndex}" min-pixel-width="${() => minColumnWidth}">First Name</${tableColumnTextTag}>
+        <${tableColumnTextTag} field-name="lastName" min-pixel-width="${() => minColumnWidth}">Last Name</${tableColumnTextTag}>
+        <${tableColumnTextTag} field-name="favoriteColor" min-pixel-width="${() => minColumnWidth}">Favorite Color</${tableColumnTextTag}>
     </${tableTag}>
 `;
 
@@ -67,20 +74,20 @@ const playFunction = async (rowCount: number): Promise<void> => {
 };
 
 export const tableFitRowsHeightWith5Rows: StoryFn = createFixedThemeStory(
-    createMatrix(component, [groupingStates]),
+    createMatrix(component, [groupingStates, minColumnWidthStates]),
     backgroundStates[0]
 );
 
 tableFitRowsHeightWith5Rows.play = async () => await playFunction(5);
 
 export const tableFitRowsHeightWith10Rows: StoryFn = createFixedThemeStory(
-    createMatrix(component, [groupingStates]),
+    createMatrix(component, [groupingStates, minColumnWidthStates]),
     backgroundStates[0]
 );
 tableFitRowsHeightWith10Rows.play = async () => await playFunction(10);
 
 export const tableFitRowsHeightWith50Rows: StoryFn = createFixedThemeStory(
-    createMatrix(component, [groupingStates]),
+    createMatrix(component, [groupingStates, minColumnWidthStates]),
     backgroundStates[0]
 );
 tableFitRowsHeightWith50Rows.play = async () => await playFunction(50);

--- a/packages/storybook/src/nimble/table/table-fit-rows-height-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table/table-fit-rows-height-matrix.stories.ts
@@ -31,7 +31,7 @@ type GroupingState = (typeof groupingStates)[number];
 
 const minColumnWidthStates = [
     ['Small Minimum', 100],
-    ['Large Minimum', 500]
+    ['Large Minimum (show horizontal scrollbar)', 500]
 ] as const;
 type MinColumnWidthState = (typeof minColumnWidthStates)[number];
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #2520 

## 👩‍💻 Implementation

The issue is that when the horizontal scrollbar was present while styling the table with a height of `tableFitRowsHeight`, a vertical scrollbar would be present because the height token's value didn't account for the height of the horizontal scrollbar. Now, the virtualizer's ResizeObserver hander calculates the height of the horizontal scrollbar (which is 0 if there isn't a horizontal scrollbar), and exposes that value as an `@observable`, similar to `scrollHeight`. As a result, the table can use both values in its calculation of `tableFitRowsHeight`, resulting in no vertical scrollbar when using the token (unless the max-height of the table is reached).

## 🧪 Testing

Manually tested, including the following scenarios to ensure the auto height of the table adjusted correctly as a horizontal scrollbar was added/removed:
- toggle the value of `column-visible` on a column
- add/remove a column from the DOM
- increase/decrease the minimum width of a column
- resize browser window

New auto tests, including chromatic test that loads a table with auto height and a horizontal scrollbar

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
