### PR TITLE
Configure Renovate to update @ni npm deps immediately

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -40,7 +40,7 @@
       "enabled": true
     },
     {
-      "groupName": "npm NI dependencies",
+      "groupName": "npm NI dependencies update to latest",
       "matchManagers": ["npm"],
       "rangeStrategy": "update-lockfile",
       "matchDepTypes": ["dependencies", "devDependencies", "peerDependencies"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -40,6 +40,14 @@
       "enabled": true
     },
     {
+      "groupName": "npm NI dependencies",
+      "matchManagers": ["npm"],
+      "rangeStrategy": "update-lockfile",
+      "matchDepTypes": ["dependencies", "devDependencies", "peerDependencies"],
+      "matchPackageNames": "@ni/**",
+      "schedule": ["at any time"]
+    },
+    {
       "groupName": "nuget dependencies",
       "matchManagers": ["nuget"],
       "excludePackagePatterns":[


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

#2557 

## 👩‍💻 Implementation

Add a configuration for npm dependencies starting with `@ni/` to update immediately. This should include the FAST forks and javascript-styleguide packages.

## 🧪 Testing

I was hoping Renovate would ping this PR to let us know what it'll do but I don't think that's how it works ([yet](https://github.com/renovatebot/renovate/pull/34696)). I'll see what PR it creates after I complete this PR.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
