### PR TITLE
Rename matrix tests

### DIFF
--- a/packages/storybook/CONTRIBUTING.md
+++ b/packages/storybook/CONTRIBUTING.md
@@ -104,6 +104,32 @@ All other Markdown formatting is supported. See any
 [Markdown Cheatsheet](https://www.markdownguide.org/cheat-sheet/) for more
 information.
 
+### Matrix story naming
+
+The names of stories within matrix tests should conform to the following guidelines:
+
+1. Do not include component name in the story name.
+    - Do: `Hidden`, `Theme Matrix`
+    - Don't: `Hidden Text Field`, `Select Theme Matrix`
+1. Do not include tests for multiple components under one storybook group.
+    - Do: `Radio Group >> Hidden`, `Radio >> Hidden`
+    - Don't: `Radio Group >> Hidden Radio Group` and `Radio Group >> Hidden Radio`
+1. Use `$` as a delimiter in test names that have a constant value for a matrix dimension.
+    - Do: `LightTheme$ Open$ No Filter`
+    - Don't: `Light Theme Open No Filter`
+1. Consider including a "false" attribute in a story name when there is a story for the value being both "false" and "true". This name should be in the form of "BooleanPropertyName" and "BooleanPropertyNameAbsent".
+    - Do: `Read Only Absent$ Disabled`, `Read Only$ Disabled Absent`
+    - Don't: `Editable$ Disabled`, `ReadOnly$ Enabled`
+1. Specify the theme as the first segment of the story name when it is a fixed value.
+    - Do: `Light Theme$ Open $No Filter`
+    - Don't: `Open$ No Filter$ Light Theme`
+1. Do not include the theme in the story name if it isn't part of the test dimension. If a test is run only for a single theme to test something unrelated to theme, the theme should not be included in the story name.
+    - Do: `Light Theme$ Open$ No Filter` (if there are also  `Dark Theme$ Open$ No Filter` and  `Color Theme$ Open$ No Filter`)
+    - Don't: `Light Theme$ Open$ No Filter` (if there are not also  `Dark Theme$ Open$ No Filter` and  `Color Theme$ Open$ No Filter`)
+1. Do not include the background color in the story name.
+    - Do: `Light Theme$ Open$ No Filter`
+    - Don't: `Light Theme White Background$ Open$ No Filter`, `Light Theme$ White Background$ Open$ No Filter`
+
 ### Testing
 
 When you run Storybook (See **Getting Started** above), you should see the

--- a/packages/storybook/CONTRIBUTING.md
+++ b/packages/storybook/CONTRIBUTING.md
@@ -106,29 +106,40 @@ information.
 
 ### Matrix story naming
 
-The names of stories within matrix tests should conform to the following guidelines:
+The names of stories within matrix tests should conform to the following
+guidelines:
 
 1. Do not include component name in the story name.
     - Do: `Hidden`, `Theme Matrix`
     - Don't: `Hidden Text Field`, `Select Theme Matrix`
 1. Do not include tests for multiple components under one storybook group.
     - Do: `Radio Group >> Hidden`, `Radio >> Hidden`
-    - Don't: `Radio Group >> Hidden Radio Group` and `Radio Group >> Hidden Radio`
-1. Use `$` as a delimiter in test names that have a constant value for a matrix dimension.
+    - Don't: `Radio Group >> Hidden Radio Group` and
+      `Radio Group >> Hidden Radio`
+1. Use `$` as a delimiter in test names that have a constant value for a matrix
+   dimension.
     - Do: `LightTheme$ Open$ No Filter`
     - Don't: `Light Theme Open No Filter`
-1. Consider including a "false" attribute in a story name when there is a story for the value being both "false" and "true". This name should be in the form of "BooleanPropertyName" and "BooleanPropertyNameAbsent".
+1. Consider including a "false" attribute in a story name when there is a story
+   for the value being both "false" and "true". This name should be in the form
+   of "BooleanPropertyName" and "BooleanPropertyNameAbsent".
     - Do: `Read Only Absent$ Disabled`, `Read Only$ Disabled Absent`
     - Don't: `Editable$ Disabled`, `ReadOnly$ Enabled`
-1. Specify the theme as the first segment of the story name when it is a fixed value.
+1. Specify the theme as the first segment of the story name when it is a fixed
+   value.
     - Do: `Light Theme$ Open $No Filter`
     - Don't: `Open$ No Filter$ Light Theme`
-1. Do not include the theme in the story name if it isn't part of the test dimension. If a test is run only for a single theme to test something unrelated to theme, the theme should not be included in the story name.
-    - Do: `Light Theme$ Open$ No Filter` (if there are also  `Dark Theme$ Open$ No Filter` and  `Color Theme$ Open$ No Filter`)
-    - Don't: `Light Theme$ Open$ No Filter` (if there are not also  `Dark Theme$ Open$ No Filter` and  `Color Theme$ Open$ No Filter`)
+1. Do not include the theme in the story name if it isn't part of the test
+   dimension. If a test is run only for a single theme to test something
+   unrelated to theme, the theme should not be included in the story name.
+    - Do: `Light Theme$ Open$ No Filter` (if there are also
+      `Dark Theme$ Open$ No Filter` and `Color Theme$ Open$ No Filter`)
+    - Don't: `Light Theme$ Open$ No Filter` (if there are not also
+      `Dark Theme$ Open$ No Filter` and `Color Theme$ Open$ No Filter`)
 1. Do not include the background color in the story name.
     - Do: `Light Theme$ Open$ No Filter`
-    - Don't: `Light Theme White Background$ Open$ No Filter`, `Light Theme$ White Background$ Open$ No Filter`
+    - Don't: `Light Theme White Background$ Open$ No Filter`,
+      `Light Theme$ White Background$ Open$ No Filter`
 
 ### Testing
 

--- a/packages/storybook/CONTRIBUTING.md
+++ b/packages/storybook/CONTRIBUTING.md
@@ -118,7 +118,7 @@ guidelines:
       `Radio Group >> Hidden Radio`
 1. Use `$` as a delimiter in test names that have a constant value for a matrix
    dimension.
-    - Do: `LightTheme$ Open$ No Filter`
+    - Do: `Light Theme$ Open$ No Filter`
     - Don't: `Light Theme Open No Filter`
 1. Consider including a "false" attribute in a story name when there is a story
    for the value being both "false" and "true". This name should be in the form

--- a/packages/storybook/src/nimble/anchor-button/anchor-button-matrix.stories.ts
+++ b/packages/storybook/src/nimble/anchor-button/anchor-button-matrix.stories.ts
@@ -57,7 +57,7 @@ const component = (
     </${anchorButtonTag}>
 `;
 
-export const anchorButtonThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         disabledStates,
         appearanceStates,
@@ -80,7 +80,7 @@ const interactionStates = cartesianProduct([
     [partVisibilityStatesOnlyLabel]
 ] as const);
 
-export const anchorButtonInteractionsThemeMatrix: StoryFn = createMatrixThemeStory(
+export const interactionsThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrixInteractionsFromStates(component, {
         hover: interactionStatesHover,
         hoverActive: interactionStates,
@@ -89,7 +89,7 @@ export const anchorButtonInteractionsThemeMatrix: StoryFn = createMatrixThemeSto
     })
 );
 
-export const hiddenAnchorButton: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${anchorButtonTag} hidden
             >Hidden Anchor Button</${anchorButtonTag}

--- a/packages/storybook/src/nimble/anchor-tabs/anchor-tabs-matrix.stories.ts
+++ b/packages/storybook/src/nimble/anchor-tabs/anchor-tabs-matrix.stories.ts
@@ -51,11 +51,11 @@ const component = (
     </${anchorTabsTag}>
 `;
 
-export const anchorTabsThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [tabsToolbarStates, disabledStates, widthStates])
 );
 
-export const hiddenTabs: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${anchorTabsTag} hidden>
             <${anchorTabTag}>Tab One</${anchorTabTag}>

--- a/packages/storybook/src/nimble/anchor/anchor-matrix.stories.ts
+++ b/packages/storybook/src/nimble/anchor/anchor-matrix.stories.ts
@@ -54,7 +54,7 @@ const component = (
             ${() => `${underlineHiddenName} ${appearanceName} ${disabledName} Link`}</${anchorTag}>
 `;
 
-export const anchorThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         disabledStates,
         underlineHiddenStates,
@@ -74,7 +74,7 @@ const interactionStates = cartesianProduct([
     appearanceStates
 ] as const);
 
-export const anchorInteractionsThemeMatrix: StoryFn = createMatrixThemeStory(
+export const interactionsThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrixInteractionsFromStates(component, {
         hover: interactionStatesHover,
         hoverActive: interactionStates,
@@ -83,7 +83,7 @@ export const anchorInteractionsThemeMatrix: StoryFn = createMatrixThemeStory(
     })
 );
 
-export const hiddenAnchor: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(html`<${anchorTag} hidden>Hidden Anchor</${anchorTag}>`)
 );
 

--- a/packages/storybook/src/nimble/anchored-region/anchored-region-matrix.stories.ts
+++ b/packages/storybook/src/nimble/anchored-region/anchored-region-matrix.stories.ts
@@ -90,11 +90,11 @@ const component = (
         <div></div>
     </div>`;
 
-export const anchoredRegionThemeMatrix: StoryFn = createStory(
+export const themeMatrix: StoryFn = createStory(
     createMatrix(component, [horizontalPositionStates, verticalPositionStates])
 );
 
-export const hiddenAnchoredRegion: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${anchoredRegionTag} hidden>Hidden Anchored Region</${anchoredRegionTag}>`
     )

--- a/packages/storybook/src/nimble/banner/banner-matrix.stories.ts
+++ b/packages/storybook/src/nimble/banner/banner-matrix.stories.ts
@@ -84,7 +84,7 @@ const component = (
     <div style="height: var(${bannerGapSize.cssCustomProperty})"></div>
 `;
 
-export const bannerThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         severityStates,
         actionStates,
@@ -93,7 +93,7 @@ export const bannerThemeMatrix: StoryFn = createMatrixThemeStory(
     ])
 );
 
-export const hiddenBanner: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${bannerTag} hidden>
             <span slot="title">Hidden banner</span>

--- a/packages/storybook/src/nimble/breadcrumb/breadcrumb-matrix.stories.ts
+++ b/packages/storybook/src/nimble/breadcrumb/breadcrumb-matrix.stories.ts
@@ -44,7 +44,7 @@ const component = (
         <${breadcrumbItemTag}>Current (No Link)</${breadcrumbItemTag}>
     </${breadcrumbTag}>
 `;
-export const breadcrumbThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [appearanceStates, disabledStates])
 );
 
@@ -53,7 +53,7 @@ const interactionStates = cartesianProduct([
     disabledStates
 ] as const);
 
-export const breadcrumbInteractionsThemeMatrix: StoryFn = createMatrixThemeStory(
+export const interactionsThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrixInteractionsFromStates(component, {
         hover: interactionStates,
         hoverActive: interactionStates,
@@ -62,7 +62,7 @@ export const breadcrumbInteractionsThemeMatrix: StoryFn = createMatrixThemeStory
     })
 );
 
-export const hiddenBreadcrumb: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${breadcrumbTag} hidden>
             <${breadcrumbItemTag} href="#">Item 1</${breadcrumbItemTag}>

--- a/packages/storybook/src/nimble/button/button-matrix.stories.ts
+++ b/packages/storybook/src/nimble/button/button-matrix.stories.ts
@@ -57,7 +57,7 @@ const component = (
     </${buttonTag}>
 `;
 
-export const buttonThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         disabledStates,
         appearanceStates,
@@ -80,7 +80,7 @@ const interactionStatesHover = cartesianProduct([
     [partVisibilityStatesOnlyLabel]
 ] as const);
 
-export const buttonInteractionsThemeMatrix: StoryFn = createMatrixThemeStory(
+export const interactionsThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrixInteractionsFromStates(component, {
         hover: interactionStatesHover,
         hoverActive: interactionStates,
@@ -89,7 +89,7 @@ export const buttonInteractionsThemeMatrix: StoryFn = createMatrixThemeStory(
     })
 );
 
-export const hiddenButton: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(html`<${buttonTag} hidden>Hidden Button</${buttonTag}>`)
 );
 

--- a/packages/storybook/src/nimble/card-button/card-button-matrix.stories.ts
+++ b/packages/storybook/src/nimble/card-button/card-button-matrix.stories.ts
@@ -63,11 +63,11 @@ const component = (
 </${cardButtonTag}>
 `;
 
-export const buttonThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [disabledStates, selectedStates])
 );
 
-export const hiddenButton: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${cardButtonTag} hidden>Hidden Card Button</${cardButtonTag}>`
     )

--- a/packages/storybook/src/nimble/card/card-matrix.stories.ts
+++ b/packages/storybook/src/nimble/card/card-matrix.stories.ts
@@ -35,10 +35,10 @@ const component = (): ViewTemplate => html`
     </${cardTag}>
 `;
 
-export const cardThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component)
 );
 
-export const hiddenCard: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(html`<${cardTag} hidden>Hidden Card</${cardTag}>`)
 );

--- a/packages/storybook/src/nimble/checkbox/checkbox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/checkbox/checkbox-matrix.stories.ts
@@ -59,7 +59,7 @@ const component = (
     ${checkedName} ${indeterminateName} ${disabledName} ${errorName} ${extraText}
 </${checkboxTag}>`;
 
-export const checkboxThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         disabledStates,
         checkedStates,
@@ -69,7 +69,7 @@ export const checkboxThemeMatrix: StoryFn = createMatrixThemeStory(
     ])
 );
 
-export const hiddenCheckbox: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(html`<${checkboxTag} hidden>Hidden Checkbox</${checkboxTag}>`)
 );
 

--- a/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
@@ -74,7 +74,7 @@ const component = (
     </${comboboxTag}>
 `;
 
-export const comboboxThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         requiredVisibleStates,
         disabledStates,
@@ -84,7 +84,7 @@ export const comboboxThemeMatrix: StoryFn = createMatrixThemeStory(
     ])
 );
 
-export const hiddenCombobox: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${comboboxTag} hidden style="width: 250px;">
             <${listOptionTag} value="1">Option 1</${listOptionTag}>

--- a/packages/storybook/src/nimble/combobox/combobox-opened-in-div.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox-opened-in-div.stories.ts
@@ -36,9 +36,9 @@ const component = ([
     </div>
 `;
 
-export const comboboxBelowNotConfinedByDiv: StoryFn = createStory(
+export const openBelow$NotConfinedByDiv: StoryFn = createStory(
     component(positionStates[0])
 );
-export const comboboxAboveNotConfinedByDiv: StoryFn = createStory(
+export const openAbove$NotConfinedByDiv: StoryFn = createStory(
     component(positionStates[1])
 );

--- a/packages/storybook/src/nimble/combobox/combobox-opened-matrix.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox-opened-matrix.stories.ts
@@ -63,32 +63,32 @@ if (remaining.length > 0) {
     throw new Error('New backgrounds need to be supported');
 }
 
-export const comboboxBelowOpenLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme$OpenBelow: StoryFn = createFixedThemeStory(
     component({ position: DropdownPosition.below }),
     lightThemeWhiteBackground
 );
 
-export const comboboxAboveOpenLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme$OpenAbove: StoryFn = createFixedThemeStory(
     component({ position: DropdownPosition.above }),
     lightThemeWhiteBackground
 );
 
-export const comboboxBelowOpenColorThemeDarkGreenBackground: StoryFn = createFixedThemeStory(
+export const colorTheme$OpenBelow: StoryFn = createFixedThemeStory(
     component({ position: DropdownPosition.below }),
     colorThemeDarkGreenBackground
 );
 
-export const comboboxAboveOpenColorThemeDarkGreenBackground: StoryFn = createFixedThemeStory(
+export const colorTheme$OpenAbove: StoryFn = createFixedThemeStory(
     component({ position: DropdownPosition.above }),
     colorThemeDarkGreenBackground
 );
 
-export const comboboxBelowOpenDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme$OpenBelow: StoryFn = createFixedThemeStory(
     component({ position: DropdownPosition.below }),
     darkThemeBlackBackground
 );
 
-export const comboboxAboveOpenDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme$OpenAbove: StoryFn = createFixedThemeStory(
     component({ position: DropdownPosition.above }),
     darkThemeBlackBackground
 );
@@ -98,19 +98,19 @@ const noMatchesPlayFunction = (): void => {
     combobox.value = 'abc';
 };
 
-export const comboboxBelowOpenNoMatchLightTheme: StoryFn = createFixedThemeStory(
+export const openBelow$NoMatch: StoryFn = createFixedThemeStory(
     component({ position: DropdownPosition.below }),
     lightThemeWhiteBackground
 );
-comboboxBelowOpenNoMatchLightTheme.play = noMatchesPlayFunction;
+openBelow$NoMatch.play = noMatchesPlayFunction;
 
-export const comboboxAboveOpenNoMatchDarkTheme: StoryFn = createFixedThemeStory(
+export const openAbove$NoMatch: StoryFn = createFixedThemeStory(
     component({ position: DropdownPosition.above }),
     darkThemeBlackBackground
 );
-comboboxAboveOpenNoMatchDarkTheme.play = noMatchesPlayFunction;
+openAbove$NoMatch.play = noMatchesPlayFunction;
 
-export const comboboxBelowOpenManyOptions: StoryFn = createFixedThemeStory(
+export const openBelow$ManyOptions: StoryFn = createFixedThemeStory(
     component({
         position: DropdownPosition.below,
         manyOptions: true
@@ -118,7 +118,7 @@ export const comboboxBelowOpenManyOptions: StoryFn = createFixedThemeStory(
     lightThemeWhiteBackground
 );
 
-export const comboboxAboveOpenManyOptions: StoryFn = createFixedThemeStory(
+export const openAbove$ManyOptions: StoryFn = createFixedThemeStory(
     component({
         position: DropdownPosition.above,
         manyOptions: true

--- a/packages/storybook/src/nimble/dialog/dialog-matrix.stories.ts
+++ b/packages/storybook/src/nimble/dialog/dialog-matrix.stories.ts
@@ -91,34 +91,34 @@ const playFunction = (): void => {
     void document.querySelector(dialogTag)!.show();
 };
 
-export const dialogLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme: StoryFn = createFixedThemeStory(
     component,
     lightThemeWhiteBackground
 );
 
-dialogLightThemeWhiteBackground.play = playFunction;
+lightTheme.play = playFunction;
 
-export const dialogColorThemeDarkGreenBackground: StoryFn = createFixedThemeStory(component, colorThemeDarkGreenBackground);
+export const colorTheme: StoryFn = createFixedThemeStory(component, colorThemeDarkGreenBackground);
 
-dialogColorThemeDarkGreenBackground.play = playFunction;
+colorTheme.play = playFunction;
 
-export const dialogDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme: StoryFn = createFixedThemeStory(
     component,
     darkThemeBlackBackground
 );
 
-dialogDarkThemeBlackBackground.play = playFunction;
+darkTheme.play = playFunction;
 
-export const dialogSmallSize: StoryFn = createFixedThemeStory(
+export const smallSize: StoryFn = createFixedThemeStory(
     dialogSizingTestCase(sizeStates[0]),
     lightThemeWhiteBackground
 );
 
-dialogSmallSize.play = playFunction;
+smallSize.play = playFunction;
 
-export const dialogLargeSize: StoryFn = createFixedThemeStory(
+export const largeSize: StoryFn = createFixedThemeStory(
     dialogSizingTestCase(sizeStates[1]),
     lightThemeWhiteBackground
 );
 
-dialogLargeSize.play = playFunction;
+largeSize.play = playFunction;

--- a/packages/storybook/src/nimble/dialog/dialog-matrix.stories.ts
+++ b/packages/storybook/src/nimble/dialog/dialog-matrix.stories.ts
@@ -98,7 +98,10 @@ export const lightTheme: StoryFn = createFixedThemeStory(
 
 lightTheme.play = playFunction;
 
-export const colorTheme: StoryFn = createFixedThemeStory(component, colorThemeDarkGreenBackground);
+export const colorTheme: StoryFn = createFixedThemeStory(
+    component,
+    colorThemeDarkGreenBackground
+);
 
 colorTheme.play = playFunction;
 

--- a/packages/storybook/src/nimble/drawer/drawer-matrix.stories.ts
+++ b/packages/storybook/src/nimble/drawer/drawer-matrix.stories.ts
@@ -42,7 +42,10 @@ export const lightTheme: StoryFn = createFixedThemeStory(
 
 lightTheme.play = playFunction;
 
-export const colorTheme: StoryFn = createFixedThemeStory(component, colorThemeDarkGreenBackground);
+export const colorTheme: StoryFn = createFixedThemeStory(
+    component,
+    colorThemeDarkGreenBackground
+);
 
 colorTheme.play = playFunction;
 

--- a/packages/storybook/src/nimble/drawer/drawer-matrix.stories.ts
+++ b/packages/storybook/src/nimble/drawer/drawer-matrix.stories.ts
@@ -35,20 +35,20 @@ const playFunction = (): void => {
     void document.querySelector(drawerTag)!.show();
 };
 
-export const drawerLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme: StoryFn = createFixedThemeStory(
     component,
     lightThemeWhiteBackground
 );
 
-drawerLightThemeWhiteBackground.play = playFunction;
+lightTheme.play = playFunction;
 
-export const drawerColorThemeDarkGreenBackground: StoryFn = createFixedThemeStory(component, colorThemeDarkGreenBackground);
+export const colorTheme: StoryFn = createFixedThemeStory(component, colorThemeDarkGreenBackground);
 
-drawerColorThemeDarkGreenBackground.play = playFunction;
+colorTheme.play = playFunction;
 
-export const drawerDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme: StoryFn = createFixedThemeStory(
     component,
     darkThemeBlackBackground
 );
 
-drawerDarkThemeBlackBackground.play = playFunction;
+darkTheme.play = playFunction;

--- a/packages/storybook/src/nimble/icon-base/icon-matrix.stories.ts
+++ b/packages/storybook/src/nimble/icon-base/icon-matrix.stories.ts
@@ -36,10 +36,10 @@ const component = ([stateName, state]: SeverityState): ViewTemplate => html`
     <${iconCheckTag} severity="${() => state}"></${iconCheckTag}>
 `;
 
-export const iconThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [severityStates])
 );
 
-export const hiddenIcon: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(html`<${iconCheckTag} hidden></${iconCheckTag}>`)
 );

--- a/packages/storybook/src/nimble/menu-button/menu-button-matrix.stories.ts
+++ b/packages/storybook/src/nimble/menu-button/menu-button-matrix.stories.ts
@@ -63,7 +63,7 @@ const component = (
     </${menuButtonTag}>
 `;
 
-export const menuButtonThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         openStates,
         partVisibilityStates,
@@ -89,7 +89,7 @@ const interactionStates = cartesianProduct([
     appearanceVariantStates
 ] as const);
 
-export const menuButtonInteractionsThemeMatrix: StoryFn = createMatrixThemeStory(
+export const interactionsThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrixInteractionsFromStates(component, {
         hover: interactionStatesHover,
         hoverActive: interactionStates,
@@ -98,7 +98,7 @@ export const menuButtonInteractionsThemeMatrix: StoryFn = createMatrixThemeStory
     })
 );
 
-export const hiddenMenuButton: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${menuButtonTag} hidden>Hidden Menu Button</${menuButtonTag}>`
     )

--- a/packages/storybook/src/nimble/menu-button/menu-button-opened-matrix.stories.ts
+++ b/packages/storybook/src/nimble/menu-button/menu-button-opened-matrix.stories.ts
@@ -48,29 +48,29 @@ if (remaining.length > 0) {
     throw new Error('New backgrounds need to be supported');
 }
 
-export const menuButtonBelowOpenLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme$OpenBelow: StoryFn = createFixedThemeStory(
     component(positionStates[0]),
     lightThemeWhiteBackground
 );
-export const menuButtonAboveOpenLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme$OpenAbove: StoryFn = createFixedThemeStory(
     component(positionStates[1]),
     lightThemeWhiteBackground
 );
 
-export const menuButtonBelowOpenColorThemeDarkGreenBackground: StoryFn = createFixedThemeStory(
+export const colorTheme$OpenBelow: StoryFn = createFixedThemeStory(
     component(positionStates[0]),
     colorThemeDarkGreenBackground
 );
-export const menuButtonAboveOpenColorThemeDarkGreenBackground: StoryFn = createFixedThemeStory(
+export const colorTheme$OpenAbove: StoryFn = createFixedThemeStory(
     component(positionStates[1]),
     colorThemeDarkGreenBackground
 );
 
-export const menuButtonBelowOpenDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme$OpenBelow: StoryFn = createFixedThemeStory(
     component(positionStates[0]),
     darkThemeBlackBackground
 );
-export const menuButtonAboveOpenDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme$OpenAbove: StoryFn = createFixedThemeStory(
     component(positionStates[1]),
     darkThemeBlackBackground
 );

--- a/packages/storybook/src/nimble/menu/menu-matrix.stories.ts
+++ b/packages/storybook/src/nimble/menu/menu-matrix.stories.ts
@@ -71,11 +71,11 @@ const component = (
     </span>
 `;
 
-export const menuThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [iconVisibleStates, subMenuStates])
 );
 
-export const hiddenMenu: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${menuTag} hidden>
             <${menuItemTag}>Item 1</${menuItemTag}>

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -83,7 +83,7 @@ const component = (
     </${numberFieldTag}>
 `;
 
-export const numberFieldThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         requiredVisibleStates,
         readOnlyStates,
@@ -117,7 +117,7 @@ const interactionStates = cartesianProduct([
     appearanceStates
 ] as const);
 
-export const numberFieldInteractionsThemeMatrix: StoryFn = createMatrixThemeStory(
+export const interactionsThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrixInteractionsFromStates(component, {
         hover: interactionStatesHover,
         hoverActive: interactionStates,
@@ -126,7 +126,7 @@ export const numberFieldInteractionsThemeMatrix: StoryFn = createMatrixThemeStor
     })
 );
 
-export const hiddenNumberField: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`
             <${numberFieldTag} hidden>

--- a/packages/storybook/src/nimble/patterns/required-visible/required-visible.stories.ts
+++ b/packages/storybook/src/nimble/patterns/required-visible/required-visible.stories.ts
@@ -104,4 +104,4 @@ const metadata: Meta<RequiredVisiblePatternArgs> = {
 
 export default metadata;
 
-export const requiredVisiblePattern: StoryObj<RequiredVisiblePatternArgs> = {};
+export const pattern: StoryObj<RequiredVisiblePatternArgs> = {};

--- a/packages/storybook/src/nimble/radio-group/radio-group-matrix.stories.ts
+++ b/packages/storybook/src/nimble/radio-group/radio-group-matrix.stories.ts
@@ -55,7 +55,7 @@ const component = (
     <${radioTag} value="2">Option 2</${radioTag}>
 </${radioGroupTag}>`;
 
-export const radioGroupThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         requiredVisibleStates,
         disabledStates,
@@ -64,14 +64,10 @@ export const radioGroupThemeMatrix: StoryFn = createMatrixThemeStory(
     ])
 );
 
-export const hiddenRadioGroup: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${radioGroupTag} hidden>Hidden Radio Group</${radioGroupTag}>`
     )
-);
-
-export const hiddenRadio: StoryFn = createStory(
-    hiddenWrapper(html`<${radioTag} hidden>Hidden Radio</${radioTag}>`)
 );
 
 export const textCustomized: StoryFn = createMatrixThemeStory(

--- a/packages/storybook/src/nimble/radio/radio-matrix.stories.ts
+++ b/packages/storybook/src/nimble/radio/radio-matrix.stories.ts
@@ -1,0 +1,19 @@
+import type { StoryFn, Meta } from '@storybook/html';
+import { html } from '@ni/fast-element';
+import { radioTag } from '../../../../nimble-components/src/radio';
+import { sharedMatrixParameters } from '../../utilities/matrix';
+import { createStory } from '../../utilities/storybook';
+import { hiddenWrapper } from '../../utilities/hidden';
+
+const metadata: Meta = {
+    title: 'Tests/Radio',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
+
+export const hidden: StoryFn = createStory(
+    hiddenWrapper(html`<${radioTag} hidden>Hidden Radio</${radioTag}>`)
+);

--- a/packages/storybook/src/nimble/rich-text-mention/users/view/rich-text-mention-users-view-matrix.stories.ts
+++ b/packages/storybook/src/nimble/rich-text-mention/users/view/rich-text-mention-users-view-matrix.stories.ts
@@ -50,4 +50,4 @@ const component = ([
     </div>
 `;
 
-export const richTextMentionUserViewThemeMatrix: StoryFn = createMatrixThemeStory(createMatrix(component, [disabledStates]));
+export const themeMatrix: StoryFn = createMatrixThemeStory(createMatrix(component, [disabledStates]));

--- a/packages/storybook/src/nimble/rich-text-mention/users/view/rich-text-mention-users-view-matrix.stories.ts
+++ b/packages/storybook/src/nimble/rich-text-mention/users/view/rich-text-mention-users-view-matrix.stories.ts
@@ -50,4 +50,6 @@ const component = ([
     </div>
 `;
 
-export const themeMatrix: StoryFn = createMatrixThemeStory(createMatrix(component, [disabledStates]));
+export const themeMatrix: StoryFn = createMatrixThemeStory(
+    createMatrix(component, [disabledStates])
+);

--- a/packages/storybook/src/nimble/rich-text/editor/rich-text-editor-matrix.stories.ts
+++ b/packages/storybook/src/nimble/rich-text/editor/rich-text-editor-matrix.stories.ts
@@ -136,7 +136,7 @@ const slotButtonsTextCase = (
     </${richTextEditorTag}>
 `;
 
-export const richTextEditorThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         disabledStates,
         footerHiddenStates,
@@ -144,9 +144,9 @@ export const richTextEditorThemeMatrix: StoryFn = createMatrixThemeStory(
         [placeholderValueStates[0]]
     ])
 );
-richTextEditorThemeMatrix.play = playFunction;
+themeMatrix.play = playFunction;
 
-export const errorStateThemeMatrixWithLengthyContent: StoryFn = createMatrixThemeStory(
+export const errorState$LongContent: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         [disabledStates[0]],
         [footerHiddenStates[0]],
@@ -154,9 +154,9 @@ export const errorStateThemeMatrixWithLengthyContent: StoryFn = createMatrixThem
         [placeholderValueStates[0]]
     ])
 );
-errorStateThemeMatrixWithLengthyContent.play = longTextPlayFunction;
+errorState$LongContent.play = longTextPlayFunction;
 
-export const placeholderStateThemeMatrix: StoryFn = createMatrixThemeStory(
+export const placeholder: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         disabledStates,
         [footerHiddenStates[0]],
@@ -165,7 +165,7 @@ export const placeholderStateThemeMatrix: StoryFn = createMatrixThemeStory(
     ])
 );
 
-export const richTextEditorSizing: StoryFn = createStory(html`
+export const sizing: StoryFn = createStory(html`
     ${createMatrix(editorSizingTestCase, [
         [
             ['No width', ''],
@@ -180,7 +180,7 @@ export const richTextEditorSizing: StoryFn = createStory(html`
     ])}
 `);
 
-export const richTextEditorSlotButtons: StoryFn = createStory(html`
+export const slottedButtons: StoryFn = createStory(html`
     ${createMatrix(slotButtonsTextCase, [slotButtons])}
 `);
 
@@ -202,8 +202,8 @@ const mobileWidthComponent = html`
     </${richTextEditorTag}>
 `;
 
-export const plainTextContentInMobileWidth: StoryFn = createStory(mobileWidthComponent);
-plainTextContentInMobileWidth.play = (): void => {
+export const plainTextContent$MobileWidth: StoryFn = createStory(mobileWidthComponent);
+plainTextContent$MobileWidth.play = (): void => {
     document.querySelector(richTextEditorTag)!.setMarkdown(loremIpsum);
 };
 
@@ -218,8 +218,8 @@ const multipleSubPointsContent = `
                      1. Sub point 8
                         1. Sub point 9`;
 
-export const multipleSubPointsContentInMobileWidth: StoryFn = createStory(mobileWidthComponent);
-multipleSubPointsContentInMobileWidth.play = (): void => {
+export const multipleSubPointsContent$MobileWidth: StoryFn = createStory(mobileWidthComponent);
+multipleSubPointsContent$MobileWidth.play = (): void => {
     document
         .querySelector(richTextEditorTag)!
         .setMarkdown(multipleSubPointsContent);
@@ -239,8 +239,8 @@ differentListElementInSameLevel.play = (): void => {
         .setMarkdown(differentListElementContentInSameLevel);
 };
 
-export const longWordContentInMobileWidth: StoryFn = createStory(mobileWidthComponent);
-longWordContentInMobileWidth.play = (): void => {
+export const longWordContent$MobileWidth: StoryFn = createStory(mobileWidthComponent);
+longWordContent$MobileWidth.play = (): void => {
     document
         .querySelector(richTextEditorTag)!
         .setMarkdown(
@@ -261,15 +261,15 @@ This line enters new line in paragraph tag
       Hard break sub point content
 `;
 
-export const newLineWithForceLineBreakInMobileWidth: StoryFn = createStory(mobileWidthComponent);
-newLineWithForceLineBreakInMobileWidth.play = (): void => {
+export const newLineWithForceLineBreak$MobileWidth: StoryFn = createStory(mobileWidthComponent);
+newLineWithForceLineBreak$MobileWidth.play = (): void => {
     document
         .querySelector(richTextEditorTag)!
         .setMarkdown(newLineWithForceLineBreakContent);
 };
 
-export const longLinkInMobileWidth: StoryFn = createStory(mobileWidthComponent);
-longLinkInMobileWidth.play = (): void => {
+export const longLink$MobileWidth: StoryFn = createStory(mobileWidthComponent);
+longLink$MobileWidth.play = (): void => {
     document
         .querySelector(richTextEditorTag)!
         .setMarkdown(
@@ -277,6 +277,6 @@ longLinkInMobileWidth.play = (): void => {
         );
 };
 
-export const hiddenRichTextEditor: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(html`<${richTextEditorTag} hidden></${richTextEditorTag}>`)
 );

--- a/packages/storybook/src/nimble/rich-text/mention-listbox/mention-listbox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/rich-text/mention-listbox/mention-listbox-matrix.stories.ts
@@ -56,7 +56,9 @@ const component = (): ViewTemplate => html`
 
 `;
 
-export const themeMatrix: StoryFn = createMatrixThemeStory(createMatrix(component));
+export const themeMatrix: StoryFn = createMatrixThemeStory(
+    createMatrix(component)
+);
 themeMatrix.play = playFunction;
 
 export const hidden: StoryFn = createStory(

--- a/packages/storybook/src/nimble/rich-text/mention-listbox/mention-listbox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/rich-text/mention-listbox/mention-listbox-matrix.stories.ts
@@ -56,10 +56,10 @@ const component = (): ViewTemplate => html`
 
 `;
 
-export const richTextMentionListboxThemeMatrix: StoryFn = createMatrixThemeStory(createMatrix(component));
-richTextMentionListboxThemeMatrix.play = playFunction;
+export const themeMatrix: StoryFn = createMatrixThemeStory(createMatrix(component));
+themeMatrix.play = playFunction;
 
-export const hiddenRichTextMentionListbox: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${richTextMentionListboxTag} hidden>
             <${listOptionTag} value="1">Option 1</${listOptionTag}>

--- a/packages/storybook/src/nimble/rich-text/viewer/rich-text-viewer-matrix.stories.ts
+++ b/packages/storybook/src/nimble/rich-text/viewer/rich-text-viewer-matrix.stories.ts
@@ -81,11 +81,11 @@ const componentFitToContent = ([widthLabel, widthStyle]: [
     </${richTextViewerTag}>
 `;
 
-export const richTextViewerThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component)
 );
 
-export const richTextViewerSizing: StoryFn = createStory(html`
+export const sizing: StoryFn = createStory(html`
     ${createMatrix(viewerSizingTestCase, [
         [
             ['No width', ''],
@@ -100,7 +100,7 @@ export const richTextViewerSizing: StoryFn = createStory(html`
     ])}
 `);
 
-export const differentContentsInMobileWidth: StoryFn = createStory(html`
+export const differentContents$MobileWidth: StoryFn = createStory(html`
     ${createMatrix(viewerDifferentContentTestCase, [
         [
             ['No content', ''],
@@ -138,6 +138,6 @@ export const fitToContentTest: StoryFn = createStory(html`
     ])}
 `);
 
-export const hiddenRichTextViewer: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(html`<${richTextViewerTag} hidden></${richTextViewerTag}>`)
 );

--- a/packages/storybook/src/nimble/select/select-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-matrix.stories.ts
@@ -82,7 +82,7 @@ const component = (
     </${selectTag}>
 `;
 
-export const selectThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         requiredVisibleStates,
         disabledStates,
@@ -93,7 +93,7 @@ export const selectThemeMatrix: StoryFn = createMatrixThemeStory(
     ])
 );
 
-export const hiddenSelect: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${selectTag} hidden style="width: 250px;">
             <${listOptionTag} value="1">Option 1</${listOptionTag}>

--- a/packages/storybook/src/nimble/select/select-opened-in-div.stories.ts
+++ b/packages/storybook/src/nimble/select/select-opened-in-div.stories.ts
@@ -36,9 +36,9 @@ const component = ([
     </div>
 `;
 
-export const selectBelowNotConfinedByDiv: StoryFn = createStory(
+export const openBelow$NotConfinedByDiv: StoryFn = createStory(
     component(positionStates[0])
 );
-export const selectAboveNotConfinedByDiv: StoryFn = createStory(
+export const openAbove$NotConfinedByDiv: StoryFn = createStory(
     component(positionStates[1])
 );

--- a/packages/storybook/src/nimble/select/select-opened-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-opened-matrix.stories.ts
@@ -124,7 +124,7 @@ if (remaining.length > 0) {
     throw new Error('New backgrounds need to be supported');
 }
 
-export const selectBelowOpenNoFilterLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme$OpenBelow$NoFilter: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.none
@@ -132,7 +132,7 @@ export const selectBelowOpenNoFilterLightThemeWhiteBackground: StoryFn = createF
     lightThemeWhiteBackground
 );
 
-export const selectBelowOpenStandardFilterLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme$OpenBelow$StandardFilter: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard
@@ -140,7 +140,7 @@ export const selectBelowOpenStandardFilterLightThemeWhiteBackground: StoryFn = c
     lightThemeWhiteBackground
 );
 
-export const selectAboveOpenNoFilterLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme$OpenAbove$NoFilter: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.above,
         filterMode: FilterMode.none
@@ -148,7 +148,7 @@ export const selectAboveOpenNoFilterLightThemeWhiteBackground: StoryFn = createF
     lightThemeWhiteBackground
 );
 
-export const selectAboveOpenStandardFilterLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme$OpenAbove$StandardFilter: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.above,
         filterMode: FilterMode.standard
@@ -156,7 +156,7 @@ export const selectAboveOpenStandardFilterLightThemeWhiteBackground: StoryFn = c
     lightThemeWhiteBackground
 );
 
-export const selectBelowOpenColorNoFilterThemeDarkGreenBackground: StoryFn = createFixedThemeStory(
+export const colorTheme$OpenBelow$NoFilter: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.none
@@ -164,7 +164,7 @@ export const selectBelowOpenColorNoFilterThemeDarkGreenBackground: StoryFn = cre
     colorThemeDarkGreenBackground
 );
 
-export const selectBelowOpenColorStandardFilterThemeDarkGreenBackground: StoryFn = createFixedThemeStory(
+export const colorTheme$OpenBelow$StandardFilter: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard
@@ -172,7 +172,7 @@ export const selectBelowOpenColorStandardFilterThemeDarkGreenBackground: StoryFn
     colorThemeDarkGreenBackground
 );
 
-export const selectAboveOpenNoFilterColorThemeDarkGreenBackground: StoryFn = createFixedThemeStory(
+export const colorTheme$OpenAbove$NoFilter: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.above,
         filterMode: FilterMode.none
@@ -180,7 +180,7 @@ export const selectAboveOpenNoFilterColorThemeDarkGreenBackground: StoryFn = cre
     colorThemeDarkGreenBackground
 );
 
-export const selectAboveOpenStandardFilterColorThemeDarkGreenBackground: StoryFn = createFixedThemeStory(
+export const colorTheme$OpenAbove$StandardFilter: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.above,
         filterMode: FilterMode.standard
@@ -188,7 +188,7 @@ export const selectAboveOpenStandardFilterColorThemeDarkGreenBackground: StoryFn
     colorThemeDarkGreenBackground
 );
 
-export const selectBelowOpenNoFilterDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme$OpenBelow$NoFilter: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.none
@@ -196,7 +196,7 @@ export const selectBelowOpenNoFilterDarkThemeBlackBackground: StoryFn = createFi
     darkThemeBlackBackground
 );
 
-export const selectBelowOpenStandardFilterDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme$OpenBelow$StandardFilter: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard
@@ -204,7 +204,7 @@ export const selectBelowOpenStandardFilterDarkThemeBlackBackground: StoryFn = cr
     darkThemeBlackBackground
 );
 
-export const selectAboveOpenNoFilterDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme$OpenAbove$NoFilter: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.above,
         filterMode: FilterMode.none
@@ -212,7 +212,7 @@ export const selectAboveOpenNoFilterDarkThemeBlackBackground: StoryFn = createFi
     darkThemeBlackBackground
 );
 
-export const selectAboveOpenStandardFilterDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme$OpenAbove$StandardFilter: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.above,
         filterMode: FilterMode.standard
@@ -225,67 +225,61 @@ const noMatchesFilterPlayFunction = (): void => {
     select!.filter = 'abc';
 };
 
-export const selectAboveOpenFilterNoMatchDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme$OpenAbove$NoMatch: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.above,
         filterMode: FilterMode.standard
     }),
     darkThemeBlackBackground
 );
+darkTheme$OpenAbove$NoMatch.play = noMatchesFilterPlayFunction;
 
-selectAboveOpenFilterNoMatchDarkThemeBlackBackground.play = noMatchesFilterPlayFunction;
-
-export const selectAboveOpenFilterNoMatchLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme$OpenAbove$NoMatch: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.above,
         filterMode: FilterMode.standard
     }),
     lightThemeWhiteBackground
 );
+lightTheme$OpenAbove$NoMatch.play = noMatchesFilterPlayFunction;
 
-selectAboveOpenFilterNoMatchLightThemeWhiteBackground.play = noMatchesFilterPlayFunction;
-
-export const selectAboveOpenFilterNoMatchColorThemeDarkGreenBackground: StoryFn = createFixedThemeStory(
+export const colorTheme$OpenAbove$NoMatch: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.above,
         filterMode: FilterMode.standard
     }),
     colorThemeDarkGreenBackground
 );
+colorTheme$OpenAbove$NoMatch.play = noMatchesFilterPlayFunction;
 
-selectAboveOpenFilterNoMatchColorThemeDarkGreenBackground.play = noMatchesFilterPlayFunction;
-
-export const selectBelowOpenFilterNoMatchDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme$OpenBelow$NoMatch: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard
     }),
     darkThemeBlackBackground
 );
+darkTheme$OpenBelow$NoMatch.play = noMatchesFilterPlayFunction;
 
-selectBelowOpenFilterNoMatchDarkThemeBlackBackground.play = noMatchesFilterPlayFunction;
-
-export const selectBelowOpenFilterNoMatchLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme$OpenBelow$NoMatch: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard
     }),
     lightThemeWhiteBackground
 );
+lightTheme$OpenBelow$NoMatch.play = noMatchesFilterPlayFunction;
 
-selectBelowOpenFilterNoMatchLightThemeWhiteBackground.play = noMatchesFilterPlayFunction;
-
-export const selectBelowOpenFilterNoMatchColorThemeDarkGreenBackground: StoryFn = createFixedThemeStory(
+export const colorTheme$OpenBelow$NoMatch: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard
     }),
     colorThemeDarkGreenBackground
 );
+colorTheme$OpenBelow$NoMatch.play = noMatchesFilterPlayFunction;
 
-selectBelowOpenFilterNoMatchColorThemeDarkGreenBackground.play = noMatchesFilterPlayFunction;
-
-export const selectBelowOpenNoFilterLightThemeWhiteBackgroundWithPlaceholder: StoryFn = createFixedThemeStory(
+export const lightTheme$OpenBelow$NoFilter$WithPlaceholder: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.none,
@@ -294,7 +288,7 @@ export const selectBelowOpenNoFilterLightThemeWhiteBackgroundWithPlaceholder: St
     lightThemeWhiteBackground
 );
 
-export const selectBelowOpenNoFilterColorThemeDarkGreenBackgroundWithPlaceholder: StoryFn = createFixedThemeStory(
+export const colorTheme$OpenBelow$NoFilter$WithPlaceholder: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.none,
@@ -303,7 +297,7 @@ export const selectBelowOpenNoFilterColorThemeDarkGreenBackgroundWithPlaceholder
     colorThemeDarkGreenBackground
 );
 
-export const selectBelowOpenNoFilterDarkThemeBlackBackgroundWithPlaceholder: StoryFn = createFixedThemeStory(
+export const darkTheme$OpenBelow$NoFilter$WithPlaceholder: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.none,
@@ -312,7 +306,7 @@ export const selectBelowOpenNoFilterDarkThemeBlackBackgroundWithPlaceholder: Sto
     darkThemeBlackBackground
 );
 
-export const selectGroupedOptionsLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme$GroupedOptions: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard,
@@ -322,7 +316,7 @@ export const selectGroupedOptionsLightThemeWhiteBackground: StoryFn = createFixe
     lightThemeWhiteBackground
 );
 
-export const selectGroupedOptionsColorThemeDarkGreenBackground: StoryFn = createFixedThemeStory(
+export const colorTheme$GroupedOptions: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard,
@@ -332,7 +326,7 @@ export const selectGroupedOptionsColorThemeDarkGreenBackground: StoryFn = create
     colorThemeDarkGreenBackground
 );
 
-export const selectGroupedOptionsDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme$GroupedOptions: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard,
@@ -342,7 +336,7 @@ export const selectGroupedOptionsDarkThemeBlackBackground: StoryFn = createFixed
     darkThemeBlackBackground
 );
 
-export const selectGroupedAndNotGroupedOptionsLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme$GroupedAndUngroupedOptions: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard,
@@ -353,7 +347,7 @@ export const selectGroupedAndNotGroupedOptionsLightThemeWhiteBackground: StoryFn
     lightThemeWhiteBackground
 );
 
-export const selectGroupedAndNotGroupedOptionsColorThemeDarkGreenBackground: StoryFn = createFixedThemeStory(
+export const colorTheme$GroupedAndUngroupedOptions: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard,
@@ -364,7 +358,7 @@ export const selectGroupedAndNotGroupedOptionsColorThemeDarkGreenBackground: Sto
     colorThemeDarkGreenBackground
 );
 
-export const selectGroupedAndNotGroupedOptionsDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme$GroupedAndUngroupedOptions: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard,
@@ -375,7 +369,7 @@ export const selectGroupedAndNotGroupedOptionsDarkThemeBlackBackground: StoryFn 
     darkThemeBlackBackground
 );
 
-export const selectGroupedWithSlottedLabelLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme$SlottedGroupLabel: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard,
@@ -386,7 +380,7 @@ export const selectGroupedWithSlottedLabelLightThemeWhiteBackground: StoryFn = c
     lightThemeWhiteBackground
 );
 
-export const selectGroupedWithSlottedLabelColorThemeDarkGreenBackground: StoryFn = createFixedThemeStory(
+export const colorTheme$SlottedGroupLabel: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard,
@@ -397,7 +391,7 @@ export const selectGroupedWithSlottedLabelColorThemeDarkGreenBackground: StoryFn
     colorThemeDarkGreenBackground
 );
 
-export const selectGroupedWithSlottedLabelDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme$SlottedGroupLabel: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard,
@@ -408,7 +402,7 @@ export const selectGroupedWithSlottedLabelDarkThemeBlackBackground: StoryFn = cr
     darkThemeBlackBackground
 );
 
-export const selectBelowOpenLoadingVisibleNoGroupsLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme$OpenBelow$LoadingVisible: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard,
@@ -417,7 +411,7 @@ export const selectBelowOpenLoadingVisibleNoGroupsLightThemeWhiteBackground: Sto
     lightThemeWhiteBackground
 );
 
-export const selectBelowOpenLoadingVisibleNoGroupsDarkGreenBackground: StoryFn = createFixedThemeStory(
+export const colorTheme$OpenBelow$LoadingVisible: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard,
@@ -426,7 +420,7 @@ export const selectBelowOpenLoadingVisibleNoGroupsDarkGreenBackground: StoryFn =
     colorThemeDarkGreenBackground
 );
 
-export const selectBelowOpenLoadingVisibleNoGroupsDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme$OpenBelow$LoadingVisible: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard,
@@ -435,7 +429,7 @@ export const selectBelowOpenLoadingVisibleNoGroupsDarkThemeBlackBackground: Stor
     darkThemeBlackBackground
 );
 
-export const selectAboveOpenLoadingVisibleNoGroupsLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme$OpenAbove$LoadingVisible: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.above,
         filterMode: FilterMode.standard,
@@ -444,7 +438,7 @@ export const selectAboveOpenLoadingVisibleNoGroupsLightThemeWhiteBackground: Sto
     lightThemeWhiteBackground
 );
 
-export const selectAboveOpenLoadingVisibleNoGroupsDarkGreenBackground: StoryFn = createFixedThemeStory(
+export const colorTheme$OpenAbove$LoadingVisible: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.above,
         filterMode: FilterMode.standard,
@@ -453,7 +447,7 @@ export const selectAboveOpenLoadingVisibleNoGroupsDarkGreenBackground: StoryFn =
     colorThemeDarkGreenBackground
 );
 
-export const selectAboveOpenLoadingVisibleNoGroupsDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme$OpenAbove$LoadingVisible: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.above,
         filterMode: FilterMode.standard,
@@ -462,7 +456,7 @@ export const selectAboveOpenLoadingVisibleNoGroupsDarkThemeBlackBackground: Stor
     darkThemeBlackBackground
 );
 
-export const selectBelowLoadingVisibleNoMatchesLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const openBelow$NoMatches$LoadingVisible: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard,
@@ -470,10 +464,9 @@ export const selectBelowLoadingVisibleNoMatchesLightThemeWhiteBackground: StoryF
     }),
     lightThemeWhiteBackground
 );
+openBelow$NoMatches$LoadingVisible.play = noMatchesFilterPlayFunction;
 
-selectBelowLoadingVisibleNoMatchesLightThemeWhiteBackground.play = noMatchesFilterPlayFunction;
-
-export const selectAboveLoadingVisibleNoMatchesLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const openAbove$NoMatches$LoadingVisible: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.above,
         filterMode: FilterMode.standard,
@@ -481,10 +474,9 @@ export const selectAboveLoadingVisibleNoMatchesLightThemeWhiteBackground: StoryF
     }),
     lightThemeWhiteBackground
 );
+openAbove$NoMatches$LoadingVisible.play = noMatchesFilterPlayFunction;
 
-selectAboveLoadingVisibleNoMatchesLightThemeWhiteBackground.play = noMatchesFilterPlayFunction;
-
-export const selectBelowOpenNoFilterManyOptions: StoryFn = createFixedThemeStory(
+export const openBelow$NoFilter$ManyOptions: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.none,
@@ -493,7 +485,7 @@ export const selectBelowOpenNoFilterManyOptions: StoryFn = createFixedThemeStory
     lightThemeWhiteBackground
 );
 
-export const selectBelowOpenNoFilterLoadingVisibleManyOptions: StoryFn = createFixedThemeStory(
+export const openBelow$NoFilter$LoadingVisible$ManyOptions: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.none,
@@ -503,7 +495,7 @@ export const selectBelowOpenNoFilterLoadingVisibleManyOptions: StoryFn = createF
     lightThemeWhiteBackground
 );
 
-export const selectBelowOpenStandardFilterManyOptions: StoryFn = createFixedThemeStory(
+export const openBelow$StandardFilter$ManyOptions: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard,
@@ -512,7 +504,7 @@ export const selectBelowOpenStandardFilterManyOptions: StoryFn = createFixedThem
     lightThemeWhiteBackground
 );
 
-export const selectBelowOpenStandardFilterLoadingVisibleManyOptions: StoryFn = createFixedThemeStory(
+export const openBelow$StandardFilter$LoadingVisible$ManyOptions: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard,
@@ -522,7 +514,7 @@ export const selectBelowOpenStandardFilterLoadingVisibleManyOptions: StoryFn = c
     lightThemeWhiteBackground
 );
 
-export const selectBelowOpenStandardFilterGroupedManyOptions: StoryFn = createFixedThemeStory(
+export const openBelow$StandardFilter$Grouped$ManyOptions: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.below,
         filterMode: FilterMode.standard,
@@ -532,7 +524,7 @@ export const selectBelowOpenStandardFilterGroupedManyOptions: StoryFn = createFi
     lightThemeWhiteBackground
 );
 
-export const selectAboveOpenNoFilterManyOptions: StoryFn = createFixedThemeStory(
+export const openAbove$NoFilter$ManyOptions: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.above,
         filterMode: FilterMode.none,
@@ -541,7 +533,7 @@ export const selectAboveOpenNoFilterManyOptions: StoryFn = createFixedThemeStory
     lightThemeWhiteBackground
 );
 
-export const selectAboveOpenStandardFilterManyOptions: StoryFn = createFixedThemeStory(
+export const openAbove$StandardFilter$ManyOptions: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.above,
         filterMode: FilterMode.standard,
@@ -550,7 +542,7 @@ export const selectAboveOpenStandardFilterManyOptions: StoryFn = createFixedThem
     lightThemeWhiteBackground
 );
 
-export const selectAboveOpenStandardFilterLoadingVisibleManyOptions: StoryFn = createFixedThemeStory(
+export const openAbove$StandardFilter$LoadingVisible$ManyOptions: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.above,
         filterMode: FilterMode.standard,
@@ -560,7 +552,7 @@ export const selectAboveOpenStandardFilterLoadingVisibleManyOptions: StoryFn = c
     lightThemeWhiteBackground
 );
 
-export const selectAboveOpenStandardFilterGroupedManyOptions: StoryFn = createFixedThemeStory(
+export const openAbove$StandardFilter$Grouped$ManyOptions: StoryFn = createFixedThemeStory(
     component({
         positionState: DropdownPosition.above,
         filterMode: FilterMode.standard,

--- a/packages/storybook/src/nimble/spinner/spinner-matrix.stories.ts
+++ b/packages/storybook/src/nimble/spinner/spinner-matrix.stories.ts
@@ -56,10 +56,10 @@ const component = (
     </${spinnerTag}>
 `;
 
-export const spinnerThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [sizeStates, appearanceStates])
 );
 
-export const hiddenSpinner: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(html`<${spinnerTag} hidden></${spinnerTag}>`)
 );

--- a/packages/storybook/src/nimble/switch/switch-matrix.stories.ts
+++ b/packages/storybook/src/nimble/switch/switch-matrix.stories.ts
@@ -46,12 +46,12 @@ const component = (
     </${switchTag}>
 `;
 
-export const switchThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [checkedStates, disabledStates, messagesStates])
 );
 
 // prettier-ignore
-export const hiddenSwitch: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${switchTag} hidden>Hidden Switch</${switchTag}>`
     )

--- a/packages/storybook/src/nimble/table-column/anchor/table-column-anchor-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/anchor/table-column-anchor-matrix.stories.ts
@@ -83,7 +83,7 @@ const component = (
     </${tableTag}>
 `;
 
-export const tableColumnAnchorThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         appearanceStates,
         underlineHiddenStates,
@@ -91,7 +91,7 @@ export const tableColumnAnchorThemeMatrix: StoryFn = createMatrixThemeStory(
     ])
 );
 
-tableColumnAnchorThemeMatrix.play = async (): Promise<void> => {
+themeMatrix.play = async (): Promise<void> => {
     await Promise.all(
         Array.from(document.querySelectorAll(tableTag)).map(async table => {
             await table.setData(data);

--- a/packages/storybook/src/nimble/table-column/date-text/table-column-date-text-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/date-text/table-column-date-text-matrix.stories.ts
@@ -58,11 +58,11 @@ const component = (
     </${tableTag}>
 `;
 
-export const tableColumnDateTextThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [placeholderStates])
 );
 
-tableColumnDateTextThemeMatrix.play = async (): Promise<void> => {
+themeMatrix.play = async (): Promise<void> => {
     await Promise.all(
         Array.from(document.querySelectorAll(tableTag)).map(async table => {
             await table.setData(data);

--- a/packages/storybook/src/nimble/table-column/duration-text/table-column-duration-text-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/duration-text/table-column-duration-text-matrix.stories.ts
@@ -57,9 +57,9 @@ const component = (
     </${tableTag}>
 `;
 
-export const tableColumnDurationTextThemeMatrix: StoryFn = createMatrixThemeStory(createMatrix(component, [placeholderStates]));
+export const themeMatrix: StoryFn = createMatrixThemeStory(createMatrix(component, [placeholderStates]));
 
-tableColumnDurationTextThemeMatrix.play = async (): Promise<void> => {
+themeMatrix.play = async (): Promise<void> => {
     await Promise.all(
         Array.from(document.querySelectorAll(tableTag)).map(async table => {
             await table.setData(data);

--- a/packages/storybook/src/nimble/table-column/duration-text/table-column-duration-text-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/duration-text/table-column-duration-text-matrix.stories.ts
@@ -57,7 +57,9 @@ const component = (
     </${tableTag}>
 `;
 
-export const themeMatrix: StoryFn = createMatrixThemeStory(createMatrix(component, [placeholderStates]));
+export const themeMatrix: StoryFn = createMatrixThemeStory(
+    createMatrix(component, [placeholderStates])
+);
 
 themeMatrix.play = async (): Promise<void> => {
     await Promise.all(

--- a/packages/storybook/src/nimble/table-column/mapping/table-column-mapping-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/mapping/table-column-mapping-matrix.stories.ts
@@ -102,9 +102,9 @@ const component = (): ViewTemplate => html`
     </${tableTag}>
 `;
 
-export const tableColumnMappingThemeMatrix: StoryFn = createMatrixThemeStory(component());
+export const themeMatrix: StoryFn = createMatrixThemeStory(component());
 
-tableColumnMappingThemeMatrix.play = async (): Promise<void> => {
+themeMatrix.play = async (): Promise<void> => {
     await Promise.all(
         Array.from(document.querySelectorAll(tableTag)).map(async table => {
             await table.setData(data);

--- a/packages/storybook/src/nimble/table-column/menu-button/table-column-menu-button-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/menu-button/table-column-menu-button-matrix.stories.ts
@@ -51,11 +51,11 @@ const component = (): ViewTemplate => html`
     </${tableTag}>
 `;
 
-export const tableColumnMenuButtonThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component)
 );
 
-tableColumnMenuButtonThemeMatrix.play = async (): Promise<void> => {
+themeMatrix.play = async (): Promise<void> => {
     await Promise.all(
         Array.from(document.querySelectorAll(tableTag)).map(async table => {
             await table.setData(data);

--- a/packages/storybook/src/nimble/table-column/menu-button/table-column-menu-button-opened-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/menu-button/table-column-menu-button-opened-matrix.stories.ts
@@ -72,14 +72,11 @@ const playFunction = async (): Promise<void> => {
     await columnPageObject.getMenuButton(0, 0)!.openMenu();
 };
 
-export const tableColumnMenuButtonOpenedLightThemeWhiteBackground: StoryFn = createFixedThemeStory(component, lightThemeWhiteBackground);
+export const lightTheme$Open: StoryFn = createFixedThemeStory(component, lightThemeWhiteBackground);
+lightTheme$Open.play = playFunction;
 
-tableColumnMenuButtonOpenedLightThemeWhiteBackground.play = playFunction;
+export const colorTheme$Open: StoryFn = createFixedThemeStory(component, colorThemeDarkGreenBackground);
+colorTheme$Open.play = playFunction;
 
-export const tableColumnMenuButtonOpenedColorThemeDarkGreenBackground: StoryFn = createFixedThemeStory(component, colorThemeDarkGreenBackground);
-
-tableColumnMenuButtonOpenedColorThemeDarkGreenBackground.play = playFunction;
-
-export const tableColumnMenuButtonOpenedDarkThemeBlackBackground: StoryFn = createFixedThemeStory(component, darkThemeBlackBackground);
-
-tableColumnMenuButtonOpenedDarkThemeBlackBackground.play = playFunction;
+export const darkTheme$Open: StoryFn = createFixedThemeStory(component, darkThemeBlackBackground);
+darkTheme$Open.play = playFunction;

--- a/packages/storybook/src/nimble/table-column/menu-button/table-column-menu-button-opened-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/menu-button/table-column-menu-button-opened-matrix.stories.ts
@@ -72,11 +72,20 @@ const playFunction = async (): Promise<void> => {
     await columnPageObject.getMenuButton(0, 0)!.openMenu();
 };
 
-export const lightTheme$Open: StoryFn = createFixedThemeStory(component, lightThemeWhiteBackground);
+export const lightTheme$Open: StoryFn = createFixedThemeStory(
+    component,
+    lightThemeWhiteBackground
+);
 lightTheme$Open.play = playFunction;
 
-export const colorTheme$Open: StoryFn = createFixedThemeStory(component, colorThemeDarkGreenBackground);
+export const colorTheme$Open: StoryFn = createFixedThemeStory(
+    component,
+    colorThemeDarkGreenBackground
+);
 colorTheme$Open.play = playFunction;
 
-export const darkTheme$Open: StoryFn = createFixedThemeStory(component, darkThemeBlackBackground);
+export const darkTheme$Open: StoryFn = createFixedThemeStory(
+    component,
+    darkThemeBlackBackground
+);
 darkTheme$Open.play = playFunction;

--- a/packages/storybook/src/nimble/table-column/number-text/table-column-number-text-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/number-text/table-column-number-text-matrix.stories.ts
@@ -81,11 +81,11 @@ const component = (
     </${tableTag}>
 `;
 
-export const tableColumnNumberTextThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [alignmentStates, placeholderStates])
 );
 
-tableColumnNumberTextThemeMatrix.play = async (): Promise<void> => {
+themeMatrix.play = async (): Promise<void> => {
     await Promise.all(
         Array.from(document.querySelectorAll(tableTag)).map(async table => {
             await table.setData(data);

--- a/packages/storybook/src/nimble/table-column/text/table-column-text-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table-column/text/table-column-text-matrix.stories.ts
@@ -68,11 +68,11 @@ const component = (
     </${tableTag}>
 `;
 
-export const tableColumnTextThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [placeholderStates])
 );
 
-tableColumnTextThemeMatrix.play = async (): Promise<void> => {
+themeMatrix.play = async (): Promise<void> => {
     await Promise.all(
         Array.from(document.querySelectorAll(tableTag)).map(async table => {
             await table.setData(data);

--- a/packages/storybook/src/nimble/table/table-action-menu-opened-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table/table-action-menu-opened-matrix.stories.ts
@@ -80,14 +80,23 @@ const playFunction = async (): Promise<void> => {
     await pageObject.clickCellActionMenu(0, 0);
 };
 
-export const lightTheme$ActionMenuOpened: StoryFn = createFixedThemeStory(component, lightThemeWhiteBackground);
+export const lightTheme$ActionMenuOpened: StoryFn = createFixedThemeStory(
+    component,
+    lightThemeWhiteBackground
+);
 
 lightTheme$ActionMenuOpened.play = playFunction;
 
-export const colorTheme$ActionMenuOpened: StoryFn = createFixedThemeStory(component, colorThemeDarkGreenBackground);
+export const colorTheme$ActionMenuOpened: StoryFn = createFixedThemeStory(
+    component,
+    colorThemeDarkGreenBackground
+);
 
 colorTheme$ActionMenuOpened.play = playFunction;
 
-export const darkTheme$ActionMenuOpened: StoryFn = createFixedThemeStory(component, darkThemeBlackBackground);
+export const darkTheme$ActionMenuOpened: StoryFn = createFixedThemeStory(
+    component,
+    darkThemeBlackBackground
+);
 
 darkTheme$ActionMenuOpened.play = playFunction;

--- a/packages/storybook/src/nimble/table/table-action-menu-opened-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table/table-action-menu-opened-matrix.stories.ts
@@ -80,14 +80,14 @@ const playFunction = async (): Promise<void> => {
     await pageObject.clickCellActionMenu(0, 0);
 };
 
-export const tableActionMenuOpenedLightThemeWhiteBackground: StoryFn = createFixedThemeStory(component, lightThemeWhiteBackground);
+export const lightTheme$ActionMenuOpened: StoryFn = createFixedThemeStory(component, lightThemeWhiteBackground);
 
-tableActionMenuOpenedLightThemeWhiteBackground.play = playFunction;
+lightTheme$ActionMenuOpened.play = playFunction;
 
-export const tableActionMenuOpenedColorThemeDarkGreenBackground: StoryFn = createFixedThemeStory(component, colorThemeDarkGreenBackground);
+export const colorTheme$ActionMenuOpened: StoryFn = createFixedThemeStory(component, colorThemeDarkGreenBackground);
 
-tableActionMenuOpenedColorThemeDarkGreenBackground.play = playFunction;
+colorTheme$ActionMenuOpened.play = playFunction;
 
-export const tableActionMenuOpenedDarkThemeBlackBackground: StoryFn = createFixedThemeStory(component, darkThemeBlackBackground);
+export const darkTheme$ActionMenuOpened: StoryFn = createFixedThemeStory(component, darkThemeBlackBackground);
 
-tableActionMenuOpenedDarkThemeBlackBackground.play = playFunction;
+darkTheme$ActionMenuOpened.play = playFunction;

--- a/packages/storybook/src/nimble/table/table-fit-rows-height-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table/table-fit-rows-height-matrix.stories.ts
@@ -76,21 +76,21 @@ const playFunction = async (rowCount: number): Promise<void> => {
     );
 };
 
-export const tableFitRowsHeightWith5Rows: StoryFn = createFixedThemeStory(
+export const fit5Rows: StoryFn = createFixedThemeStory(
     createMatrix(component, [groupingStates, minColumnWidthStates]),
     backgroundStates[0]
 );
 
-tableFitRowsHeightWith5Rows.play = async () => await playFunction(5);
+fit5Rows.play = async () => await playFunction(5);
 
-export const tableFitRowsHeightWith10Rows: StoryFn = createFixedThemeStory(
+export const fit10Rows: StoryFn = createFixedThemeStory(
     createMatrix(component, [groupingStates, minColumnWidthStates]),
     backgroundStates[0]
 );
-tableFitRowsHeightWith10Rows.play = async () => await playFunction(10);
+fit10Rows.play = async () => await playFunction(10);
 
-export const tableFitRowsHeightWith50Rows: StoryFn = createFixedThemeStory(
+export const fit50Rows: StoryFn = createFixedThemeStory(
     createMatrix(component, [groupingStates, minColumnWidthStates]),
     backgroundStates[0]
 );
-tableFitRowsHeightWith50Rows.play = async () => await playFunction(50);
+fit50Rows.play = async () => await playFunction(50);

--- a/packages/storybook/src/nimble/table/table-matrix.stories.ts
+++ b/packages/storybook/src/nimble/table/table-matrix.stories.ts
@@ -144,28 +144,28 @@ const playFunction = async (): Promise<void> => {
     );
 };
 
-export const tableNoSelectionThemeMatrix: StoryFn = createMatrixThemeStory(
+export const noSelectionThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [[undefined], groupedStates, hierarchyStates])
 );
-tableNoSelectionThemeMatrix.play = playFunction;
+noSelectionThemeMatrix.play = playFunction;
 
-export const tableSingleSelectionThemeMatrix: StoryFn = createMatrixThemeStory(
+export const singleSelectionThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         [TableRowSelectionMode.single],
         groupedStates,
         hierarchyStates
     ])
 );
-tableSingleSelectionThemeMatrix.play = playFunction;
+singleSelectionThemeMatrix.play = playFunction;
 
-export const tableMultipleSelectionThemeMatrix: StoryFn = createMatrixThemeStory(
+export const multipleSelectionThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         [TableRowSelectionMode.multiple],
         groupedStates,
         hierarchyStates
     ])
 );
-tableMultipleSelectionThemeMatrix.play = playFunction;
+multipleSelectionThemeMatrix.play = playFunction;
 
 const groupedStatesGroupingEnabled = groupedStates[0];
 const hierarchyStatesHierarchyEnabled = hierarchyStates[0];
@@ -174,7 +174,7 @@ const tableKeyboardFocusStates = cartesianProduct([
     [groupedStatesGroupingEnabled],
     [hierarchyStatesHierarchyEnabled]
 ] as const);
-export const tableKeyboardFocusThemeMatrix: StoryFn = createMatrixThemeStory(
+export const keyboardFocusThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrixInteractionsFromStates(component, {
         hover: [],
         hoverActive: [],
@@ -182,8 +182,8 @@ export const tableKeyboardFocusThemeMatrix: StoryFn = createMatrixThemeStory(
         focus: tableKeyboardFocusStates
     })
 );
-tableKeyboardFocusThemeMatrix.play = playFunction;
+keyboardFocusThemeMatrix.play = playFunction;
 
-export const hiddenTable: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(html`<${tableTag} hidden></${tableTag}>`)
 );

--- a/packages/storybook/src/nimble/tabs/tabs-matrix.stories.ts
+++ b/packages/storybook/src/nimble/tabs/tabs-matrix.stories.ts
@@ -58,11 +58,11 @@ const component = (
     </${tabsTag}>
 `;
 
-export const tabsThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [tabsToolbarStates, disabledStates, widthStates])
 );
 
-export const hiddenTabs: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${tabsTag} hidden>
             <${tabTag}>Tab One</${tabTag}>

--- a/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
@@ -68,7 +68,7 @@ const component = (
     </${textAreaTag}>
 `;
 
-export const textAreaThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         requiredVisibleStates,
         readOnlyStates,
@@ -109,7 +109,7 @@ const heightSizingTestCase = (
     </div>
 `;
 
-export const textAreaSizing: StoryFn = createStory(html`
+export const sizing: StoryFn = createStory(html`
     ${createMatrix(widthSizingTestCase, [
         [
             ['No width', ''],
@@ -134,7 +134,7 @@ export const textAreaSizing: StoryFn = createStory(html`
     ])}
 `);
 
-export const hiddenTextArea: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${textAreaTag} hidden>Hidden text area</${textAreaTag}>`
     )

--- a/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
@@ -161,7 +161,7 @@ const requiredVisibleStatesComponent = (
     </${textFieldTag}>
 `;
 
-export const lightTheme$Editable$Enabled$WithoutButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnlyAbsent$DisabledAbsent$AppearanceReadOnlyAbsent$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.none],
         [actionButtonStates[0]],
@@ -175,7 +175,7 @@ export const lightTheme$Editable$Enabled$WithoutButtons: StoryFn = createFixedTh
     lightThemeWhiteBackground
 );
 
-export const lightTheme$Editable$Enabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnlyAbsent$DisabledAbsent$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.appearanceReadOnly],
         [actionButtonStates[0]],
@@ -189,7 +189,7 @@ export const lightTheme$Editable$Enabled$AppearanceReadOnly$WithoutButtons: Stor
     lightThemeWhiteBackground
 );
 
-export const lightTheme$Editable$Enabled$WithButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnlyAbsent$DisabledAbsent$AppearanceReadOnlyAbsent$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.none],
         [actionButtonStates[1]],
@@ -203,7 +203,7 @@ export const lightTheme$Editable$Enabled$WithButtons: StoryFn = createFixedTheme
     lightThemeWhiteBackground
 );
 
-export const lightTheme$Editable$Enabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnlyAbsent$DisabledAbsent$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.appearanceReadOnly],
         [actionButtonStates[1]],
@@ -217,7 +217,7 @@ export const lightTheme$Editable$Enabled$AppearanceReadOnly$WithButtons: StoryFn
     lightThemeWhiteBackground
 );
 
-export const lightTheme$Editable$Disabled$WithoutButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnlyAbsent$Disabled$AppearanceReadOnlyAbsent$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabled],
         [actionButtonStates[0]],
@@ -231,7 +231,7 @@ export const lightTheme$Editable$Disabled$WithoutButtons: StoryFn = createFixedT
     lightThemeWhiteBackground
 );
 
-export const lightTheme$Editable$Disabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnlyAbsent$Disabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabledAppearanceReadOnly],
         [actionButtonStates[0]],
@@ -245,7 +245,7 @@ export const lightTheme$Editable$Disabled$AppearanceReadOnly$WithoutButtons: Sto
     lightThemeWhiteBackground
 );
 
-export const lightTheme$Editable$Disabled$WithButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnlyAbsent$Disabled$AppearanceReadOnlyAbsent$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabled],
         [actionButtonStates[1]],
@@ -259,7 +259,7 @@ export const lightTheme$Editable$Disabled$WithButtons: StoryFn = createFixedThem
     lightThemeWhiteBackground
 );
 
-export const lightTheme$Editable$Disabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnlyAbsent$Disabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabledAppearanceReadOnly],
         [actionButtonStates[1]],
@@ -273,7 +273,7 @@ export const lightTheme$Editable$Disabled$AppearanceReadOnly$WithButtons: StoryF
     lightThemeWhiteBackground
 );
 
-export const lightTheme$ReadOnly$Enabled$WithoutButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnly$DisabledAbsent$AppearanceReadOnlyAbsent$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnly],
         [actionButtonStates[0]],
@@ -287,7 +287,7 @@ export const lightTheme$ReadOnly$Enabled$WithoutButtons: StoryFn = createFixedTh
     lightThemeWhiteBackground
 );
 
-export const lightTheme$ReadOnly$Enabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnly$DisabledAbsent$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyAppearanceReadOnly],
         [actionButtonStates[0]],
@@ -301,7 +301,7 @@ export const lightTheme$ReadOnly$Enabled$AppearanceReadOnly$WithoutButtons: Stor
     lightThemeWhiteBackground
 );
 
-export const lightTheme$ReadOnly$Enabled$WithButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnly$DisabledAbsent$AppearanceReadOnlyAbsent$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnly],
         [actionButtonStates[1]],
@@ -315,7 +315,7 @@ export const lightTheme$ReadOnly$Enabled$WithButtons: StoryFn = createFixedTheme
     lightThemeWhiteBackground
 );
 
-export const lightTheme$ReadOnly$Enabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnly$DisabledAbsent$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyAppearanceReadOnly],
         [actionButtonStates[1]],
@@ -329,7 +329,7 @@ export const lightTheme$ReadOnly$Enabled$AppearanceReadOnly$WithButtons: StoryFn
     lightThemeWhiteBackground
 );
 
-export const lightTheme$ReadOnly$Disabled$WithoutButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnly$Disabled$AppearanceReadOnlyAbsent$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabled],
         [actionButtonStates[0]],
@@ -357,7 +357,7 @@ export const lightTheme$ReadOnly$Disabled$AppearanceReadOnly$WithoutButtons: Sto
     lightThemeWhiteBackground
 );
 
-export const lightTheme$ReadOnly$Disabled$WithButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnly$Disabled$AppearanceReadOnlyAbsent$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabled],
         [actionButtonStates[1]],
@@ -385,7 +385,7 @@ export const lightTheme$ReadOnly$Disabled$AppearanceReadOnly$WithButtons: StoryF
     lightThemeWhiteBackground
 );
 
-export const darkTheme$Editable$Enabled$WithoutButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnlyAbsent$DisabledAbsent$AppearanceReadOnlyAbsent$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.none],
         [actionButtonStates[0]],
@@ -399,7 +399,7 @@ export const darkTheme$Editable$Enabled$WithoutButtons: StoryFn = createFixedThe
     darkThemeBlackBackground
 );
 
-export const darkTheme$Editable$Enabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnlyAbsent$DisabledAbsent$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.appearanceReadOnly],
         [actionButtonStates[0]],
@@ -413,7 +413,7 @@ export const darkTheme$Editable$Enabled$AppearanceReadOnly$WithoutButtons: Story
     darkThemeBlackBackground
 );
 
-export const darkTheme$Editable$Enabled$WithButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnlyAbsent$DisabledAbsent$AppearanceReadOnlyAbsent$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.none],
         [actionButtonStates[1]],
@@ -427,7 +427,7 @@ export const darkTheme$Editable$Enabled$WithButtons: StoryFn = createFixedThemeS
     darkThemeBlackBackground
 );
 
-export const darkTheme$Editable$Enabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnlyAbsent$DisabledAbsent$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.appearanceReadOnly],
         [actionButtonStates[1]],
@@ -441,7 +441,7 @@ export const darkTheme$Editable$Enabled$AppearanceReadOnly$WithButtons: StoryFn 
     darkThemeBlackBackground
 );
 
-export const darkTheme$Editable$Disabled$WithoutButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnlyAbsent$Disabled$AppearanceReadOnlyAbsent$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabled],
         [actionButtonStates[0]],
@@ -455,7 +455,7 @@ export const darkTheme$Editable$Disabled$WithoutButtons: StoryFn = createFixedTh
     darkThemeBlackBackground
 );
 
-export const darkTheme$Editable$Disabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnlyAbsent$Disabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabledAppearanceReadOnly],
         [actionButtonStates[0]],
@@ -469,7 +469,7 @@ export const darkTheme$Editable$Disabled$AppearanceReadOnly$WithoutButtons: Stor
     darkThemeBlackBackground
 );
 
-export const darkTheme$Editable$Disabled$WithButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnlyAbsent$Disabled$AppearanceReadOnlyAbsent$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabled],
         [actionButtonStates[1]],
@@ -483,7 +483,7 @@ export const darkTheme$Editable$Disabled$WithButtons: StoryFn = createFixedTheme
     darkThemeBlackBackground
 );
 
-export const darkTheme$Editable$Disabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnlyAbsent$Disabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabledAppearanceReadOnly],
         [actionButtonStates[1]],
@@ -497,7 +497,7 @@ export const darkTheme$Editable$Disabled$AppearanceReadOnly$WithButtons: StoryFn
     darkThemeBlackBackground
 );
 
-export const darkTheme$ReadOnly$Enabled$WithoutButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnly$DisabledAbsent$AppearanceReadOnlyAbsent$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnly],
         [actionButtonStates[0]],
@@ -511,7 +511,7 @@ export const darkTheme$ReadOnly$Enabled$WithoutButtons: StoryFn = createFixedThe
     darkThemeBlackBackground
 );
 
-export const darkTheme$ReadOnly$Enabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnly$DisabledAbsent$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyAppearanceReadOnly],
         [actionButtonStates[0]],
@@ -525,7 +525,7 @@ export const darkTheme$ReadOnly$Enabled$AppearanceReadOnly$WithoutButtons: Story
     darkThemeBlackBackground
 );
 
-export const darkTheme$ReadOnly$Enabled$WithButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnly$DisabledAbsent$AppearanceReadOnlyAbsent$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnly],
         [actionButtonStates[1]],
@@ -539,7 +539,7 @@ export const darkTheme$ReadOnly$Enabled$WithButtons: StoryFn = createFixedThemeS
     darkThemeBlackBackground
 );
 
-export const darkTheme$ReadOnly$Enabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnly$DisabledAbsent$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyAppearanceReadOnly],
         [actionButtonStates[1]],
@@ -553,7 +553,7 @@ export const darkTheme$ReadOnly$Enabled$AppearanceReadOnly$WithButtons: StoryFn 
     darkThemeBlackBackground
 );
 
-export const darkTheme$ReadOnly$Disabled$WithoutButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnly$Disabled$AppearanceReadOnlyAbsent$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabled],
         [actionButtonStates[0]],
@@ -581,7 +581,7 @@ export const darkTheme$ReadOnly$Disabled$AppearanceReadOnly$WithoutButtons: Stor
     darkThemeBlackBackground
 );
 
-export const darkTheme$ReadOnly$Disabled$WithButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnly$Disabled$AppearanceReadOnlyAbsent$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabled],
         [actionButtonStates[1]],
@@ -609,7 +609,7 @@ export const darkTheme$ReadOnly$Disabled$AppearanceReadOnly$WithButtons: StoryFn
     darkThemeBlackBackground
 );
 
-export const colorTheme$Editable$Enabled$WithoutButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnlyAbsent$DisabledAbsent$AppearanceReadOnlyAbsent$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.none],
         [actionButtonStates[0]],
@@ -623,7 +623,7 @@ export const colorTheme$Editable$Enabled$WithoutButtons: StoryFn = createFixedTh
     colorThemeDarkGreenBackground
 );
 
-export const colorTheme$Editable$Enabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnlyAbsent$DisabledAbsent$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.appearanceReadOnly],
         [actionButtonStates[0]],
@@ -637,7 +637,7 @@ export const colorTheme$Editable$Enabled$AppearanceReadOnly$WithoutButtons: Stor
     colorThemeDarkGreenBackground
 );
 
-export const colorTheme$Editable$Enabled$WithButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnlyAbsent$DisabledAbsent$AppearanceReadOnlyAbsent$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.none],
         [actionButtonStates[1]],
@@ -651,7 +651,7 @@ export const colorTheme$Editable$Enabled$WithButtons: StoryFn = createFixedTheme
     colorThemeDarkGreenBackground
 );
 
-export const colorTheme$Editable$Enabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnlyAbsent$DisabledAbsent$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.appearanceReadOnly],
         [actionButtonStates[1]],
@@ -665,7 +665,7 @@ export const colorTheme$Editable$Enabled$AppearanceReadOnly$WithButtons: StoryFn
     colorThemeDarkGreenBackground
 );
 
-export const colorTheme$Editable$Disabled$WithoutButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnlyAbsent$Disabled$AppearanceReadOnlyAbsent$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabled],
         [actionButtonStates[0]],
@@ -679,7 +679,7 @@ export const colorTheme$Editable$Disabled$WithoutButtons: StoryFn = createFixedT
     colorThemeDarkGreenBackground
 );
 
-export const colorTheme$Editable$Disabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnlyAbsent$Disabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabledAppearanceReadOnly],
         [actionButtonStates[0]],
@@ -693,7 +693,7 @@ export const colorTheme$Editable$Disabled$AppearanceReadOnly$WithoutButtons: Sto
     colorThemeDarkGreenBackground
 );
 
-export const colorTheme$Editable$Disabled$WithButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnlyAbsent$Disabled$AppearanceReadOnlyAbsent$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabled],
         [actionButtonStates[1]],
@@ -707,7 +707,7 @@ export const colorTheme$Editable$Disabled$WithButtons: StoryFn = createFixedThem
     colorThemeDarkGreenBackground
 );
 
-export const colorTheme$Editable$Disabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnlyAbsent$Disabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabledAppearanceReadOnly],
         [actionButtonStates[1]],
@@ -721,7 +721,7 @@ export const colorTheme$Editable$Disabled$AppearanceReadOnly$WithButtons: StoryF
     colorThemeDarkGreenBackground
 );
 
-export const colorTheme$ReadOnly$Enabled$WithoutButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnly$DisabledAbsent$AppearanceReadOnlyAbsent$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnly],
         [actionButtonStates[0]],
@@ -735,7 +735,7 @@ export const colorTheme$ReadOnly$Enabled$WithoutButtons: StoryFn = createFixedTh
     colorThemeDarkGreenBackground
 );
 
-export const colorTheme$ReadOnly$Enabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnly$DisabledAbsent$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyAppearanceReadOnly],
         [actionButtonStates[0]],
@@ -749,7 +749,7 @@ export const colorTheme$ReadOnly$Enabled$AppearanceReadOnly$WithoutButtons: Stor
     colorThemeDarkGreenBackground
 );
 
-export const colorTheme$ReadOnly$Enabled$WithButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnly$DisabledAbsent$AppearanceReadOnlyAbsent$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnly],
         [actionButtonStates[1]],
@@ -763,7 +763,7 @@ export const colorTheme$ReadOnly$Enabled$WithButtons: StoryFn = createFixedTheme
     colorThemeDarkGreenBackground
 );
 
-export const colorTheme$ReadOnly$Enabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnly$DisabledAbsent$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyAppearanceReadOnly],
         [actionButtonStates[1]],
@@ -777,7 +777,7 @@ export const colorTheme$ReadOnly$Enabled$AppearanceReadOnly$WithButtons: StoryFn
     colorThemeDarkGreenBackground
 );
 
-export const colorTheme$ReadOnly$Disabled$WithoutButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnly$Disabled$AppearanceReadOnlyAbsent$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabled],
         [actionButtonStates[0]],
@@ -805,7 +805,7 @@ export const colorTheme$ReadOnly$Disabled$AppearanceReadOnly$WithoutButtons: Sto
     colorThemeDarkGreenBackground
 );
 
-export const colorTheme$ReadOnly$Disabled$WithButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnly$Disabled$AppearanceReadOnlyAbsent$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabled],
         [actionButtonStates[1]],

--- a/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
@@ -161,7 +161,7 @@ const requiredVisibleStatesComponent = (
     </${textFieldTag}>
 `;
 
-export const lightThemeEditableEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$Editable$Enabled$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.none],
         [actionButtonStates[0]],
@@ -175,7 +175,7 @@ export const lightThemeEditableEnabledWithoutButtons: StoryFn = createFixedTheme
     lightThemeWhiteBackground
 );
 
-export const lightThemeEditableEnabledAppearanceReadOnlyWithoutButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$Editable$Enabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.appearanceReadOnly],
         [actionButtonStates[0]],
@@ -189,7 +189,7 @@ export const lightThemeEditableEnabledAppearanceReadOnlyWithoutButtons: StoryFn 
     lightThemeWhiteBackground
 );
 
-export const lightThemeEditableEnabledWithButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$Editable$Enabled$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.none],
         [actionButtonStates[1]],
@@ -203,7 +203,7 @@ export const lightThemeEditableEnabledWithButtons: StoryFn = createFixedThemeSto
     lightThemeWhiteBackground
 );
 
-export const lightThemeEditableEnabledAppearanceReadOnlyWithButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$Editable$Enabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.appearanceReadOnly],
         [actionButtonStates[1]],
@@ -217,7 +217,7 @@ export const lightThemeEditableEnabledAppearanceReadOnlyWithButtons: StoryFn = c
     lightThemeWhiteBackground
 );
 
-export const lightThemeEditableDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$Editable$Disabled$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabled],
         [actionButtonStates[0]],
@@ -231,7 +231,7 @@ export const lightThemeEditableDisabledWithoutButtons: StoryFn = createFixedThem
     lightThemeWhiteBackground
 );
 
-export const lightThemeEditableDisabledAppearanceReadOnlyWithoutButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$Editable$Disabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabledAppearanceReadOnly],
         [actionButtonStates[0]],
@@ -245,7 +245,7 @@ export const lightThemeEditableDisabledAppearanceReadOnlyWithoutButtons: StoryFn
     lightThemeWhiteBackground
 );
 
-export const lightThemeEditableDisabledWithButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$Editable$Disabled$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabled],
         [actionButtonStates[1]],
@@ -259,7 +259,7 @@ export const lightThemeEditableDisabledWithButtons: StoryFn = createFixedThemeSt
     lightThemeWhiteBackground
 );
 
-export const lightThemeEditableDisabledAppearanceReadOnlyWithButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$Editable$Disabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabledAppearanceReadOnly],
         [actionButtonStates[1]],
@@ -273,7 +273,7 @@ export const lightThemeEditableDisabledAppearanceReadOnlyWithButtons: StoryFn = 
     lightThemeWhiteBackground
 );
 
-export const lightThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnly$Enabled$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnly],
         [actionButtonStates[0]],
@@ -287,7 +287,7 @@ export const lightThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedTheme
     lightThemeWhiteBackground
 );
 
-export const lightThemeReadOnlyEnabledAppearanceReadOnlyWithoutButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnly$Enabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyAppearanceReadOnly],
         [actionButtonStates[0]],
@@ -301,7 +301,7 @@ export const lightThemeReadOnlyEnabledAppearanceReadOnlyWithoutButtons: StoryFn 
     lightThemeWhiteBackground
 );
 
-export const lightThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnly$Enabled$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnly],
         [actionButtonStates[1]],
@@ -315,7 +315,7 @@ export const lightThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeSto
     lightThemeWhiteBackground
 );
 
-export const lightThemeReadOnlyEnabledAppearanceReadOnlyWithButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnly$Enabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyAppearanceReadOnly],
         [actionButtonStates[1]],
@@ -329,7 +329,7 @@ export const lightThemeReadOnlyEnabledAppearanceReadOnlyWithButtons: StoryFn = c
     lightThemeWhiteBackground
 );
 
-export const lightThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnly$Disabled$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabled],
         [actionButtonStates[0]],
@@ -343,7 +343,7 @@ export const lightThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedThem
     lightThemeWhiteBackground
 );
 
-export const lightThemeReadOnlyDisabledAppearanceReadOnlyWithoutButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnly$Disabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabledAppearanceReadOnly],
         [actionButtonStates[0]],
@@ -357,7 +357,7 @@ export const lightThemeReadOnlyDisabledAppearanceReadOnlyWithoutButtons: StoryFn
     lightThemeWhiteBackground
 );
 
-export const lightThemeReadOnlyDisabledWithButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnly$Disabled$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabled],
         [actionButtonStates[1]],
@@ -371,7 +371,7 @@ export const lightThemeReadOnlyDisabledWithButtons: StoryFn = createFixedThemeSt
     lightThemeWhiteBackground
 );
 
-export const lightThemeReadOnlyDisabledAppearanceReadOnlyWithButtons: StoryFn = createFixedThemeStory(
+export const lightTheme$ReadOnly$Disabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabledAppearanceReadOnly],
         [actionButtonStates[1]],
@@ -385,7 +385,7 @@ export const lightThemeReadOnlyDisabledAppearanceReadOnlyWithButtons: StoryFn = 
     lightThemeWhiteBackground
 );
 
-export const darkThemeEditableEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$Editable$Enabled$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.none],
         [actionButtonStates[0]],
@@ -399,7 +399,7 @@ export const darkThemeEditableEnabledWithoutButtons: StoryFn = createFixedThemeS
     darkThemeBlackBackground
 );
 
-export const darkThemeEditableEnabledAppearanceReadOnlyWithoutButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$Editable$Enabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.appearanceReadOnly],
         [actionButtonStates[0]],
@@ -413,7 +413,7 @@ export const darkThemeEditableEnabledAppearanceReadOnlyWithoutButtons: StoryFn =
     darkThemeBlackBackground
 );
 
-export const darkThemeEditableEnabledWithButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$Editable$Enabled$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.none],
         [actionButtonStates[1]],
@@ -427,7 +427,7 @@ export const darkThemeEditableEnabledWithButtons: StoryFn = createFixedThemeStor
     darkThemeBlackBackground
 );
 
-export const darkThemeEditableEnabledAppearanceReadOnlyWithButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$Editable$Enabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.appearanceReadOnly],
         [actionButtonStates[1]],
@@ -441,7 +441,7 @@ export const darkThemeEditableEnabledAppearanceReadOnlyWithButtons: StoryFn = cr
     darkThemeBlackBackground
 );
 
-export const darkThemeEditableDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$Editable$Disabled$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabled],
         [actionButtonStates[0]],
@@ -455,7 +455,7 @@ export const darkThemeEditableDisabledWithoutButtons: StoryFn = createFixedTheme
     darkThemeBlackBackground
 );
 
-export const darkThemeEditableDisabledAppearanceReadOnlyWithoutButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$Editable$Disabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabledAppearanceReadOnly],
         [actionButtonStates[0]],
@@ -469,7 +469,7 @@ export const darkThemeEditableDisabledAppearanceReadOnlyWithoutButtons: StoryFn 
     darkThemeBlackBackground
 );
 
-export const darkThemeEditableDisabledWithButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$Editable$Disabled$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabled],
         [actionButtonStates[1]],
@@ -483,7 +483,7 @@ export const darkThemeEditableDisabledWithButtons: StoryFn = createFixedThemeSto
     darkThemeBlackBackground
 );
 
-export const darkThemeEditableDisabledAppearanceReadOnlyWithButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$Editable$Disabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabledAppearanceReadOnly],
         [actionButtonStates[1]],
@@ -497,7 +497,7 @@ export const darkThemeEditableDisabledAppearanceReadOnlyWithButtons: StoryFn = c
     darkThemeBlackBackground
 );
 
-export const darkThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnly$Enabled$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnly],
         [actionButtonStates[0]],
@@ -511,7 +511,7 @@ export const darkThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeS
     darkThemeBlackBackground
 );
 
-export const darkThemeReadOnlyEnabledAppearanceReadOnlyWithoutButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnly$Enabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyAppearanceReadOnly],
         [actionButtonStates[0]],
@@ -525,7 +525,7 @@ export const darkThemeReadOnlyEnabledAppearanceReadOnlyWithoutButtons: StoryFn =
     darkThemeBlackBackground
 );
 
-export const darkThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnly$Enabled$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnly],
         [actionButtonStates[1]],
@@ -539,7 +539,7 @@ export const darkThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStor
     darkThemeBlackBackground
 );
 
-export const darkThemeReadOnlyEnabledAppearanceReadOnlyWithButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnly$Enabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyAppearanceReadOnly],
         [actionButtonStates[1]],
@@ -553,7 +553,7 @@ export const darkThemeReadOnlyEnabledAppearanceReadOnlyWithButtons: StoryFn = cr
     darkThemeBlackBackground
 );
 
-export const darkThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnly$Disabled$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabled],
         [actionButtonStates[0]],
@@ -567,7 +567,7 @@ export const darkThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedTheme
     darkThemeBlackBackground
 );
 
-export const darkThemeReadOnlyDisabledAppearanceReadOnlyWithoutButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnly$Disabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabledAppearanceReadOnly],
         [actionButtonStates[0]],
@@ -581,7 +581,7 @@ export const darkThemeReadOnlyDisabledAppearanceReadOnlyWithoutButtons: StoryFn 
     darkThemeBlackBackground
 );
 
-export const darkThemeReadOnlyDisabledWithButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnly$Disabled$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabled],
         [actionButtonStates[1]],
@@ -595,7 +595,7 @@ export const darkThemeReadOnlyDisabledWithButtons: StoryFn = createFixedThemeSto
     darkThemeBlackBackground
 );
 
-export const darkThemeReadOnlyDisabledAppearanceReadOnlyWithButtons: StoryFn = createFixedThemeStory(
+export const darkTheme$ReadOnly$Disabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabledAppearanceReadOnly],
         [actionButtonStates[1]],
@@ -609,7 +609,7 @@ export const darkThemeReadOnlyDisabledAppearanceReadOnlyWithButtons: StoryFn = c
     darkThemeBlackBackground
 );
 
-export const colorThemeEditableEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$Editable$Enabled$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.none],
         [actionButtonStates[0]],
@@ -623,7 +623,7 @@ export const colorThemeEditableEnabledWithoutButtons: StoryFn = createFixedTheme
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeEditableEnabledAppearanceReadOnlyWithoutButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$Editable$Enabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.appearanceReadOnly],
         [actionButtonStates[0]],
@@ -637,7 +637,7 @@ export const colorThemeEditableEnabledAppearanceReadOnlyWithoutButtons: StoryFn 
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeEditableEnabledWithButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$Editable$Enabled$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.none],
         [actionButtonStates[1]],
@@ -651,7 +651,7 @@ export const colorThemeEditableEnabledWithButtons: StoryFn = createFixedThemeSto
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeEditableEnabledAppearanceReadOnlyWithButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$Editable$Enabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.appearanceReadOnly],
         [actionButtonStates[1]],
@@ -665,7 +665,7 @@ export const colorThemeEditableEnabledAppearanceReadOnlyWithButtons: StoryFn = c
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeEditableDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$Editable$Disabled$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabled],
         [actionButtonStates[0]],
@@ -679,7 +679,7 @@ export const colorThemeEditableDisabledWithoutButtons: StoryFn = createFixedThem
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeEditableDisabledAppearanceReadOnlyWithoutButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$Editable$Disabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabledAppearanceReadOnly],
         [actionButtonStates[0]],
@@ -693,7 +693,7 @@ export const colorThemeEditableDisabledAppearanceReadOnlyWithoutButtons: StoryFn
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeEditableDisabledWithButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$Editable$Disabled$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabled],
         [actionButtonStates[1]],
@@ -707,7 +707,7 @@ export const colorThemeEditableDisabledWithButtons: StoryFn = createFixedThemeSt
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeEditableDisabledAppearanceReadOnlyWithButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$Editable$Disabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.disabledAppearanceReadOnly],
         [actionButtonStates[1]],
@@ -721,7 +721,7 @@ export const colorThemeEditableDisabledAppearanceReadOnlyWithButtons: StoryFn = 
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnly$Enabled$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnly],
         [actionButtonStates[0]],
@@ -735,7 +735,7 @@ export const colorThemeReadOnlyEnabledWithoutButtons: StoryFn = createFixedTheme
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeReadOnlyEnabledAppearanceReadOnlyWithoutButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnly$Enabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyAppearanceReadOnly],
         [actionButtonStates[0]],
@@ -749,7 +749,7 @@ export const colorThemeReadOnlyEnabledAppearanceReadOnlyWithoutButtons: StoryFn 
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnly$Enabled$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnly],
         [actionButtonStates[1]],
@@ -763,7 +763,7 @@ export const colorThemeReadOnlyEnabledWithButtons: StoryFn = createFixedThemeSto
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeReadOnlyEnabledAppearanceReadOnlyWithButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnly$Enabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyAppearanceReadOnly],
         [actionButtonStates[1]],
@@ -777,7 +777,7 @@ export const colorThemeReadOnlyEnabledAppearanceReadOnlyWithButtons: StoryFn = c
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnly$Disabled$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabled],
         [actionButtonStates[0]],
@@ -791,7 +791,7 @@ export const colorThemeReadOnlyDisabledWithoutButtons: StoryFn = createFixedThem
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeReadOnlyDisabledAppearanceReadOnlyWithoutButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnly$Disabled$AppearanceReadOnly$WithoutButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabledAppearanceReadOnly],
         [actionButtonStates[0]],
@@ -805,7 +805,7 @@ export const colorThemeReadOnlyDisabledAppearanceReadOnlyWithoutButtons: StoryFn
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeReadOnlyDisabledWithButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnly$Disabled$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabled],
         [actionButtonStates[1]],
@@ -819,7 +819,7 @@ export const colorThemeReadOnlyDisabledWithButtons: StoryFn = createFixedThemeSt
     colorThemeDarkGreenBackground
 );
 
-export const colorThemeReadOnlyDisabledAppearanceReadOnlyWithButtons: StoryFn = createFixedThemeStory(
+export const colorTheme$ReadOnly$Disabled$AppearanceReadOnly$WithButtons: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         [disabledReadOnlyState.readOnlyDisabledAppearanceReadOnly],
         [actionButtonStates[1]],
@@ -833,7 +833,7 @@ export const colorThemeReadOnlyDisabledAppearanceReadOnlyWithButtons: StoryFn = 
     colorThemeDarkGreenBackground
 );
 
-export const textFieldRequiredVisibleThemeMatrix: StoryFn = createMatrixThemeStory(
+export const requiredVisibleThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(requiredVisibleStatesComponent, [
         requiredVisibleStates,
         appearanceStates,
@@ -843,7 +843,7 @@ export const textFieldRequiredVisibleThemeMatrix: StoryFn = createMatrixThemeSto
     ])
 );
 
-export const hiddenTextField: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${textFieldTag} hidden>Hidden text field</${textFieldTag}>`
     )

--- a/packages/storybook/src/nimble/toggle-button/toggle-button-matrix.stories.ts
+++ b/packages/storybook/src/nimble/toggle-button/toggle-button-matrix.stories.ts
@@ -64,7 +64,7 @@ const component = (
     </${toggleButtonTag}>
 `;
 
-export const toggleButtonThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         partVisibilityStates,
         checkedStates,
@@ -90,7 +90,7 @@ const interactionStates = cartesianProduct([
     appearanceVariantStates
 ] as const);
 
-export const toggleButtonInteractionsThemeMatrix: StoryFn = createMatrixThemeStory(
+export const interactionsThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrixInteractionsFromStates(component, {
         hover: interactionStatesHover,
         hoverActive: interactionStates,
@@ -99,7 +99,7 @@ export const toggleButtonInteractionsThemeMatrix: StoryFn = createMatrixThemeSto
     })
 );
 
-export const hiddenButton: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${toggleButtonTag} hidden
             >Hidden Toggle Button</${toggleButtonTag}

--- a/packages/storybook/src/nimble/toolbar/toolbar-matrix.stories.ts
+++ b/packages/storybook/src/nimble/toolbar/toolbar-matrix.stories.ts
@@ -61,8 +61,8 @@ const component = html`
     </${toolbarTag}>
 `;
 
-export const toolbarThemeMatrix: StoryFn = createMatrixThemeStory(component);
+export const themeMatrix: StoryFn = createMatrixThemeStory(component);
 
-export const hiddenToolbar: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(html`<${toolbarTag} hidden>Hidden Toolbar</${toolbarTag}>`)
 );

--- a/packages/storybook/src/nimble/tooltip/tooltip-matrix.stories.ts
+++ b/packages/storybook/src/nimble/tooltip/tooltip-matrix.stories.ts
@@ -106,11 +106,7 @@ lightTheme.parameters = {
 };
 
 export const colorTheme: StoryFn = createFixedThemeStory(
-    createMatrix(component, [
-        textStates,
-        severityStates,
-        iconVisibleStates
-    ]),
+    createMatrix(component, [textStates, severityStates, iconVisibleStates]),
     colorThemeDarkGreenBackground
 );
 

--- a/packages/storybook/src/nimble/tooltip/tooltip-matrix.stories.ts
+++ b/packages/storybook/src/nimble/tooltip/tooltip-matrix.stories.ts
@@ -94,18 +94,18 @@ const [
     darkThemeBlackBackground
 ] = backgroundStates;
 
-export const tooltipLightThemeWhiteBackground: StoryFn = createFixedThemeStory(
+export const lightTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [textStates, severityStates, iconVisibleStates]),
     lightThemeWhiteBackground
 );
 
 // Temporarily disabling this test because of flakiness
 // See: https://github.com/ni/nimble/issues/1106
-tooltipLightThemeWhiteBackground.parameters = {
+lightTheme.parameters = {
     chromatic: { disableSnapshot: true }
 };
 
-export const tooltipColorThemeDarkGreenBackground: StoryFn = createFixedThemeStory(
+export const colorTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         textStates,
         severityStates,
@@ -116,21 +116,21 @@ export const tooltipColorThemeDarkGreenBackground: StoryFn = createFixedThemeSto
 
 // Temporarily disabling this test because of flakiness
 // See: https://github.com/ni/nimble/issues/1106
-tooltipColorThemeDarkGreenBackground.parameters = {
+colorTheme.parameters = {
     chromatic: { disableSnapshot: true }
 };
 
-export const tooltipDarkThemeBlackBackground: StoryFn = createFixedThemeStory(
+export const darkTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [textStates, severityStates, iconVisibleStates]),
     darkThemeBlackBackground
 );
 
 // Temporarily disabling this test because of flakiness
 // See: https://github.com/ni/nimble/issues/1106
-tooltipDarkThemeBlackBackground.parameters = {
+darkTheme.parameters = {
     chromatic: { disableSnapshot: true }
 };
 
-export const hiddenTooltip: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(html`<${tooltipTag} hidden>Hidden Tooltip</${tooltipTag}>`)
 );

--- a/packages/storybook/src/nimble/tree-view/tree-view-matrix.stories.ts
+++ b/packages/storybook/src/nimble/tree-view/tree-view-matrix.stories.ts
@@ -77,7 +77,7 @@ const component = (
     </${treeViewTag}>
 `;
 
-export const treeViewThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         disabledStates,
         expandedStates,
@@ -86,7 +86,7 @@ export const treeViewThemeMatrix: StoryFn = createMatrixThemeStory(
     ])
 );
 
-export const hiddenTreeView: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${treeViewTag} hidden>
             <${treeItemTag}>Item 1</${treeItemTag}>

--- a/packages/storybook/src/nimble/wafer-map/wafer-map-matrix.stories.ts
+++ b/packages/storybook/src/nimble/wafer-map/wafer-map-matrix.stories.ts
@@ -255,64 +255,64 @@ const componentWaferWithHighlightedTags = (
 >
 </${waferMapTag}>`;
 
-export const waferMapThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(simpleWaferWithDies)
 );
 
-export const experimentalWaferMapThemeMatrix: StoryFn = createMatrixThemeStory(
+export const experimentalThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(simpleExperimentalWaferWithDies)
 );
 
-export const waferMapDiesAndOrientationTest: StoryFn = createStory(
+export const diesAndOrientationTest: StoryFn = createStory(
     createMatrix(componentWaferWithOrientation, [orientationStates])
 );
 
-export const experimentalWaferMapDiesAndOrientationTest: StoryFn = createStory(
+export const experimental$DiesAndOrientationTest: StoryFn = createStory(
     createMatrix(componentExperimentalWaferWithOrientation, [orientationStates])
 );
 
-export const waferMapDieLabelAndColorScaleTest: StoryFn = createStory(
+export const dieLabelAndColorScaleTest: StoryFn = createStory(
     createMatrix(componentWaferWithHiddenDieLabel, [
         colorsScaleStates,
         dieLabelHiddenStates
     ])
 );
 
-export const experimentalWaferMapDieLabelAndColorScaleTest: StoryFn = createStory(
+export const experimental$DieLabelAndColorScaleTest: StoryFn = createStory(
     createMatrix(componentExperimentalWaferWithHiddenDieLabel, [
         colorsScaleStates,
         dieLabelHiddenStates
     ])
 );
 
-export const waferMapOriginLocationTest: StoryFn = createStory(
+export const originLocationTest: StoryFn = createStory(
     createMatrix(componentWaferWithOriginLocation, [originLocationStates])
 );
 
-export const experimentalWaferMapOriginLocationTest: StoryFn = createStory(
+export const experimental$OriginLocationTest: StoryFn = createStory(
     createMatrix(componentExperimentalWaferWithOriginLocation, [
         originLocationStates
     ])
 );
 
-export const waferMapResizeTest: StoryFn = createStory(
+export const resizeTest: StoryFn = createStory(
     createMatrix(componentWaferResize, [sizeStates])
 );
 
-export const experimentalWaferMapResizeTest: StoryFn = createStory(
+export const experimental$ResizeTest: StoryFn = createStory(
     createMatrix(componentExperimentalWaferResize, [sizeStates])
 );
 
-export const waferMapGridDimensionsTest: StoryFn = createStory(
+export const gridDimensionsTest: StoryFn = createStory(
     createMatrix(componentWaferWithGridDimensions, [gridDimensionStates])
 );
 
-export const experimentalWaferMapGridDimensionsTest: StoryFn = createStory(
+export const experimental$GridDimensionsTest: StoryFn = createStory(
     createMatrix(componentExperimentalWaferWithGridDimensions, [
         gridDimensionStates
     ])
 );
 
-export const waferMapHighlightedTest: StoryFn = createStory(
+export const highlightedTest: StoryFn = createStory(
     createMatrix(componentWaferWithHighlightedTags, [highlightedTagStates])
 );

--- a/packages/storybook/src/spright/chat/conversation/chat-conversation-matrix.stories.ts
+++ b/packages/storybook/src/spright/chat/conversation/chat-conversation-matrix.stories.ts
@@ -163,7 +163,7 @@ const slottedButtons = (
                     border: 1px blue solid;
                     display: inline-block;
                 "
-                >Placehoder text</div>
+                >Placeholder text</div>
                 ${repeat(() => footerActions, html<string>`
                     <${buttonTag} content-hidden slot="footer-actions" appearance="ghost">
                         <${iconThumbUpTag} slot="start"></${iconThumbUpTag}>
@@ -188,20 +188,8 @@ export const slottedButtonsSizing: StoryFn = createMatrixThemeStory(html`
     ])}
 `);
 
-export const conversationHidden: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${chatConversationTag} hidden>Hidden Chat Conversation</${chatConversationTag}>`
-    )
-);
-
-export const messageHidden: StoryFn = createStory(
-    hiddenWrapper(
-        html`<${chatMessageTag} hidden>Hidden Chat Message</${chatMessageTag}>`
-    )
-);
-
-export const messageTextCustomized: StoryFn = createMatrixThemeStory(
-    textCustomizationWrapper(
-        html`<${chatMessageTag}>Message</${chatMessageTag}>`
     )
 );

--- a/packages/storybook/src/spright/chat/conversation/chat-conversation-matrix.stories.ts
+++ b/packages/storybook/src/spright/chat/conversation/chat-conversation-matrix.stories.ts
@@ -10,7 +10,6 @@ import {
 import { createStory } from '../../../utilities/storybook';
 import { hiddenWrapper } from '../../../utilities/hidden';
 import { chatConversationTag } from '../../../../../spright-components/src/chat/conversation';
-import { textCustomizationWrapper } from '../../../utilities/text-customization';
 import {
     bodyFont,
     bodyFontColor

--- a/packages/storybook/src/spright/chat/message/chat-message-matrix.stories.ts
+++ b/packages/storybook/src/spright/chat/message/chat-message-matrix.stories.ts
@@ -1,0 +1,31 @@
+import type { StoryFn, Meta } from '@storybook/html';
+import { html } from '@ni/fast-element';
+import { chatMessageTag } from '../../../../../spright-components/src/chat/message';
+import {
+    sharedMatrixParameters,
+    createMatrixThemeStory
+} from '../../../utilities/matrix';
+import { createStory } from '../../../utilities/storybook';
+import { hiddenWrapper } from '../../../utilities/hidden';
+import { textCustomizationWrapper } from '../../../utilities/text-customization';
+
+const metadata: Meta = {
+    title: 'Tests Spright/Chat Message',
+    parameters: {
+        ...sharedMatrixParameters()
+    }
+};
+
+export default metadata;
+
+export const hidden: StoryFn = createStory(
+    hiddenWrapper(
+        html`<${chatMessageTag} hidden>Hidden Chat Message</${chatMessageTag}>`
+    )
+);
+
+export const textCustomized: StoryFn = createMatrixThemeStory(
+    textCustomizationWrapper(
+        html`<${chatMessageTag}>Message</${chatMessageTag}>`
+    )
+);

--- a/packages/storybook/src/spright/rectangle/rectangle-matrix.stories.ts
+++ b/packages/storybook/src/spright/rectangle/rectangle-matrix.stories.ts
@@ -35,7 +35,7 @@ const component = ([
             ${() => `${disabledName} Rectangle`}</${rectangleTag}>
 `;
 
-export const rectangleThemeMatrix: StoryFn = createMatrixThemeStory(
+export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [disabledStates])
 );
 
@@ -43,7 +43,7 @@ const interactionStatesHover = cartesianProduct([disabledStates] as const);
 
 const interactionStates = cartesianProduct([[disabledStateIsEnabled]] as const);
 
-export const rectangleInteractionsThemeMatrix: StoryFn = createMatrixThemeStory(
+export const interactionsThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrixInteractionsFromStates(component, {
         hover: interactionStatesHover,
         hoverActive: interactionStates,
@@ -52,7 +52,7 @@ export const rectangleInteractionsThemeMatrix: StoryFn = createMatrixThemeStory(
     })
 );
 
-export const hiddenRectangle: StoryFn = createStory(
+export const hidden: StoryFn = createStory(
     hiddenWrapper(
         html`<${rectangleTag} hidden>Hidden Rectangle</${rectangleTag}>`
     )


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This is a follow up change from #2596 to rename the matrix tests to use `$` as a delimiter when the name includes which dimension a test is using.

## 👩‍💻 Implementation

Rename matrix tests using the following guidelines:
- Don't include the name of the component in the test name
- If the theme is part of the name of the test, put it first without the background color (e.g. without `WhiteBackground`)
- Don't include theme in the name if it isn't part of the test dimension. For example, if a test is run only for one theme to test something unrelated to theme, it doesn't need to be included in the name.
- Use `$` as a delimiter in the test name when the name includes multiple constant dimension values

In addition, I split the test for a hidden radio item into its own test file under `Tests/Radio`. It had been a story under `Tests/Radio Group`.

## 🧪 Testing

Tested in storybook locally

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
