### PR TITLE
Revert divider background color token change

### DIFF
--- a/change/@ni-nimble-components-347d4696-0295-49d7-a212-07d3f33ad3a4.json
+++ b/change/@ni-nimble-components-347d4696-0295-49d7-a212-07d3f33ad3a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert dividerBackgroundColor token change",
+  "packageName": "@ni/nimble-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/theme-provider/design-tokens.ts
+++ b/packages/nimble-components/src/theme-provider/design-tokens.ts
@@ -159,12 +159,7 @@ export const sectionBackgroundImage = DesignToken.create<string>(
 
 export const dividerBackgroundColor = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.dividerBackgroundColor)
-).withDefault((element: HTMLElement) => getColorForTheme(
-    element,
-    hexToRgbaCssColor(Black91, 0.2),
-    hexToRgbaCssColor(Black15, 0.2),
-    hexToRgbaCssColor(White, 0.2)
-));
+).withDefault((element: HTMLElement) => getColorForTheme(element, Black15, Black80, ForestGreen));
 
 export const fillSelectedColor = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.fillSelectedColor)


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

In #2639 I made the `dividerBackgroundColor` token darker (in light theme) but didn't do a good job of verifying the places it is used. It turns out it is [used for](https://dev.azure.com/ni/DevCentral/_search?action=contents&text=%24ni-nimble-divider-background-color&type=code&lp=code-Project&filters=ProjectFilters%7BDevCentral%7DRepositoryFilters%7BSkyline%7D&pageSize=25&result=DefaultCollection/DevCentral/Skyline/GBmaster//Web/Workspaces/TestInsights/src/app/dataspaces/components/chip/chip.component.scss) 
- many dividers but not all dividers
- some things that are not dividers

The end result is that many SLE apps now have inconsistent styling. For example, some control borders and some of the dividers in this screenshot got darker but others didn't.
![image](https://github.com/user-attachments/assets/4204eefa-179f-439e-9108-371363faecaf)


## 👩‍💻 Implementation

Temporarily set the token back to its previous value. This is fine for the one place I cared about since it's still behind a feature flag. I'll work with Brandon to audit these usages and create new tokens for the ones that shouldn't be using this one.

## 🧪 Testing

Storybook inspection. I'll inspect SLE apps as this propagates out too.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
