### PR TITLE
Spright `ChatInput` remove `resetInput`

### DIFF
--- a/change/@ni-spright-components-4795f510-5b35-4ec4-b04d-6935fca41947.json
+++ b/change/@ni-spright-components-4795f510-5b35-4ec4-b04d-6935fca41947.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Remove resetInput event and auto-clear text on send for chat input.",
+  "packageName": "@ni/spright-components",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/angular-workspace/example-client-app/src/app/customapp/customapp.component.ts
+++ b/packages/angular-workspace/example-client-app/src/app/customapp/customapp.component.ts
@@ -286,7 +286,6 @@ export class CustomAppComponent implements AfterViewInit {
 
     public onChatInputSend(e: Event): void {
         const chatInputSendEvent = (e as CustomEvent<ChatInputSendEventDetail>);
-        (chatInputSendEvent.target as ChatInput).resetInput();
         this.chatUserMessages.push(chatInputSendEvent.detail.text);
     }
 

--- a/packages/angular-workspace/example-client-app/src/app/customapp/customapp.component.ts
+++ b/packages/angular-workspace/example-client-app/src/app/customapp/customapp.component.ts
@@ -6,7 +6,7 @@ import { NimbleTableDirective, TableRecordDelayedHierarchyState, type TableRecor
 import { NimbleRichTextEditorDirective } from '@ni/nimble-angular/rich-text/editor';
 import { BehaviorSubject, Observable } from 'rxjs';
 import type { MenuButtonColumnToggleEventDetail } from '@ni/nimble-angular/table-column/menu-button';
-import type { ChatInput, ChatInputSendEventDetail } from '@ni/spright-angular/chat/input';
+import type { ChatInputSendEventDetail } from '@ni/spright-angular/chat/input';
 
 const colors = ['Red', 'Green', 'Blue', 'Black', 'Yellow'] as const;
 type Color = typeof colors[number];

--- a/packages/spright-components/src/chat/input/index.ts
+++ b/packages/spright-components/src/chat/input/index.ts
@@ -87,8 +87,8 @@ export class ChatInput extends FoundationElement {
         const eventDetail: ChatInputSendEventDetail = {
             text: this.textArea!.value
         };
-        this.$emit('send', eventDetail);
         this.resetInput();
+        this.$emit('send', eventDetail);
     }
 
     private shouldDisableSendButton(): boolean {

--- a/packages/spright-components/src/chat/input/index.ts
+++ b/packages/spright-components/src/chat/input/index.ts
@@ -40,18 +40,6 @@ export class ChatInput extends FoundationElement {
     public disableSendButton = true;
 
     /**
-     * Clears the text input and gives it focus.
-     */
-    public resetInput(): void {
-        this.value = '';
-        this.disableSendButton = true;
-        if (this.textArea) {
-            this.textArea.value = '';
-            this.textArea.focus();
-        }
-    }
-
-    /**
      * @internal
      */
     public textAreaKeydownHandler(e: KeyboardEvent): boolean {
@@ -100,10 +88,20 @@ export class ChatInput extends FoundationElement {
             text: this.textArea!.value
         };
         this.$emit('send', eventDetail);
+        this.resetInput();
     }
 
     private shouldDisableSendButton(): boolean {
         return this.textArea!.value.length === 0;
+    }
+
+    private resetInput(): void {
+        this.value = '';
+        this.disableSendButton = true;
+        if (this.textArea) {
+            this.textArea.value = '';
+            this.textArea.focus();
+        }
     }
 }
 

--- a/packages/spright-components/src/chat/input/testing/chat-input.pageobject.ts
+++ b/packages/spright-components/src/chat/input/testing/chat-input.pageobject.ts
@@ -18,6 +18,10 @@ export class ChatInputPageObject {
         return !this.getSendButton().disabled;
     }
 
+    public isTextAreaFocused(): boolean {
+        return this.element.textArea === this.element.shadowRoot?.activeElement;
+    }
+
     public clickSendButton(): void {
         this.getSendButton().click();
     }

--- a/packages/spright-components/src/chat/input/tests/chat-input.spec.ts
+++ b/packages/spright-components/src/chat/input/tests/chat-input.spec.ts
@@ -205,53 +205,6 @@ describe('ChatInput', () => {
         });
     });
 
-    describe('resetInput method', () => {
-        beforeEach(async () => {
-            await connect();
-        });
-
-        it('clears the input contents, sets focus, and disables the button', () => {
-            page.setText('new value');
-            element.resetInput();
-            processUpdates();
-
-            expect(element.value).toEqual('');
-            expect(page.getRenderedText()).toEqual('');
-            expect(page.textAreaHasFocus()).toBeTrue();
-            expect(page.isSendButtonEnabled()).toBeFalse();
-        });
-
-        it('can be called from send event handler', async () => {
-            const spy = jasmine.createSpy('send', () => {
-                element.resetInput();
-                processUpdates();
-
-                expect(element.value).toEqual('');
-                expect(page.getRenderedText()).toEqual('');
-                expect(page.textAreaHasFocus()).toBeTrue();
-                expect(page.isSendButtonEnabled()).toBeFalse();
-            });
-
-            element.addEventListener('send', spy);
-            element.value = 'new value';
-            processUpdates();
-
-            await page.pressEnterKey();
-            expect(spy).toHaveBeenCalledTimes(1);
-        });
-
-        it('can be called when not connected', async () => {
-            element.value = 'hello';
-            await disconnect();
-            element.resetInput();
-            await connect();
-            processUpdates();
-            expect(element.value).toEqual('');
-            expect(page.getRenderedText()).toEqual('');
-            expect(page.isSendButtonEnabled()).toBeFalse();
-        });
-    });
-
     describe('sendButtonLabel', () => {
         beforeEach(async () => {
             await connect();

--- a/packages/spright-components/src/chat/input/tests/chat-input.spec.ts
+++ b/packages/spright-components/src/chat/input/tests/chat-input.spec.ts
@@ -176,11 +176,15 @@ describe('ChatInput', () => {
             expect(spy).toHaveBeenCalled();
         });
 
-        it('clears value', () => {
-            element.value = 'new value';
-            processUpdates();
+        it('clears the input contents, sets focus, and disables the button', () => {
+            page.setText('new value');
             page.clickSendButton();
+            processUpdates();
+
             expect(element.value).toEqual('');
+            expect(page.getRenderedText()).toEqual('');
+            expect(page.textAreaHasFocus()).toBeTrue();
+            expect(page.isSendButtonEnabled()).toBeFalse();
         });
 
         it('via button click with no text triggers no send event', () => {

--- a/packages/spright-components/src/chat/input/tests/chat-input.spec.ts
+++ b/packages/spright-components/src/chat/input/tests/chat-input.spec.ts
@@ -114,12 +114,6 @@ describe('ChatInput', () => {
             expect(page.isSendButtonEnabled()).toBeFalse();
         });
 
-        it("Enter doesn't modify value", async () => {
-            page.setText('new value');
-            await page.pressEnterKey();
-            expect(element.value).toEqual('new value');
-        });
-
         it('Shift-Enter adds newline', async () => {
             page.setText('new value');
             await page.pressShiftEnterKey();

--- a/packages/spright-components/src/chat/input/tests/chat-input.spec.ts
+++ b/packages/spright-components/src/chat/input/tests/chat-input.spec.ts
@@ -28,6 +28,13 @@ describe('ChatInput', () => {
         expect(document.createElement(chatInputTag)).toBeInstanceOf(ChatInput);
     });
 
+    it('calling focus sets focus on the text area', async () => {
+        await connect();
+        element.focus();
+        processUpdates();
+        expect(page.isTextAreaFocused()).toBeTrue();
+    });
+
     describe('initial state', () => {
         beforeEach(async () => {
             await connect();
@@ -156,6 +163,17 @@ describe('ChatInput', () => {
                     detail: { text: 'new value', newState: true }
                 })
             );
+        });
+
+        it('updates value before send event', async () => {
+            const sendListener = waitForEvent(element, 'send', () => {
+                expect(element.value).toEqual('');
+            });
+            element.value = 'new value';
+            processUpdates();
+
+            await page.pressEnterKey();
+            await sendListener;
         });
 
         it('is called synchronously', () => {

--- a/packages/spright-components/src/chat/input/tests/chat-input.spec.ts
+++ b/packages/spright-components/src/chat/input/tests/chat-input.spec.ts
@@ -176,6 +176,13 @@ describe('ChatInput', () => {
             expect(spy).toHaveBeenCalled();
         });
 
+        it('clears value', () => {
+            element.value = 'new value';
+            processUpdates();
+            page.clickSendButton();
+            expect(element.value).toEqual('');
+        });
+
         it('via button click with no text triggers no send event', () => {
             const spy = jasmine.createSpy();
             element.addEventListener('send', spy);

--- a/packages/storybook/src/spright/chat/conversation/chat-conversation.stories.ts
+++ b/packages/storybook/src/spright/chat/conversation/chat-conversation.stories.ts
@@ -36,11 +36,9 @@ interface ChatConversationArgs {
     content: string;
     input: boolean;
     conversationRef: ChatConversation;
-    inputRef: ChatInput;
     sendMessage: (
         event: CustomEvent<ChatInputSendEventDetail>,
-        conversationRef: ChatConversation,
-        inputRef: ChatInput
+        conversationRef: ChatConversation
     ) => void;
 }
 
@@ -111,7 +109,7 @@ export const chatConversation: StoryObj<ChatConversationArgs> = {
             </${chatMessageTag}>
             ${when(x => x.input, html<ChatConversationArgs, ChatInput>`
                 <${chatInputTag} slot='input' placeholder='Type a message' send-button-label='Send' ${ref('inputRef')}
-                    @send="${(x2, c2) => x2.sendMessage(c2.event as CustomEvent<ChatInputSendEventDetail>, x2.conversationRef, x2.inputRef)}"
+                    @send="${(x2, c2) => x2.sendMessage(c2.event as CustomEvent<ChatInputSendEventDetail>, x2.conversationRef)}"
                 ></${chatInputTag}>
             `)}
         </${chatConversationTag}>
@@ -133,8 +131,7 @@ export const chatConversation: StoryObj<ChatConversationArgs> = {
     },
     args: {
         input: true,
-        sendMessage: (event, conversationRef, inputRef) => {
-            inputRef.resetInput();
+        sendMessage: (event, conversationRef) => {
             const message = document.createElement(chatMessageTag);
             message.messageType = ChatMessageType.outbound;
             const span = document.createElement('span');

--- a/packages/storybook/src/spright/chat/input/chat-input.stories.ts
+++ b/packages/storybook/src/spright/chat/input/chat-input.stories.ts
@@ -13,7 +13,6 @@ interface ChatInputArgs {
     sendButtonLabel: string;
     value: string;
     send: undefined;
-    resetInput: undefined;
 }
 
 const metadata: Meta<ChatInputArgs> = {
@@ -58,12 +57,6 @@ export const chatInput: StoryObj<ChatInputArgs> = {
             description:
                 'Emitted when the user clicks the button or presses Enter with text present. Includes `ChatInputSendEventDetail` which is an object with a `text` field containing the input.',
             table: { category: apiCategory.events }
-        },
-        resetInput: {
-            name: 'resetInput()',
-            description:
-                'Clear the input and gives it focus. This should typically be called from the `send` event handler.',
-            table: { category: apiCategory.methods }
         }
     },
     args: {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The design for the chat input calls to _always_ clear the text in the input once a user sends the message. There does not seem to be a compelling enough reason to make the client call a method in response to the `send` event to make this happen ([additional context](https://github.com/ni/nimble/pull/2611#discussion_r2226714997)).

## 👩‍💻 Implementation

Make `resetInput` private and call it from the `sendButtonClickHandler`.

## 🧪 Testing

Unit test.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
