### PR TITLE
Add appearance-readonly to nimble-number-field

### DIFF
--- a/change/@ni-nimble-components-3b2df972-f5ae-4415-be0f-8e4268970423.json
+++ b/change/@ni-nimble-components-3b2df972-f5ae-4415-be0f-8e4268970423.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add appearance-readonly to nimble-number-field",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/number-field/index.ts
+++ b/packages/nimble-components/src/number-field/index.ts
@@ -34,6 +34,9 @@ export class NumberField extends mixinErrorPattern(
     @attr
     public appearance: NumberFieldAppearance = NumberFieldAppearance.underline;
 
+    @attr({ attribute: 'appearance-readonly', mode: 'boolean' })
+    public appearanceReadOnly = false;
+
     public override connectedCallback(): void {
         super.connectedCallback();
 

--- a/packages/nimble-components/src/number-field/styles.ts
+++ b/packages/nimble-components/src/number-field/styles.ts
@@ -40,7 +40,10 @@ export const styles = css`
 
     :host([disabled]) {
         color: ${bodyDisabledFontColor};
-        cursor: default;
+    }
+
+    :host([disabled][appearance-readonly]) {
+        color: ${bodyFontColor};
     }
 
     .label {
@@ -51,6 +54,10 @@ export const styles = css`
 
     :host([disabled]) .label {
         color: ${controlLabelDisabledFontColor};
+    }
+
+    :host([disabled][appearance-readonly]) .label {
+        color: ${controlLabelFontColor};
     }
 
     .root {
@@ -138,12 +145,20 @@ export const styles = css`
         outline: none;
     }
 
+    :host([disabled][appearance-readonly]) .control {
+        cursor: text;
+    }
+
     .control::placeholder {
         color: ${controlLabelFontColor};
     }
 
-    .control[disabled]::placeholder {
+    :host([disabled]) .control::placeholder {
         color: ${bodyDisabledFontColor};
+    }
+
+    :host([disabled][appearance-readonly]) .control::placeholder {
+        color: ${controlLabelFontColor};
     }
 
     .controls {

--- a/packages/nimble-components/src/text-field/styles.ts
+++ b/packages/nimble-components/src/text-field/styles.ts
@@ -171,6 +171,10 @@ export const styles = css`
         text-overflow: clip;
     }
 
+    :host([disabled][appearance-readonly]) .control {
+        cursor: text;
+    }
+
     .control::placeholder {
         color: ${controlLabelFontColor};
     }

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -2,13 +2,13 @@ import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@ni/fast-element';
 import { numberFieldTag } from '../../../../nimble-components/src/number-field';
 import { NumberFieldAppearance } from '../../../../nimble-components/src/number-field/types';
-import { createStory } from '../../utilities/storybook';
+import { createFixedThemeStory, createStory } from '../../utilities/storybook';
 import {
     createMatrixThemeStory,
-    createMatrix,
     sharedMatrixParameters,
     cartesianProduct,
-    createMatrixInteractionsFromStates
+    createMatrixInteractionsFromStates,
+    createMatrix
 } from '../../utilities/matrix';
 import {
     errorStates,
@@ -19,7 +19,8 @@ import {
     requiredVisibleStates,
     type DisabledReadOnlyState,
     disabledReadOnlyStates,
-    disabledReadOnlyState
+    disabledReadOnlyState,
+    backgroundStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -86,7 +87,18 @@ const component = (
     </${numberFieldTag}>
 `;
 
-export const numberFieldThemeMatrix: StoryFn = createMatrixThemeStory(
+const [
+    lightThemeWhiteBackground,
+    colorThemeDarkGreenBackground,
+    darkThemeBlackBackground,
+    ...remaining
+] = backgroundStates;
+
+if (remaining.length > 0) {
+    throw new Error('New backgrounds need to be supported');
+}
+
+export const lightTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         requiredVisibleStates,
         disabledReadOnlyStates,
@@ -94,7 +106,32 @@ export const numberFieldThemeMatrix: StoryFn = createMatrixThemeStory(
         valueStates,
         errorStates,
         appearanceStates
-    ])
+    ]),
+    lightThemeWhiteBackground
+);
+
+export const colorTheme: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        requiredVisibleStates,
+        disabledReadOnlyStates,
+        hideStepStates,
+        valueStates,
+        errorStates,
+        appearanceStates
+    ]),
+    colorThemeDarkGreenBackground
+);
+
+export const darkTheme: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        requiredVisibleStates,
+        disabledReadOnlyStates,
+        hideStepStates,
+        valueStates,
+        errorStates,
+        appearanceStates
+    ]),
+    darkThemeBlackBackground
 );
 
 const notRequiredState = requiredVisibleStates[0];

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -55,17 +55,17 @@ const metadata: Meta = {
 export default metadata;
 
 const component = (
-    [appearanceName, appearance]: AppearanceState,
     [
         disabledReadOnlyName,
         readonly,
         disabled,
         appearanceReadOnly
     ]: DisabledReadOnlyState,
-    [errorName, errorVisible, errorText]: ErrorState,
-    [hideStepName, hideStep]: HideStepState,
+    [appearanceName, appearance]: AppearanceState,
     [requiredVisibleName, requiredVisible]: RequiredVisibleState,
-    [valueName, valueValue, placeholderValue]: ValueState
+    [hideStepName, hideStep]: HideStepState,
+    [valueName, valueValue, placeholderValue]: ValueState,
+    [errorName, errorVisible, errorText]: ErrorState
 ): ViewTemplate => html`
     <style>
         ${numberFieldTag} {
@@ -104,36 +104,36 @@ if (remaining.length > 0) {
 
 export const lightTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        appearanceStates,
         disabledReadOnlyStates,
-        errorStates,
-        hideStepStates,
+        appearanceStates,
         requiredVisibleStates,
-        valueStates
+        hideStepStates,
+        valueStates,
+        errorStates
     ]),
     lightThemeWhiteBackground
 );
 
 export const colorTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        appearanceStates,
         disabledReadOnlyStates,
-        errorStates,
-        hideStepStates,
+        appearanceStates,
         requiredVisibleStates,
-        valueStates
+        hideStepStates,
+        valueStates,
+        errorStates
     ]),
     colorThemeDarkGreenBackground
 );
 
 export const darkTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        appearanceStates,
         disabledReadOnlyStates,
-        errorStates,
-        hideStepStates,
+        appearanceStates,
         requiredVisibleStates,
-        valueStates
+        hideStepStates,
+        valueStates,
+        errorStates
     ]),
     darkThemeBlackBackground
 );
@@ -141,21 +141,21 @@ export const darkTheme: StoryFn = createFixedThemeStory(
 const notRequiredState = requiredVisibleStates[0];
 
 const interactionStatesHover = cartesianProduct([
-    appearanceStates,
     disabledReadOnlyStates,
-    [errorStatesNoError, errorStatesErrorWithMessage],
-    [hideStepStateStepVisible],
+    appearanceStates,
     [notRequiredState],
-    [valueStatesHasValue]
+    [hideStepStateStepVisible],
+    [valueStatesHasValue],
+    [errorStatesNoError, errorStatesErrorWithMessage]
 ] as const);
 
 const interactionStates = cartesianProduct([
-    appearanceStates,
     disabledReadOnlyStates,
-    [errorStatesNoError, errorStatesErrorWithMessage],
-    [hideStepStateStepVisible],
+    appearanceStates,
     [notRequiredState],
-    [valueStatesHasValue]
+    [hideStepStateStepVisible],
+    [valueStatesHasValue],
+    [errorStatesNoError, errorStatesErrorWithMessage]
 ] as const);
 
 export const interactionsThemeMatrix: StoryFn = createMatrixThemeStory(

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -147,7 +147,7 @@ const interactionStatesHover = cartesianProduct([
 
 const interactionStates = cartesianProduct([
     [notRequiredState],
-    disabledReadOnlyState.allNotDisabledStates,
+    disabledReadOnlyState.allDisabledAbsentStates,
     [hideStepStateStepVisible],
     [valueStatesHasValue],
     [errorStatesNoError, errorStatesErrorWithMessage],

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -19,7 +19,6 @@ import {
     requiredVisibleStates,
     type DisabledReadOnlyState,
     disabledReadOnlyStates,
-    disabledReadOnlyState,
     backgroundStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
@@ -56,20 +55,25 @@ const metadata: Meta = {
 export default metadata;
 
 const component = (
-    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
+    [appearanceName, appearance]: AppearanceState,
     [
         disabledReadOnlyName,
         readonly,
         disabled,
         appearanceReadOnly
     ]: DisabledReadOnlyState,
-    [hideStepName, hideStep]: HideStepState,
-    [valueName, valueValue, placeholderValue]: ValueState,
     [errorName, errorVisible, errorText]: ErrorState,
-    [appearanceName, appearance]: AppearanceState
+    [hideStepName, hideStep]: HideStepState,
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
+    [valueName, valueValue, placeholderValue]: ValueState
 ): ViewTemplate => html`
+    <style>
+        ${numberFieldTag} {
+            width: 250px;
+            margin: 0px 8px 16px 8px;
+        }
+    </style>
     <${numberFieldTag}
-        style="width: 250px; margin: 8px;"
         value="${() => valueValue}"
         placeholder="${() => placeholderValue}"
         appearance="${() => appearance}"
@@ -100,36 +104,36 @@ if (remaining.length > 0) {
 
 export const lightTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        appearanceStates,
         disabledReadOnlyStates,
-        hideStepStates,
-        valueStates,
         errorStates,
-        appearanceStates
+        hideStepStates,
+        requiredVisibleStates,
+        valueStates
     ]),
     lightThemeWhiteBackground
 );
 
 export const colorTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        appearanceStates,
         disabledReadOnlyStates,
-        hideStepStates,
-        valueStates,
         errorStates,
-        appearanceStates
+        hideStepStates,
+        requiredVisibleStates,
+        valueStates
     ]),
     colorThemeDarkGreenBackground
 );
 
 export const darkTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
+        appearanceStates,
         disabledReadOnlyStates,
-        hideStepStates,
-        valueStates,
         errorStates,
-        appearanceStates
+        hideStepStates,
+        requiredVisibleStates,
+        valueStates
     ]),
     darkThemeBlackBackground
 );
@@ -137,21 +141,21 @@ export const darkTheme: StoryFn = createFixedThemeStory(
 const notRequiredState = requiredVisibleStates[0];
 
 const interactionStatesHover = cartesianProduct([
-    [notRequiredState],
+    appearanceStates,
     disabledReadOnlyStates,
-    [hideStepStateStepVisible],
-    [valueStatesHasValue],
     [errorStatesNoError, errorStatesErrorWithMessage],
-    appearanceStates
+    [hideStepStateStepVisible],
+    [notRequiredState],
+    [valueStatesHasValue]
 ] as const);
 
 const interactionStates = cartesianProduct([
-    [notRequiredState],
-    disabledReadOnlyState.allDisabledAbsentStates,
-    [hideStepStateStepVisible],
-    [valueStatesHasValue],
+    appearanceStates,
+    disabledReadOnlyStates,
     [errorStatesNoError, errorStatesErrorWithMessage],
-    appearanceStates
+    [hideStepStateStepVisible],
+    [notRequiredState],
+    [valueStatesHasValue]
 ] as const);
 
 export const interactionsThemeMatrix: StoryFn = createMatrixThemeStory(

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -12,16 +12,17 @@ import {
 } from '../../utilities/matrix';
 import {
     disabledStates,
-    type DisabledState,
     errorStates,
     type ErrorState,
     disabledStateIsEnabled,
     errorStatesNoError,
     errorStatesErrorWithMessage,
-    type ReadOnlyState,
     readOnlyStates,
     type RequiredVisibleState,
-    requiredVisibleStates
+    requiredVisibleStates,
+    type DisabledReadOnlyState,
+    disabledReadOnlyStates,
+    disabledReadOnlyState
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -58,8 +59,7 @@ export default metadata;
 
 const component = (
     [requiredVisibleName, requiredVisible]: RequiredVisibleState,
-    [readOnlyName, readonly]: ReadOnlyState,
-    [disabledName, disabled]: DisabledState,
+    [disabledReadOnlyName, readonly, disabled, appearanceReadOnly]: DisabledReadOnlyState,
     [hideStepName, hideStep]: HideStepState,
     [valueName, valueValue, placeholderValue]: ValueState,
     [errorName, errorVisible, errorText]: ErrorState,
@@ -73,12 +73,13 @@ const component = (
         ?hide-step="${() => hideStep}"
         ?readonly="${() => readonly}"
         ?disabled="${() => disabled}"
+        ?appearance-readonly="${() => appearanceReadOnly}"
         error-text="${() => errorText}"
         ?error-visible="${() => errorVisible}"
         ?required-visible="${() => requiredVisible}"
     >
         ${() => errorName} ${() => appearanceName} ${() => valueName}
-        ${() => hideStepName} ${() => disabledName} ${() => readOnlyName}
+        ${() => hideStepName} ${() => disabledReadOnlyName}
         ${() => requiredVisibleName}
     </${numberFieldTag}>
 `;
@@ -86,8 +87,7 @@ const component = (
 export const numberFieldThemeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         requiredVisibleStates,
-        readOnlyStates,
-        disabledStates,
+        disabledReadOnlyStates,
         hideStepStates,
         valueStates,
         errorStates,
@@ -99,8 +99,7 @@ const notRequiredState = requiredVisibleStates[0];
 
 const interactionStatesHover = cartesianProduct([
     [notRequiredState],
-    readOnlyStates,
-    disabledStates,
+    disabledReadOnlyStates,
     [hideStepStateStepVisible],
     [valueStatesHasValue],
     [errorStatesNoError, errorStatesErrorWithMessage],
@@ -109,8 +108,7 @@ const interactionStatesHover = cartesianProduct([
 
 const interactionStates = cartesianProduct([
     [notRequiredState],
-    readOnlyStates,
-    [disabledStateIsEnabled],
+    disabledReadOnlyState.allNotDisabledStates,
     [hideStepStateStepVisible],
     [valueStatesHasValue],
     [errorStatesNoError, errorStatesErrorWithMessage],

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -59,7 +59,12 @@ export default metadata;
 
 const component = (
     [requiredVisibleName, requiredVisible]: RequiredVisibleState,
-    [disabledReadOnlyName, readonly, disabled, appearanceReadOnly]: DisabledReadOnlyState,
+    [
+        disabledReadOnlyName,
+        readonly,
+        disabled,
+        appearanceReadOnly
+    ]: DisabledReadOnlyState,
     [hideStepName, hideStep]: HideStepState,
     [valueName, valueValue, placeholderValue]: ValueState,
     [errorName, errorVisible, errorText]: ErrorState,

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -11,13 +11,10 @@ import {
     createMatrixInteractionsFromStates
 } from '../../utilities/matrix';
 import {
-    disabledStates,
     errorStates,
     type ErrorState,
-    disabledStateIsEnabled,
     errorStatesNoError,
     errorStatesErrorWithMessage,
-    readOnlyStates,
     type RequiredVisibleState,
     requiredVisibleStates,
     type DisabledReadOnlyState,

--- a/packages/storybook/src/nimble/number-field/number-field.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field.stories.ts
@@ -22,7 +22,8 @@ import {
     errorVisibleDescription,
     slottedLabelDescription,
     requiredVisibleDescription,
-    placeholderDescription
+    placeholderDescription,
+    appearanceReadOnlyDescription
 } from '../../utilities/storybook';
 
 interface NumberFieldArgs extends LabelUserArgs {
@@ -41,6 +42,7 @@ interface NumberFieldArgs extends LabelUserArgs {
     change: undefined;
     input: undefined;
     requiredVisible: boolean;
+    appearanceReadOnly: boolean;
 }
 
 const metadata: Meta<NumberFieldArgs> = {
@@ -62,6 +64,7 @@ const metadata: Meta<NumberFieldArgs> = {
             appearance="${x => x.appearance}"
             ?readonly="${x => x.readonly}"
             ?disabled="${x => x.disabled}"
+            ?appearance-readonly="${x => x.appearanceReadOnly}"
             ?error-visible="${x => x.errorVisible}"
             error-text="${x => x.errorText}"
             ?required-visible="${x => x.requiredVisible}"
@@ -100,6 +103,13 @@ const metadata: Meta<NumberFieldArgs> = {
         },
         disabled: {
             description: disabledDescription({ componentName: 'number field' }),
+            table: { category: apiCategory.attributes }
+        },
+        appearanceReadOnly: {
+            name: 'appearance-readonly',
+            description: appearanceReadOnlyDescription({
+                componentName: 'number field'
+            }),
             table: { category: apiCategory.attributes }
         },
         step: {
@@ -162,7 +172,8 @@ const metadata: Meta<NumberFieldArgs> = {
         disabled: false,
         errorVisible: false,
         errorText: 'Value is invalid',
-        requiredVisible: false
+        requiredVisible: false,
+        appearanceReadOnly: false
     }
 };
 addLabelUseMetadata(

--- a/packages/storybook/src/utilities/states.ts
+++ b/packages/storybook/src/utilities/states.ts
@@ -79,5 +79,7 @@ export const disabledReadOnlyState = {
     readOnlyAppearanceReadOnly: disabledReadOnlyStates[5],
     readOnlyDisabled: disabledReadOnlyStates[6],
     readOnlyDisabledAppearanceReadOnly: disabledReadOnlyStates[7],
-    allNotDisabledStates: disabledReadOnlyStates.filter((x: readonly (boolean | string)[]) => x[2] === false)
+    allNotDisabledStates: disabledReadOnlyStates.filter(
+        (x: readonly (boolean | string)[]) => x[2] === false
+    )
 } as const;

--- a/packages/storybook/src/utilities/states.ts
+++ b/packages/storybook/src/utilities/states.ts
@@ -78,8 +78,9 @@ export const disabledReadOnlyState = {
     readOnly: disabledReadOnlyStates[4],
     readOnlyAppearanceReadOnly: disabledReadOnlyStates[5],
     readOnlyDisabled: disabledReadOnlyStates[6],
-    readOnlyDisabledAppearanceReadOnly: disabledReadOnlyStates[7],
-    allDisabledAbsentStates: disabledReadOnlyStates.filter(
-        (x: readonly (boolean | string)[]) => x[2] === false
-    )
+    readOnlyDisabledAppearanceReadOnly: disabledReadOnlyStates[7]
 } as const;
+
+export const onlyDisabledAbsentStates = disabledReadOnlyStates.filter(
+    (state: readonly [name: string, readOnly: boolean, disabled: boolean, appearanceReadonly: boolean]) => state[2] === false
+);

--- a/packages/storybook/src/utilities/states.ts
+++ b/packages/storybook/src/utilities/states.ts
@@ -78,5 +78,6 @@ export const disabledReadOnlyState = {
     readOnly: disabledReadOnlyStates[4],
     readOnlyAppearanceReadOnly: disabledReadOnlyStates[5],
     readOnlyDisabled: disabledReadOnlyStates[6],
-    readOnlyDisabledAppearanceReadOnly: disabledReadOnlyStates[7]
+    readOnlyDisabledAppearanceReadOnly: disabledReadOnlyStates[7],
+    allNotDisabledStates: disabledReadOnlyStates.filter((x: readonly (boolean | string)[]) => x[2] === false)
 } as const;

--- a/packages/storybook/src/utilities/states.ts
+++ b/packages/storybook/src/utilities/states.ts
@@ -91,3 +91,4 @@ export const onlyDisabledAbsentStates = disabledReadOnlyStates.filter(
         ]
     ) => state[2] === false
 );
+export type OnlyDisabledAbsentState = (typeof onlyDisabledAbsentStates)[number];

--- a/packages/storybook/src/utilities/states.ts
+++ b/packages/storybook/src/utilities/states.ts
@@ -79,7 +79,7 @@ export const disabledReadOnlyState = {
     readOnlyAppearanceReadOnly: disabledReadOnlyStates[5],
     readOnlyDisabled: disabledReadOnlyStates[6],
     readOnlyDisabledAppearanceReadOnly: disabledReadOnlyStates[7],
-    allNotDisabledStates: disabledReadOnlyStates.filter(
+    allDisabledAbsentStates: disabledReadOnlyStates.filter(
         (x: readonly (boolean | string)[]) => x[2] === false
     )
 } as const;

--- a/packages/storybook/src/utilities/states.ts
+++ b/packages/storybook/src/utilities/states.ts
@@ -82,5 +82,12 @@ export const disabledReadOnlyState = {
 } as const;
 
 export const onlyDisabledAbsentStates = disabledReadOnlyStates.filter(
-    (state: readonly [name: string, readOnly: boolean, disabled: boolean, appearanceReadonly: boolean]) => state[2] === false
+    (
+        state: readonly [
+            name: string,
+            readOnly: boolean,
+            disabled: boolean,
+            appearanceReadonly: boolean
+        ]
+    ) => state[2] === false
 );


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Add `appearance-readonly` attribute to the `nimble-number-field` to style the component as readonly when it is disabled.

I also realized that the cursor was wrong for the `disabled + appearanceReadOnly` state on the `nimble-text-field`, so I fixed it.

## 👩‍💻 Implementation

- Add `appearance-readonly` attribute (tied to `appearanceReadOnly` property) on the number field
- Updated styles to make `disabled + appearanceReadOnly` look like the `readonly` styles
- Updated storybook docs
- Updated matrix tests
    - As part of the matrix test updates, I split the number field matrix tests into 3 different tests (one for each theme) because the canvas of the story got too tall for chromatic otherwise.

## 🧪 Testing

- Manually tested
- Chromatic test

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
