### PR TITLE
Disable tab scroll tests

### DIFF
--- a/change/@ni-nimble-components-282313f7-142b-4953-8477-ad5fc3a724bb.json
+++ b/change/@ni-nimble-components-282313f7-142b-4953-8477-ad5fc3a724bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Disable intermittent tabs/anchorTabs scroll tests",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
+++ b/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
@@ -373,7 +373,8 @@ describe('AnchorTabs', () => {
         });
     });
 
-    describe('scroll buttons', () => {
+    // TODO: Fix tests and enable them - https://github.com/ni/nimble/issues/2603
+    xdescribe('scroll buttons', () => {
         async function setup(): Promise<Fixture<AnchorTabs>> {
             return await fixture<AnchorTabs>(
                 html`<${anchorTabsTag} activeid="tab-two">

--- a/packages/nimble-components/src/tabs/tests/tabs.spec.ts
+++ b/packages/nimble-components/src/tabs/tests/tabs.spec.ts
@@ -55,7 +55,8 @@ describe('Tabs', () => {
         await disconnect();
     });
 
-    describe('Scroll buttons', () => {
+    // TODO: Fix tests and enable them - https://github.com/ni/nimble/issues/2603
+    xdescribe('Scroll buttons', () => {
         let tabsPageObject: TabsPageObject;
         let element: Tabs;
         let connect: () => Promise<void>;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

There have been a lot of tests failing intermittently related to tab scrolling (both on chrome & WebKit and both regular tabs and anchor tabs).

Therefore, I am disabling all these test. Fixing the tests is tracked by #2603. 


## 👩‍💻 Implementation

Disable tests with TODO to enable them again. 

## 🧪 Testing

none

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
