### PR TITLE
Remove Storybook documentation of old pattern for showing "prompt" buttons

### DIFF
--- a/packages/storybook/src/spright/chat/conversation/chat-conversation.mdx
+++ b/packages/storybook/src/spright/chat/conversation/chat-conversation.mdx
@@ -52,11 +52,6 @@ Clients can place any HTML content within the message.
 <Canvas of={messageStories.chatMessageImage} />
 <Controls of={messageStories.chatMessageImage} />
 
-#### Prompt buttons message content
-
-<Canvas of={messageStories.chatMessagePrompts} />
-<Controls of={messageStories.chatMessagePrompts} />
-
 ## Usage
 
 These components are part of [Spright](?path=/docs/spright-docs--docs). They can

--- a/packages/storybook/src/spright/chat/message/chat-message.stories.ts
+++ b/packages/storybook/src/spright/chat/message/chat-message.stories.ts
@@ -214,36 +214,3 @@ export const chatMessageImage: StoryObj<ChatMessageArgs> = {
         endButtons: false
     }
 };
-
-// prettier-ignore
-export const chatMessagePrompts: StoryObj<ChatMessageArgs> = {
-    render: createUserSelectedThemeStory(html`
-        <${chatMessageTag} message-type="${x => ChatMessageType[x.messageType]}">
-            <${buttonTag} appearance="${() => ButtonAppearance.block}">Eat my shorts</${buttonTag}>
-            <${buttonTag} appearance="${() => ButtonAppearance.block}">Do the Bartman</${buttonTag}>
-            ${when(x => x.footerActions, html`
-                <${buttonTag} slot="footer-actions" appearance="ghost" title="Like" content-hidden>
-                    <${iconThumbUpTag} slot="start"></${iconThumbUpTag}>
-                    Like
-                </${buttonTag}>
-                <${buttonTag} slot="footer-actions" appearance="ghost" title="Dislike" content-hidden>
-                    <${iconThumbDownTag} slot="start"></${iconThumbDownTag}>
-                    Dislike
-                </${buttonTag}>
-            `)}
-            ${when(x => x.endButtons, html`
-                <${buttonTag} slot="end" appearance="block">
-                    Order a tab
-                </${buttonTag}>
-                <${buttonTag} slot="end" appearance="block">
-                    Check core temperature
-                </${buttonTag}>
-            `)}
-        </${chatMessageTag}>
-    `),
-    args: {
-        messageType: 'system',
-        footerActions: false,
-        endButtons: false
-    }
-};

--- a/packages/storybook/src/spright/chat/message/chat-message.stories.ts
+++ b/packages/storybook/src/spright/chat/message/chat-message.stories.ts
@@ -12,7 +12,6 @@ import { richTextViewerTag } from '../../../../../nimble-components/src/rich-tex
 import { spinnerTag } from '../../../../../nimble-components/src/spinner';
 import { imgBlobUrl, markdownExample } from '../conversation/story-helpers';
 import { SpinnerAppearance } from '../../../../../nimble-components/src/spinner/types';
-import { ButtonAppearance } from '../../../../../nimble-components/src/menu-button/types';
 import { isChromatic } from '../../../utilities/isChromatic';
 import { iconThumbUpTag } from '../../../../../nimble-components/src/icons/thumb-up';
 import { iconThumbDownTag } from '../../../../../nimble-components/src/icons/thumb-down';


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

After #2552 completed I noticed that we still documented an approach of creating a dedicated message containing "prompt" buttons. The preferred approach is to use the new `end` slot on an existing message.

## 👩‍💻 Implementation

Delete content from storybook

## 🧪 Testing

Inspected storybook

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
