### PR TITLE
Add appearance-readonly to nimble-select and nimble-combobox

### DIFF
--- a/change/@ni-nimble-components-6d5224ae-9cd5-4a8d-8bc9-18f667db282b.json
+++ b/change/@ni-nimble-components-6d5224ae-9cd5-4a8d-8bc9-18f667db282b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add appearance-readonly to nimble-select and nimble-combobox",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/combobox/index.ts
+++ b/packages/nimble-components/src/combobox/index.ts
@@ -53,6 +53,9 @@ export class Combobox
     @attr
     public appearance: DropdownAppearance = DropdownAppearance.underline;
 
+    @attr({ attribute: 'appearance-readonly', mode: 'boolean' })
+    public appearanceReadOnly = false;
+
     /**
      * The autocomplete attribute.
      */

--- a/packages/nimble-components/src/combobox/styles.ts
+++ b/packages/nimble-components/src/combobox/styles.ts
@@ -54,7 +54,7 @@ export const styles = css`
     .selected-value${focusVisible} {
         outline: none;
     }
-        
+
     .selected-value::placeholder {
         color: ${placeholderFontColor};
     }

--- a/packages/nimble-components/src/combobox/styles.ts
+++ b/packages/nimble-components/src/combobox/styles.ts
@@ -5,7 +5,8 @@ import {
     borderRgbPartialColor,
     smallPadding,
     borderHoverColor,
-    borderWidth
+    borderWidth,
+    placeholderFontColor
 } from '../theme-provider/design-tokens';
 
 import { styles as dropdownStyles } from '../patterns/dropdown/styles';
@@ -14,7 +15,6 @@ import { styles as requiredVisibleStyles } from '../patterns/required-visible/st
 import { focusVisible } from '../utilities/style/focus';
 import { appearanceBehavior } from '../utilities/style/appearance';
 import { DropdownAppearance } from '../select/types';
-import { userSelectNone } from '../utilities/style/user-select';
 
 export const styles = css`
     ${dropdownStyles}
@@ -27,12 +27,6 @@ export const styles = css`
         --ni-private-height-within-border: calc(
             ${controlHeight} - 2 * ${borderWidth}
         );
-    }
-
-    :host([disabled]) *,
-    :host([disabled]) {
-        ${userSelectNone}
-        color: ${bodyDisabledFontColor};
     }
 
     .control {
@@ -60,6 +54,18 @@ export const styles = css`
     .selected-value${focusVisible} {
         outline: none;
     }
+        
+    .selected-value::placeholder {
+        color: ${placeholderFontColor};
+    }
+
+    :host([disabled]) .selected-value::placeholder {
+        color: ${bodyDisabledFontColor};
+    }
+
+    :host([disabled][appearance-readonly]) .selected-value::placeholder {
+        color: ${placeholderFontColor};
+    }
 
     [part='indicator'] {
         display: none;
@@ -69,6 +75,10 @@ export const styles = css`
         display: flex;
         align-items: baseline;
         padding-right: ${smallPadding};
+    }
+
+    :host([disabled][appearance-readonly]) .end-slot-container {
+        display: none;
     }
 
     .separator {

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -50,12 +50,6 @@ export const styles = css`
         --ni-private-indicator-lines-gap: 1px;
     }
 
-    :host([disabled][appearance-readonly]) {
-        cursor: text;
-        user-select: text;
-        -webkit-user-select: text;
-    }
-
     :host::before {
         content: '';
         position: absolute;
@@ -176,19 +170,8 @@ export const styles = css`
     }
 
     :host([disabled][appearance-readonly]) .selected-value {
+        cursor: text;
         padding-right: ${smallPadding};
-    }
-    
-    .selected-value.placeholder {
-        color: ${placeholderFontColor};
-    }
-
-    :host([disabled]) .selected-value.placeholder {
-        color: ${bodyDisabledFontColor};
-    }
-
-    :host([disabled][appearnce-readonly]) .selected-value.placeholder {
-        color: ${placeholderFontColor};
     }
 
     .indicator {

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -170,6 +170,8 @@ export const styles = css`
 
     :host([disabled][appearance-readonly]) .selected-value {
         cursor: text;
+        user-select: text;
+        -webkit-user-select: text;
         padding-right: ${smallPadding};
     }
 

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -143,7 +143,6 @@ export const styles = css`
     }
 
     :host([disabled][appearance-readonly]) .control {
-        cursor: text;
         color: ${bodyFontColor};
         border-color: rgba(${borderRgbPartialColor}, 0.3);
     }

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -50,6 +50,12 @@ export const styles = css`
         --ni-private-indicator-lines-gap: 1px;
     }
 
+    :host([disabled][appearance-readonly]) {
+        cursor: text;
+        user-select: text;
+        -webkit-user-select: text;
+    }
+
     :host::before {
         content: '';
         position: absolute;
@@ -117,6 +123,10 @@ export const styles = css`
         color: ${controlLabelDisabledFontColor};
     }
 
+    :host([disabled][appearance-readonly]) .label {
+        color: ${controlLabelFontColor};
+    }
+
     .control {
         align-items: center;
         cursor: pointer;
@@ -136,6 +146,12 @@ export const styles = css`
         cursor: default;
         color: ${bodyDisabledFontColor};
         border-color: rgba(${borderRgbPartialColor}, 0.1);
+    }
+
+    :host([disabled][appearance-readonly]) .control {
+        cursor: text;
+        color: ${bodyFontColor};
+        border-color: rgba(${borderRgbPartialColor}, 0.3);
     }
 
     :host([error-visible]) .control,
@@ -159,8 +175,20 @@ export const styles = css`
         padding-left: ${mediumPadding};
     }
 
-    .selected-value[disabled]::placeholder {
+    :host([disabled][appearance-readonly]) .selected-value {
+        padding-right: ${smallPadding};
+    }
+    
+    .selected-value.placeholder {
+        color: ${placeholderFontColor};
+    }
+
+    :host([disabled]) .selected-value.placeholder {
         color: ${bodyDisabledFontColor};
+    }
+
+    :host([disabled][appearnce-readonly]) .selected-value.placeholder {
+        color: ${placeholderFontColor};
     }
 
     .indicator {
@@ -170,6 +198,10 @@ export const styles = css`
         display: flex;
         justify-content: center;
         align-items: center;
+    }
+
+    :host([disabled][appearance-readonly]) .indicator {
+        display: none;
     }
 
     .indicator slot[name='indicator'] svg {
@@ -275,10 +307,6 @@ export const styles = css`
             .control {
                 border-bottom-width: ${borderWidth};
                 padding-bottom: 0;
-            }
-
-            :host([disabled]) .control {
-                border-color: rgba(${borderRgbPartialColor}, 0.1);
             }
         `
     ),

--- a/packages/nimble-components/src/select/index.ts
+++ b/packages/nimble-components/src/select/index.ts
@@ -71,6 +71,9 @@ export class Select
     @attr
     public appearance: DropdownAppearance = DropdownAppearance.underline;
 
+    @attr({ attribute: 'appearance-readonly', mode: 'boolean' })
+    public appearanceReadOnly = false;
+
     /**
      * Reflects the placement for the listbox when the select is open.
      *

--- a/packages/nimble-components/src/select/styles.ts
+++ b/packages/nimble-components/src/select/styles.ts
@@ -37,6 +37,18 @@ export const styles = css`
     .selected-value {
         order: 1;
     }
+    
+    .selected-value.placeholder {
+        color: ${placeholderFontColor};
+    }
+
+    :host([disabled]) .selected-value.placeholder {
+        color: ${bodyDisabledFontColor};
+    }
+
+    :host([disabled][appearance-readonly]) .selected-value.placeholder {
+        color: ${placeholderFontColor};
+    }
 
     .clear-button {
         order: 3;

--- a/packages/nimble-components/src/select/styles.ts
+++ b/packages/nimble-components/src/select/styles.ts
@@ -34,14 +34,6 @@ export const styles = css`
          error icon, and dropdown arrow because they are not "interactive" i.e. part of the tab order */ ''
     }
 
-    .selected-value.placeholder {
-        color: ${placeholderFontColor};
-    }
-
-    :host([disabled]) .selected-value.placeholder {
-        color: ${bodyDisabledFontColor};
-    }
-
     .selected-value {
         order: 1;
     }

--- a/packages/nimble-components/src/select/styles.ts
+++ b/packages/nimble-components/src/select/styles.ts
@@ -33,10 +33,6 @@ export const styles = css`
         /* We are using flex `order` to define the visual ordering of the selected value,
          error icon, and dropdown arrow because they are not "interactive" i.e. part of the tab order */ ''
     }
-
-    .selected-value {
-        order: 1;
-    }
     
     .selected-value.placeholder {
         color: ${placeholderFontColor};
@@ -48,6 +44,10 @@ export const styles = css`
 
     :host([disabled][appearance-readonly]) .selected-value.placeholder {
         color: ${placeholderFontColor};
+    }
+
+    .selected-value {
+        order: 1;
     }
 
     .clear-button {

--- a/packages/nimble-components/src/select/styles.ts
+++ b/packages/nimble-components/src/select/styles.ts
@@ -33,7 +33,7 @@ export const styles = css`
         /* We are using flex `order` to define the visual ordering of the selected value,
          error icon, and dropdown arrow because they are not "interactive" i.e. part of the tab order */ ''
     }
-    
+
     .selected-value.placeholder {
         color: ${placeholderFontColor};
     }

--- a/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
@@ -46,9 +46,9 @@ export default metadata;
 
 // prettier-ignore
 const component = (
-    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [disabledReadOnlyName, _readOnly, disabled, appearanceReadOnly]: DisabledReadOnlyState,
     [appearanceName, appearance]: AppearanceState,
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [errorName, errorVisible, errorText]: ErrorState,
     [valueName, value, placeholder]: ValueState
 ): ViewTemplate => html`
@@ -77,9 +77,9 @@ const component = (
 
 export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
         disabledReadOnlyState.allReadOnlyAbsentStates,
         appearanceStates,
+        requiredVisibleStates,
         errorStates,
         valueStates
     ])

--- a/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
@@ -15,8 +15,8 @@ import {
     type ErrorState,
     type RequiredVisibleState,
     requiredVisibleStates,
-    type DisabledReadOnlyState,
-    disabledReadOnlyState
+    type OnlyReadOnlyAbsentState,
+    onlyReadOnlyAbsentStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { loremIpsum } from '../../utilities/lorem-ipsum';
@@ -46,7 +46,7 @@ export default metadata;
 
 // prettier-ignore
 const component = (
-    [disabledReadOnlyName, _readOnly, disabled, appearanceReadOnly]: DisabledReadOnlyState,
+    [disabledReadOnlyName, _readOnly, disabled, appearanceReadOnly]: OnlyReadOnlyAbsentState,
     [appearanceName, appearance]: AppearanceState,
     [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [errorName, errorVisible, errorText]: ErrorState,
@@ -77,7 +77,7 @@ const component = (
 
 export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
-        disabledReadOnlyState.allReadOnlyAbsentStates,
+        onlyReadOnlyAbsentStates,
         appearanceStates,
         requiredVisibleStates,
         errorStates,

--- a/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
@@ -11,12 +11,12 @@ import {
     sharedMatrixParameters
 } from '../../utilities/matrix';
 import {
-    disabledStates,
-    type DisabledState,
     errorStates,
     type ErrorState,
     type RequiredVisibleState,
-    requiredVisibleStates
+    requiredVisibleStates,
+    type DisabledReadOnlyState,
+    disabledReadOnlyState
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { loremIpsum } from '../../utilities/lorem-ipsum';
@@ -47,13 +47,14 @@ export default metadata;
 // prettier-ignore
 const component = (
     [requiredVisibleName, requiredVisible]: RequiredVisibleState,
-    [disabledName, disabled]: DisabledState,
+    [disabledReadOnlyName, _readOnly, disabled, appearanceReadOnly]: DisabledReadOnlyState,
     [appearanceName, appearance]: AppearanceState,
     [errorName, errorVisible, errorText]: ErrorState,
     [valueName, value, placeholder]: ValueState
 ): ViewTemplate => html`
     <${comboboxTag} 
         ?disabled="${() => disabled}"
+        ?appearance-readonly="${() => appearanceReadOnly}"
         appearance="${() => appearance}"
         ?error-visible="${() => errorVisible}"
         error-text="${() => errorText}"
@@ -62,7 +63,7 @@ const component = (
         ?required-visible="${() => requiredVisible}"
         style="width: 250px; margin: var(${standardPadding.cssCustomProperty});"
     >
-        ${() => disabledName}
+        ${() => disabledReadOnlyName}
         ${() => appearanceName}
         ${() => errorName}
         ${() => valueName}
@@ -77,7 +78,7 @@ const component = (
 export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         requiredVisibleStates,
-        disabledStates,
+        disabledReadOnlyState.allReadOnlyAbsentStates,
         appearanceStates,
         errorStates,
         valueStates

--- a/packages/storybook/src/nimble/combobox/combobox.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox.stories.ts
@@ -158,7 +158,9 @@ const metadata: Meta<ComboboxArgs> = {
         },
         appearanceReadOnly: {
             name: 'appearance-readonly',
-            description: appearanceReadOnlyDescription({ componentName: 'combobox' }),
+            description: appearanceReadOnlyDescription({
+                componentName: 'combobox'
+            }),
             table: { category: apiCategory.attributes }
         },
         errorText: {

--- a/packages/storybook/src/nimble/combobox/combobox.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox.stories.ts
@@ -12,6 +12,7 @@ import {
 import {
     apiCategory,
     appearanceDescription,
+    appearanceReadOnlyDescription,
     createUserSelectedThemeStory,
     disableStorybookZoomTransform,
     disabledDescription,
@@ -38,6 +39,7 @@ interface ComboboxArgs {
     placeholder: string;
     change: undefined;
     input: undefined;
+    appearanceReadOnly: boolean;
 }
 
 interface OptionArgs {
@@ -111,6 +113,7 @@ const metadata: Meta<ComboboxArgs> = {
             value="${x => x.currentValue}"
             placeholder="${x => x.placeholder}"
             ?required-visible="${x => x.requiredVisible}"
+            ?appearance-readonly="${x => x.appearanceReadOnly}"
             style="min-width: 250px;"
         >
             ${x => x.label}
@@ -151,6 +154,11 @@ const metadata: Meta<ComboboxArgs> = {
         },
         disabled: {
             description: disabledDescription({ componentName: 'combobox' }),
+            table: { category: apiCategory.attributes }
+        },
+        appearanceReadOnly: {
+            name: 'appearance-readonly',
+            description: appearanceReadOnlyDescription({ componentName: 'combobox' }),
             table: { category: apiCategory.attributes }
         },
         errorText: {
@@ -209,7 +217,8 @@ const metadata: Meta<ComboboxArgs> = {
         appearance: DropdownAppearance.underline,
         placeholder: 'Select value...',
         optionsType: ExampleOptionsType.simpleOptions,
-        requiredVisible: false
+        requiredVisible: false,
+        appearanceReadOnly: false
     }
 };
 

--- a/packages/storybook/src/nimble/select/select-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-matrix.stories.ts
@@ -19,7 +19,7 @@ import {
     type ErrorState,
     errorStates,
     requiredVisibleStates,
-    type RequiredVisibleState,
+    type RequiredVisibleState
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';

--- a/packages/storybook/src/nimble/select/select-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-matrix.stories.ts
@@ -57,9 +57,9 @@ export default metadata;
 
 // prettier-ignore
 const component = (
-    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [disabledReadOnlyName, _readOnly, disabled, appearanceReadOnly]: DisabledReadOnlyState,
     [appearanceName, appearance]: AppearanceState,
+    [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [errorName, errorVisible, errorText]: ErrorState,
     [valueName, selectedValue]: ValueState,
     [clearableName, clearable]: ClearableState
@@ -97,9 +97,9 @@ if (remaining.length > 0) {
 
 export const lightTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
         disabledReadOnlyState.allReadOnlyAbsentStates,
         appearanceStates,
+        requiredVisibleStates,
         errorStates,
         valueStates,
         clearableStates
@@ -109,9 +109,9 @@ export const lightTheme: StoryFn = createFixedThemeStory(
 
 export const colorTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
         disabledReadOnlyState.allReadOnlyAbsentStates,
         appearanceStates,
+        requiredVisibleStates,
         errorStates,
         valueStates,
         clearableStates
@@ -121,9 +121,9 @@ export const colorTheme: StoryFn = createFixedThemeStory(
 
 export const darkTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        requiredVisibleStates,
         disabledReadOnlyState.allReadOnlyAbsentStates,
         appearanceStates,
+        requiredVisibleStates,
         errorStates,
         valueStates,
         clearableStates

--- a/packages/storybook/src/nimble/select/select-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-matrix.stories.ts
@@ -14,13 +14,13 @@ import {
     sharedMatrixParameters
 } from '../../utilities/matrix';
 import {
-    type DisabledReadOnlyState,
-    disabledReadOnlyState,
     type ErrorState,
     errorStates,
     requiredVisibleStates,
     type RequiredVisibleState,
-    backgroundStates
+    backgroundStates,
+    type OnlyReadOnlyAbsentState,
+    onlyReadOnlyAbsentStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -57,7 +57,7 @@ export default metadata;
 
 // prettier-ignore
 const component = (
-    [disabledReadOnlyName, _readOnly, disabled, appearanceReadOnly]: DisabledReadOnlyState,
+    [disabledReadOnlyName, _readOnly, disabled, appearanceReadOnly]: OnlyReadOnlyAbsentState,
     [appearanceName, appearance]: AppearanceState,
     [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [errorName, errorVisible, errorText]: ErrorState,
@@ -97,7 +97,7 @@ if (remaining.length > 0) {
 
 export const lightTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        disabledReadOnlyState.allReadOnlyAbsentStates,
+        onlyReadOnlyAbsentStates,
         appearanceStates,
         requiredVisibleStates,
         errorStates,
@@ -109,7 +109,7 @@ export const lightTheme: StoryFn = createFixedThemeStory(
 
 export const colorTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        disabledReadOnlyState.allReadOnlyAbsentStates,
+        onlyReadOnlyAbsentStates,
         appearanceStates,
         requiredVisibleStates,
         errorStates,
@@ -121,7 +121,7 @@ export const colorTheme: StoryFn = createFixedThemeStory(
 
 export const darkTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
-        disabledReadOnlyState.allReadOnlyAbsentStates,
+        onlyReadOnlyAbsentStates,
         appearanceStates,
         requiredVisibleStates,
         errorStates,

--- a/packages/storybook/src/nimble/select/select-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-matrix.stories.ts
@@ -14,12 +14,12 @@ import {
     sharedMatrixParameters
 } from '../../utilities/matrix';
 import {
-    disabledStates,
-    type DisabledState,
+    type DisabledReadOnlyState,
+    disabledReadOnlyState,
     type ErrorState,
     errorStates,
     requiredVisibleStates,
-    type RequiredVisibleState
+    type RequiredVisibleState,
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -57,7 +57,7 @@ export default metadata;
 // prettier-ignore
 const component = (
     [requiredVisibleName, requiredVisible]: RequiredVisibleState,
-    [disabledName, disabled]: DisabledState,
+    [disabledReadOnlyName, _readOnly, disabled, appearanceReadOnly]: DisabledReadOnlyState,
     [appearanceName, appearance]: AppearanceState,
     [errorName, errorVisible, errorText]: ErrorState,
     [valueName, selectedValue]: ValueState,
@@ -67,13 +67,14 @@ const component = (
         ?error-visible="${() => errorVisible}"
         error-text="${() => errorText}"
         ?disabled="${() => disabled}"
+        ?appearance-readonly="${() => appearanceReadOnly}"
         ?clearable="${() => clearable}"
         appearance="${() => appearance}"
         ?required-visible="${() => requiredVisible}"
         current-value="${() => selectedValue}"
         style="width: 250px; margin: var(${standardPadding.cssCustomProperty});"
     >
-        ${() => errorName} ${() => disabledName} ${() => appearanceName} ${() => valueName} ${() => clearableName} ${() => requiredVisibleName}
+        ${() => errorName} ${() => disabledReadOnlyName} ${() => appearanceName} ${() => valueName} ${() => clearableName} ${() => requiredVisibleName}
         <${listOptionTag} value="1">Option 1</${listOptionTag}>
         <${listOptionTag} value="2">${loremIpsum}</${listOptionTag}>
         <${listOptionTag} value="3" disabled>Option 3</${listOptionTag}>
@@ -85,7 +86,7 @@ const component = (
 export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         requiredVisibleStates,
-        disabledStates,
+        disabledReadOnlyState.allReadOnlyAbsentStates,
         appearanceStates,
         errorStates,
         valueStates,

--- a/packages/storybook/src/nimble/select/select-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-matrix.stories.ts
@@ -7,7 +7,7 @@ import { listOptionGroupTag } from '../../../../nimble-components/src/list-optio
 import { selectTag } from '../../../../nimble-components/src/select';
 import { DropdownAppearance } from '../../../../nimble-components/src/patterns/dropdown/types';
 import { waitForUpdatesAsync } from '../../../../nimble-components/src/testing/async-helpers';
-import { createStory } from '../../utilities/storybook';
+import { createFixedThemeStory, createStory } from '../../utilities/storybook';
 import {
     createMatrixThemeStory,
     createMatrix,
@@ -19,7 +19,8 @@ import {
     type ErrorState,
     errorStates,
     requiredVisibleStates,
-    type RequiredVisibleState
+    type RequiredVisibleState,
+    backgroundStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -83,7 +84,18 @@ const component = (
     </${selectTag}>
 `;
 
-export const themeMatrix: StoryFn = createMatrixThemeStory(
+const [
+    lightThemeWhiteBackground,
+    colorThemeDarkGreenBackground,
+    darkThemeBlackBackground,
+    ...remaining
+] = backgroundStates;
+
+if (remaining.length > 0) {
+    throw new Error('New backgrounds need to be supported');
+}
+
+export const lightTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         requiredVisibleStates,
         disabledReadOnlyState.allReadOnlyAbsentStates,
@@ -91,7 +103,32 @@ export const themeMatrix: StoryFn = createMatrixThemeStory(
         errorStates,
         valueStates,
         clearableStates
-    ])
+    ]),
+    lightThemeWhiteBackground
+);
+
+export const colorTheme: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        requiredVisibleStates,
+        disabledReadOnlyState.allReadOnlyAbsentStates,
+        appearanceStates,
+        errorStates,
+        valueStates,
+        clearableStates
+    ]),
+    colorThemeDarkGreenBackground
+);
+
+export const darkTheme: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        requiredVisibleStates,
+        disabledReadOnlyState.allReadOnlyAbsentStates,
+        appearanceStates,
+        errorStates,
+        valueStates,
+        clearableStates
+    ]),
+    darkThemeBlackBackground
 );
 
 export const hidden: StoryFn = createStory(

--- a/packages/storybook/src/nimble/select/select.stories.ts
+++ b/packages/storybook/src/nimble/select/select.stories.ts
@@ -214,7 +214,9 @@ const metadata: Meta<SelectArgs> = {
         },
         appearanceReadOnly: {
             name: 'appearance-readonly',
-            description: appearanceReadOnlyDescription({ componentName: 'select' }),
+            description: appearanceReadOnlyDescription({
+                componentName: 'select'
+            }),
             table: { category: apiCategory.attributes }
         },
         errorText: {

--- a/packages/storybook/src/nimble/select/select.stories.ts
+++ b/packages/storybook/src/nimble/select/select.stories.ts
@@ -10,6 +10,7 @@ import { DropdownAppearance } from '../../../../nimble-components/src/patterns/d
 import {
     apiCategory,
     appearanceDescription,
+    appearanceReadOnlyDescription,
     createUserSelectedThemeStory,
     disableStorybookZoomTransform,
     disabledDescription,
@@ -37,6 +38,7 @@ interface SelectArgs {
     value: string;
     change: undefined;
     filterInput: undefined;
+    appearanceReadOnly: boolean;
 }
 
 interface OptionArgs {
@@ -147,6 +149,7 @@ const metadata: Meta<SelectArgs> = {
             filter-mode="${x => (x.filterMode === 'none' ? undefined : x.filterMode)}"
             ?loading-visible="${x => x.loadingVisible}"
             ?required-visible="${x => x.requiredVisible}"
+            ?appearance-readonly="${x => x.appearanceReadOnly}"
             style="width:250px;"
         >
             ${x => x.label}
@@ -207,6 +210,11 @@ const metadata: Meta<SelectArgs> = {
         },
         disabled: {
             description: disabledDescription({ componentName: 'select' }),
+            table: { category: apiCategory.attributes }
+        },
+        appearanceReadOnly: {
+            name: 'appearance-readonly',
+            description: appearanceReadOnlyDescription({ componentName: 'select' }),
             table: { category: apiCategory.attributes }
         },
         errorText: {
@@ -281,7 +289,8 @@ const metadata: Meta<SelectArgs> = {
         optionsType: ExampleOptionsType.simpleOptions,
         clearable: false,
         loadingVisible: false,
-        requiredVisible: false
+        requiredVisible: false,
+        appearanceReadOnly: false
     }
 };
 

--- a/packages/storybook/src/utilities/states.ts
+++ b/packages/storybook/src/utilities/states.ts
@@ -78,5 +78,6 @@ export const disabledReadOnlyState = {
     readOnly: disabledReadOnlyStates[4],
     readOnlyAppearanceReadOnly: disabledReadOnlyStates[5],
     readOnlyDisabled: disabledReadOnlyStates[6],
-    readOnlyDisabledAppearanceReadOnly: disabledReadOnlyStates[7]
+    readOnlyDisabledAppearanceReadOnly: disabledReadOnlyStates[7],
+    allReadOnlyAbsentStates: disabledReadOnlyStates.filter(x => x[1] === false)
 } as const;

--- a/packages/storybook/src/utilities/states.ts
+++ b/packages/storybook/src/utilities/states.ts
@@ -78,8 +78,7 @@ export const disabledReadOnlyState = {
     readOnly: disabledReadOnlyStates[4],
     readOnlyAppearanceReadOnly: disabledReadOnlyStates[5],
     readOnlyDisabled: disabledReadOnlyStates[6],
-    readOnlyDisabledAppearanceReadOnly: disabledReadOnlyStates[7],
-    allReadOnlyAbsentStates: disabledReadOnlyStates.filter(x => x[1] === false)
+    readOnlyDisabledAppearanceReadOnly: disabledReadOnlyStates[7]
 } as const;
 
 export const onlyDisabledAbsentStates = disabledReadOnlyStates.filter(
@@ -93,3 +92,15 @@ export const onlyDisabledAbsentStates = disabledReadOnlyStates.filter(
     ) => state[2] === false
 );
 export type OnlyDisabledAbsentState = (typeof onlyDisabledAbsentStates)[number];
+
+export const onlyReadOnlyAbsentStates = disabledReadOnlyStates.filter(
+    (
+        state: readonly [
+            name: string,
+            readOnly: boolean,
+            disabled: boolean,
+            appearanceReadonly: boolean
+        ]
+    ) => state[1] === false
+);
+export type OnlyReadOnlyAbsentState = (typeof onlyReadOnlyAbsentStates)[number];


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Add `appearance-readonly` attribute to the `nimble-select` and `nimble-combobox` to style the components as readonly when they are disabled.

## 👩‍💻 Implementation

- Add `appearance-readonly` attribute (tied to `appearanceReadOnly` property) on the select and combobox
- Added styles to make `disabled + appearanceReadOnly` look like other readonly controls (neither select nor combobox has a `readonly` property or styles today)
- Updated storybook docs
- Updated matrix tests
    - As part of the matrix test updates, I split the select matrix story into 3 stories (one for each theme) because chromatic was timing out loading the story

## 🧪 Testing

- Manually tested
- Chromatic test

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
