### PR TITLE
Add icon metaphors

### DIFF
--- a/change/@ni-nimble-components-8596878d-563e-4202-8a8d-76d1ccf93348.json
+++ b/change/@ni-nimble-components-8596878d-563e-4202-8a8d-76d1ccf93348.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add additional icon metaphors",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/icon-base/tests/icon-metadata.ts
+++ b/packages/nimble-components/src/icon-base/tests/icon-metadata.ts
@@ -173,7 +173,7 @@ export const iconMetadata: {
         tags: ['assets']
     },
     IconCheck: {
-        tags: ['status', 'success', 'alarm acknowledged']
+        tags: ['status', 'success', 'alarm acknowledged', 'approve']
     },
     IconCheckDot: {
         tags: ['status', 'done']
@@ -185,7 +185,7 @@ export const iconMetadata: {
         tags: ['status', 'disconnected']
     },
     IconCircleCheck: {
-        tags: ['status', 'acknowledged']
+        tags: ['status', 'acknowledged', 'ready']
     },
     IconCircleFilled: {
         tags: []
@@ -676,7 +676,7 @@ export const iconMetadata: {
         tags: ['status', 'custom']
     },
     IconXmark: {
-        tags: ['status', 'fail']
+        tags: ['status', 'fail', 'cancel']
     },
     IconXmarkCheck: {
         tags: ['self test']


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Some of the nimble icons will be used to represent actions for workflows on test plans. Since these icons have been approved for this usage, I'm ensuring the alias of the icon within the workflows code is represented as a metaphor within the nimble documentation.

Most of these already existed as metaphors, but there were a few that needed to be added.

## 👩‍💻 Implementation

N/A

## 🧪 Testing

Verified the storybook story still renders as expected.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
