### PR TITLE
Sync packages to release versions after package publish fail

### DIFF
--- a/change/@ni-nimble-angular-c420485b-44d3-42a8-891f-737f1b9eff97.json
+++ b/change/@ni-nimble-angular-c420485b-44d3-42a8-891f-737f1b9eff97.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Re-release packages",
+  "packageName": "@ni/nimble-angular",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-blazor-5ad99698-07b8-4b4d-94e5-b79732be1fa9.json
+++ b/change/@ni-nimble-blazor-5ad99698-07b8-4b4d-94e5-b79732be1fa9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Re-release packages",
+  "packageName": "@ni/nimble-blazor",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-95195c6b-f085-469e-9a1c-716c492ef6f8.json
+++ b/change/@ni-nimble-components-95195c6b-f085-469e-9a1c-716c492ef6f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Re-release packages",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-spright-angular-4f0d1068-b9a9-4f08-8c15-118c646654ff.json
+++ b/change/@ni-spright-angular-4f0d1068-b9a9-4f08-8c15-118c646654ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Re-release packages",
+  "packageName": "@ni/spright-angular",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-spright-blazor-0c226bde-1287-4bb7-8e11-9a7211d84060.json
+++ b/change/@ni-spright-blazor-0c226bde-1287-4bb7-8e11-9a7211d84060.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Re-release packages",
+  "packageName": "@ni/spright-blazor",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-spright-components-ea1ac31f-cfe0-4235-b0d4-1b35d1ef7f80.json
+++ b/change/@ni-spright-components-ea1ac31f-cfe0-4235-b0d4-1b35d1ef7f80.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Re-release packages",
+  "packageName": "@ni/spright-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30622,7 +30622,7 @@
     },
     "packages/angular-workspace/nimble-angular": {
       "name": "@ni/nimble-angular",
-      "version": "30.0.1",
+      "version": "30.0.2",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.2.0"
@@ -30633,7 +30633,7 @@
         "@angular/forms": "^18.2.13",
         "@angular/localize": "^18.2.13",
         "@angular/router": "^18.2.13",
-        "@ni/nimble-components": "^33.0.1"
+        "@ni/nimble-components": "^33.0.2"
       }
     },
     "packages/angular-workspace/spright-angular": {
@@ -30646,7 +30646,7 @@
       "peerDependencies": {
         "@angular/common": "^18.2.13",
         "@angular/core": "^18.2.13",
-        "@ni/spright-components": "^5.0.1"
+        "@ni/spright-components": "^5.0.2"
       }
     },
     "packages/blazor-workspace": {
@@ -30670,7 +30670,7 @@
       "version": "20.0.1",
       "license": "MIT",
       "peerDependencies": {
-        "@ni/nimble-components": "^33.0.1",
+        "@ni/nimble-components": "^33.0.2",
         "@ni/nimble-tokens": "^8.7.0",
         "cross-env": "^7.0.3",
         "rimraf": "^6.0.0"
@@ -30780,7 +30780,7 @@
       "version": "4.0.1",
       "license": "MIT",
       "peerDependencies": {
-        "@ni/spright-components": "^5.0.1",
+        "@ni/spright-components": "^5.0.2",
         "cross-env": "^7.0.3",
         "rimraf": "^6.0.0"
       }
@@ -30815,7 +30815,7 @@
     },
     "packages/nimble-components": {
       "name": "@ni/nimble-components",
-      "version": "33.0.1",
+      "version": "33.0.2",
       "license": "MIT",
       "dependencies": {
         "@ni/fast-colors": "^10.0.0",
@@ -30915,7 +30915,7 @@
         "@lhci/cli": "^0.14.0",
         "@ni-private/eslint-config-nimble": "*",
         "typescript": "~5.4.5",
-        "vite": "^6.2.3"
+        "vite": "^6.0.0"
       }
     },
     "packages/site": {
@@ -30928,17 +30928,17 @@
         "@11ty/eleventy": "^3.0.0",
         "@ni-private/eslint-config-nimble": "*",
         "typescript": "~5.4.5",
-        "vite": "^6.2.3"
+        "vite": "^6.0.0"
       }
     },
     "packages/spright-components": {
       "name": "@ni/spright-components",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "MIT",
       "dependencies": {
         "@ni/fast-element": "^10.0.0",
         "@ni/fast-foundation": "^10.0.0",
-        "@ni/nimble-components": "^33.0.1",
+        "@ni/nimble-components": "^33.0.2",
         "tslib": "^2.2.0"
       },
       "devDependencies": {

--- a/packages/angular-workspace/nimble-angular/package.json
+++ b/packages/angular-workspace/nimble-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ni/nimble-angular",
-  "version": "30.0.1",
+  "version": "30.0.2",
   "description": "Angular components for the NI Nimble Design System",
   "scripts": {
     "invoke-publish": "npm run invoke-publish:setup && cd ../dist/nimble-angular && npm publish",
@@ -32,7 +32,7 @@
     "@angular/forms": "^18.2.13",
     "@angular/localize": "^18.2.13",
     "@angular/router": "^18.2.13",
-    "@ni/nimble-components": "^33.0.1"
+    "@ni/nimble-components": "^33.0.2"
   },
   "dependencies": {
     "tslib": "^2.2.0"

--- a/packages/angular-workspace/spright-angular/package.json
+++ b/packages/angular-workspace/spright-angular/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "@angular/common": "^18.2.13",
     "@angular/core": "^18.2.13",
-    "@ni/spright-components": "^5.0.1"
+    "@ni/spright-components": "^5.0.2"
   },
   "dependencies": {
     "tslib": "^2.2.0"

--- a/packages/blazor-workspace/NimbleBlazor/package.json
+++ b/packages/blazor-workspace/NimbleBlazor/package.json
@@ -25,7 +25,7 @@
     "!*"
   ],
   "peerDependencies": {
-    "@ni/nimble-components": "^33.0.1",
+    "@ni/nimble-components": "^33.0.2",
     "@ni/nimble-tokens": "^8.7.0",
     "cross-env": "^7.0.3",
     "rimraf": "^6.0.0"

--- a/packages/blazor-workspace/SprightBlazor/package.json
+++ b/packages/blazor-workspace/SprightBlazor/package.json
@@ -25,7 +25,7 @@
     "!*"
   ],
   "peerDependencies": {
-    "@ni/spright-components": "^5.0.1",
+    "@ni/spright-components": "^5.0.2",
     "cross-env": "^7.0.3",
     "rimraf": "^6.0.0"
   }

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ni/nimble-components",
-  "version": "33.0.1",
+  "version": "33.0.2",
   "description": "Styled web components for the NI Nimble Design System",
   "scripts": {
     "build": "npm run generate-icons && npm run generate-workers && npm run build-components && npm run bundle-components && npm run generate-scss",

--- a/packages/spright-components/package.json
+++ b/packages/spright-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ni/spright-components",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "NI Spright Components",
   "scripts": {
     "build": "npm run build-components && npm run bundle-components",
@@ -50,7 +50,7 @@
   "dependencies": {
     "@ni/fast-element": "^10.0.0",
     "@ni/fast-foundation": "^10.0.0",
-    "@ni/nimble-components": "^33.0.1",
+    "@ni/nimble-components": "^33.0.2",
     "tslib": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The package publish steps failed due to an expired Nuget API token during publishing of the latest Blazor packages.

## 👩‍💻 Implementation

- Updated the Nuget API key for publishing (and removed nuget.org from my spam filter)
- Performed the [Recovering from a failed beachball publish](https://github.com/ni/nimble/blob/sb-import-update/CONTRIBUTING.md#recovering-from-a-failed-beachball-publish) steps.

## 🧪 Testing

Rely on CI.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
