### PR TITLE
Delegate focus to chat input when other area is clicked

### DIFF
--- a/change/@ni-spright-components-50182611-73fb-4bf7-86a9-153c03644f22.json
+++ b/change/@ni-spright-components-50182611-73fb-4bf7-86a9-153c03644f22.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Delegate focus to input when chat is clicked",
+  "packageName": "@ni/spright-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/spright-components/src/chat/input/index.ts
+++ b/packages/spright-components/src/chat/input/index.ts
@@ -107,7 +107,10 @@ export class ChatInput extends FoundationElement {
 const sprightChatInput = ChatInput.compose({
     baseName: 'chat-input',
     template,
-    styles
+    styles,
+    shadowOptions: {
+        delegatesFocus: true
+    }
 });
 
 DesignSystem.getOrCreate().withPrefix('spright').register(sprightChatInput());


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

On the spright chat input component I found myself clicking the area below the text area in an attempt to give it focus. But that had no effect because only the text area could receive focus.

## 👩‍💻 Implementation

Configure the chat input to delegate focus to its first focusable element (the text area). [Several other components](https://github.com/search?q=repo%3Ani%2Fnimble%20delegatesfocus&type=code) do the same thing.

## 🧪 Testing

I didn't see any test coverage for this codepath for other components so I propose not writing an auto test for this one.

I'll manually confirm on several browsers that I can click anywhere in the chat input to give it focus.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
