### PR TITLE
Remove unnecessary require.resolve that is causing error

### DIFF
--- a/packages/storybook/.storybook/main.js
+++ b/packages/storybook/.storybook/main.js
@@ -38,7 +38,7 @@ export function webpackFinal(config) {
         test: /\.(ts|tsx)$/,
         use: [
             {
-                loader: require.resolve('ts-loader')
+                loader: 'ts-loader'
             }
         ]
     });


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Locally, Storybook doesn't build for me. It gives error: 

```
> @ni-private/storybook@1.0.0 start
> storybook dev --quiet -p 6006

@storybook/core v8.6.3

info => Serving static files from ./.\.storybook\public at /
info Addon-docs: using MDX3
info => Using implicit CSS loaders
=> Failed to build the preview
ReferenceError: require is not defined
    at Object.webpackFinal (file:///C:/dev/nimble/packages/storybook/.storybook/main.js:41:25)
    at C:\dev\nimble\node_modules\@storybook\core\dist\common\index.cjs:16550:18
    at async Object.webpack (C:\dev\nimble\node_modules\@storybook\builder-webpack5\dist\presets\custom-webpack-preset.js:1:3280)
    at async starter (C:\dev\nimble\node_modules\@storybook\builder-webpack5\dist\index.js:1:22247)
    at async Module.start (C:\dev\nimble\node_modules\@storybook\builder-webpack5\dist\index.js:1:26052)
    at async storybookDevServer (C:\dev\nimble\node_modules\@storybook\core\dist\core-server\index.cjs:36411:79)
    at async buildOrThrow (C:\dev\nimble\node_modules\@storybook\core\dist\core-server\index.cjs:35035:12)
    at async buildDevStandalone (C:\dev\nimble\node_modules\@storybook\core\dist\core-server\index.cjs:37616:78)
    at async withTelemetry (C:\dev\nimble\node_modules\@storybook\core\dist\core-server\index.cjs:35774:12)
    at async dev (C:\dev\nimble\node_modules\@storybook\core\dist\cli\bin\index.cjs:2566:3)

WARN Broken build, fix the error above.
WARN You may need to refresh the browser.
```

## 👩‍💻 Implementation

I suspect it has something to do with my version of Node.js, which is 23.10.0. It doesn't seem like we actually need to resolve the module path, though, because [webpack will use standard module resolution](https://webpack.js.org/concepts/loaders/#resolving-loaders) to find it.

## 🧪 Testing

Local build runs.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
