### PR TITLE
Update nimble-number-field to support frameless and full-bleed styling

### DIFF
--- a/change/@ni-nimble-components-66b0fc49-9117-4442-8063-c9c8baf59521.json
+++ b/change/@ni-nimble-components-66b0fc49-9117-4442-8063-c9c8baf59521.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update nimble-number-field to support frameless and full-bleed styling",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/number-field/index.ts
+++ b/packages/nimble-components/src/number-field/index.ts
@@ -34,6 +34,9 @@ export class NumberField extends mixinErrorPattern(
     @attr
     public appearance: NumberFieldAppearance = NumberFieldAppearance.underline;
 
+    @attr({ attribute: 'full-bleed', mode: 'boolean' })
+    public fullBleed = false;
+
     @attr({ attribute: 'appearance-readonly', mode: 'boolean' })
     public appearanceReadOnly = false;
 

--- a/packages/nimble-components/src/number-field/styles.ts
+++ b/packages/nimble-components/src/number-field/styles.ts
@@ -239,5 +239,18 @@ export const styles = css`
                 padding: 0;
             }
         `
+    ),
+    appearanceBehavior(
+        NumberFieldAppearance.frameless,
+        css`
+            .root {
+                padding-left: ${borderWidth};
+                padding-right: ${borderWidth};
+            }
+
+            :host([full-bleed]) .control {
+                padding-left: 0px;
+            }
+        `
     )
 );

--- a/packages/nimble-components/src/number-field/types.ts
+++ b/packages/nimble-components/src/number-field/types.ts
@@ -4,7 +4,8 @@
 export const NumberFieldAppearance = {
     underline: 'underline',
     outline: 'outline',
-    block: 'block'
+    block: 'block',
+    frameless: 'fameless'
 } as const;
 
 export type NumberFieldAppearance =

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -19,7 +19,9 @@ import {
     requiredVisibleStates,
     type DisabledReadOnlyState,
     disabledReadOnlyStates,
-    backgroundStates
+    backgroundStates,
+    fullBleedStates,
+    type FullBleedState
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -27,7 +29,8 @@ import { textCustomizationWrapper } from '../../utilities/text-customization';
 const appearanceStates = [
     ['Underline', NumberFieldAppearance.underline],
     ['Outline', NumberFieldAppearance.outline],
-    ['Block', NumberFieldAppearance.block]
+    ['Block', NumberFieldAppearance.block],
+    ['Frameless', NumberFieldAppearance.frameless]
 ] as const;
 type AppearanceState = (typeof appearanceStates)[number];
 
@@ -62,6 +65,7 @@ const component = (
         appearanceReadOnly
     ]: DisabledReadOnlyState,
     [appearanceName, appearance]: AppearanceState,
+    [fullBleedName, fullBleed]: FullBleedState,
     [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [hideStepName, hideStep]: HideStepState,
     [valueName, valueValue, placeholderValue]: ValueState,
@@ -84,10 +88,11 @@ const component = (
         error-text="${() => errorText}"
         ?error-visible="${() => errorVisible}"
         ?required-visible="${() => requiredVisible}"
+        ?full-bleed="${() => fullBleed}"
     >
-        ${() => errorName} ${() => appearanceName} ${() => valueName}
-        ${() => hideStepName} ${() => disabledReadOnlyName}
-        ${() => requiredVisibleName}
+        ${() => errorName} ${() => appearanceName} ${() => fullBleedName}
+        ${() => valueName} ${() => hideStepName}
+        ${() => disabledReadOnlyName} ${() => requiredVisibleName}
     </${numberFieldTag}>
 `;
 
@@ -106,6 +111,7 @@ export const lightTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         disabledReadOnlyStates,
         appearanceStates,
+        fullBleedStates,
         requiredVisibleStates,
         hideStepStates,
         valueStates,
@@ -118,6 +124,7 @@ export const colorTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         disabledReadOnlyStates,
         appearanceStates,
+        fullBleedStates,
         requiredVisibleStates,
         hideStepStates,
         valueStates,
@@ -130,6 +137,7 @@ export const darkTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         disabledReadOnlyStates,
         appearanceStates,
+        fullBleedStates,
         requiredVisibleStates,
         hideStepStates,
         valueStates,
@@ -143,6 +151,7 @@ const notRequiredState = requiredVisibleStates[0];
 const interactionStatesHover = cartesianProduct([
     disabledReadOnlyStates,
     appearanceStates,
+    fullBleedStates,
     [notRequiredState],
     [hideStepStateStepVisible],
     [valueStatesHasValue],
@@ -152,6 +161,7 @@ const interactionStatesHover = cartesianProduct([
 const interactionStates = cartesianProduct([
     disabledReadOnlyStates,
     appearanceStates,
+    fullBleedStates,
     [notRequiredState],
     [hideStepStateStepVisible],
     [valueStatesHasValue],

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -21,7 +21,8 @@ import {
     disabledReadOnlyStates,
     backgroundStates,
     fullBleedStates,
-    type FullBleedState
+    type FullBleedState,
+    onlyDisabledAbsentStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -201,7 +202,7 @@ const interactionStatesHover = cartesianProduct([
 ] as const);
 
 const interactionStates = cartesianProduct([
-    disabledReadOnlyStates,
+    onlyDisabledAbsentStates,
     appearanceStates,
     fullBleedStates,
     [notRequiredState],

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -107,39 +107,81 @@ if (remaining.length > 0) {
     throw new Error('New backgrounds need to be supported');
 }
 
-export const lightTheme: StoryFn = createFixedThemeStory(
+const stepsVisibleState = hideStepStates[0];
+const stepsHiddenState = hideStepStates[1];
+
+export const lightTheme$StepsHidden: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         disabledReadOnlyStates,
         appearanceStates,
         fullBleedStates,
         requiredVisibleStates,
-        hideStepStates,
+        [stepsHiddenState],
         valueStates,
         errorStates
     ]),
     lightThemeWhiteBackground
 );
 
-export const colorTheme: StoryFn = createFixedThemeStory(
+export const lightTheme$StepsVisible: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         disabledReadOnlyStates,
         appearanceStates,
         fullBleedStates,
         requiredVisibleStates,
-        hideStepStates,
+        [stepsVisibleState],
+        valueStates,
+        errorStates
+    ]),
+    lightThemeWhiteBackground
+);
+
+export const colorTheme$StepsHidden: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        disabledReadOnlyStates,
+        appearanceStates,
+        fullBleedStates,
+        requiredVisibleStates,
+        [stepsHiddenState],
         valueStates,
         errorStates
     ]),
     colorThemeDarkGreenBackground
 );
 
-export const darkTheme: StoryFn = createFixedThemeStory(
+export const colorTheme$StepsVisible: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         disabledReadOnlyStates,
         appearanceStates,
         fullBleedStates,
         requiredVisibleStates,
-        hideStepStates,
+        [stepsVisibleState],
+        valueStates,
+        errorStates
+    ]),
+    colorThemeDarkGreenBackground
+);
+
+export const darkTheme$StepsHidden: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        disabledReadOnlyStates,
+        appearanceStates,
+        fullBleedStates,
+        requiredVisibleStates,
+        [stepsHiddenState],
+        valueStates,
+        errorStates
+    ]),
+    darkThemeBlackBackground
+);
+
+export const darkTheme$StepsVisible: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        disabledReadOnlyStates,
+        appearanceStates,
+        fullBleedStates,
+        requiredVisibleStates,
+        [stepsVisibleState],
         valueStates,
         errorStates
     ]),

--- a/packages/storybook/src/nimble/number-field/number-field.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field.stories.ts
@@ -23,7 +23,8 @@ import {
     slottedLabelDescription,
     requiredVisibleDescription,
     placeholderDescription,
-    appearanceReadOnlyDescription
+    appearanceReadOnlyDescription,
+    fullBleedDescription
 } from '../../utilities/storybook';
 
 interface NumberFieldArgs extends LabelUserArgs {
@@ -43,6 +44,7 @@ interface NumberFieldArgs extends LabelUserArgs {
     input: undefined;
     requiredVisible: boolean;
     appearanceReadOnly: boolean;
+    fullBleed: boolean;
 }
 
 const metadata: Meta<NumberFieldArgs> = {
@@ -68,6 +70,7 @@ const metadata: Meta<NumberFieldArgs> = {
             ?error-visible="${x => x.errorVisible}"
             error-text="${x => x.errorText}"
             ?required-visible="${x => x.requiredVisible}"
+            ?full-bleed="${x => x.fullBleed}"
         >
             ${x => x.label}
         </${numberFieldTag}>
@@ -93,6 +96,13 @@ const metadata: Meta<NumberFieldArgs> = {
             options: Object.values(NumberFieldAppearance),
             control: { type: 'radio' },
             description: appearanceDescription({
+                componentName: 'number field'
+            }),
+            table: { category: apiCategory.attributes }
+        },
+        fullBleed: {
+            name: 'full-bleed',
+            description: fullBleedDescription({
                 componentName: 'number field'
             }),
             table: { category: apiCategory.attributes }
@@ -168,12 +178,13 @@ const metadata: Meta<NumberFieldArgs> = {
         min: -10,
         max: 50,
         appearance: NumberFieldAppearance.underline,
+        fullBleed: false,
         readonly: false,
         disabled: false,
+        appearanceReadOnly: false,
         errorVisible: false,
         errorText: 'Value is invalid',
-        requiredVisible: false,
-        appearanceReadOnly: false
+        requiredVisible: false
     }
 };
 addLabelUseMetadata(
@@ -203,5 +214,12 @@ export const blockNumberField: StoryObj<NumberFieldArgs> = {
     args: {
         label: 'Block Number Field',
         appearance: NumberFieldAppearance.block
+    }
+};
+
+export const framelessNumberField: StoryObj<NumberFieldArgs> = {
+    args: {
+        label: 'Frameless Number Field',
+        appearance: NumberFieldAppearance.frameless
     }
 };

--- a/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
@@ -26,7 +26,9 @@ import {
     type RequiredVisibleState,
     requiredVisibleStates,
     type DisabledReadOnlyState,
-    disabledReadOnlyState
+    disabledReadOnlyState,
+    type FullBleedState,
+    fullBleedStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -56,12 +58,6 @@ const appearanceStates = [
     ['Frameless', TextFieldAppearance.frameless]
 ] as const;
 type AppearanceState = (typeof appearanceStates)[number];
-
-const fullBleedStates = [
-    ['', false],
-    ['Full Bleed', true]
-] as const;
-type FullBleedState = (typeof fullBleedStates)[number];
 
 const leftIconStates = [
     ['', false],

--- a/packages/storybook/src/nimble/text-field/text-field.stories.ts
+++ b/packages/storybook/src/nimble/text-field/text-field.stories.ts
@@ -20,7 +20,8 @@ import {
     placeholderDescription,
     slottedLabelDescription,
     requiredVisibleDescription,
-    appearanceReadOnlyDescription
+    appearanceReadOnlyDescription,
+    fullBleedDescription
 } from '../../utilities/storybook';
 
 interface TextFieldArgs {
@@ -114,8 +115,7 @@ const metadata: Meta<TextFieldArgs> = {
         },
         fullBleed: {
             name: 'full-bleed',
-            description:
-                'Remove the start and end margins causing the text to stretch across the full control width. Only applies to the frameless appearance.',
+            description: fullBleedDescription({ componentName: 'text field' }),
             table: { category: apiCategory.attributes }
         },
         value: {

--- a/packages/storybook/src/utilities/states.ts
+++ b/packages/storybook/src/utilities/states.ts
@@ -58,6 +58,12 @@ export const requiredVisibleStates = [
 ] as const;
 export type RequiredVisibleState = (typeof requiredVisibleStates)[number];
 
+export const fullBleedStates = [
+    ['', false],
+    ['Full Bleed', true]
+] as const;
+export type FullBleedState = (typeof fullBleedStates)[number];
+
 export const disabledReadOnlyStates = [
     ['', false, false, false],
     ['Appearance-Read-Only', false, false, true],

--- a/packages/storybook/src/utilities/storybook.ts
+++ b/packages/storybook/src/utilities/storybook.ts
@@ -177,6 +177,9 @@ export const apiCategory = {
 export const appearanceDescription = (options: {
     componentName: string
 }): string => `This attribute affects the appearance of the ${options.componentName}.`;
+export const fullBleedDescription = (options: {
+    componentName: string
+}): string => `Removes the start and end margins of the ${options.componentName} causing the text to stretch across the full control width. This property only applies to the frameless appearance.`;
 export const iconDescription = 'Set `slot="start"` to include an icon before the text content.';
 export const disabledDescription = (options: {
     componentName: string


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Updated the `nimble-number-field` appearance modes to include `frameless` and to also have the option to be `full-bleed` (which only applies when the appearance is `frameless`). This is part of the effort to be able to render more nimble controls in a "read-only" manner where the value is aligned with the label.

See #2592 

## 👩‍💻 Implementation

- Add `frameless` appearance for the number field
- Add `full-bleed` attribute to the number field

## 🧪 Testing

- Manual testing in storybook
- Updated chromatic tests
    - Because the theme tests got too big for the number field, I split each story into 2 -- one with the step buttons visible and one with the step buttons hidden.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
