### PR TITLE
Update select and combobox to support frameless and full-bleed styling

### DIFF
--- a/change/@ni-nimble-components-b44508aa-2a65-4419-8047-367e63603ea2.json
+++ b/change/@ni-nimble-components-b44508aa-2a65-4419-8047-367e63603ea2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update select and combobox to support frameless and full-bleed styling",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/combobox/index.ts
+++ b/packages/nimble-components/src/combobox/index.ts
@@ -56,6 +56,9 @@ export class Combobox
     @attr({ attribute: 'appearance-readonly', mode: 'boolean' })
     public appearanceReadOnly = false;
 
+    @attr({ attribute: 'full-bleed', mode: 'boolean' })
+    public fullBleed = false;
+
     /**
      * The autocomplete attribute.
      */

--- a/packages/nimble-components/src/patterns/dropdown/styles.ts
+++ b/packages/nimble-components/src/patterns/dropdown/styles.ts
@@ -320,6 +320,19 @@ export const styles = css`
             }
         `
     ),
+    appearanceBehavior(
+        DropdownAppearance.frameless,
+        css`
+            .control {
+                border-width: 0;
+                padding: ${borderWidth};
+            }
+
+            :host([full-bleed]) .selected-value {
+                padding-left: 0;
+            }
+        `
+    ),
     themeBehavior(
         Theme.color,
         css`

--- a/packages/nimble-components/src/patterns/dropdown/types.ts
+++ b/packages/nimble-components/src/patterns/dropdown/types.ts
@@ -19,7 +19,8 @@ export type DropdownPosition =
 export const DropdownAppearance = {
     underline: 'underline',
     outline: 'outline',
-    block: 'block'
+    block: 'block',
+    frameless: 'frameless'
 } as const;
 export type DropdownAppearance =
     (typeof DropdownAppearance)[keyof typeof DropdownAppearance];

--- a/packages/nimble-components/src/select/index.ts
+++ b/packages/nimble-components/src/select/index.ts
@@ -74,6 +74,9 @@ export class Select
     @attr({ attribute: 'appearance-readonly', mode: 'boolean' })
     public appearanceReadOnly = false;
 
+    @attr({ attribute: 'full-bleed', mode: 'boolean' })
+    public fullBleed = false;
+
     /**
      * Reflects the placement for the listbox when the select is open.
      *

--- a/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
@@ -16,7 +16,9 @@ import {
     type RequiredVisibleState,
     requiredVisibleStates,
     type OnlyReadOnlyAbsentState,
-    onlyReadOnlyAbsentStates
+    onlyReadOnlyAbsentStates,
+    type FullBleedState,
+    fullBleedStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { loremIpsum } from '../../utilities/lorem-ipsum';
@@ -24,7 +26,8 @@ import { loremIpsum } from '../../utilities/lorem-ipsum';
 const appearanceStates = [
     ['Underline', DropdownAppearance.underline],
     ['Outline', DropdownAppearance.outline],
-    ['Block', DropdownAppearance.block]
+    ['Block', DropdownAppearance.block],
+    ['Frameless', DropdownAppearance.frameless]
 ] as const;
 type AppearanceState = (typeof appearanceStates)[number];
 
@@ -48,6 +51,7 @@ export default metadata;
 const component = (
     [disabledReadOnlyName, _readOnly, disabled, appearanceReadOnly]: OnlyReadOnlyAbsentState,
     [appearanceName, appearance]: AppearanceState,
+    [fullBleedName, fullBleed]: FullBleedState,
     [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [errorName, errorVisible, errorText]: ErrorState,
     [valueName, value, placeholder]: ValueState
@@ -56,6 +60,7 @@ const component = (
         ?disabled="${() => disabled}"
         ?appearance-readonly="${() => appearanceReadOnly}"
         appearance="${() => appearance}"
+        ?full-bleed="${() => fullBleed}"
         ?error-visible="${() => errorVisible}"
         error-text="${() => errorText}"
         value="${() => value}"
@@ -65,6 +70,7 @@ const component = (
     >
         ${() => disabledReadOnlyName}
         ${() => appearanceName}
+        ${() => fullBleedName}
         ${() => errorName}
         ${() => valueName}
         ${() => requiredVisibleName}
@@ -79,6 +85,7 @@ export const themeMatrix: StoryFn = createMatrixThemeStory(
     createMatrix(component, [
         onlyReadOnlyAbsentStates,
         appearanceStates,
+        fullBleedStates,
         requiredVisibleStates,
         errorStates,
         valueStates

--- a/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
@@ -4,9 +4,8 @@ import { standardPadding } from '../../../../nimble-components/src/theme-provide
 import { listOptionTag } from '../../../../nimble-components/src/list-option';
 import { comboboxTag } from '../../../../nimble-components/src/combobox';
 import { DropdownAppearance } from '../../../../nimble-components/src/patterns/dropdown/types';
-import { createStory } from '../../utilities/storybook';
+import { createFixedThemeStory, createStory } from '../../utilities/storybook';
 import {
-    createMatrixThemeStory,
     createMatrix,
     sharedMatrixParameters
 } from '../../utilities/matrix';
@@ -18,7 +17,8 @@ import {
     type OnlyReadOnlyAbsentState,
     onlyReadOnlyAbsentStates,
     type FullBleedState,
-    fullBleedStates
+    fullBleedStates,
+    backgroundStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { loremIpsum } from '../../utilities/lorem-ipsum';
@@ -81,7 +81,18 @@ const component = (
     </${comboboxTag}>
 `;
 
-export const themeMatrix: StoryFn = createMatrixThemeStory(
+const [
+    lightThemeWhiteBackground,
+    colorThemeDarkGreenBackground,
+    darkThemeBlackBackground,
+    ...remaining
+] = backgroundStates;
+
+if (remaining.length > 0) {
+    throw new Error('New backgrounds need to be supported');
+}
+
+export const lightTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         onlyReadOnlyAbsentStates,
         appearanceStates,
@@ -89,7 +100,32 @@ export const themeMatrix: StoryFn = createMatrixThemeStory(
         requiredVisibleStates,
         errorStates,
         valueStates
-    ])
+    ]),
+    lightThemeWhiteBackground
+);
+
+export const colorTheme: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        onlyReadOnlyAbsentStates,
+        appearanceStates,
+        fullBleedStates,
+        requiredVisibleStates,
+        errorStates,
+        valueStates
+    ]),
+    colorThemeDarkGreenBackground
+);
+
+export const darkTheme: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        onlyReadOnlyAbsentStates,
+        appearanceStates,
+        fullBleedStates,
+        requiredVisibleStates,
+        errorStates,
+        valueStates
+    ]),
+    darkThemeBlackBackground
 );
 
 export const hidden: StoryFn = createStory(

--- a/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
@@ -5,10 +5,7 @@ import { listOptionTag } from '../../../../nimble-components/src/list-option';
 import { comboboxTag } from '../../../../nimble-components/src/combobox';
 import { DropdownAppearance } from '../../../../nimble-components/src/patterns/dropdown/types';
 import { createFixedThemeStory, createStory } from '../../utilities/storybook';
-import {
-    createMatrix,
-    sharedMatrixParameters
-} from '../../utilities/matrix';
+import { createMatrix, sharedMatrixParameters } from '../../utilities/matrix';
 import {
     errorStates,
     type ErrorState,

--- a/packages/storybook/src/nimble/combobox/combobox.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox.stories.ts
@@ -19,6 +19,7 @@ import {
     dropdownPositionDescription,
     errorTextDescription,
     errorVisibleDescription,
+    fullBleedDescription,
     optionsDescription,
     placeholderDescription,
     requiredVisibleDescription,
@@ -40,6 +41,7 @@ interface ComboboxArgs {
     change: undefined;
     input: undefined;
     appearanceReadOnly: boolean;
+    fullBleed: boolean;
 }
 
 interface OptionArgs {
@@ -114,6 +116,7 @@ const metadata: Meta<ComboboxArgs> = {
             placeholder="${x => x.placeholder}"
             ?required-visible="${x => x.requiredVisible}"
             ?appearance-readonly="${x => x.appearanceReadOnly}"
+            ?full-bleed="${x => x.fullBleed}"
             style="min-width: 250px;"
         >
             ${x => x.label}
@@ -150,6 +153,13 @@ const metadata: Meta<ComboboxArgs> = {
             options: Object.values(DropdownAppearance),
             control: { type: 'radio' },
             description: appearanceDescription({ componentName: 'combobox' }),
+            table: { category: apiCategory.attributes }
+        },
+        fullBleed: {
+            name: 'full-bleed',
+            description: fullBleedDescription({
+                componentName: 'combobox'
+            }),
             table: { category: apiCategory.attributes }
         },
         disabled: {
@@ -220,7 +230,8 @@ const metadata: Meta<ComboboxArgs> = {
         placeholder: 'Select value...',
         optionsType: ExampleOptionsType.simpleOptions,
         requiredVisible: false,
-        appearanceReadOnly: false
+        appearanceReadOnly: false,
+        fullBleed: false
     }
 };
 

--- a/packages/storybook/src/nimble/select/select-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-matrix.stories.ts
@@ -1,7 +1,7 @@
 import type { StoryFn, Meta } from '@storybook/html';
 import { html, ViewTemplate } from '@ni/fast-element';
 import { keyArrowDown } from '@ni/fast-web-utilities';
-import { standardPadding } from '../../../../nimble-components/src/theme-provider/design-tokens';
+import { mediumPadding } from '../../../../nimble-components/src/theme-provider/design-tokens';
 import { listOptionTag } from '../../../../nimble-components/src/list-option';
 import { listOptionGroupTag } from '../../../../nimble-components/src/list-option-group';
 import { selectTag } from '../../../../nimble-components/src/select';
@@ -66,7 +66,7 @@ const component = (
     [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [errorName, errorVisible, errorText]: ErrorState,
     [valueName, selectedValue]: ValueState,
-    [clearableName, clearable]: ClearableState
+    [_clearableName, clearable]: ClearableState
 ): ViewTemplate => html`
     <${selectTag}
         ?error-visible="${() => errorVisible}"
@@ -78,11 +78,11 @@ const component = (
         ?full-bleed="${() => fullBleed}"
         ?required-visible="${() => requiredVisible}"
         current-value="${() => selectedValue}"
-        style="width: 250px; margin: var(${standardPadding.cssCustomProperty});"
+        style="width: 250px; margin: var(${mediumPadding.cssCustomProperty});"
     >
         ${() => errorName} ${() => disabledReadOnlyName}
         ${() => appearanceName} ${() => fullBleedName}
-        ${() => valueName} ${() => clearableName} ${() => requiredVisibleName}
+        ${() => valueName} ${() => requiredVisibleName}
 
         <${listOptionTag} value="1">Option 1</${listOptionTag}>
         <${listOptionTag} value="2">${loremIpsum}</${listOptionTag}>
@@ -103,7 +103,10 @@ if (remaining.length > 0) {
     throw new Error('New backgrounds need to be supported');
 }
 
-export const lightTheme: StoryFn = createFixedThemeStory(
+const notClearableState = clearableStates[0];
+const clearableState = clearableStates[1];
+
+export const lightTheme$NotClearable: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         onlyReadOnlyAbsentStates,
         appearanceStates,
@@ -111,12 +114,12 @@ export const lightTheme: StoryFn = createFixedThemeStory(
         requiredVisibleStates,
         errorStates,
         valueStates,
-        clearableStates
+        [notClearableState]
     ]),
     lightThemeWhiteBackground
 );
 
-export const colorTheme: StoryFn = createFixedThemeStory(
+export const lightTheme$Clearable: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         onlyReadOnlyAbsentStates,
         appearanceStates,
@@ -124,12 +127,25 @@ export const colorTheme: StoryFn = createFixedThemeStory(
         requiredVisibleStates,
         errorStates,
         valueStates,
-        clearableStates
+        [clearableState]
+    ]),
+    lightThemeWhiteBackground
+);
+
+export const colorTheme$NotClearable: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        onlyReadOnlyAbsentStates,
+        appearanceStates,
+        fullBleedStates,
+        requiredVisibleStates,
+        errorStates,
+        valueStates,
+        [notClearableState]
     ]),
     colorThemeDarkGreenBackground
 );
 
-export const darkTheme: StoryFn = createFixedThemeStory(
+export const colorTheme$Clearable: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         onlyReadOnlyAbsentStates,
         appearanceStates,
@@ -137,7 +153,33 @@ export const darkTheme: StoryFn = createFixedThemeStory(
         requiredVisibleStates,
         errorStates,
         valueStates,
-        clearableStates
+        [clearableState]
+    ]),
+    colorThemeDarkGreenBackground
+);
+
+export const darkTheme$NotClearable: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        onlyReadOnlyAbsentStates,
+        appearanceStates,
+        fullBleedStates,
+        requiredVisibleStates,
+        errorStates,
+        valueStates,
+        [notClearableState]
+    ]),
+    darkThemeBlackBackground
+);
+
+export const darkTheme$Clearable: StoryFn = createFixedThemeStory(
+    createMatrix(component, [
+        onlyReadOnlyAbsentStates,
+        appearanceStates,
+        fullBleedStates,
+        requiredVisibleStates,
+        errorStates,
+        valueStates,
+        [clearableState]
     ]),
     darkThemeBlackBackground
 );

--- a/packages/storybook/src/nimble/select/select-matrix.stories.ts
+++ b/packages/storybook/src/nimble/select/select-matrix.stories.ts
@@ -20,7 +20,9 @@ import {
     type RequiredVisibleState,
     backgroundStates,
     type OnlyReadOnlyAbsentState,
-    onlyReadOnlyAbsentStates
+    onlyReadOnlyAbsentStates,
+    type FullBleedState,
+    fullBleedStates
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
@@ -29,7 +31,8 @@ import { loremIpsum } from '../../utilities/lorem-ipsum';
 const appearanceStates = [
     ['Underline', DropdownAppearance.underline],
     ['Outline', DropdownAppearance.outline],
-    ['Block', DropdownAppearance.block]
+    ['Block', DropdownAppearance.block],
+    ['Frameless', DropdownAppearance.frameless]
 ] as const;
 type AppearanceState = (typeof appearanceStates)[number];
 
@@ -59,6 +62,7 @@ export default metadata;
 const component = (
     [disabledReadOnlyName, _readOnly, disabled, appearanceReadOnly]: OnlyReadOnlyAbsentState,
     [appearanceName, appearance]: AppearanceState,
+    [fullBleedName, fullBleed]: FullBleedState,
     [requiredVisibleName, requiredVisible]: RequiredVisibleState,
     [errorName, errorVisible, errorText]: ErrorState,
     [valueName, selectedValue]: ValueState,
@@ -71,11 +75,15 @@ const component = (
         ?appearance-readonly="${() => appearanceReadOnly}"
         ?clearable="${() => clearable}"
         appearance="${() => appearance}"
+        ?full-bleed="${() => fullBleed}"
         ?required-visible="${() => requiredVisible}"
         current-value="${() => selectedValue}"
         style="width: 250px; margin: var(${standardPadding.cssCustomProperty});"
     >
-        ${() => errorName} ${() => disabledReadOnlyName} ${() => appearanceName} ${() => valueName} ${() => clearableName} ${() => requiredVisibleName}
+        ${() => errorName} ${() => disabledReadOnlyName}
+        ${() => appearanceName} ${() => fullBleedName}
+        ${() => valueName} ${() => clearableName} ${() => requiredVisibleName}
+
         <${listOptionTag} value="1">Option 1</${listOptionTag}>
         <${listOptionTag} value="2">${loremIpsum}</${listOptionTag}>
         <${listOptionTag} value="3" disabled>Option 3</${listOptionTag}>
@@ -99,6 +107,7 @@ export const lightTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         onlyReadOnlyAbsentStates,
         appearanceStates,
+        fullBleedStates,
         requiredVisibleStates,
         errorStates,
         valueStates,
@@ -111,6 +120,7 @@ export const colorTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         onlyReadOnlyAbsentStates,
         appearanceStates,
+        fullBleedStates,
         requiredVisibleStates,
         errorStates,
         valueStates,
@@ -123,6 +133,7 @@ export const darkTheme: StoryFn = createFixedThemeStory(
     createMatrix(component, [
         onlyReadOnlyAbsentStates,
         appearanceStates,
+        fullBleedStates,
         requiredVisibleStates,
         errorStates,
         valueStates,

--- a/packages/storybook/src/nimble/select/select.stories.ts
+++ b/packages/storybook/src/nimble/select/select.stories.ts
@@ -17,6 +17,7 @@ import {
     dropdownPositionDescription,
     errorTextDescription,
     errorVisibleDescription,
+    fullBleedDescription,
     optionsDescription,
     requiredVisibleDescription,
     slottedLabelDescription
@@ -39,6 +40,7 @@ interface SelectArgs {
     change: undefined;
     filterInput: undefined;
     appearanceReadOnly: boolean;
+    fullBleed: boolean;
 }
 
 interface OptionArgs {
@@ -150,6 +152,7 @@ const metadata: Meta<SelectArgs> = {
             ?loading-visible="${x => x.loadingVisible}"
             ?required-visible="${x => x.requiredVisible}"
             ?appearance-readonly="${x => x.appearanceReadOnly}"
+            ?full-bleed="${x => x.fullBleed}"
             style="width:250px;"
         >
             ${x => x.label}
@@ -199,6 +202,13 @@ const metadata: Meta<SelectArgs> = {
             options: Object.values(DropdownAppearance),
             control: { type: 'radio' },
             description: appearanceDescription({ componentName: 'select' }),
+            table: { category: apiCategory.attributes }
+        },
+        fullBleed: {
+            name: 'full-bleed',
+            description: fullBleedDescription({
+                componentName: 'select'
+            }),
             table: { category: apiCategory.attributes }
         },
         filterMode: {
@@ -292,7 +302,8 @@ const metadata: Meta<SelectArgs> = {
         clearable: false,
         loadingVisible: false,
         requiredVisible: false,
-        appearanceReadOnly: false
+        appearanceReadOnly: false,
+        fullBleed: false
     }
 };
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Updated the `nimble-select` and `nimble-combobox` appearance modes to include `frameless` and to also have the option to be `full-bleed` (which only applies when the appearance is `frameless`). This is part of the effort to be able to render more nimble controls in a "read-only" manner where the value is aligned with the label.

See #2592 

## 👩‍💻 Implementation

- Add `frameless` appearance for the drop-down appearance modes
- Add `full-bleed` attribute to the select and combobox

## 🧪 Testing

- Manual testing in storybook
- Updated chromatic tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
