### PR TITLE
Update table number text column docs for unit to use slots API category

### DIFF
--- a/packages/storybook/src/nimble/table-column/number-text/table-column-number-text.stories.ts
+++ b/packages/storybook/src/nimble/table-column/number-text/table-column-number-text.stories.ts
@@ -224,6 +224,7 @@ export const numberTextColumn: StoryObj<NumberTextColumnTableArgs> = {
             table: { category: apiCategory.attributes }
         },
         unit: {
+            name: 'default',
             description: unitDescription,
             options: [
                 'default',
@@ -234,7 +235,7 @@ export const numberTextColumn: StoryObj<NumberTextColumnTableArgs> = {
                 'volt'
             ],
             control: { type: 'radio' },
-            table: { category: apiCategory.attributes }
+            table: { category: apiCategory.slots }
         },
         checkValidity: {
             name: 'checkValidity()',


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

I noticed that the docs for how to set units on `nimble-table-column-number-text` were incorrect. They correctly state that you specify units by slotting a unit element in the default slot. But those docs appeared in the attributes section of the API table.

## 👩‍💻 Implementation

Change the API category to "slots" and the display name to "default"

## 🧪 Testing

Local storybook

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
