### PR TITLE
Fix color of placeholder text in disabled select

### DIFF
--- a/change/@ni-nimble-components-2f1afb28-1f86-43f7-9618-d0e54d7221e0.json
+++ b/change/@ni-nimble-components-2f1afb28-1f86-43f7-9618-d0e54d7221e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix color of placeholder text in disabled select",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/select/styles.ts
+++ b/packages/nimble-components/src/select/styles.ts
@@ -4,6 +4,7 @@ import { styles as dropdownStyles } from '../patterns/dropdown/styles';
 import { styles as errorStyles } from '../patterns/error/styles';
 import { styles as requiredVisibleStyles } from '../patterns/required-visible/styles';
 import {
+    bodyDisabledFontColor,
     borderRgbPartialColor,
     borderWidth,
     controlHeight,
@@ -35,6 +36,10 @@ export const styles = css`
 
     .selected-value.placeholder {
         color: ${placeholderFontColor};
+    }
+
+    :host([disabled]) .selected-value.placeholder {
+        color: ${bodyDisabledFontColor};
     }
 
     .selected-value {

--- a/packages/storybook/src/nimble/select/select-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-matrix.stories.ts
@@ -18,8 +18,8 @@ import {
     type DisabledState,
     type ErrorState,
     errorStates,
-    errorStatesNoError,
-    errorStatesErrorNoMessage
+    requiredVisibleStates,
+    type RequiredVisibleState
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -33,8 +33,9 @@ const appearanceStates = [
 type AppearanceState = (typeof appearanceStates)[number];
 
 const valueStates = [
-    ['Short Value', 'Option 1'],
-    ['Long Value', loremIpsum]
+    ['Short Value', 1],
+    ['Long Value', 2],
+    ['Placeholder', undefined]
 ] as const;
 type ValueState = (typeof valueStates)[number];
 
@@ -55,10 +56,11 @@ export default metadata;
 
 // prettier-ignore
 const component = (
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [disabledName, disabled]: DisabledState,
     [appearanceName, appearance]: AppearanceState,
     [errorName, errorVisible, errorText]: ErrorState,
-    [valueName, valueValue]: ValueState,
+    [valueName, selectedValue]: ValueState,
     [clearableName, clearable]: ClearableState
 ): ViewTemplate => html`
     <${selectTag}
@@ -67,18 +69,22 @@ const component = (
         ?disabled="${() => disabled}"
         ?clearable="${() => clearable}"
         appearance="${() => appearance}"
+        ?required-visible="${() => requiredVisible}"
+        current-value="${() => selectedValue}"
         style="width: 250px; margin: var(${standardPadding.cssCustomProperty});"
     >
-        ${() => errorName} ${() => disabledName} ${() => appearanceName} ${() => valueName} ${() => clearableName}
-        <${listOptionTag} value="1">${valueValue}</${listOptionTag}>
-        <${listOptionTag} value="2" disabled>Option 2</${listOptionTag}>
-        <${listOptionTag} value="3">Option 3</${listOptionTag}>
+        ${() => errorName} ${() => disabledName} ${() => appearanceName} ${() => valueName} ${() => clearableName} ${() => requiredVisibleName}
+        <${listOptionTag} value="1">Option 1</${listOptionTag}>
+        <${listOptionTag} value="2">${loremIpsum}</${listOptionTag}>
+        <${listOptionTag} value="3" disabled>Option 3</${listOptionTag}>
         <${listOptionTag} value="4" hidden>Option 4</${listOptionTag}>
+        <${listOptionTag} value="5" disabled hidden>Placeholder</${listOptionTag}>
     </${selectTag}>
 `;
 
 export const selectThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
+        requiredVisibleStates,
         disabledStates,
         appearanceStates,
         errorStates,
@@ -146,49 +152,6 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
             </${selectTag}>
         `
     )
-);
-
-// prettier-ignore
-const requiredTestComponent = (
-    [disabledName, disabled]: DisabledState,
-): ViewTemplate => html`
-    <${selectTag}
-        ?disabled="${() => disabled}"
-        required-visible
-        style="width: 250px; margin: var(${standardPadding.cssCustomProperty});"
-    >
-        ${() => disabledName} Select Label
-        <${listOptionTag} value="1">Option 1</${listOptionTag}>
-    </${selectTag}>
-`;
-
-export const requiredAsterisk: StoryFn = createMatrixThemeStory(
-    createMatrix(requiredTestComponent, [disabledStates])
-);
-
-// prettier-ignore
-const placeholderTestComponent = (
-    [disabledName, disabled]: DisabledState,
-    [errorName, errorVisible, errorText]: ErrorState
-): ViewTemplate => html`
-    <${selectTag}
-        ?error-visible="${() => errorVisible}"
-        error-text="${() => errorText}"
-        ?disabled="${() => disabled}"
-        clearable
-        style="width: 250px; margin: var(${standardPadding.cssCustomProperty});"
-    >
-        ${() => errorName} ${() => disabledName} Clearable
-        <${listOptionTag} value="1" disabled hidden>${loremIpsum}</${listOptionTag}>
-        <${listOptionTag} value="2">Option 2</${listOptionTag}>
-    </${selectTag}>
-`;
-
-export const placeholder: StoryFn = createMatrixThemeStory(
-    createMatrix(placeholderTestComponent, [
-        disabledStates,
-        [errorStatesNoError, errorStatesErrorNoMessage]
-    ])
 );
 
 export const heightTest: StoryFn = createStory(

--- a/packages/storybook/src/nimble/select/select-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-matrix.stories.ts
@@ -18,8 +18,8 @@ import {
     type DisabledState,
     type ErrorState,
     errorStates,
-    requiredVisibleStates,
-    type RequiredVisibleState
+    errorStatesNoError,
+    errorStatesErrorNoMessage
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -55,7 +55,6 @@ export default metadata;
 
 // prettier-ignore
 const component = (
-    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [disabledName, disabled]: DisabledState,
     [appearanceName, appearance]: AppearanceState,
     [errorName, errorVisible, errorText]: ErrorState,
@@ -68,10 +67,9 @@ const component = (
         ?disabled="${() => disabled}"
         ?clearable="${() => clearable}"
         appearance="${() => appearance}"
-        ?required-visible="${() => requiredVisible}"
         style="width: 250px; margin: var(${standardPadding.cssCustomProperty});"
     >
-        ${() => errorName} ${() => disabledName} ${() => appearanceName} ${() => valueName} ${() => clearableName} ${() => requiredVisibleName}
+        ${() => errorName} ${() => disabledName} ${() => appearanceName} ${() => valueName} ${() => clearableName}
         <${listOptionTag} value="1">${valueValue}</${listOptionTag}>
         <${listOptionTag} value="2" disabled>Option 2</${listOptionTag}>
         <${listOptionTag} value="3">Option 3</${listOptionTag}>
@@ -81,7 +79,6 @@ const component = (
 
 export const selectThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
         disabledStates,
         appearanceStates,
         errorStates,
@@ -149,6 +146,49 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
             </${selectTag}>
         `
     )
+);
+
+// prettier-ignore
+const requiredTestComponent = (
+    [disabledName, disabled]: DisabledState,
+): ViewTemplate => html`
+    <${selectTag}
+        ?disabled="${() => disabled}"
+        required-visible
+        style="width: 250px; margin: var(${standardPadding.cssCustomProperty});"
+    >
+        ${() => disabledName} Select Label
+        <${listOptionTag} value="1">Option 1</${listOptionTag}>
+    </${selectTag}>
+`;
+
+export const requiredAsterisk: StoryFn = createMatrixThemeStory(
+    createMatrix(requiredTestComponent, [disabledStates])
+);
+
+// prettier-ignore
+const placeholderTestComponent = (
+    [disabledName, disabled]: DisabledState,
+    [errorName, errorVisible, errorText]: ErrorState
+): ViewTemplate => html`
+    <${selectTag}
+        ?error-visible="${() => errorVisible}"
+        error-text="${() => errorText}"
+        ?disabled="${() => disabled}"
+        clearable
+        style="width: 250px; margin: var(${standardPadding.cssCustomProperty});"
+    >
+        ${() => errorName} ${() => disabledName} Clearable
+        <${listOptionTag} value="1" disabled hidden>${loremIpsum}</${listOptionTag}>
+        <${listOptionTag} value="2">Option 2</${listOptionTag}>
+    </${selectTag}>
+`;
+
+export const placeholder: StoryFn = createMatrixThemeStory(
+    createMatrix(placeholderTestComponent, [
+        disabledStates,
+        [errorStatesNoError, errorStatesErrorNoMessage]
+    ])
 );
 
 export const heightTest: StoryFn = createStory(


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #2555 

## 👩‍💻 Implementation

There are six Nimble components that have placeholder text:
- combobox
- number-field
- rich-text editor
- select
- text-area
- text-field

All of them except the select already dim the placeholder text when the component is disabled.

Because the combobox and select use different CSS selectors to control this styling (`:host([disabled]) .selected-value.placeholder` vs `.selected-value[disabled]::placeholder`), I added the missing styling to the select's stylesheet rather than the shared "dropdown" stylesheet .

## 🧪 Testing

Added visual test case for select placeholder text. Checked in local Storybook build.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
