### PR TITLE
Localize decimal separator in number-field

### DIFF
--- a/change/@ni-nimble-angular-4e9a7814-cc51-49f1-a3b7-b9e5723f5660.json
+++ b/change/@ni-nimble-angular-4e9a7814-cc51-49f1-a3b7-b9e5723f5660.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Expose number-field pageobject from Angular package",
+  "packageName": "@ni/nimble-angular",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-components-939685fd-01fb-4080-8431-b6aab0c7b29f.json
+++ b/change/@ni-nimble-components-939685fd-01fb-4080-8431-b6aab0c7b29f.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Localize number-field decimal separator. Breaking change: users in locales with a comma as the decimal separator will need to input a comma rather than a period in the nimble-number-field component.",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-react-582721be-6e05-4741-a9cd-58b411afe210.json
+++ b/change/@ni-nimble-react-582721be-6e05-4741-a9cd-58b411afe210.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update fast-react-wrapper dependency",
+  "packageName": "@ni/nimble-react",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-spright-components-6934ce0c-bf4e-4210-80ea-708d5ebd6ecb.json
+++ b/change/@ni-spright-components-6934ce0c-bf4e-4210-80ea-708d5ebd6ecb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update to ni/fast-foundation v10.1.0",
+  "packageName": "@ni/spright-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-spright-react-a01a8961-ab26-4ba1-b3fc-bf0bc3073fe3.json
+++ b/change/@ni-spright-react-a01a8961-ab26-4ba1-b3fc-bf0bc3073fe3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update fast-react-wrapper dependency",
+  "packageName": "@ni/spright-react",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6219,9 +6219,9 @@
       "license": "MIT"
     },
     "node_modules/@ni/fast-foundation": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@ni/fast-foundation/-/fast-foundation-10.0.2.tgz",
-      "integrity": "sha512-UJTjwtXOALLuje/5vJM/sZ+dGTsCCKUG9XOZzuguWd4igRWStrp0cTv87KQsiT1kZxzdHHorkfTL5FiHubrgvg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@ni/fast-foundation/-/fast-foundation-10.1.0.tgz",
+      "integrity": "sha512-msGrv9nJ4kWTFMyiRAU1Zju7Vw55cBKmm9dsODK2QBisYqBgPbMjgqWrQ/Y5f5TspidA23+TxGEohBYfUXNLyg==",
       "license": "MIT",
       "dependencies": {
         "@ni/fast-element": "^10.0.2",
@@ -31355,7 +31355,7 @@
       "dependencies": {
         "@ni/fast-colors": "^10.0.0",
         "@ni/fast-element": "^10.0.0",
-        "@ni/fast-foundation": "^10.0.0",
+        "@ni/fast-foundation": "^10.1.0",
         "@ni/fast-web-utilities": "^10.0.0",
         "@ni/nimble-tokens": "^8.10.0",
         "@tanstack/table-core": "^8.19.3",
@@ -31524,7 +31524,7 @@
       "license": "MIT",
       "dependencies": {
         "@ni/fast-element": "^10.0.0",
-        "@ni/fast-foundation": "^10.0.0",
+        "@ni/fast-foundation": "^10.1.0",
         "@ni/fast-web-utilities": "^10.0.0",
         "@ni/nimble-components": "^33.11.1",
         "tslib": "^2.2.0"
@@ -31568,7 +31568,7 @@
         "@chromatic-com/storybook": "^3.2.2",
         "@ni-private/eslint-config-nimble": "*",
         "@ni/fast-element": "^10.0.0",
-        "@ni/fast-foundation": "^10.0.0",
+        "@ni/fast-foundation": "^10.1.0",
         "@ni/fast-react-wrapper": "^10.0.0",
         "@ni/fast-web-utilities": "^10.0.0",
         "@ni/nimble-components": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6231,13 +6231,13 @@
       }
     },
     "node_modules/@ni/fast-react-wrapper": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@ni/fast-react-wrapper/-/fast-react-wrapper-10.1.0.tgz",
-      "integrity": "sha512-iMvZuIYG+mB/A0mB98QlQz9dORdEFFSXqh4WQ+kjV/03jpHgLi0pQC3+saxj8JHs9QBsbDvPYKjDQSd0nTdMRA==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@ni/fast-react-wrapper/-/fast-react-wrapper-10.1.1.tgz",
+      "integrity": "sha512-HqDu1kw9IA/Zgnnoc34N1wl1FnTDciAkloNVGV7rK2eJzjELq73v2XETi+Pa76Ms7CGdHG+6GYVEL6AQXevzjA==",
       "license": "MIT",
       "peerDependencies": {
         "@ni/fast-element": "^10.0.2",
-        "@ni/fast-foundation": "^10.0.2",
+        "@ni/fast-foundation": "^10.1.0",
         "react": "^16 || ^17 || ^18"
       }
     },
@@ -31466,7 +31466,7 @@
         "typescript": "~5.4.5"
       },
       "peerDependencies": {
-        "@ni/fast-react-wrapper": "^10.1.0",
+        "@ni/fast-react-wrapper": "^10.1.1",
         "@ni/nimble-components": "^33.11.1",
         "react": "^16 || ^17 || ^18"
       }
@@ -31500,7 +31500,7 @@
         "typescript": "~5.4.5"
       },
       "peerDependencies": {
-        "@ni/fast-react-wrapper": "^10.1.0",
+        "@ni/fast-react-wrapper": "^10.1.1",
         "@ni/spright-components": "^5.5.0",
         "react": "^16 || ^17 || ^18"
       }
@@ -31569,7 +31569,7 @@
         "@ni-private/eslint-config-nimble": "*",
         "@ni/fast-element": "^10.0.0",
         "@ni/fast-foundation": "^10.1.0",
-        "@ni/fast-react-wrapper": "^10.0.0",
+        "@ni/fast-react-wrapper": "^10.1.1",
         "@ni/fast-web-utilities": "^10.0.0",
         "@ni/nimble-components": "*",
         "@ni/nimble-react": "*",

--- a/packages/angular-workspace/nimble-angular/number-field/testing/ng-package.json
+++ b/packages/angular-workspace/nimble-angular/number-field/testing/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+      "entryFile": "public-api.ts"
+    }
+}

--- a/packages/angular-workspace/nimble-angular/number-field/testing/number-field.pageobject.ts
+++ b/packages/angular-workspace/nimble-angular/number-field/testing/number-field.pageobject.ts
@@ -1,0 +1,3 @@
+import { NumberFieldPageObject } from '@ni/nimble-components/dist/esm/number-field/testing/number-field.pageobject';
+
+export { NumberFieldPageObject };

--- a/packages/angular-workspace/nimble-angular/number-field/testing/public-api.ts
+++ b/packages/angular-workspace/nimble-angular/number-field/testing/public-api.ts
@@ -1,0 +1,1 @@
+export * from './number-field.pageobject';

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@ni/fast-colors": "^10.0.0",
     "@ni/fast-element": "^10.0.0",
-    "@ni/fast-foundation": "^10.0.0",
+    "@ni/fast-foundation": "^10.1.0",
     "@ni/fast-web-utilities": "^10.0.0",
     "@ni/nimble-tokens": "^8.10.0",
     "@tanstack/table-core": "^8.19.3",

--- a/packages/nimble-components/src/number-field/index.ts
+++ b/packages/nimble-components/src/number-field/index.ts
@@ -87,8 +87,10 @@ export class NumberField extends mixinErrorPattern(
         this.decimalSeparator = this.getSeparatorForLanguange(
             lang.getValueFor(this)
         );
-        this.inputFilterRegExp = this.buildFilterRegExp(this.decimalSeparator);
         if (this.decimalSeparator !== previousSeparator) {
+            this.inputFilterRegExp = this.buildFilterRegExp(
+                this.decimalSeparator
+            );
             this.control.value = this.control.value.replace(
                 previousSeparator,
                 this.decimalSeparator

--- a/packages/nimble-components/src/number-field/index.ts
+++ b/packages/nimble-components/src/number-field/index.ts
@@ -66,6 +66,7 @@ export class NumberField extends mixinErrorPattern(
     // Same implementation as FAST NumberField, except:
     //   - uses a variable regex to filter input, and
     //   - ensures the decimal separator is always '.' in this.value
+    // https://github.com/ni/fast/blob/53628f75d9ca8057483b1872223f72e7c74baa8a/packages/web-components/fast-foundation/src/number-field/number-field.ts#L342
     public override handleTextInput(): void {
         this.control.value = this.control.value.replace(
             new RegExp(`[^0-9\\-+e${this.decimalSeparator}]`, 'g'),

--- a/packages/nimble-components/src/number-field/index.ts
+++ b/packages/nimble-components/src/number-field/index.ts
@@ -43,7 +43,7 @@ export class NumberField extends mixinErrorPattern(
     public appearanceReadOnly = false;
 
     private decimalSeparator = '.';
-    private inputFilterRegExp: RegExp | null = null;
+    private inputFilterRegExp = this.buildFilterRegExp(this.decimalSeparator);
 
     private readonly langSubscriber: DesignTokenSubscriber<typeof lang> = {
         handleChange: () => this.updateDecimalSeparatorAndInputFilter()
@@ -65,7 +65,7 @@ export class NumberField extends mixinErrorPattern(
     }
 
     protected override sanitizeInput(inputText: string): string {
-        return inputText.replace(this.inputFilterRegExp!, '');
+        return inputText.replace(this.inputFilterRegExp, '');
     }
 
     // this.value <-- this.control.value
@@ -87,10 +87,7 @@ export class NumberField extends mixinErrorPattern(
         this.decimalSeparator = this.getSeparatorForLanguange(
             lang.getValueFor(this)
         );
-        this.inputFilterRegExp = new RegExp(
-            `[^0-9\\-+e${this.decimalSeparator}]`,
-            'g'
-        );
+        this.inputFilterRegExp = this.buildFilterRegExp(this.decimalSeparator);
         if (this.decimalSeparator !== previousSeparator) {
             this.control.value = this.control.value.replace(
                 previousSeparator,
@@ -103,6 +100,10 @@ export class NumberField extends mixinErrorPattern(
         return Intl.NumberFormat(language)
             .formatToParts(1.1)
             .find(x => x.type === 'decimal')!.value;
+    }
+
+    private buildFilterRegExp(decimalSeparator: string): RegExp {
+        return new RegExp(`[^0-9\\-+e${decimalSeparator}]`, 'g');
     }
 }
 

--- a/packages/nimble-components/src/number-field/index.ts
+++ b/packages/nimble-components/src/number-field/index.ts
@@ -64,54 +64,19 @@ export class NumberField extends mixinErrorPattern(
         lang.unsubscribe(this.langSubscriber, this);
     }
 
-    // Same implementation as FAST NumberField, except:
-    //   - uses a variable regex to filter input, and
-    //   - ensures the decimal separator is always '.' in this.value
-    // https://github.com/ni/fast/blob/53628f75d9ca8057483b1872223f72e7c74baa8a/packages/web-components/fast-foundation/src/number-field/number-field.ts#L342
-    public override handleTextInput(): void {
-        this.control.value = this.control.value.replace(
-            this.inputFilterRegExp!,
-            ''
-        );
-        // Necessary to access private property in base class
-        // eslint-disable-next-line @typescript-eslint/dot-notation
-        this['isUserInput'] = true;
-        this.syncValueFromInnerControl();
-    }
-
-    public override valueChanged(previous: string, next: string): void {
-        // Necessary to access private property in base class
-        // eslint-disable-next-line @typescript-eslint/dot-notation
-        const wasUserInput = this['isUserInput'] as boolean;
-        super.valueChanged(previous, this.value);
-        // Because super.valueChanged may coerce and re-assign the value, this handler can recurse.
-        // If the this.value now differs from what was originally assigned, we know there was a
-        // recursive call that already handled everything, so we can exit early.
-        if (next !== this.value) {
-            return;
-        }
-        // for user input, the UI value isn't updated until the control loses focus
-        if (this.control && !wasUserInput) {
-            this.syncValueToInnerControl();
-        }
-    }
-
-    // This override does the same thing as the base implementation (i.e. writes the component's value to the inner control),
-    // but makes sure the value is copied with the correct, locale-dependent decimal separator.
-    // https://github.com/ni/fast/blob/53628f75d9ca8057483b1872223f72e7c74baa8a/packages/web-components/fast-foundation/src/number-field/number-field.ts#L386
-    public override handleBlur(): void {
-        this.syncValueToInnerControl();
+    protected override sanitizeInput(inputText: string): string {
+        return inputText.replace(this.inputFilterRegExp!, '');
     }
 
     // this.value <-- this.control.value
-    private syncValueFromInnerControl(): void {
+    protected override syncValueFromInnerControl(): void {
         this.value = this.decimalSeparator !== '.'
             ? this.control.value.replace(this.decimalSeparator, '.')
             : this.control.value;
     }
 
     // this.value --> this.control.value
-    private syncValueToInnerControl(): void {
+    protected override syncValueToInnerControl(): void {
         this.control.value = this.decimalSeparator !== '.'
             ? this.value.replace('.', this.decimalSeparator)
             : this.value;

--- a/packages/nimble-components/src/number-field/template.ts
+++ b/packages/nimble-components/src/number-field/template.ts
@@ -49,7 +49,7 @@ NumberFieldOptions
                 ?required="${x => x.required}"
                 size="${x => x.size}"
                 type="text"
-                inputmode="numeric"
+                inputmode="decimal"
                 min="${x => x.min}"
                 max="${x => x.max}"
                 step="${x => x.step}"

--- a/packages/nimble-components/src/number-field/template.ts
+++ b/packages/nimble-components/src/number-field/template.ts
@@ -49,7 +49,7 @@ NumberFieldOptions
                 ?required="${x => x.required}"
                 size="${x => x.size}"
                 type="text"
-                inputmode="decimal"
+                inputmode="text"
                 min="${x => x.min}"
                 max="${x => x.max}"
                 step="${x => x.step}"

--- a/packages/nimble-components/src/number-field/testing/number-field.pageobject.ts
+++ b/packages/nimble-components/src/number-field/testing/number-field.pageobject.ts
@@ -1,0 +1,44 @@
+import type { NumberField } from '..';
+
+/**
+ * Page object for `nimble-number-field` component to provide consistent ways
+ * of querying and interacting with the component during tests.
+ */
+export class NumberFieldPageObject {
+    public constructor(protected readonly numberFieldElement: NumberField) {}
+
+    /**
+     * @returns The string visible in the control.
+     */
+    public getDisplayValue(): string {
+        return this.inputControl.value;
+    }
+
+    /**
+     * Inputs the given text via a single input event.
+     */
+    public inputText(text: string): void {
+        this.inputTextInternal(text);
+    }
+
+    /**
+     * Inputs the given text via a single input event, replacing any text that was already there.
+     */
+    public setText(text: string): void {
+        this.inputTextInternal(text, true);
+    }
+
+    private inputTextInternal(text: string, replace = false): void {
+        this.inputControl.value = text;
+        this.inputControl.dispatchEvent(
+            new InputEvent('input', {
+                data: text,
+                inputType: replace ? 'deleteContentForward' : 'insertText'
+            })
+        );
+    }
+
+    private get inputControl(): HTMLInputElement {
+        return this.numberFieldElement.shadowRoot!.querySelector('input')!;
+    }
+}

--- a/packages/nimble-components/src/number-field/tests/number-field.spec.ts
+++ b/packages/nimble-components/src/number-field/tests/number-field.spec.ts
@@ -80,7 +80,7 @@ describe('NumberField', () => {
         expect(element.control.getAttribute('aria-required')).toBe('false');
     });
 
-    it('disallows input of characters that cannot be used in a number', () => {
+    it('disallows input of characters that cannot be used in a number for default "en" locale', () => {
         page.setText('0123+-.abcdeABCDE,!@#$%^&*()_[]{}|;:\'"<>?/456789');
         expect(page.getDisplayValue()).toEqual('0123+-.e456789');
     });

--- a/packages/nimble-components/src/number-field/tests/number-field.spec.ts
+++ b/packages/nimble-components/src/number-field/tests/number-field.spec.ts
@@ -85,7 +85,7 @@ describe('NumberField', () => {
         expect(page.getDisplayValue()).toEqual('0123+-.e456789');
     });
 
-    const badInputCases = [
+    const inputParsingCases = [
         { name: '01...2', expectedValue: '1' },
         { name: '0...2', expectedValue: '0' },
         { name: '...2', expectedValue: '' },
@@ -98,7 +98,7 @@ describe('NumberField', () => {
         { name: '1.12e4', expectedValue: '11200' },
         { name: '112e4', expectedValue: '1120000' }
     ] as const;
-    parameterizeSpec(badInputCases, (spec, name, value) => {
+    parameterizeSpec(inputParsingCases, (spec, name, value) => {
         spec(
             `sets value to float-parsable leading portion of input string "${name}"`,
             () => {
@@ -137,13 +137,13 @@ describe('NumberField localization', () => {
     afterEach(async () => {
         await disconnect();
     });
-
     const localeCases = [
-        { name: 'en-US', expectedSeparator: '.' },
-        { name: 'zh', expectedSeparator: '.' },
-        { name: 'ja', expectedSeparator: '.' },
-        { name: 'fr-CA', expectedSeparator: ',' },
-        { name: 'de', expectedSeparator: ',' }
+        { name: 'en-US', expectedSeparator: '.', disallowedSeparator: ',' },
+        { name: 'zh', expectedSeparator: '.', disallowedSeparator: ',' },
+        { name: 'ja', expectedSeparator: '.', disallowedSeparator: ',' },
+        { name: 'fr-CA', expectedSeparator: ',', disallowedSeparator: '.' },
+        { name: 'de', expectedSeparator: ',', disallowedSeparator: '.' },
+        { name: 'ar-SA', expectedSeparator: '٫', disallowedSeparator: '.' }
     ] as const;
     parameterizeSuite(localeCases, (suite, name, value) => {
         suite(`for "${name}"`, () => {
@@ -159,8 +159,7 @@ describe('NumberField localization', () => {
 
             it('disallows input of wrong separator', async () => {
                 await setupWithLocaleAndConnect(name);
-                const disallowedSeparator = value.expectedSeparator === '.' ? ',' : '.';
-                page.inputText(`10${disallowedSeparator}1`);
+                page.inputText(`10${value.disallowedSeparator}1`);
                 expect(page.getDisplayValue()).toEqual('101');
             });
         });

--- a/packages/react-workspace/nimble-react/package.json
+++ b/packages/react-workspace/nimble-react/package.json
@@ -36,7 +36,7 @@
     "typescript": "~5.4.5"
   },
   "peerDependencies": {
-    "@ni/fast-react-wrapper": "^10.1.0",
+    "@ni/fast-react-wrapper": "^10.1.1",
     "@ni/nimble-components": "^33.11.1",
     "react": "^16 || ^17 || ^18"
   }

--- a/packages/react-workspace/spright-react/package.json
+++ b/packages/react-workspace/spright-react/package.json
@@ -28,7 +28,7 @@
     "typescript": "~5.4.5"
   },
   "peerDependencies": {
-    "@ni/fast-react-wrapper": "^10.1.0",
+    "@ni/fast-react-wrapper": "^10.1.1",
     "@ni/spright-components": "^5.5.0",
     "react": "^16 || ^17 || ^18"
   }

--- a/packages/spright-components/package.json
+++ b/packages/spright-components/package.json
@@ -49,7 +49,7 @@
   "homepage": "https://github.com/ni/nimble#readme",
   "dependencies": {
     "@ni/fast-element": "^10.0.0",
-    "@ni/fast-foundation": "^10.0.0",
+    "@ni/fast-foundation": "^10.1.0",
     "@ni/fast-web-utilities": "^10.0.0",
     "@ni/nimble-components": "^33.11.1",
     "tslib": "^2.2.0"

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -17,7 +17,7 @@
     "@chromatic-com/storybook": "^3.2.2",
     "@ni-private/eslint-config-nimble": "*",
     "@ni/fast-element": "^10.0.0",
-    "@ni/fast-foundation": "^10.0.0",
+    "@ni/fast-foundation": "^10.1.0",
     "@ni/fast-react-wrapper": "^10.0.0",
     "@ni/fast-web-utilities": "^10.0.0",
     "@ni/nimble-components": "*",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -18,7 +18,7 @@
     "@ni-private/eslint-config-nimble": "*",
     "@ni/fast-element": "^10.0.0",
     "@ni/fast-foundation": "^10.1.0",
-    "@ni/fast-react-wrapper": "^10.0.0",
+    "@ni/fast-react-wrapper": "^10.1.1",
     "@ni/fast-web-utilities": "^10.0.0",
     "@ni/nimble-components": "*",
     "@ni/nimble-react": "*",

--- a/packages/storybook/src/nimble/number-field/number-field.mdx
+++ b/packages/storybook/src/nimble/number-field/number-field.mdx
@@ -5,8 +5,11 @@ import ComponentApisLink from '../../docs/component-apis-link.mdx';
 <Meta of={numberFieldStories} />
 <Title of={numberFieldStories} />
 
-Similar to a single line text box but only used for numeric data. The controls
-allow the user to increment and decrement the value.
+Similar to a single-line text box but only used for numeric data. The controls
+allow the user to increment and decrement the value. The decimal separator
+character used for input and display is locale-specific. It depends on the value
+of the `lang` token, which can be set via the
+[nimble-theme-provider](?path=/docs/tokens-theme-provider--docs).
 
 <Canvas of={numberFieldStories.underlineNumberField} />
 

--- a/packages/storybook/src/nimble/number-field/number-field.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field.stories.ts
@@ -29,7 +29,8 @@ import {
 
 interface NumberFieldArgs extends LabelUserArgs {
     label: string;
-    value: number;
+    value: string;
+    valueAsNumber: number;
     placeholder: string;
     step: number;
     hideStep: boolean;
@@ -83,8 +84,14 @@ const metadata: Meta<NumberFieldArgs> = {
         },
         value: {
             description:
-                'The number displayed in the number field. Note that the property value is not synced to an attribute.',
+                'The string representation of the number displayed in the number field. This value is not locale-dependent and always uses a dot as the decimal separator. Note that the `value` property is not synced to the `value` attribute, which only controls the initial value.',
             table: { category: apiCategory.nonAttributeProperties }
+        },
+        valueAsNumber: {
+            description: 'The number displayed in the number field.',
+            table: { category: apiCategory.nonAttributeProperties },
+            control: false,
+            type: 'number'
         },
         placeholder: {
             description: placeholderDescription({
@@ -171,7 +178,7 @@ const metadata: Meta<NumberFieldArgs> = {
     },
     args: {
         label: 'default label',
-        value: 42,
+        value: '42',
         placeholder: 'Enter number...',
         step: 1,
         hideStep: false,

--- a/packages/storybook/src/nimble/number-field/number-field.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field.stories.ts
@@ -88,7 +88,8 @@ const metadata: Meta<NumberFieldArgs> = {
             table: { category: apiCategory.nonAttributeProperties }
         },
         valueAsNumber: {
-            description: 'The number displayed in the number field.',
+            description:
+                "The number displayed in the number field. This property is not exposed in Angular or Blazor, as those frameworks already access the component's value as a numeric type.",
             table: { category: apiCategory.nonAttributeProperties },
             control: false,
             type: 'number'

--- a/packages/storybook/src/nimble/theme-provider/theme-provider.stories.ts
+++ b/packages/storybook/src/nimble/theme-provider/theme-provider.stories.ts
@@ -7,7 +7,6 @@ import {
     themeProviderTag
 } from '@ni/nimble-components/dist/esm/theme-provider';
 import { Theme } from '@ni/nimble-components/dist/esm/theme-provider/types';
-import { numberFieldTag } from '@ni/nimble-components/dist/esm/number-field';
 import {
     sharedTableArgTypes,
     type SharedTableArgs,
@@ -85,8 +84,6 @@ export const themeProvider: StoryObj<ThemeProviderArgs> = {
                 Date
                 </${tableColumnDateTextTag}>
             </${tableTag}>
-            <${numberFieldTag} value="42">
-            </${numberFieldTag}>
         </${themeProviderTag}>
     `),
     argTypes: {

--- a/packages/storybook/src/nimble/theme-provider/theme-provider.stories.ts
+++ b/packages/storybook/src/nimble/theme-provider/theme-provider.stories.ts
@@ -7,6 +7,7 @@ import {
     themeProviderTag
 } from '@ni/nimble-components/dist/esm/theme-provider';
 import { Theme } from '@ni/nimble-components/dist/esm/theme-provider/types';
+import { numberFieldTag } from '@ni/nimble-components/dist/esm/number-field';
 import {
     sharedTableArgTypes,
     type SharedTableArgs,
@@ -84,6 +85,8 @@ export const themeProvider: StoryObj<ThemeProviderArgs> = {
                 Date
                 </${tableColumnDateTextTag}>
             </${tableTag}>
+            <${numberFieldTag} value="42">
+            </${numberFieldTag}>
         </${themeProviderTag}>
     `),
     argTypes: {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Adding support for localization of the decimal separator in the `nimble-number-field`, similar to how the number-text table column localizes the separator character. Part of #1855.

## 👩‍💻 Implementation

- As proposed in [HLD](https://github.com/ni/nimble/blob/main/packages/nimble-components/src/number-field/specs/localized-decimal-separator-hld.md), overriding several functions from the `@ni/fast-components` number-field implementation to support dynamically updating the view and input filter based on the value of the `lang` design token. `Intl.NumberFormat` is used to determine the correct decimal separator character for the given locale identifier (i.e. value of `lang`).
- Changed `inputmode` attribute of HTML `input` in the number-field's shadow DOM from `"numeric"` to `"text"`. Manually testing showed the desired input mode of [`decimal`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode#decimal) did not include negative in the virtual keyboard so instead a full keyboard was chosen.
- Updated documentation, including changing the type of the `value` property to string (from number, which was confusing). I also added documentation for the `valueAsNumber` property, which helps reinforce the message that `value` is a string.

## 🧪 Testing

Added automated unit tests to verify the new functionality. Additionally, since the added function overrides contain logic not directly related to this new functionality (i.e. the bits of logic that needed to be duplicated from the base implementation), I added a couple tests to ensure we haven't introduced regressions.

I added a (minimal) page object for the number-field as well.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
