### PR TITLE
Make renovate update package.json for NI packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -60,15 +60,27 @@
       ]
     },
     {
-      "groupName": "npm NI dependencies update to latest",
+      "groupName": "npm NI non-dev dependencies update to latest",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "peerDependencies"
+      ],
+      "matchPackageNames": "@ni/**",
+      "schedule": [
+        "at any time"
+      ]
+    },
+    {
+      "groupName": "npm NI devDependencies update to latest",
       "matchManagers": [
         "npm"
       ],
       "rangeStrategy": "update-lockfile",
       "matchDepTypes": [
-        "dependencies",
-        "devDependencies",
-        "peerDependencies"
+        "devDependencies"
       ],
       "matchPackageNames": "@ni/**",
       "schedule": [


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Fixes #2662 

## 👩‍💻 Implementation

Create separate config for NI dev dependencies and non-dev dependencies, with the former remaining lock-file-only updates, but the latter now updating the package.json as well.

## 🧪 Testing
None
