### PR TITLE
Changed Rich Text Viewer markdown property to an attribute

### DIFF
--- a/change/@ni-nimble-components-33b8266d-c20f-4ec8-92a9-a6ecf81fe328.json
+++ b/change/@ni-nimble-components-33b8266d-c20f-4ec8-92a9-a6ecf81fe328.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed Rich Text Viewer markdown property to an attribute",
+  "packageName": "@ni/nimble-components",
+  "email": "107654185+joseahdz@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/rich-text/viewer/index.ts
+++ b/packages/nimble-components/src/rich-text/viewer/index.ts
@@ -22,7 +22,7 @@ export class RichTextViewer extends RichText {
      * @remarks
      * HTML Attribute: markdown
      */
-    @attr
+    @attr({ mode: 'fromView' })
     public markdown = '';
 
     /**

--- a/packages/nimble-components/src/rich-text/viewer/index.ts
+++ b/packages/nimble-components/src/rich-text/viewer/index.ts
@@ -1,5 +1,5 @@
 import { DesignSystem } from '@microsoft/fast-foundation';
-import { observable } from '@microsoft/fast-element';
+import { attr } from '@microsoft/fast-element';
 import { template } from './template';
 import { styles } from './styles';
 import { RichTextMarkdownParser } from '../models/markdown-parser';
@@ -19,8 +19,10 @@ export class RichTextViewer extends RichText {
      *
      * @public
      * Markdown string to render its corresponding rich text content in the component.
+     * @remarks
+     * HTML Attribute: markdown
      */
-    @observable
+    @attr
     public markdown = '';
 
     /**

--- a/packages/nimble-components/src/rich-text/viewer/tests/rich-text-viewer.spec.ts
+++ b/packages/nimble-components/src/rich-text/viewer/tests/rich-text-viewer.spec.ts
@@ -82,10 +82,10 @@ describe('RichTextViewer', () => {
         expect(element.markdown).toBe('**markdown string**');
     });
 
-    it('set the markdown property and ensure there is markdown attribute', () => {
+    it('set the markdown property and ensure there is no markdown attribute', () => {
         element.markdown = '**markdown string**';
 
-        expect(element.hasAttribute('markdown')).toBeTrue();
+        expect(element.hasAttribute('markdown')).toBeFalse();
     });
 
     it('set the markdown property and ensure that getting the markdown property returns the same value', () => {

--- a/packages/nimble-components/src/rich-text/viewer/tests/rich-text-viewer.spec.ts
+++ b/packages/nimble-components/src/rich-text/viewer/tests/rich-text-viewer.spec.ts
@@ -76,16 +76,16 @@ describe('RichTextViewer', () => {
         );
     });
 
-    it('set the markdown attribute and ensure the markdown property is not modified', () => {
+    it('set the markdown attribute and ensure the markdown property is modified', () => {
         element.setAttribute('markdown', '**markdown string**');
 
-        expect(element.markdown).toBe('');
+        expect(element.markdown).toBe('**markdown string**');
     });
 
-    it('set the markdown property and ensure there is no markdown attribute', () => {
+    it('set the markdown property and ensure there is markdown attribute', () => {
         element.markdown = '**markdown string**';
 
-        expect(element.hasAttribute('markdown')).toBeFalse();
+        expect(element.hasAttribute('markdown')).toBeTrue();
     });
 
     it('set the markdown property and ensure that getting the markdown property returns the same value', () => {

--- a/packages/storybook/src/nimble/rich-text/viewer/rich-text-viewer-matrix.stories.ts
+++ b/packages/storybook/src/nimble/rich-text/viewer/rich-text-viewer-matrix.stories.ts
@@ -28,7 +28,7 @@ export default metadata;
 
 // prettier-ignore
 const component = (): ViewTemplate => html`
-    <${richTextViewerTag} :markdown="${_ => richTextMarkdownString}">
+    <${richTextViewerTag} markdown="${_ => richTextMarkdownString}">
         <${richTextMentionUsersTag} pattern="^user:(.*)">
             <${mappingUserTag} key="user:1" display-name="John Doe"></${mappingUserTag}>
         </${richTextMentionUsersTag}>
@@ -45,7 +45,7 @@ const viewerSizingTestCase = (
     <div style="width: 500px; height: 150px; outline: 1px dotted black">
         <${richTextViewerTag}
             style="${widthStyle}; ${heightStyle}; outline: 1px dashed red;"
-            :markdown="${_ => richTextMarkdownString}"
+            markdown="${_ => richTextMarkdownString}"
         >
             <${richTextMentionUsersTag} pattern="^user:(.*)">
                 <${mappingUserTag} key="user:1" display-name="John Doe"></${mappingUserTag}>
@@ -63,7 +63,7 @@ const viewerDifferentContentTestCase = (
     )}); margin-bottom: 0px;">${label}; ${heightLabel}</p>
     <div style="width: 300px; outline: 1px dotted black; ${parentHeightStyle}">
         <${richTextViewerTag}
-            :markdown="${_ => markdownContent}"
+            markdown="${_ => markdownContent}"
         >
         </${richTextViewerTag}>
     </div>
@@ -77,7 +77,7 @@ const componentFitToContent = ([widthLabel, widthStyle]: [
         tokenNames.bodyFont
     )}); margin-bottom: 0px;">${widthLabel}</p>
     <${richTextViewerTag} style="${widthStyle}; outline: 1px dotted black" 
-        :markdown="${_ => `${loremIpsum}\n\n **${loremIpsum}**\n\n ${loremIpsum}`}">
+        markdown="${_ => `${loremIpsum}\n\n **${loremIpsum}**\n\n ${loremIpsum}`}">
     </${richTextViewerTag}>
 `;
 

--- a/packages/storybook/src/nimble/rich-text/viewer/rich-text-viewer.stories.ts
+++ b/packages/storybook/src/nimble/rich-text/viewer/rich-text-viewer.stories.ts
@@ -60,7 +60,7 @@ const metadata: Meta<RichTextViewerArgs> = {
         markdown: {
             description:
                 'Input markdown string for the supported text formatting options in a [CommonMark](https://commonmark.org/) flavor.',
-            table: { category: apiCategory.nonAttributeProperties }
+            table: { category: apiCategory.attributes }
         },
         data: {
             name: 'default',

--- a/packages/storybook/src/nimble/rich-text/viewer/rich-text-viewer.stories.ts
+++ b/packages/storybook/src/nimble/rich-text/viewer/rich-text-viewer.stories.ts
@@ -45,7 +45,7 @@ const metadata: Meta<RichTextViewerArgs> = {
         statusLink: 'https://github.com/ni/nimble/issues/1288'
     })}
     <${richTextViewerTag}
-        :markdown="${x => x.markdown}"
+        markdown="${x => x.markdown}"
     >
         <${richTextMentionUsersTag} pattern="${x => dataSets[x.data].pattern}">
             <${mappingUserTag} key="${x => dataSets[x.data].href}1" display-name="John Doe"></${mappingUserTag}>

--- a/packages/storybook/src/spright/chat/conversation/chat-conversation.stories.ts
+++ b/packages/storybook/src/spright/chat/conversation/chat-conversation.stories.ts
@@ -34,7 +34,7 @@ export const chatConversation: StoryObj<ChatConversationArgs> = {
                 Where is the Any key?
             </${chatMessageTag}>
             <${chatMessageTag} message-type="${() => ChatMessageType.outbound}">
-                <${richTextViewerTag} :markdown="${() => markdownExample}"></${richTextViewerTag}>
+                <${richTextViewerTag} markdown="${() => markdownExample}"></${richTextViewerTag}>
             </${chatMessageTag}>
             <${chatMessageTag} message-type="${() => ChatMessageType.system}">
                 <${spinnerTag} appearance="${() => SpinnerAppearance.accent}"></${spinnerTag}>

--- a/packages/storybook/src/spright/chat/message/chat-message.stories.ts
+++ b/packages/storybook/src/spright/chat/message/chat-message.stories.ts
@@ -65,7 +65,7 @@ interface ChatMessageRichTextArgs extends ChatMessageArgs {
 export const chatMessageRichText: StoryObj<ChatMessageRichTextArgs> = {
     render: createUserSelectedThemeStory(html`
         <${chatMessageTag} message-type="${x => ChatMessageType[x.messageType]}">
-            <${richTextViewerTag} :markdown="${x => x.markdown}"></${richTextViewerTag}>
+            <${richTextViewerTag} markdown="${x => x.markdown}"></${richTextViewerTag}>
         </${chatMessageTag}>
     `),
     argTypes: {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The markdown property cannot be set from Blazor since [Blazor does not currently support setting properties](https://github.com/dotnet/aspnetcore/issues/5506#issuecomment-485385419). 

Some options are:
- Use JS to programmatically change the property value. Potentially following a similar pattern as [FluentCheckbox for the indeterminate state](https://github.com/microsoft/fluentui-blazor/blob/f0f1bf8c93ef23c6425b30bd4accf217a1256a20/src/Core/Components/Checkbox/FluentCheckbox.razor.cs#L131)
- Change the `@observable` property to an `@attr` property + attribute

For the rich text viewer `markdown` property there does not seem to be a specific reason to avoid configuring `markdown` as an attribute. 

## 👩‍💻 Implementation

Changed markdown property from `observable` to `attr`.  Also, updated story book to show `markdown` as an attribute instead of a property.

The `fromView` mode will be used to avoid unnecessarily reflecting large strings set as properties back as attributes.

## 🧪 Testing

Fixed a couple of tests due to changing from a property to an attribute.  All other tests are passing.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
