### PR TITLE
Rebuild chromatic snapshots on new infrastructure version

### DIFF
--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -105,5 +105,5 @@ configureActions({
     depth: 1
 });
 
-// Update the GUID on this line to trigger a turbosnap full rebuild: b7f3e8d2-4c5e-4a8b-9f3e-2b6e1a7d9c3f
+// Update the GUID on this line to trigger a turbosnap full rebuild: b7f3e8d2-4c5e-4a8b-9f3e-2b6e1a7d9c33
 // See https://www.chromatic.com/docs/turbosnap/#full-rebuilds

--- a/packages/storybook/src/spright/chat/conversation/chat-conversation.stories.ts
+++ b/packages/storybook/src/spright/chat/conversation/chat-conversation.stories.ts
@@ -13,6 +13,7 @@ import {
 import { imgBlobUrl, markdownExample } from './story-helpers';
 import { ButtonAppearance } from '../../../../../nimble-components/src/menu-button/types';
 import { SpinnerAppearance } from '../../../../../nimble-components/src/spinner/types';
+import { isChromatic } from '../../../utilities/isChromatic';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface ChatConversationArgs {}
@@ -37,7 +38,10 @@ export const chatConversation: StoryObj<ChatConversationArgs> = {
                 <${richTextViewerTag} markdown="${() => markdownExample}"></${richTextViewerTag}>
             </${chatMessageTag}>
             <${chatMessageTag} message-type="${() => ChatMessageType.system}">
-                <${spinnerTag} appearance="${() => SpinnerAppearance.accent}"></${spinnerTag}>
+                <${spinnerTag}
+                    style="${isChromatic() ? '--ni-private-spinner-animation-play-state:paused' : ''}"
+                    appearance="${() => SpinnerAppearance.accent}"
+                ></${spinnerTag}>
             </${chatMessageTag}>
             <${chatMessageTag} message-type="${() => ChatMessageType.inbound}">
                 <img width="100" height="100" :src=${() => imgBlobUrl}>

--- a/packages/storybook/src/spright/chat/message/chat-message.stories.ts
+++ b/packages/storybook/src/spright/chat/message/chat-message.stories.ts
@@ -13,6 +13,7 @@ import { spinnerTag } from '../../../../../nimble-components/src/spinner';
 import { imgBlobUrl, markdownExample } from '../conversation/story-helpers';
 import { SpinnerAppearance } from '../../../../../nimble-components/src/spinner/types';
 import { ButtonAppearance } from '../../../../../nimble-components/src/menu-button/types';
+import { isChromatic } from '../../../utilities/isChromatic';
 
 interface ChatMessageArgs {
     messageType: keyof typeof ChatMessageType;
@@ -83,7 +84,10 @@ export const chatMessageRichText: StoryObj<ChatMessageRichTextArgs> = {
 export const chatMessageSpinner: StoryObj<ChatMessageArgs> = {
     render: createUserSelectedThemeStory(html`
         <${chatMessageTag} message-type="${x => ChatMessageType[x.messageType]}">
-            <${spinnerTag} appearance="${() => SpinnerAppearance.accent}"></${spinnerTag}>
+            <${spinnerTag}
+                style="${isChromatic() ? '--ni-private-spinner-animation-play-state:paused' : ''}"
+                appearance="${() => SpinnerAppearance.accent}"
+            ></${spinnerTag}>
         </${chatMessageTag}>
     `),
     args: {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Chromatic infrastructure was updated and [new baselines were auto-accepted](https://www.chromatic.com/docs/infrastructure-upgrades/#upgrade-builds) but when running a full re-build there are still dirty changes because:
- Chromatic auto accepted the incorrect version of the [unstable fiirefox menu story](https://github.com/ni/nimble/issues/1862)
- chat message and chat conversation stories were unstable due to animated spinner usage

## 👩‍💻 Implementation

- Disable the chat stories spinner animations
- Tweak preview.js for a full build
- Accept the changes as new baselines

## 🧪 Testing

Rely on CI

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
