### PR TITLE
Enable cron schedule task to validate reduced intermittency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - '**'
+  schedule:
+    - cron: 0 0-23 * * *
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Recently added test retry code on the CI to reduce intermittency in #2701 
However we also don't have as high natural nimble CI runs to validate reduced intermittency.
Have the CI run on main every hour to exercise for intermittency on the CI.
We can let it run for a while, maybe a week or so?

## 👩‍💻 Implementation

Add a [cron schedule trigger](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule) to run the CI every hour.

## 🧪 Testing

The testing is the CI

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
