### PR TITLE
Update Actions to Ubuntu 24.04 and Playwright to 1.51.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         if: env.HAS_GITHUBPAGESDEPLOYTOKEN == 'true'

--- a/change/@ni-jasmine-parameterized-5db36204-edc0-4b51-99c8-f3abdb299ccc.json
+++ b/change/@ni-jasmine-parameterized-5db36204-edc0-4b51-99c8-f3abdb299ccc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update ubuntu and playwright versions",
+  "packageName": "@ni/jasmine-parameterized",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-nimble-angular-2842943b-1c92-47a9-aa0f-7b33090f134e.json
+++ b/change/@ni-nimble-angular-2842943b-1c92-47a9-aa0f-7b33090f134e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update ubuntu and playwright versions",
+  "packageName": "@ni/nimble-angular",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-nimble-components-afe4a5e0-f271-4bd3-800d-f4c5a921457d.json
+++ b/change/@ni-nimble-components-afe4a5e0-f271-4bd3-800d-f4c5a921457d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update ubuntu and playwright versions",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-spright-angular-7cdaa54e-b2cf-43ff-849f-586c97ad850b.json
+++ b/change/@ni-spright-angular-7cdaa54e-b2cf-43ff-849f-586c97ad850b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update ubuntu and playwright versions",
+  "packageName": "@ni/spright-angular",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-spright-components-a47705af-43f6-467b-95a0-bda2851493c7.json
+++ b/change/@ni-spright-components-a47705af-43f6-467b-95a0-bda2851493c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update ubuntu and playwright versions",
+  "packageName": "@ni/spright-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "concurrently": "^9.0.0",
         "cross-env": "^7.0.3",
         "patch-package": "^8.0.0",
-        "playwright": "1.44.0"
+        "playwright": "1.51.0"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -24219,35 +24219,33 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
-      "integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.0.tgz",
+      "integrity": "sha512-442pTfGM0xxfCYxuBa/Pu6B2OqxqqaYq39JS8QDMGThUvIOCd6s0ANDog3uwA0cHavVlnTQzGCN7Id2YekDSXA==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.44.0"
+        "playwright-core": "1.51.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
-      "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.0.tgz",
+      "integrity": "sha512-x47yPE3Zwhlil7wlNU/iktF7t2r/URR3VLbH6EknJd/04Qc/PSJ0EY3CMXipmglLG+zyRxW6HNo2EGbKLHPWMg==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/please-upgrade-node": {
@@ -30643,7 +30641,7 @@
         "karma-jasmine-html-reporter": "^2.0.0",
         "karma-spec-reporter": "^0.0.36",
         "ng-packagr": "^18.2.1",
-        "playwright": "1.44.0",
+        "playwright": "1.51.0",
         "rollup": "^4.12.0",
         "typescript": "~5.4.5"
       }
@@ -30689,7 +30687,7 @@
         "@rollup/plugin-node-resolve": "^16.0.0",
         "cross-env": "^7.0.3",
         "glob": "^11.0.0",
-        "playwright": "1.44.0",
+        "playwright": "1.51.0",
         "rollup": "^4.12.0"
       }
     },
@@ -30837,7 +30835,7 @@
         "karma-jasmine": "^5.1.0",
         "karma-jasmine-html-reporter": "^2.0.0",
         "karma-spec-reporter": "^0.0.36",
-        "playwright": "1.44.0",
+        "playwright": "1.51.0",
         "typescript": "~5.4.5"
       }
     },
@@ -30907,7 +30905,7 @@
         "karma-spec-reporter": "^0.0.36",
         "karma-webkit-launcher": "^2.6.0",
         "karma-webpack": "^5.0.0",
-        "playwright": "1.44.0",
+        "playwright": "1.51.0",
         "prettier-eslint": "^16.3.0",
         "prettier-eslint-cli": "^8.0.1",
         "rollup": "^4.12.0",
@@ -30990,7 +30988,7 @@
         "karma-spec-reporter": "^0.0.36",
         "karma-webkit-launcher": "^2.6.0",
         "karma-webpack": "^5.0.0",
-        "playwright": "1.44.0",
+        "playwright": "1.51.0",
         "prettier-eslint": "^16.3.0",
         "prettier-eslint-cli": "^8.0.1",
         "rollup": "^4.12.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "concurrently": "^9.0.0",
     "cross-env": "^7.0.3",
     "patch-package": "^8.0.0",
-    "playwright": "1.44.0"
+    "playwright": "1.51.0"
   }
 }

--- a/packages/angular-workspace/example-client-app/karma.conf.js
+++ b/packages/angular-workspace/example-client-app/karma.conf.js
@@ -10,6 +10,24 @@ const karmaCoverage = require('karma-coverage');
 const karmaAngular = require('@angular-devkit/build-angular/plugins/karma');
 const path = require('path');
 
+const commonChromeFlags = [
+    '--no-default-browser-check',
+    '--no-first-run',
+    '--no-sandbox',
+    '--no-managed-user-acknowledgment-check',
+    '--disable-background-timer-throttling',
+    '--disable-backing-store-limit',
+    '--disable-boot-animation',
+    '--disable-cloud-import',
+    '--disable-contextual-search',
+    '--disable-default-apps',
+    '--disable-extensions',
+    '--disable-infobars',
+    '--disable-translate',
+    '--force-prefers-reduced-motion',
+    '--lang=en-US'
+];
+
 module.exports = config => {
     config.set({
         basePath: '',
@@ -53,7 +71,18 @@ module.exports = config => {
         colors: true,
         logLevel: config.LOG_INFO,
         autoWatch: true,
-        browsers: ['ChromeHeadless'],
+        browsers: ['ChromeHeadlessOpt'],
+        customLaunchers: {
+            ChromeDebugging: {
+                base: 'Chrome',
+                flags: [...commonChromeFlags, '--remote-debugging-port=9333'],
+                debug: true
+            },
+            ChromeHeadlessOpt: {
+                base: 'ChromeHeadless',
+                flags: [...commonChromeFlags]
+            }
+        },
         singleRun: false,
         restartOnFileChange: true,
         customHeaders: [

--- a/packages/angular-workspace/nimble-angular/karma.conf.js
+++ b/packages/angular-workspace/nimble-angular/karma.conf.js
@@ -10,6 +10,24 @@ const karmaCoverage = require('karma-coverage');
 const karmaAngular = require('@angular-devkit/build-angular/plugins/karma');
 const path = require('path');
 
+const commonChromeFlags = [
+    '--no-default-browser-check',
+    '--no-first-run',
+    '--no-sandbox',
+    '--no-managed-user-acknowledgment-check',
+    '--disable-background-timer-throttling',
+    '--disable-backing-store-limit',
+    '--disable-boot-animation',
+    '--disable-cloud-import',
+    '--disable-contextual-search',
+    '--disable-default-apps',
+    '--disable-extensions',
+    '--disable-infobars',
+    '--disable-translate',
+    '--force-prefers-reduced-motion',
+    '--lang=en-US'
+];
+
 module.exports = config => {
     config.set({
         basePath: '',
@@ -53,7 +71,18 @@ module.exports = config => {
         colors: true,
         logLevel: config.LOG_INFO,
         autoWatch: true,
-        browsers: ['ChromeHeadless'],
+        browsers: ['ChromeHeadlessOpt'],
+        customLaunchers: {
+            ChromeDebugging: {
+                base: 'Chrome',
+                flags: [...commonChromeFlags, '--remote-debugging-port=9333'],
+                debug: true
+            },
+            ChromeHeadlessOpt: {
+                base: 'ChromeHeadless',
+                flags: [...commonChromeFlags]
+            }
+        },
         singleRun: false,
         restartOnFileChange: true,
         customHeaders: [

--- a/packages/angular-workspace/package.json
+++ b/packages/angular-workspace/package.json
@@ -64,7 +64,7 @@
     "karma-jasmine-html-reporter": "^2.0.0",
     "karma-spec-reporter": "^0.0.36",
     "ng-packagr": "^18.2.1",
-    "playwright": "1.44.0",
+    "playwright": "1.51.0",
     "rollup": "^4.12.0",
     "typescript": "~5.4.5"
   }

--- a/packages/angular-workspace/spright-angular/karma.conf.js
+++ b/packages/angular-workspace/spright-angular/karma.conf.js
@@ -10,6 +10,24 @@ const karmaCoverage = require('karma-coverage');
 const karmaAngular = require('@angular-devkit/build-angular/plugins/karma');
 const path = require('path');
 
+const commonChromeFlags = [
+    '--no-default-browser-check',
+    '--no-first-run',
+    '--no-sandbox',
+    '--no-managed-user-acknowledgment-check',
+    '--disable-background-timer-throttling',
+    '--disable-backing-store-limit',
+    '--disable-boot-animation',
+    '--disable-cloud-import',
+    '--disable-contextual-search',
+    '--disable-default-apps',
+    '--disable-extensions',
+    '--disable-infobars',
+    '--disable-translate',
+    '--force-prefers-reduced-motion',
+    '--lang=en-US'
+];
+
 module.exports = config => {
     config.set({
         basePath: '',
@@ -53,7 +71,18 @@ module.exports = config => {
         colors: true,
         logLevel: config.LOG_INFO,
         autoWatch: true,
-        browsers: ['ChromeHeadless'],
+        browsers: ['ChromeHeadlessOpt'],
+        customLaunchers: {
+            ChromeDebugging: {
+                base: 'Chrome',
+                flags: [...commonChromeFlags, '--remote-debugging-port=9333'],
+                debug: true
+            },
+            ChromeHeadlessOpt: {
+                base: 'ChromeHeadless',
+                flags: [...commonChromeFlags]
+            }
+        },
         singleRun: false,
         restartOnFileChange: true,
         customHeaders: [

--- a/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Acceptance/BlazorWorkspace.Testing.Acceptance.csproj
+++ b/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Acceptance/BlazorWorkspace.Testing.Acceptance.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="[1.44.0]" />
+    <PackageReference Include="Microsoft.Playwright" Version="[1.51.0]" />
     <PackageReference Include="NI.CSharp.Analyzers" Version="2.0.28" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Acceptance/packages.lock.json
+++ b/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Acceptance/packages.lock.json
@@ -41,13 +41,13 @@
       },
       "Microsoft.Playwright": {
         "type": "Direct",
-        "requested": "[1.44.0, 1.44.0]",
-        "resolved": "1.44.0",
-        "contentHash": "stag3Jv/FtjqR5/8UcVfyYyktPt9AHxBnNazyytu4cq5W8/J5DQDQEednk/cK2iGy2Y/dC0hUcCdxp9cFDckmA==",
+        "requested": "[1.51.0, 1.51.0]",
+        "resolved": "1.51.0",
+        "contentHash": "4nOOBtTwXyB+cE+XwkjnQGJVmjbrTrZ+nuKzLz+oCnv5z1FiB7PQLT9FH8wETmHLSawzXh/ucPdBeGA8mRGJEw==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
           "System.ComponentModel.Annotations": "5.0.0",
-          "System.Text.Json": "6.0.0"
+          "System.Text.Json": "6.0.10"
         }
       },
       "NI.CSharp.Analyzers": {
@@ -600,8 +600,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "zaJsHfESQvJ11vbXnNlkrR46IaMULk/gHxYsJphzSF+07kTjPHv+Oc14w6QEOfo3Q4hqLJgStUaYB9DBl0TmWg==",
+        "resolved": "6.0.10",
+        "contentHash": "NSB0kDipxn2ychp88NXWfFRFlmi1bst/xynOutbnpEfRCT9JZkZ7KOmF/I/hNKo2dILiMGnqblm+j1sggdLB9g==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Text.Encodings.Web": "6.0.0"

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests.Acceptance/NimbleBlazor.Tests.Acceptance.csproj
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests.Acceptance/NimbleBlazor.Tests.Acceptance.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="[1.44.0]" />
+    <PackageReference Include="Microsoft.Playwright" Version="[1.51.0]" />
     <PackageReference Include="NI.CSharp.Analyzers" Version="2.0.28" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests.Acceptance/packages.lock.json
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests.Acceptance/packages.lock.json
@@ -35,13 +35,13 @@
       },
       "Microsoft.Playwright": {
         "type": "Direct",
-        "requested": "[1.44.0, 1.44.0]",
-        "resolved": "1.44.0",
-        "contentHash": "stag3Jv/FtjqR5/8UcVfyYyktPt9AHxBnNazyytu4cq5W8/J5DQDQEednk/cK2iGy2Y/dC0hUcCdxp9cFDckmA==",
+        "requested": "[1.51.0, 1.51.0]",
+        "resolved": "1.51.0",
+        "contentHash": "4nOOBtTwXyB+cE+XwkjnQGJVmjbrTrZ+nuKzLz+oCnv5z1FiB7PQLT9FH8wETmHLSawzXh/ucPdBeGA8mRGJEw==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
           "System.ComponentModel.Annotations": "5.0.0",
-          "System.Text.Json": "6.0.0"
+          "System.Text.Json": "6.0.10"
         }
       },
       "NI.CSharp.Analyzers": {
@@ -619,8 +619,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "zaJsHfESQvJ11vbXnNlkrR46IaMULk/gHxYsJphzSF+07kTjPHv+Oc14w6QEOfo3Q4hqLJgStUaYB9DBl0TmWg==",
+        "resolved": "6.0.10",
+        "contentHash": "NSB0kDipxn2ychp88NXWfFRFlmi1bst/xynOutbnpEfRCT9JZkZ7KOmF/I/hNKo2dILiMGnqblm+j1sggdLB9g==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Text.Encodings.Web": "6.0.0"
@@ -670,7 +670,7 @@
           "Microsoft.AspNetCore.Mvc.Testing": "[8.0.11, )",
           "Microsoft.Extensions.Configuration": "[8.0.0, )",
           "Microsoft.NET.Test.Sdk": "[17.12.0, )",
-          "Microsoft.Playwright": "[1.44.0, 1.44.0]",
+          "Microsoft.Playwright": "[1.51.0, 1.51.0]",
           "NI.CSharp.Analyzers": "[2.0.28, )",
           "NimbleBlazor": "[1.0.0, )",
           "System.ComponentModel": "[4.3.0, )",

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests.Acceptance/SprightBlazor.Tests.Acceptance.csproj
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests.Acceptance/SprightBlazor.Tests.Acceptance.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="[1.44.0]" />
+    <PackageReference Include="Microsoft.Playwright" Version="[1.51.0]" />
     <PackageReference Include="NI.CSharp.Analyzers" Version="2.0.28" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests.Acceptance/packages.lock.json
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests.Acceptance/packages.lock.json
@@ -35,13 +35,13 @@
       },
       "Microsoft.Playwright": {
         "type": "Direct",
-        "requested": "[1.44.0, 1.44.0]",
-        "resolved": "1.44.0",
-        "contentHash": "stag3Jv/FtjqR5/8UcVfyYyktPt9AHxBnNazyytu4cq5W8/J5DQDQEednk/cK2iGy2Y/dC0hUcCdxp9cFDckmA==",
+        "requested": "[1.51.0, 1.51.0]",
+        "resolved": "1.51.0",
+        "contentHash": "4nOOBtTwXyB+cE+XwkjnQGJVmjbrTrZ+nuKzLz+oCnv5z1FiB7PQLT9FH8wETmHLSawzXh/ucPdBeGA8mRGJEw==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
           "System.ComponentModel.Annotations": "5.0.0",
-          "System.Text.Json": "6.0.0"
+          "System.Text.Json": "6.0.10"
         }
       },
       "NI.CSharp.Analyzers": {
@@ -599,8 +599,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "zaJsHfESQvJ11vbXnNlkrR46IaMULk/gHxYsJphzSF+07kTjPHv+Oc14w6QEOfo3Q4hqLJgStUaYB9DBl0TmWg==",
+        "resolved": "6.0.10",
+        "contentHash": "NSB0kDipxn2ychp88NXWfFRFlmi1bst/xynOutbnpEfRCT9JZkZ7KOmF/I/hNKo2dILiMGnqblm+j1sggdLB9g==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Text.Encodings.Web": "6.0.0"
@@ -650,7 +650,7 @@
           "Microsoft.AspNetCore.Mvc.Testing": "[8.0.11, )",
           "Microsoft.Extensions.Configuration": "[8.0.0, )",
           "Microsoft.NET.Test.Sdk": "[17.12.0, )",
-          "Microsoft.Playwright": "[1.44.0, 1.44.0]",
+          "Microsoft.Playwright": "[1.51.0, 1.51.0]",
           "NI.CSharp.Analyzers": "[2.0.28, )",
           "NimbleBlazor": "[1.0.0, )",
           "System.ComponentModel": "[4.3.0, )",

--- a/packages/blazor-workspace/package.json
+++ b/packages/blazor-workspace/package.json
@@ -33,7 +33,7 @@
     "@rollup/plugin-node-resolve": "^16.0.0",
     "cross-env": "^7.0.3",
     "glob": "^11.0.0",
-    "playwright": "1.44.0",
+    "playwright": "1.51.0",
     "rollup": "^4.12.0"
   }
 }

--- a/packages/jasmine-parameterized/package.json
+++ b/packages/jasmine-parameterized/package.json
@@ -50,7 +50,7 @@
     "karma-jasmine": "^5.1.0",
     "karma-jasmine-html-reporter": "^2.0.0",
     "karma-spec-reporter": "^0.0.36",
-    "playwright": "1.44.0",
+    "playwright": "1.51.0",
     "typescript": "~5.4.5"
   }
 }

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -123,7 +123,7 @@
     "karma-spec-reporter": "^0.0.36",
     "karma-webkit-launcher": "^2.6.0",
     "karma-webpack": "^5.0.0",
-    "playwright": "1.44.0",
+    "playwright": "1.51.0",
     "prettier-eslint": "^16.3.0",
     "prettier-eslint-cli": "^8.0.1",
     "rollup": "^4.12.0",

--- a/packages/spright-components/package.json
+++ b/packages/spright-components/package.json
@@ -74,7 +74,7 @@
     "karma-spec-reporter": "^0.0.36",
     "karma-webkit-launcher": "^2.6.0",
     "karma-webpack": "^5.0.0",
-    "playwright": "1.44.0",
+    "playwright": "1.51.0",
     "prettier-eslint": "^16.3.0",
     "prettier-eslint-cli": "^8.0.1",
     "rollup": "^4.12.0",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

- Updates playwright to latest versions available in both npm and nuget
- Updates the GitHub Action runner to the latest ubuntu release

## 👩‍💻 Implementation

- Performed updates above but did not attempt to re-enable previously failing tests mentioned in Manual Tasks issue. Will attempt to re-enable those in a follow-up (or when Manual Tasks are re-evaluated, whichever is first).
- In the Angular workspace ran into error:
   ```
   Cannot start ChromeHeadless
   [test:sequential                  ] 	[9840:9840:0328/170111.541561:FATAL:zygote_host_impl_linux.cc(132)] No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
   ```
   Looking at other karma configurations we already had the flag `--no-sandbox` configured for chrome. I just updated the karma workspace to use the same set of chrome flags as all the others.

## 🧪 Testing

- Rely on CI

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
