### PR TITLE
Add theme aware token for calendar event outline

### DIFF
--- a/change/@ni-nimble-components-5ca55480-68c5-44d8-8401-fe25f9e550fa.json
+++ b/change/@ni-nimble-components-5ca55480-68c5-44d8-8401-fe25f9e550fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add theme aware token for calendar event outline",
+  "packageName": "@ni/nimble-components",
+  "email": "aagash.maridas@emerson.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-5ca55480-68c5-44d8-8401-fe25f9e550fa.json
+++ b/change/@ni-nimble-components-5ca55480-68c5-44d8-8401-fe25f9e550fa.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "Add theme aware token for calendar event outline",
   "packageName": "@ni/nimble-components",
-  "email": "aagash.maridas@emerson.com",
+  "email": "123377167+aagash-ni@users.noreply.github.com",
   "dependentChangeType": "patch"
 }

--- a/packages/nimble-components/src/theme-provider/design-token-comments.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-comments.ts
@@ -314,6 +314,8 @@ export const comments: { readonly [key in TokenName]: string } = {
         'Color while hovering dynamic calendar events',
     calendarEventBackgroundHoverTransientColor:
         'Color while hovering transient calendar events',
+    calendarEventOutlineHighlightColor:
+        'Outline color for calendar events when highlighted',
     calendarRowBackgroundSelectedColor:
         'Background color while calendar resource is selected/highlighted',
     calendarEventFillBlockedColor:

--- a/packages/nimble-components/src/theme-provider/design-token-names.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-names.ts
@@ -258,6 +258,8 @@ export const tokenNames: { readonly [key in TokenName]: string } = {
         'calendar-event-background-hover-dynamic-color',
     calendarEventBackgroundHoverTransientColor:
         'calendar-event-background-hover-transient-color',
+    calendarEventOutlineHighlightColor:
+        'calendar-event-outline-highlight-color',
     calendarRowBackgroundSelectedColor:
         'calendar-row-background-selected-color',
     calendarEventFillBlockedColor: 'calendar-event-fill-blocked-color',

--- a/packages/nimble-components/src/theme-provider/design-tokens.ts
+++ b/packages/nimble-components/src/theme-provider/design-tokens.ts
@@ -419,6 +419,15 @@ export const calendarEventBackgroundHoverTransientColor = DesignToken.create<str
     DigitalGreenDark105
 ));
 
+export const calendarEventOutlineHighlightColor = DesignToken.create<string>(
+    styleNameFromTokenName(tokenNames.calendarEventOutlineHighlightColor)
+).withDefault((element: HTMLElement) => getColorForTheme(
+    element,
+    Black88,
+    hexToRgbaCssColor(White, 0.85),
+    hexToRgbaCssColor(White, 0.85)
+));
+
 export const calendarRowBackgroundSelectedColor = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.calendarRowBackgroundSelectedColor)
 ).withDefault((element: HTMLElement) => getColorForTheme(


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
Add theme aware token for calendar event outline when highlighting based on the mockup
Mockup link: https://www.figma.com/design/CkYDC25GDGsxQFfqvv1C8T/Test-Plan-automation?node-id=2072-5788&p=f&t=3PWAhIcRdH8jF5yN-0

## 👩‍💻 Implementation

- Added calendar theme-aware token for calendar event outline with respect to the mockup.

## 🧪 Testing

- Newly added token will be reflected in the existing calendar story.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
