### PR TITLE
Add appearance-readonly to nimble-text-area

### DIFF
--- a/change/@ni-nimble-components-9c2c62b5-b927-459f-add7-7465055c5a4e.json
+++ b/change/@ni-nimble-components-9c2c62b5-b927-459f-add7-7465055c5a4e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add appearance-readonly to nimble-text-area",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/text-area/index.ts
+++ b/packages/nimble-components/src/text-area/index.ts
@@ -31,6 +31,9 @@ export class TextArea extends mixinErrorPattern(
     @attr
     public appearance: TextAreaAppearance = TextAreaAppearance.outline;
 
+    @attr({ attribute: 'appearance-readonly', mode: 'boolean' })
+    public appearanceReadOnly = false;
+
     /**
      * The width of the vertical scrollbar, if displayed.
      * @internal

--- a/packages/nimble-components/src/text-area/styles.ts
+++ b/packages/nimble-components/src/text-area/styles.ts
@@ -41,6 +41,10 @@ export const styles = css`
         color: ${bodyDisabledFontColor};
     }
 
+    :host([disabled][appearance-readonly]) {
+        color: ${bodyFontColor};
+    }
+
     .label {
         display: block;
         color: ${controlLabelFontColor};
@@ -49,6 +53,10 @@ export const styles = css`
 
     :host([disabled]) .label {
         color: ${controlLabelDisabledFontColor};
+    }
+
+    :host([disabled][appearance-readonly]) .label {
+        color: ${controlLabelFontColor};
     }
 
     .container {
@@ -128,6 +136,10 @@ export const styles = css`
         border-color: rgba(${borderRgbPartialColor}, 0.1);
     }
 
+    :host([disabled][appearance-readonly]) .control {
+        cursor: text;
+    }
+
     :host([error-visible]) .control {
         border-bottom-color: ${failColor};
     }
@@ -140,8 +152,12 @@ export const styles = css`
         color: ${controlLabelFontColor};
     }
 
-    .control[disabled]::placeholder {
+    :host([disabled]) .control::placeholder {
         color: ${controlLabelDisabledFontColor};
+    }
+
+    :host([disabled][appearance-readonly]) .control::placeholder {
+        color: ${controlLabelFontColor};
     }
 
     :host([resize='both']) .control {
@@ -188,6 +204,11 @@ export const styles = css`
             :host([disabled]) .control {
                 border-color: transparent;
                 background-color: rgba(${borderRgbPartialColor}, 0.1);
+            }
+
+            :host([disabled][appearance-readonly]) .control {
+                border-color: rgba(${borderRgbPartialColor}, 0.1);
+                background-color: transparent;
             }
 
             :host([error-visible][disabled]) .control {

--- a/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
@@ -9,10 +9,8 @@ import {
     sharedMatrixParameters
 } from '../../utilities/matrix';
 import {
-    disabledStates,
-    type DisabledState,
-    type ReadOnlyState,
-    readOnlyStates,
+    type DisabledReadOnlyState,
+    disabledReadOnlyStates,
     type ErrorState,
     errorStates,
     type RequiredVisibleState,
@@ -46,8 +44,7 @@ export default metadata;
 
 const component = (
     [requiredVisibleName, requiredVisible]: RequiredVisibleState,
-    [readOnlyName, readonly]: ReadOnlyState,
-    [disabledName, disabled]: DisabledState,
+    [disabledReadOnlyName, readOnly, disabled, appearanceReadOnly]: DisabledReadOnlyState,
     [appearanceName, appearance]: AppearanceState,
     [valueName, valueValue, placeholderValue]: ValueState,
     [errorStateName, isError, errorText]: ErrorState
@@ -58,21 +55,21 @@ const component = (
         appearance="${() => appearance}"
         value="${() => valueValue}"
         placeholder="${() => placeholderValue}"
-        ?readonly="${() => readonly}"
+        ?readonly="${() => readOnly}"
+        ?appearance-readonly="${() => appearanceReadOnly}"
         ?error-visible="${() => isError}"
         error-text="${() => errorText}"
         ?required-visible="${() => requiredVisible}"
     >
-        ${() => disabledName} ${() => appearanceName} ${() => valueName}
-        ${() => readOnlyName} ${() => errorStateName} ${() => requiredVisibleName}
+        ${() => disabledReadOnlyName} ${() => appearanceName} ${() => valueName}
+        ${() => errorStateName} ${() => requiredVisibleName}
     </${textAreaTag}>
 `;
 
 export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         requiredVisibleStates,
-        readOnlyStates,
-        disabledStates,
+        disabledReadOnlyStates,
         appearanceStates,
         valueStates,
         errorStates

--- a/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
@@ -45,7 +45,12 @@ export default metadata;
 
 const component = (
     [requiredVisibleName, requiredVisible]: RequiredVisibleState,
-    [disabledReadOnlyName, readOnly, disabled, appearanceReadOnly]: DisabledReadOnlyState,
+    [
+        disabledReadOnlyName,
+        readOnly,
+        disabled,
+        appearanceReadOnly
+    ]: DisabledReadOnlyState,
     [appearanceName, appearance]: AppearanceState,
     [valueName, valueValue, placeholderValue]: ValueState,
     [errorStateName, isError, errorText]: ErrorState

--- a/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
@@ -44,7 +44,6 @@ const metadata: Meta = {
 export default metadata;
 
 const component = (
-    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [
         disabledReadOnlyName,
         readOnly,
@@ -52,11 +51,17 @@ const component = (
         appearanceReadOnly
     ]: DisabledReadOnlyState,
     [appearanceName, appearance]: AppearanceState,
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [valueName, valueValue, placeholderValue]: ValueState,
     [errorStateName, isError, errorText]: ErrorState
 ): ViewTemplate => html`
+    <style>
+        ${textAreaTag} {
+            width: 250px;
+            margin: 0px 8px 16px 8px;
+        }
+    </style>
     <${textAreaTag}
-        style="width: 250px; margin: 15px;"
         ?disabled="${() => disabled}"
         appearance="${() => appearance}"
         value="${() => valueValue}"
@@ -85,9 +90,9 @@ if (remaining.length > 0) {
 
 export const lightTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
         disabledReadOnlyStates,
         appearanceStates,
+        requiredVisibleStates,
         valueStates,
         errorStates
     ]),
@@ -96,9 +101,9 @@ export const lightTheme: StoryFn = createFixedThemeStory(
 
 export const colorTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
         disabledReadOnlyStates,
         appearanceStates,
+        requiredVisibleStates,
         valueStates,
         errorStates
     ]),
@@ -107,9 +112,9 @@ export const colorTheme: StoryFn = createFixedThemeStory(
 
 export const darkTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
         disabledReadOnlyStates,
         appearanceStates,
+        requiredVisibleStates,
         valueStates,
         errorStates
     ]),

--- a/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
@@ -2,7 +2,7 @@ import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@ni/fast-element';
 import { textAreaTag } from '../../../../nimble-components/src/text-area';
 import { TextAreaAppearance } from '../../../../nimble-components/src/text-area/types';
-import { createStory } from '../../utilities/storybook';
+import { createFixedThemeStory, createStory } from '../../utilities/storybook';
 import {
     createMatrixThemeStory,
     createMatrix,
@@ -14,7 +14,8 @@ import {
     type ErrorState,
     errorStates,
     type RequiredVisibleState,
-    requiredVisibleStates
+    requiredVisibleStates,
+    backgroundStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -66,14 +67,48 @@ const component = (
     </${textAreaTag}>
 `;
 
-export const themeMatrix: StoryFn = createMatrixThemeStory(
+const [
+    lightThemeWhiteBackground,
+    colorThemeDarkGreenBackground,
+    darkThemeBlackBackground,
+    ...remaining
+] = backgroundStates;
+
+if (remaining.length > 0) {
+    throw new Error('New backgrounds need to be supported');
+}
+
+export const lightTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         requiredVisibleStates,
         disabledReadOnlyStates,
         appearanceStates,
         valueStates,
         errorStates
-    ])
+    ]),
+    lightThemeWhiteBackground
+);
+
+export const colorTheme: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        requiredVisibleStates,
+        disabledReadOnlyStates,
+        appearanceStates,
+        valueStates,
+        errorStates
+    ]),
+    colorThemeDarkGreenBackground
+);
+
+export const darkTheme: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        requiredVisibleStates,
+        disabledReadOnlyStates,
+        appearanceStates,
+        valueStates,
+        errorStates
+    ]),
+    darkThemeBlackBackground
 );
 
 const widthSizingTestCase = (

--- a/packages/storybook/src/nimble/text-area/text-area.stories.ts
+++ b/packages/storybook/src/nimble/text-area/text-area.stories.ts
@@ -99,7 +99,9 @@ const metadata: Meta<TextAreaArgs> = {
         },
         appearanceReadOnly: {
             name: 'appearance-readonly',
-            description: appearanceReadOnlyDescription({ componentName: 'text area' }),
+            description: appearanceReadOnlyDescription({
+                componentName: 'text area'
+            }),
             table: { category: apiCategory.attributes }
         },
         errorText: {

--- a/packages/storybook/src/nimble/text-area/text-area.stories.ts
+++ b/packages/storybook/src/nimble/text-area/text-area.stories.ts
@@ -9,6 +9,7 @@ import {
 import {
     apiCategory,
     appearanceDescription,
+    appearanceReadOnlyDescription,
     createUserSelectedThemeStory,
     disabledDescription,
     errorTextDescription,
@@ -35,6 +36,7 @@ interface TextAreaArgs {
     maxlength: number;
     change: undefined;
     requiredVisible: boolean;
+    appearanceReadOnly: boolean;
 }
 
 const metadata: Meta<TextAreaArgs> = {
@@ -60,6 +62,7 @@ const metadata: Meta<TextAreaArgs> = {
             cols="${x => x.cols}"
             maxlength="${x => x.maxlength}"
             ?required-visible="${x => x.requiredVisible}"
+            ?appearance-readonly="${x => x.appearanceReadOnly}"
         >
             ${x => x.label}
         </${textAreaTag}>
@@ -92,6 +95,11 @@ const metadata: Meta<TextAreaArgs> = {
         },
         disabled: {
             description: disabledDescription({ componentName: 'text area' }),
+            table: { category: apiCategory.attributes }
+        },
+        appearanceReadOnly: {
+            name: 'appearance-readonly',
+            description: appearanceReadOnlyDescription({ componentName: 'text area' }),
             table: { category: apiCategory.attributes }
         },
         errorText: {
@@ -156,7 +164,8 @@ const metadata: Meta<TextAreaArgs> = {
         rows: 3,
         cols: 20,
         maxlength: 500,
-        requiredVisible: false
+        requiredVisible: false,
+        appearanceReadOnly: false
     }
 };
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Add `appearance-readonly` attribute to the `nimble-text-area` to style the component as readonly when it is disabled.

## 👩‍💻 Implementation

- Add `appearance-readonly` attribute (tied to `appearanceReadOnly` property) on the text area
- Updated styles to make `disabled + appearanceReadOnly` look like the `readonly` styles
- Updated storybook docs
- Updated matrix tests
    - As part of the matrix test updates, I split the number field matrix tests into 3 different tests (one for each theme) because the canvas of the story got too tall for chromatic otherwise.

## 🧪 Testing

- Manually tested
- Chromatic test

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
