### PR TITLE
Upgrade Node version from 22 to 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
           global-json-file: packages/blazor-workspace/global.json
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
       - run: npm ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ To submit changes to Nimble, the first step is to build the monorepo which requi
 
 - Sync down a copy of the nimble repository
     - Note: For one-off small contributions you can consider using a fork-pull workflow. However [fork-pull workflows are not yet supported](https://github.com/ni/nimble/issues/634) for substantial development. For substantial development you should be added as a Contributor to the repository. See the [`README.md` Community section](/README.md#community) to get in touch if you need Contributor permissions. 
-- Install Node.js version 22+ (run `node --version`) and npm version 10+ (run `npm --version`) which can be downloaded from https://nodejs.org/en/download/
+- Install Node.js version 24+ (run `node --version`) and npm version 10+ (run `npm --version`) which can be downloaded from https://nodejs.org/en/download/
 - Install .NET 8 SDK (`8.0.403` or higher) which can be downloaded from https://dotnet.microsoft.com/en-us/download
    - Run `dotnet --info` to verify the required version of the SDK is installed. A `v8` install is required, but it's fine if later versions are installed too.
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Node 24 has been "current" for a while and will become LTS. Other NI projects [like Skyline](https://dev.azure.com/ni/DevCentral/_git/Skyline/pullrequest/965486?_a=files) have upgraded to 24 and we want devs [to use a consistent version](https://teams.microsoft.com/l/message/19:aa36fb23db964a1d8931052d35f3b81a@thread.tacv2/1753889069212?tenantId=eb06985d-06ca-4a17-81da-629ab99f6505&groupId=1e74afef-f47b-4137-ad1b-e550ec9c6bef&parentMessageId=1753889069212&teamName=TM-SystemLink&channelName=SLE%20Development&createdTime=1753889069212).

## 👩‍💻 Implementation

Update version in workflow and CONTRIBUTING.md

## 🧪 Testing

I've been using 24 locally for a while. Otherwise will rely on pipeline.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
