### PR TITLE
Update Blazor components with appearance-readonly and full-bleed

### DIFF
--- a/change/@ni-nimble-blazor-4db319a8-120e-46bd-b234-085a96bdbf0c.json
+++ b/change/@ni-nimble-blazor-4db319a8-120e-46bd-b234-085a96bdbf0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update nimble-select, nimble-combobox, nimble-text-area, nimble-number-field, and nimble-text-field to support appearance-readonly and full-bleed",
+  "packageName": "@ni/nimble-blazor",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/blazor-workspace/NimbleBlazor/Components/NimbleCombobox.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Components/NimbleCombobox.razor
@@ -12,6 +12,8 @@
         error-text="@ErrorText"
         error-visible="@ErrorVisible"
         required-visible="@RequiredVisible"
+        appearance-readonly="@AppearanceReadOnly"
+        full-bleed="@FullBleed"
         @attributes="AdditionalAttributes">
         @ChildContent
     </nimble-combobox>

--- a/packages/blazor-workspace/NimbleBlazor/Components/NimbleCombobox.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Components/NimbleCombobox.razor.cs
@@ -64,6 +64,20 @@ public partial class NimbleCombobox : NimbleInputBase<string?>
     public bool? RequiredVisible { get; set; }
 
     /// <summary>
+    /// Gets or set whether or not the combobox should be rendered as
+    /// read only when it is disabled.
+    /// </summary>
+    [Parameter]
+    public bool? AppearanceReadOnly { get; set; }
+
+    /// <summary>
+    /// Gets or set whether or not the start and end margins of the control are removed.
+    /// This only applies when the <see cref="Appearance"/> is <see cref="DropdownAppearance.Frameless"/>.
+    /// </summary>
+    [Parameter]
+    public bool? FullBleed { get; set; }
+
+    /// <summary>
     /// Gets or sets the child content to be rendered inside the combobox
     /// </summary>
     [Parameter]

--- a/packages/blazor-workspace/NimbleBlazor/Components/NimbleNumberField.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Components/NimbleNumberField.razor
@@ -14,6 +14,8 @@
     error-text="@ErrorText"
     error-visible="@ErrorVisible"
     required-visible="@RequiredVisible"
+    appearance-readonly="@AppearanceReadOnly"
+    full-bleed="@FullBleed"
     @attributes="AdditionalAttributes">
     @ChildContent
 </nimble-number-field>

--- a/packages/blazor-workspace/NimbleBlazor/Components/NimbleNumberField.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Components/NimbleNumberField.razor.cs
@@ -79,6 +79,20 @@ public partial class NimbleNumberField : NimbleInputBase<double?>
     public bool? RequiredVisible { get; set; }
 
     /// <summary>
+    /// Gets or set whether or not the number field should be rendered as
+    /// read only when it is disabled.
+    /// </summary>
+    [Parameter]
+    public bool? AppearanceReadOnly { get; set; }
+
+    /// <summary>
+    /// Gets or set whether or not the start and end margins of the control are removed.
+    /// This only applies when the <see cref="Appearance"/> is <see cref="NumberFieldAppearance.Frameless"/>.
+    /// </summary>
+    [Parameter]
+    public bool? FullBleed { get; set; }
+
+    /// <summary>
     /// Gets or sets the child content to be rendered inside the combobox
     /// </summary>
     [Parameter]

--- a/packages/blazor-workspace/NimbleBlazor/Components/NimbleSelect.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Components/NimbleSelect.razor
@@ -13,6 +13,8 @@
         error-text="@ErrorText"
         error-visible="@ErrorVisible"
         required-visible="@RequiredVisible"
+        appearance-readonly="@AppearanceReadOnly"
+        full-bleed="@FullBleed"
         @attributes="AdditionalAttributes">
         @ChildContent
     </nimble-select>

--- a/packages/blazor-workspace/NimbleBlazor/Components/NimbleSelect.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Components/NimbleSelect.razor.cs
@@ -63,6 +63,20 @@ public partial class NimbleSelect : NimbleInputBase<string?>
     public bool? RequiredVisible { get; set; }
 
     /// <summary>
+    /// Gets or set whether or not the select should be rendered as
+    /// read only when it is disabled.
+    /// </summary>
+    [Parameter]
+    public bool? AppearanceReadOnly { get; set; }
+
+    /// <summary>
+    /// Gets or set whether or not the start and end margins of the control are removed.
+    /// This only applies when the <see cref="Appearance"/> is <see cref="DropdownAppearance.Frameless"/>.
+    /// </summary>
+    [Parameter]
+    public bool? FullBleed { get; set; }
+
+    /// <summary>
     /// Gets or sets the child content to be rendering inside the <see cref="NimbleSelect"/>.
     /// </summary>
     [Parameter]

--- a/packages/blazor-workspace/NimbleBlazor/Components/NimbleTextArea.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Components/NimbleTextArea.razor
@@ -18,6 +18,7 @@
     required="@Required"
     placeholder="@Placeholder"
     required-visible="@RequiredVisible"
+    appearance-readonly="@AppearanceReadOnly"
     @attributes="AdditionalAttributes">
     @ChildContent
 </nimble-text-area>

--- a/packages/blazor-workspace/NimbleBlazor/Components/NimbleTextArea.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Components/NimbleTextArea.razor.cs
@@ -96,6 +96,13 @@ public partial class NimbleTextArea : NimbleInputBase<string?>
     public bool? RequiredVisible { get; set; }
 
     /// <summary>
+    /// Gets or set whether or not the text area should be rendered as
+    /// read only when it is disabled.
+    /// </summary>
+    [Parameter]
+    public bool? AppearanceReadOnly { get; set; }
+
+    /// <summary>
     /// Gets or sets the child content of the control
     /// </summary>
     [Parameter]

--- a/packages/blazor-workspace/NimbleBlazor/Components/NimbleTextField.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Components/NimbleTextField.razor
@@ -18,6 +18,7 @@
     error-visible="@ErrorVisible"
     full-bleed="@FullBleed"
     required-visible="@RequiredVisible"
+    appearance-readonly="@AppearanceReadOnly"
     @attributes="AdditionalAttributes">
     @ChildContent
 </nimble-text-field>

--- a/packages/blazor-workspace/NimbleBlazor/Components/NimbleTextField.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Components/NimbleTextField.razor.cs
@@ -59,6 +59,13 @@ public partial class NimbleTextField : NimbleInputBase<string?>
     [Parameter]
     public bool? RequiredVisible { get; set; }
 
+    /// <summary>
+    /// Gets or set whether or not the text field should be rendered as
+    /// read only when it is disabled.
+    /// </summary>
+    [Parameter]
+    public bool? AppearanceReadOnly { get; set; }
+
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 

--- a/packages/blazor-workspace/NimbleBlazor/DropdownAppearance.cs
+++ b/packages/blazor-workspace/NimbleBlazor/DropdownAppearance.cs
@@ -4,7 +4,8 @@ public enum DropdownAppearance
 {
     Underline,
     Outline,
-    Block
+    Block,
+    Frameless
 }
 
 internal static class DropdownAppearanceExtensions

--- a/packages/blazor-workspace/NimbleBlazor/NumberFieldAppearance.cs
+++ b/packages/blazor-workspace/NimbleBlazor/NumberFieldAppearance.cs
@@ -4,7 +4,8 @@ public enum NumberFieldAppearance
 {
     Underline,
     Outline,
-    Block
+    Block,
+    Frameless
 }
 
 internal static class NumberFieldAppearanceExtensions

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleComboboxTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleComboboxTests.cs
@@ -57,6 +57,7 @@ public class NimbleComboboxTests
     [InlineData(DropdownAppearance.Block, "block")]
     [InlineData(DropdownAppearance.Underline, "underline")]
     [InlineData(DropdownAppearance.Outline, "outline")]
+    [InlineData(DropdownAppearance.Frameless, "frameless")]
     public void ComboboxAppearance_AttributeIsSet(DropdownAppearance value, string expectedAttribute)
     {
         var combobox = RenderWithPropertySet(x => x.Appearance, value);
@@ -95,6 +96,22 @@ public class NimbleComboboxTests
         var combobox = RenderWithPropertySet(x => x.RequiredVisible, true);
 
         Assert.Contains("required-visible", combobox.Markup);
+    }
+
+    [Fact]
+    public void ComboboxAppearanceReadOnly_AttributeIsSet()
+    {
+        var combobox = RenderWithPropertySet(x => x.AppearanceReadOnly, true);
+
+        Assert.Contains("appearance-readonly", combobox.Markup);
+    }
+
+    [Fact]
+    public void ComboboxFullBleed_AttributeIsSet()
+    {
+        var combobox = RenderWithPropertySet(x => x.FullBleed, true);
+
+        Assert.Contains("full-bleed", combobox.Markup);
     }
 
     [Fact]

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleNumberFieldTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleNumberFieldTests.cs
@@ -53,6 +53,7 @@ public class NimbleNumberFieldTests
     [InlineData(NumberFieldAppearance.Outline, "outline")]
     [InlineData(NumberFieldAppearance.Block, "block")]
     [InlineData(NumberFieldAppearance.Underline, "underline")]
+    [InlineData(NumberFieldAppearance.Frameless, "frameless")]
     public void NumberFieldAppearance_AttributeIsSet(NumberFieldAppearance value, string expectedAttribute)
     {
         var numberField = RenderWithPropertySet(x => x.Appearance, value);
@@ -138,6 +139,22 @@ public class NimbleNumberFieldTests
         var numberField = RenderWithPropertySet(x => x.RequiredVisible, true);
 
         Assert.Contains("required-visible", numberField.Markup);
+    }
+
+    [Fact]
+    public void NumberFieldAppearanceReadOnly_AttributeIsSet()
+    {
+        var numberField = RenderWithPropertySet(x => x.AppearanceReadOnly, true);
+
+        Assert.Contains("appearance-readonly", numberField.Markup);
+    }
+
+    [Fact]
+    public void NumberFieldFullBleed_AttributeIsSet()
+    {
+        var numberField = RenderWithPropertySet(x => x.FullBleed, true);
+
+        Assert.Contains("full-bleed", numberField.Markup);
     }
 
     private IRenderedComponent<NimbleNumberField> RenderWithPropertySet<TProperty>(Expression<Func<NimbleNumberField, TProperty>> propertyGetter, TProperty propertyValue)

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleSelectTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleSelectTests.cs
@@ -78,6 +78,7 @@ public class NimbleSelectTests
     [InlineData(DropdownAppearance.Outline, "outline")]
     [InlineData(DropdownAppearance.Block, "block")]
     [InlineData(DropdownAppearance.Underline, "underline")]
+    [InlineData(DropdownAppearance.Frameless, "frameless")]
     public void DropdownAppearance_AttributeIsSet(DropdownAppearance value, string expectedAttribute)
     {
         var select = RenderWithPropertySet(x => x.Appearance, value);
@@ -108,6 +109,22 @@ public class NimbleSelectTests
         var select = RenderWithPropertySet(x => x.Clearable, true);
 
         Assert.Contains("clearable", select.Markup);
+    }
+
+    [Fact]
+    public void SelectAppearanceReadOnly_AttributeIsSet()
+    {
+        var select = RenderWithPropertySet(x => x.AppearanceReadOnly, true);
+
+        Assert.Contains("appearance-readonly", select.Markup);
+    }
+
+    [Fact]
+    public void SelectFullBleed_AttributeIsSet()
+    {
+        var select = RenderWithPropertySet(x => x.FullBleed, true);
+
+        Assert.Contains("full-bleed", select.Markup);
     }
 
     private IRenderedComponent<NimbleSelect> RenderWithPropertySet<TProperty>(Expression<Func<NimbleSelect, TProperty>> propertyGetter, TProperty propertyValue)

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTextAreaTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTextAreaTests.cs
@@ -77,6 +77,14 @@ public class NimbleTextAreaTests
         Assert.Contains("required-visible", textArea.Markup);
     }
 
+    [Fact]
+    public void TextAreaAppearanceReadOnly_AttributeIsSet()
+    {
+        var textArea = RenderWithPropertySet(x => x.AppearanceReadOnly, true);
+
+        Assert.Contains("appearance-readonly", textArea.Markup);
+    }
+
     private IRenderedComponent<NimbleTextArea> RenderNimbleTextArea(TextAreaResize textAreaResize)
     {
         var context = new TestContext();

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTextFieldTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTextFieldTests.cs
@@ -88,6 +88,14 @@ public class NimbleTextFieldTests
         Assert.Contains("required-visible", textField.Markup);
     }
 
+    [Fact]
+    public void TextFieldAppearanceReadOnly_AttributeIsSet()
+    {
+        var textField = RenderWithPropertySet(x => x.AppearanceReadOnly, true);
+
+        Assert.Contains("appearance-readonly", textField.Markup);
+    }
+
     private IRenderedComponent<NimbleTextField> RenderWithPropertySet<TProperty>(Expression<Func<NimbleTextField, TProperty>> propertyGetter, TProperty propertyValue)
     {
         var context = new TestContext();


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

We've recently added `appearance-readonly` and `full-bleed` to some components in nimble. These attributes need to be exposed in the Blazor components.

## 👩‍💻 Implementation

- Add `appearance-readonly` to the combobox, select, text field, number field, and text area Balzor components
- Add `full-bleed` to the combobox, select, and number field Balzor components
- Add `frameless` appearance to the number field appearance modes and the drop-down appearance modes

## 🧪 Testing

New unit tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
