### PR TITLE
circle-minus icon

### DIFF
--- a/change/@ni-nimble-components-66271dae-844d-4662-a205-dafa7925dd68.json
+++ b/change/@ni-nimble-components-66271dae-844d-4662-a205-dafa7925dd68.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add new circle-minus icon",
+  "packageName": "@ni/nimble-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-66271dae-844d-4662-a205-dafa7925dd68.json
+++ b/change/@ni-nimble-components-66271dae-844d-4662-a205-dafa7925dd68.json
@@ -2,6 +2,6 @@
   "type": "minor",
   "comment": "Add new circle-minus icon",
   "packageName": "@ni/nimble-components",
-  "email": "jattasNI@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "email": "1458528+fredvisser@users.noreply.github.com",
+  "dependentChangeType": "minor"
 }

--- a/change/@ni-nimble-tokens-d755ff3f-81b3-4204-94f7-92d39c24e487.json
+++ b/change/@ni-nimble-tokens-d755ff3f-81b3-4204-94f7-92d39c24e487.json
@@ -2,6 +2,6 @@
   "type": "minor",
   "comment": "Add new circle-minus icon",
   "packageName": "@ni/nimble-tokens",
-  "email": "jattasNI@users.noreply.github.com",
+  "email": "1458528+fredvisser@users.noreply.github.com",
   "dependentChangeType": "patch"
 }

--- a/change/@ni-nimble-tokens-d755ff3f-81b3-4204-94f7-92d39c24e487.json
+++ b/change/@ni-nimble-tokens-d755ff3f-81b3-4204-94f7-92d39c24e487.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add new circle-minus icon",
+  "packageName": "@ni/nimble-tokens",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/icon-base/tests/icon-metadata.ts
+++ b/packages/nimble-components/src/icon-base/tests/icon-metadata.ts
@@ -181,6 +181,9 @@ export const iconMetadata: {
     IconCircleFilled: {
         tags: []
     },
+    IconCircleMinus: {
+        tags: ['not set', 'dash', 'hyphen']
+    },
     IconCirclePartialBroken: {
         tags: ['status', 'partially connected']
     },

--- a/packages/nimble-tokens/dist/icons/svg/circle-minus_16x16.svg
+++ b/packages/nimble-tokens/dist/icons/svg/circle-minus_16x16.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" data-name="Layer 1"
+  xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path class="cls-1" d="M8,4c2.21,0,4,1.79,4,4s-1.79,4-4,4-4-1.79-4-4,1.79-4,4-4M8,2c-3.31,0-6,2.69-6,6s2.69,6,6,6,6-2.69,6-6-2.69-6-6-6h0ZM11,9h-6v-2h6v2Z"/>
+</svg>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

#2563

Used `circle-minus` per [FontAwesome](https://fontawesome.com/icons/circle-minus?f=classic&s=regular), and metaphors: 'not set', 'dash', 'hyphen'

## 👩‍💻 Implementation

Followed [CONTRIBUTING](https://github.com/ni/nimble/blob/aebf4f3c222b8a404ecf0c3b5c9595205e1dc7a8/packages/nimble-tokens/CONTRIBUTING.md) process.

## 🧪 Testing

Manual color review and Chromatic

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
