### PR TITLE
Add background api for chat conversation

### DIFF
--- a/change/@ni-spright-components-ccb78f2f-5f4d-4606-909d-df44623238b8.json
+++ b/change/@ni-spright-components-ccb78f2f-5f4d-4606-909d-df44623238b8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add API to hide background visual for chat conversation.",
+  "packageName": "@ni/spright-components",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/spright-components/src/chat/conversation/index.ts
+++ b/packages/spright-components/src/chat/conversation/index.ts
@@ -1,5 +1,5 @@
 import { DesignSystem, FoundationElement } from '@ni/fast-foundation';
-import { observable } from '@ni/fast-element';
+import { attr, observable } from '@ni/fast-element';
 import { styles } from './styles';
 import { template } from './template';
 
@@ -13,6 +13,9 @@ declare global {
  * A Spright component for displaying a series of chat messages
  */
 export class ChatConversation extends FoundationElement {
+    @attr({ mode: 'boolean', attribute: 'hide-background' })
+    public hideBackground = false;
+
     /** @internal */
     @observable
     public inputEmpty = true;

--- a/packages/spright-components/src/chat/conversation/styles.ts
+++ b/packages/spright-components/src/chat/conversation/styles.ts
@@ -17,6 +17,10 @@ export const styles = css`
         border: ${borderWidth} solid ${applicationBackgroundColor};
     }
 
+    :host([hide-background]) {
+        background: transparent;
+    }
+
     .messages {
         flex: 1;
         display: flex;
@@ -27,6 +31,10 @@ export const styles = css`
             ${standardPadding};
         background: ${sectionBackgroundImage};
         overflow-y: auto;
+    }
+
+    :host([hide-background]) .messages {
+        background: transparent;
     }
 
     .input {

--- a/packages/storybook/src/spright/chat/conversation/chat-conversation-matrix.stories.ts
+++ b/packages/storybook/src/spright/chat/conversation/chat-conversation-matrix.stories.ts
@@ -57,6 +57,12 @@ const contentHeightStates = [
 ] as const;
 type ContentHeightStates = (typeof contentHeightStates)[number];
 
+const hideBackgroundStates = [
+    ['hide-background:true', true],
+    ['hide-background:false', false]
+] as const;
+type HideBackgroundStates = (typeof hideBackgroundStates)[number];
+
 const componentSizing = (
     [_messageTypeLabel, messageType]: MessageTypeStates,
     [viewportLabel, viewportWidth, viewportHeight]: ViewportStates,
@@ -70,7 +76,7 @@ const componentSizing = (
         margin-bottom: 0px;
         "
     >
-        viewport:${() => viewportLabel}, content:${() => contentWidthLabel},${() => contentHeightLabel} 
+        viewport:${() => viewportLabel}, content:${() => contentWidthLabel},${() => contentHeightLabel}
     </p>
     <div style="
         width: ${viewportWidth};
@@ -217,6 +223,31 @@ const conversationWithInput = (
 export const conversationWithInputSizing: StoryFn = createMatrixThemeStory(html`
     ${createMatrix(conversationWithInput, [heightStates])}
 `);
+
+export const conversationBackground: StoryFn = createStory(
+    html`
+        <p>hide-background: true</p>
+        <${chatConversationTag} hide-background="true">
+            <${chatMessageTag} message-type="inbound">
+                <span>Hello.</span>
+            </${chatMessageTag}>
+            <${chatMessageTag} message-type="outbound">
+                <span>Greetings!</span>
+            </${chatMessageTag}>
+            <${chatInputTag} slot='input'></${chatInputTag}>
+        </${chatConversationTag}>
+        <p>hide-background: false</p>
+        <${chatConversationTag} hide-background="false">
+            <${chatMessageTag} message-type="inbound">
+                <span>Hello.</span>
+            </${chatMessageTag}>
+            <${chatMessageTag} message-type="outbound">
+                <span>Greetings!</span>
+            </${chatMessageTag}>
+            <${chatInputTag} slot='input'></${chatInputTag}>
+        </${chatConversationTag}>
+    `
+);
 
 export const hidden: StoryFn = createStory(
     hiddenWrapper(

--- a/packages/storybook/src/spright/chat/conversation/chat-conversation-matrix.stories.ts
+++ b/packages/storybook/src/spright/chat/conversation/chat-conversation-matrix.stories.ts
@@ -57,12 +57,6 @@ const contentHeightStates = [
 ] as const;
 type ContentHeightStates = (typeof contentHeightStates)[number];
 
-const hideBackgroundStates = [
-    ['hide-background:true', true],
-    ['hide-background:false', false]
-] as const;
-type HideBackgroundStates = (typeof hideBackgroundStates)[number];
-
 const componentSizing = (
     [_messageTypeLabel, messageType]: MessageTypeStates,
     [viewportLabel, viewportWidth, viewportHeight]: ViewportStates,

--- a/packages/storybook/src/spright/chat/conversation/chat-conversation.stories.ts
+++ b/packages/storybook/src/spright/chat/conversation/chat-conversation.stories.ts
@@ -117,7 +117,8 @@ export const chatConversation: StoryObj<ChatConversationArgs> = {
     `),
     argTypes: {
         hideBackground: {
-            description: 'Whether to hide the background of the chat conversation.',
+            description:
+                'Whether to hide the background of the chat conversation.',
             table: { category: apiCategory.attributes }
         },
         content: {

--- a/packages/storybook/src/spright/chat/conversation/chat-conversation.stories.ts
+++ b/packages/storybook/src/spright/chat/conversation/chat-conversation.stories.ts
@@ -33,6 +33,7 @@ import { loremIpsum } from '../../../utilities/lorem-ipsum';
 import { isChromatic } from '../../../utilities/isChromatic';
 
 interface ChatConversationArgs {
+    hideBackground: boolean;
     content: string;
     input: boolean;
     conversationRef: ChatConversation;
@@ -57,7 +58,7 @@ export const chatConversation: StoryObj<ChatConversationArgs> = {
                 max-height: 600px;
             }
         </style>
-        <${chatConversationTag} ${ref('conversationRef')}>
+        <${chatConversationTag} ${ref('conversationRef')} ?hide-background="${x => x.hideBackground}">
             <${chatMessageTag} message-type="${() => ChatMessageType.system}">
                 To start, press any key.
             </${chatMessageTag}>
@@ -115,6 +116,10 @@ export const chatConversation: StoryObj<ChatConversationArgs> = {
         </${chatConversationTag}>
     `),
     argTypes: {
+        hideBackground: {
+            description: 'Whether to hide the background of the chat conversation.',
+            table: { category: apiCategory.attributes }
+        },
         content: {
             name: 'default',
             description:
@@ -130,6 +135,7 @@ export const chatConversation: StoryObj<ChatConversationArgs> = {
         }
     },
     args: {
+        hideBackground: false,
         input: true,
         sendMessage: (event, conversationRef) => {
             const message = document.createElement(chatMessageTag);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

We have use cases for the chat UI that require the background to be transparent in order for a larger app background to appear through the chat conversation area.

## 👩‍💻 Implementation

Add a simple boolean attribute to control whether or not to show the conversation background or not.

## 🧪 Testing

Chromatic tests.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
