### PR TITLE
Add theme aware token for calendar resource background conflict color

### DIFF
--- a/change/@ni-nimble-components-e08748c7-c431-42cd-b72e-82b688af44e3.json
+++ b/change/@ni-nimble-components-e08748c7-c431-42cd-b72e-82b688af44e3.json
@@ -2,6 +2,6 @@
   "type": "minor",
   "comment": "Add theme aware token for calendar resource background conflict color",
   "packageName": "@ni/nimble-components",
-  "email": "gokulprasanth.ravi@emerson.com",
+  "email": "131153319+gokulprasanth-ni@users.noreply.github.com",
   "dependentChangeType": "patch"
 }

--- a/change/@ni-nimble-components-e08748c7-c431-42cd-b72e-82b688af44e3.json
+++ b/change/@ni-nimble-components-e08748c7-c431-42cd-b72e-82b688af44e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add theme aware token for calendar resource background conflict color",
+  "packageName": "@ni/nimble-components",
+  "email": "gokulprasanth.ravi@emerson.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/theme-provider/design-token-comments.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-comments.ts
@@ -326,5 +326,7 @@ export const comments: { readonly [key in TokenName]: string } = {
         'Background fill color for the editable calendar event grab handle',
     calendarGridBorderColor: 'Border color for the calendar grid',
     calendarGroupHeaderBackgroundColor:
-        'Background color for the calendar resource group header'
+        'Background color for the calendar resource group header',
+    calendarRowBackgroundConflictColor:
+        'Background color for the calendar resource when it have conflict'
 };

--- a/packages/nimble-components/src/theme-provider/design-token-names.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-names.ts
@@ -267,7 +267,8 @@ export const tokenNames: { readonly [key in TokenName]: string } = {
     calendarEventFillBlockedColor: 'calendar-event-fill-blocked-color',
     calendarGrabHandleBackgroundColor: 'calendar-grab-handle-background-color',
     calendarGridBorderColor: 'calendar-grid-border-color',
-    calendarGroupHeaderBackgroundColor: 'calendar-group-header-background-color'
+    calendarGroupHeaderBackgroundColor: 'calendar-group-header-background-color',
+    calendarRowBackgroundConflictColor: 'calendar-row-background-conflict-color'
 };
 
 const prefix = 'ni-nimble';

--- a/packages/nimble-components/src/theme-provider/design-tokens.ts
+++ b/packages/nimble-components/src/theme-provider/design-tokens.ts
@@ -478,6 +478,15 @@ export const calendarGroupHeaderBackgroundColor = DesignToken.create<string>(
     hexToRgbaCssColor(Black91, 0.1)
 ));
 
+export const calendarRowBackgroundConflictColor = DesignToken.create<string>(
+    styleNameFromTokenName(tokenNames.calendarRowBackgroundConflictColor)
+).withDefault((element: HTMLElement) => getColorForTheme(
+    element,
+    hexToRgbaCssColor(Fail100LightUi, 0.2),
+    hexToRgbaCssColor(Fail100DarkUi, 0.2),
+    hexToRgbaCssColor(Fail100DarkUi, 0.2)
+));
+
 // Component Sizing Tokens
 export const controlHeight = DesignToken.create<string>(
     styleNameFromTokenName(tokenNames.controlHeight)


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Add theme aware token for calendar resource background conflict color based on the mockup.
Mockup link: [https://www.figma.com/design/CkYDC25GDGsxQFfqvv1C8T/Test-Plan-automation?node-id=1998-18796&t=iuJckVnLRQHy6gGw-0](https://www.figma.com/design/CkYDC25GDGsxQFfqvv1C8T/Test-Plan-automation?node-id=1998-18796&t=iuJckVnLRQHy6gGw-0
)
## 👩‍💻 Implementation

- Added `calendarRowBackgroundConflictColor` token for calendar resource background conflict color with respect to the mockup  for all three themes.

## 🧪 Testing

- Update the existing calendar story to add the new tokens and manually validate the colors by inspecting.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
