### PR TITLE
Jasmine retry helper with beforeEach and afterEach support

### DIFF
--- a/change/@ni-nimble-angular-468bce0f-235d-4855-a5dd-877111e934f2.json
+++ b/change/@ni-nimble-angular-468bce0f-235d-4855-a5dd-877111e934f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Test only change",
+  "packageName": "@ni/nimble-angular",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-nimble-components-71326c24-2a1b-4632-b12b-2ff4297f2096.json
+++ b/change/@ni-nimble-components-71326c24-2a1b-4632-b12b-2ff4297f2096.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Test only change",
+  "packageName": "@ni/nimble-components",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-ok-angular-084f41d9-a127-4177-a238-ffc4be837736.json
+++ b/change/@ni-ok-angular-084f41d9-a127-4177-a238-ffc4be837736.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Test only change",
+  "packageName": "@ni/ok-angular",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-spright-angular-f07ed9a6-4b60-4245-b5dd-77a86a619f3e.json
+++ b/change/@ni-spright-angular-f07ed9a6-4b60-4245-b5dd-77a86a619f3e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Test only change",
+  "packageName": "@ni/spright-angular",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29565,6 +29565,7 @@
         "@angular/localize": "^18.2.13",
         "@lhci/cli": "^0.15.0",
         "@ni-private/eslint-config-nimble": "*",
+        "@ni-private/jasmine-extensions": "*",
         "@ni/eslint-config-angular": "^9.0.4",
         "@ni/fast-web-utilities": "^10.0.0",
         "@ni/jasmine-parameterized": "*",

--- a/packages/angular-workspace/example-client-app/src/test.ts
+++ b/packages/angular-workspace/example-client-app/src/test.ts
@@ -7,6 +7,9 @@ import {
     BrowserDynamicTestingModule,
     platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
+import { applyExtensions } from '@ni-private/jasmine-extensions';
+
+applyExtensions();
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(

--- a/packages/angular-workspace/nimble-angular/test.ts
+++ b/packages/angular-workspace/nimble-angular/test.ts
@@ -7,6 +7,9 @@ import {
     BrowserDynamicTestingModule,
     platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
+import { applyExtensions } from '@ni-private/jasmine-extensions';
+
+applyExtensions();
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(

--- a/packages/angular-workspace/ok-angular/test.ts
+++ b/packages/angular-workspace/ok-angular/test.ts
@@ -7,6 +7,9 @@ import {
     BrowserDynamicTestingModule,
     platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
+import { applyExtensions } from '@ni-private/jasmine-extensions';
+
+applyExtensions();
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(

--- a/packages/angular-workspace/package.json
+++ b/packages/angular-workspace/package.json
@@ -58,6 +58,7 @@
     "@ni/fast-web-utilities": "^10.0.0",
     "@ni-private/eslint-config-nimble": "*",
     "@ni/eslint-config-angular": "^9.0.4",
+    "@ni-private/jasmine-extensions": "*",
     "@ni/jasmine-parameterized": "*",
     "@ni/nimble-tokens": "*",
     "@rollup/plugin-node-resolve": "^16.0.0",

--- a/packages/angular-workspace/spright-angular/test.ts
+++ b/packages/angular-workspace/spright-angular/test.ts
@@ -7,6 +7,9 @@ import {
     BrowserDynamicTestingModule,
     platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
+import { applyExtensions } from '@ni-private/jasmine-extensions';
+
+applyExtensions();
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(

--- a/packages/jasmine-extensions/src/retry-failed-tests.ts
+++ b/packages/jasmine-extensions/src/retry-failed-tests.ts
@@ -1,27 +1,28 @@
-// From: https://github.com/jasmine/jasmine/issues/960#issuecomment-2349768674
+// Modified From: https://github.com/jasmine/jasmine/issues/960#issuecomment-2349768674
 /* eslint-disable */
 export function retryFailedTests(
     retries: number,
     millisecondsBetweenRetries: number,
 ): void {
+    // Handles both styles of async (Promises and done()) and returns a
+    // Promise.  Wraps synchronous fns in a Promise, too.
+    const run = (fn: Function) => {
+        if (fn.length == 0) {
+            return fn();
+        }
+        return new Promise(resolve => {
+            fn(resolve);
+        });
+    };
+
     const setTimeout = globalThis.setTimeout;
-    // @ts-expect-error sdf
+    // @ts-expect-error Global Jasmine Spec type undefined
     const originalSpecConstructor = jasmine.Spec;
-    // @ts-expect-error sdf
+    // @ts-expect-error Global Jasmine Spec type undefined
     jasmine.Spec = function retrySpec(attrs: any): jasmine.Spec {
         const spec = new originalSpecConstructor(attrs);
         const originalTestFn = spec.queueableFn.fn;
-
-        // Handles both styles of async testing (Promises and done()) and returns a
-        // Promise.  Wraps synchronous tests in a Promise, too.
-        const runOriginalTest = () => {
-            if (originalTestFn.length == 0) {
-                return originalTestFn();
-            }
-            return new Promise(resolve => {
-                originalTestFn(resolve);
-            });
-        };
+        const beforeAfterFns = spec.beforeAndAfterFns();
 
         spec.queueableFn.fn = async function () {
             let exceptionCaught;
@@ -33,7 +34,7 @@ export function retryFailedTests(
                 exceptionCaught = undefined;
 
                 try {
-                    returnValue = await runOriginalTest();
+                    returnValue = await run(originalTestFn);
                 } catch (exception) {
                     exceptionCaught = exception;
                 }
@@ -47,7 +48,19 @@ export function retryFailedTests(
 
                 if (millisecondsBetweenRetries && i != retries - 1) {
                     console.log(
-                        `Test ${spec.getFullName()} failed, attempting retry ${i + 1} in ${millisecondsBetweenRetries}ms`
+                        `Test "${spec.getFullName()}" failed, attempting retry ${i + 1} cleanup`
+                    );
+                    for (let j = 0; j < beforeAfterFns.afters.length; j += 1) {
+                        await run(beforeAfterFns.afters[j].fn);
+                    }
+                    console.log(
+                        `Test "${spec.getFullName()}" failed, attempting retry ${i + 1} setup`
+                    );
+                    for (let j = 0; j < beforeAfterFns.befores.length; j += 1) {
+                        await run(beforeAfterFns.befores[j].fn);
+                    }
+                    console.log(
+                        `Test "${spec.getFullName()}" failed, attempting retry ${i + 1} run in ${millisecondsBetweenRetries}ms`
                     );
                     await new Promise(resolve => {
                         setTimeout(resolve, millisecondsBetweenRetries);

--- a/packages/jasmine-extensions/src/retry-failed-tests.ts
+++ b/packages/jasmine-extensions/src/retry-failed-tests.ts
@@ -49,20 +49,14 @@ export function retryFailedTests(
 
                 if (millisecondsBetweenRetries && i != retries - 1) {
                     console.log(
-                        `Test "${spec.getFullName()}" failed, attempting retry ${i + 1} cleanup`
+                        `Test "${spec.getFullName()}" failed, attempting retry ${i + 1}. Will clean-up last run by running afterEach, re-setup by running beforeEach, wait ${millisecondsBetweenRetries}ms, and rerun the test`
                     );
                     for (let j = 0; j < beforeAfterFns.afters.length; j += 1) {
                         await run(that, beforeAfterFns.afters[j].fn);
                     }
-                    console.log(
-                        `Test "${spec.getFullName()}" failed, attempting retry ${i + 1} setup`
-                    );
                     for (let j = 0; j < beforeAfterFns.befores.length; j += 1) {
                         await run(that, beforeAfterFns.befores[j].fn);
                     }
-                    console.log(
-                        `Test "${spec.getFullName()}" failed, attempting retry ${i + 1} run in ${millisecondsBetweenRetries}ms`
-                    );
                     await new Promise(resolve => {
                         setTimeout(resolve, millisecondsBetweenRetries);
                     });

--- a/packages/jasmine-extensions/src/tests/retry-failed-tests.spec.ts
+++ b/packages/jasmine-extensions/src/tests/retry-failed-tests.spec.ts
@@ -6,6 +6,14 @@ describe('Retry failed tests', () => {
         const testSpy = jasmine.createSpy();
         const beforeEachSpy = jasmine.createSpy();
         const afterEachSpy = jasmine.createSpy();
+        const beforeAllSpy = jasmine.createSpy();
+        const afterAllSpy = jasmine.createSpy();
+        beforeAll(() => {
+            beforeAllSpy();
+        });
+        afterAll(() => {
+            afterAllSpy();
+        });
         beforeEach(() => {
             beforeEachSpy();
         });
@@ -20,6 +28,8 @@ describe('Retry failed tests', () => {
             expect(beforeEachSpy.calls.count()).toBe(3);
             // the afterEach statement will have run after each retry except the last by this point (should run the last time after the test)
             expect(afterEachSpy.calls.count()).toBe(2);
+            expect(beforeAllSpy.calls.count()).toBe(1);
+            expect(afterAllSpy.calls.count()).toBe(0);
         });
     });
     describe('with tests that console.error intermittently', () => {

--- a/packages/jasmine-extensions/src/tests/retry-failed-tests.spec.ts
+++ b/packages/jasmine-extensions/src/tests/retry-failed-tests.spec.ts
@@ -16,10 +16,10 @@ describe('Retry failed tests', () => {
             testSpy();
             // The it statement will run multiple times increasing the spy count
             expect(testSpy.calls.count()).toBe(3);
-            // the beforeEach statement will run only once even if the it statement re-runs
-            expect(beforeEachSpy.calls.count()).toBe(1);
-            // the afterEach statement will only run after all possible retries so we never see it run
-            expect(afterEachSpy.calls.count()).toBe(0);
+            // the beforeEach statement will have run before each retry
+            expect(beforeEachSpy.calls.count()).toBe(3);
+            // the afterEach statement will have run after each retry except the last by this point (should run the last time after the test)
+            expect(afterEachSpy.calls.count()).toBe(2);
         });
     });
     describe('with tests that console.error intermittently', () => {

--- a/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
+++ b/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
@@ -397,9 +397,7 @@ describe('AnchorTabs', () => {
         beforeEach(async () => {
             ({ connect, disconnect, element } = await setup());
             await connect();
-            tabsPageObject = new AnchorTabsPageObject(
-                element
-            );
+            tabsPageObject = new AnchorTabsPageObject(element);
         });
 
         afterEach(async () => {

--- a/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
+++ b/packages/nimble-components/src/anchor-tabs/tests/anchor-tabs.spec.ts
@@ -389,43 +389,39 @@ describe('AnchorTabs', () => {
             );
         }
 
-        async function setupInstance(): Promise<
-        Fixture<AnchorTabs> & { tabsPageObject: AnchorTabsPageObject }
-        > {
-            const fixtureResult = await setup();
-            await fixtureResult.connect();
-            const tabsPageObject = new AnchorTabsPageObject(
-                fixtureResult.element
-            );
-            return {
-                ...fixtureResult,
-                tabsPageObject
-            };
-        }
+        let tabsPageObject: AnchorTabsPageObject;
+        let connect: () => Promise<void>;
+        let disconnect: () => Promise<void>;
+        let element: AnchorTabs;
 
-        it('should not show scroll buttons when the tabs fit within the container', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
-            expect(tabsPageObject.areScrollButtonsVisible()).toBeFalse();
+        beforeEach(async () => {
+            ({ connect, disconnect, element } = await setup());
+            await connect();
+            tabsPageObject = new AnchorTabsPageObject(
+                element
+            );
+        });
+
+        afterEach(async () => {
             await disconnect();
+        });
+
+        it('should not show scroll buttons when the tabs fit within the container', () => {
+            expect(tabsPageObject.areScrollButtonsVisible()).toBeFalse();
         });
 
         it('should show scroll buttons when the tabs overflow the container', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(300);
             expect(tabsPageObject.areScrollButtonsVisible()).toBeTrue();
-            await disconnect();
         });
 
         it('should hide scroll buttons when the tabs no longer overflow the container', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(300);
             await tabsPageObject.setTabsWidth(1000);
             expect(tabsPageObject.areScrollButtonsVisible()).toBeFalse();
-            await disconnect();
         });
 
         it('should scroll left when the left scroll button is clicked', async () => {
-            const { element, tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(300);
             element.activeid = 'tab-six'; // scrolls to the last tab
             const currentScrollOffset = tabsPageObject.getTabsViewScrollOffset();
@@ -433,27 +429,21 @@ describe('AnchorTabs', () => {
             expect(tabsPageObject.getTabsViewScrollOffset()).toBeLessThan(
                 currentScrollOffset
             );
-            await disconnect();
         });
 
         it('should not scroll left when the left scroll button is clicked and the first tab is active', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(300);
             await tabsPageObject.clickScrollLeftButton();
             expect(tabsPageObject.getTabsViewScrollOffset()).toBe(0);
-            await disconnect();
         });
 
         it('should scroll right when the right scroll button is clicked', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(300);
             await tabsPageObject.clickScrollRightButton();
             expect(tabsPageObject.getTabsViewScrollOffset()).toBeGreaterThan(0);
-            await disconnect();
         });
 
         it('should not scroll right when the right scroll button is clicked and the last tab is active', async () => {
-            const { element, tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(300);
             element.activeid = 'tab-six'; // scrolls to the last tab
             const currentScrollOffset = tabsPageObject.getTabsViewScrollOffset();
@@ -461,30 +451,24 @@ describe('AnchorTabs', () => {
             expect(tabsPageObject.getTabsViewScrollOffset()).toBe(
                 currentScrollOffset
             );
-            await disconnect();
         });
 
         it('should show scroll buttons when new tab is added and tabs overflow the container', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(450);
             expect(tabsPageObject.areScrollButtonsVisible()).toBeFalse();
             await tabsPageObject.addTab('New Tab With Extremely Long Name');
             expect(tabsPageObject.areScrollButtonsVisible()).toBeTrue();
-            await disconnect();
         });
 
         it('should hide scroll buttons when tab is removed and tabs no longer overflow the container', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(500);
             await tabsPageObject.addTab('New Tab With Extremely Long Name');
             expect(tabsPageObject.areScrollButtonsVisible()).toBeTrue();
             await tabsPageObject.removeTab(6);
             expect(tabsPageObject.areScrollButtonsVisible()).toBeFalse();
-            await disconnect();
         });
 
         it('should show scroll buttons when tab label is updated and tabs overflow the container', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(450);
             expect(tabsPageObject.areScrollButtonsVisible()).toBeFalse();
             await tabsPageObject.updateTabLabel(
@@ -492,17 +476,14 @@ describe('AnchorTabs', () => {
                 'New Tab With Extremely Long Name'
             );
             expect(tabsPageObject.areScrollButtonsVisible()).toBeTrue();
-            await disconnect();
         });
 
         it('should hide scroll buttons when tab label is updated and tabs no longer overflow the container', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(550);
             await tabsPageObject.addTab('New Tab With Extremely Long Name');
             expect(tabsPageObject.areScrollButtonsVisible()).toBeTrue();
             await tabsPageObject.updateTabLabel(6, 'Tab 6');
             expect(tabsPageObject.areScrollButtonsVisible()).toBeFalse();
-            await disconnect();
         });
     });
 });

--- a/packages/nimble-components/src/breadcrumb/tests/breadcrumb.spec.ts
+++ b/packages/nimble-components/src/breadcrumb/tests/breadcrumb.spec.ts
@@ -19,21 +19,22 @@ async function setup(): Promise<Fixture<Breadcrumb>> {
     return await fixture<Breadcrumb>(viewTemplate);
 }
 
-async function setupInstance(): Promise<
-Fixture<Breadcrumb> & { breadcrumbPageObject: BreadcrumbPageObject }
-> {
-    const fixtureResult = await setup();
-    await fixtureResult.connect();
-    const breadcrumbPageObject = new BreadcrumbPageObject(
-        fixtureResult.element
-    );
-    return {
-        ...fixtureResult,
-        breadcrumbPageObject
-    };
-}
-
 describe('Breadcrumb', () => {
+    let breadcrumbPageObject: BreadcrumbPageObject;
+    let element: Breadcrumb;
+    let connect: () => Promise<void>;
+    let disconnect: () => Promise<void>;
+
+    beforeEach(async () => {
+        ({ element, connect, disconnect } = await setup());
+        await connect();
+        breadcrumbPageObject = new BreadcrumbPageObject(element);
+    });
+
+    afterEach(async () => {
+        await disconnect();
+    });
+
     it('can construct an element instance', () => {
         expect(document.createElement(breadcrumbTag)).toBeInstanceOf(
             Breadcrumb
@@ -41,29 +42,22 @@ describe('Breadcrumb', () => {
     });
 
     describe('Scroll buttons', () => {
-        it('should not show scroll buttons when the Breadcrumb fit within the container', async () => {
-            const { breadcrumbPageObject, disconnect } = await setupInstance();
+        it('should not show scroll buttons when the Breadcrumb fit within the container', () => {
             expect(breadcrumbPageObject.areScrollButtonsVisible()).toBeFalse();
-            await disconnect();
         });
 
         it('should show scroll buttons when the Breadcrumb overflow the container', async () => {
-            const { breadcrumbPageObject, disconnect } = await setupInstance();
             await breadcrumbPageObject.setBreadcrumbWidth(300);
             expect(breadcrumbPageObject.areScrollButtonsVisible()).toBeTrue();
-            await disconnect();
         });
 
         it('should hide scroll buttons when the Breadcrumb no longer overflow the container', async () => {
-            const { breadcrumbPageObject, disconnect } = await setupInstance();
             await breadcrumbPageObject.setBreadcrumbWidth(300); // first make the Breadcrumb overflow
             await breadcrumbPageObject.setBreadcrumbWidth(1000); // then make the Breadcrumb fit
             expect(breadcrumbPageObject.areScrollButtonsVisible()).toBeFalse();
-            await disconnect();
         });
 
         it('should scroll left when the left scroll button is clicked', async () => {
-            const { breadcrumbPageObject, disconnect } = await setupInstance();
             await breadcrumbPageObject.setBreadcrumbWidth(300);
             await breadcrumbPageObject.scrollBreadcrumbItemIntoViewByIndex(5);
             const currentScrollOffset = breadcrumbPageObject.getBreadcrumbViewScrollOffset();
@@ -71,31 +65,25 @@ describe('Breadcrumb', () => {
             expect(
                 breadcrumbPageObject.getBreadcrumbViewScrollOffset()
             ).toBeLessThan(currentScrollOffset);
-            await disconnect();
         });
 
         it('should not scroll left when the left scroll button is clicked and the first breadcrumb item is active', async () => {
-            const { breadcrumbPageObject, disconnect } = await setupInstance();
             await breadcrumbPageObject.setBreadcrumbWidth(300);
             await breadcrumbPageObject.clickScrollLeftButton();
             expect(breadcrumbPageObject.getBreadcrumbViewScrollOffset()).toBe(
                 0
             );
-            await disconnect();
         });
 
         it('should scroll right when the right scroll button is clicked', async () => {
-            const { breadcrumbPageObject, disconnect } = await setupInstance();
             await breadcrumbPageObject.setBreadcrumbWidth(300);
             await breadcrumbPageObject.clickScrollRightButton();
             expect(
                 breadcrumbPageObject.getBreadcrumbViewScrollOffset()
             ).toBeGreaterThan(0);
-            await disconnect();
         });
 
         it('should not scroll right when the right scroll button is clicked and the last breadcrumb item is active', async () => {
-            const { breadcrumbPageObject, disconnect } = await setupInstance();
             await breadcrumbPageObject.setBreadcrumbWidth(300);
             await breadcrumbPageObject.scrollBreadcrumbItemIntoViewByIndex(5);
             const currentScrollOffset = breadcrumbPageObject.getBreadcrumbViewScrollOffset();
@@ -103,22 +91,18 @@ describe('Breadcrumb', () => {
             expect(breadcrumbPageObject.getBreadcrumbViewScrollOffset()).toBe(
                 currentScrollOffset
             );
-            await disconnect();
         });
 
         it('should show scroll buttons when new breadcrumb item is added and Breadcrumb overflow the container', async () => {
-            const { breadcrumbPageObject, disconnect } = await setupInstance();
             await breadcrumbPageObject.setBreadcrumbWidth(450);
             expect(breadcrumbPageObject.areScrollButtonsVisible()).toBeFalse();
             await breadcrumbPageObject.addBreadcrumbItem(
                 'New Item With Extremely Long Name'
             );
             expect(breadcrumbPageObject.areScrollButtonsVisible()).toBeTrue();
-            await disconnect();
         });
 
         it('should hide scroll buttons when breadcrumb item is removed and Breadcrumb no longer overflow the container', async () => {
-            const { breadcrumbPageObject, disconnect } = await setupInstance();
             await breadcrumbPageObject.setBreadcrumbWidth(500);
             await breadcrumbPageObject.addBreadcrumbItem(
                 'New Item With Extremely Long Name'
@@ -126,11 +110,9 @@ describe('Breadcrumb', () => {
             expect(breadcrumbPageObject.areScrollButtonsVisible()).toBeTrue();
             await breadcrumbPageObject.removeBreadcrumbItemByIndex(6);
             expect(breadcrumbPageObject.areScrollButtonsVisible()).toBeFalse();
-            await disconnect();
         });
 
         it('should show scroll buttons when breadcrumb item label is updated and Breadcrumb overflow the container', async () => {
-            const { breadcrumbPageObject, disconnect } = await setupInstance();
             await breadcrumbPageObject.setBreadcrumbWidth(450);
             expect(breadcrumbPageObject.areScrollButtonsVisible()).toBeFalse();
             await breadcrumbPageObject.updateBreadcrumbItemLabel(
@@ -138,11 +120,9 @@ describe('Breadcrumb', () => {
                 'New Item With Extremely Long Name'
             );
             expect(breadcrumbPageObject.areScrollButtonsVisible()).toBeTrue();
-            await disconnect();
         });
 
         it('should hide scroll buttons when breadcrumb item label is updated and Breadcrumb no longer overflow the container', async () => {
-            const { breadcrumbPageObject, disconnect } = await setupInstance();
             await breadcrumbPageObject.setBreadcrumbWidth(550);
             await breadcrumbPageObject.addBreadcrumbItem(
                 'New Item With Extremely Long Name'
@@ -150,7 +130,6 @@ describe('Breadcrumb', () => {
             expect(breadcrumbPageObject.areScrollButtonsVisible()).toBeTrue();
             await breadcrumbPageObject.updateBreadcrumbItemLabel(6, 'Item 6');
             expect(breadcrumbPageObject.areScrollButtonsVisible()).toBeFalse();
-            await disconnect();
         });
     });
 });

--- a/packages/nimble-components/src/select/tests/select.spec.ts
+++ b/packages/nimble-components/src/select/tests/select.spec.ts
@@ -1348,7 +1348,7 @@ describe('Select', () => {
                 expect(element.value).toBe('one');
             });
 
-            it('filtering to no available options sets ariaActiveDescendent to empty string', async () => {
+            it('filtering to no available options sets ariaActiveDescendent to empty string #SkipWebkit', async () => {
                 await pageObject.openAndSetFilterText('abc');
                 expect(element.ariaActiveDescendant).toBe('');
             });

--- a/packages/nimble-components/src/tabs/tests/tabs.spec.ts
+++ b/packages/nimble-components/src/tabs/tests/tabs.spec.ts
@@ -26,67 +26,57 @@ async function setup(): Promise<Fixture<Tabs>> {
     return await fixture<Tabs>(viewTemplate);
 }
 
-async function setupInstance(): Promise<
-Fixture<Tabs> & { tabsPageObject: TabsPageObject }
-> {
-    const fixtureResult = await setup();
-    await fixtureResult.connect();
-    const tabsPageObject = new TabsPageObject(fixtureResult.element);
-    return {
-        ...fixtureResult,
-        tabsPageObject
-    };
-}
-
 describe('Tabs', () => {
+    let tabsPageObject: TabsPageObject;
+    let element: Tabs;
+    let connect: () => Promise<void>;
+    let disconnect: () => Promise<void>;
+
+    beforeEach(async () => {
+        ({ element, connect, disconnect } = await setup());
+        await connect();
+        tabsPageObject = new TabsPageObject(element);
+    });
+
+    afterEach(async () => {
+        await disconnect();
+    });
+
     it('can construct an element instance', () => {
         expect(document.createElement(tabsTag)).toBeInstanceOf(Tabs);
     });
 
     it('setting activeid should scroll the active tab into view', async () => {
-        const { element, tabsPageObject, disconnect } = await setupInstance();
         await tabsPageObject.setTabsWidth(300);
         element.activeid = '6'; // scrolls to the last tab
         await waitForUpdatesAsync();
         expect(tabsPageObject.getTabsViewScrollOffset()).toBeGreaterThan(0);
-
-        await disconnect();
     });
 
     it('clicking on a tab that is completely in view should not scroll the tablist', async () => {
-        const { tabsPageObject, disconnect } = await setupInstance();
         await tabsPageObject.setTabsWidth(300);
         await tabsPageObject.clickTab(2); // clicks the third tab
         await waitForUpdatesAsync();
         expect(tabsPageObject.getTabsViewScrollOffset()).toBe(0);
-
-        await disconnect();
     });
 
     describe('Scroll buttons', () => {
-        it('should not show scroll buttons when the tabs fit within the container', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
+        it('should not show scroll buttons when the tabs fit within the container', () => {
             expect(tabsPageObject.areScrollButtonsVisible()).toBeFalse();
-            await disconnect();
         });
 
         it('should show scroll buttons when the tabs overflow the container', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(300);
             expect(tabsPageObject.areScrollButtonsVisible()).toBeTrue();
-            await disconnect();
         });
 
         it('should hide scroll buttons when the tabs no longer overflow the container', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(300); // first make the tabs overflow
             await tabsPageObject.setTabsWidth(1000); // then make the tabs fit
             expect(tabsPageObject.areScrollButtonsVisible()).toBeFalse();
-            await disconnect();
         });
 
         it('should scroll left when the left scroll button is clicked', async () => {
-            const { element, tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(300);
             element.activeid = '6'; // scrolls to the last tab
             const currentScrollOffset = tabsPageObject.getTabsViewScrollOffset();
@@ -94,27 +84,21 @@ describe('Tabs', () => {
             expect(tabsPageObject.getTabsViewScrollOffset()).toBeLessThan(
                 currentScrollOffset
             );
-            await disconnect();
         });
 
         it('should not scroll left when the left scroll button is clicked and the first tab is active', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(300);
             await tabsPageObject.clickScrollLeftButton();
             expect(tabsPageObject.getTabsViewScrollOffset()).toBe(0);
-            await disconnect();
         });
 
         it('should scroll right when the right scroll button is clicked', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(300);
             await tabsPageObject.clickScrollRightButton();
             expect(tabsPageObject.getTabsViewScrollOffset()).toBeGreaterThan(0);
-            await disconnect();
         });
 
         it('should not scroll right when the right scroll button is clicked and the last tab is active', async () => {
-            const { element, tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(300);
             element.activeid = '6'; // scrolls to the last tab
             const currentScrollOffset = tabsPageObject.getTabsViewScrollOffset();
@@ -122,30 +106,24 @@ describe('Tabs', () => {
             expect(tabsPageObject.getTabsViewScrollOffset()).toBe(
                 currentScrollOffset
             );
-            await disconnect();
         });
 
         it('should show scroll buttons when new tab is added and tabs overflow the container', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(450);
             expect(tabsPageObject.areScrollButtonsVisible()).toBeFalse();
             await tabsPageObject.addTab('New Tab With Extremely Long Name');
             expect(tabsPageObject.areScrollButtonsVisible()).toBeTrue();
-            await disconnect();
         });
 
         it('should hide scroll buttons when tab is removed and tabs no longer overflow the container', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(500);
             await tabsPageObject.addTab('New Tab With Extremely Long Name');
             expect(tabsPageObject.areScrollButtonsVisible()).toBeTrue();
             await tabsPageObject.removeTab(6);
             expect(tabsPageObject.areScrollButtonsVisible()).toBeFalse();
-            await disconnect();
         });
 
         it('should show scroll buttons when tab label is updated and tabs overflow the container', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(450);
             expect(tabsPageObject.areScrollButtonsVisible()).toBeFalse();
             await tabsPageObject.updateTabLabel(
@@ -153,17 +131,14 @@ describe('Tabs', () => {
                 'New Tab With Extremely Long Name'
             );
             expect(tabsPageObject.areScrollButtonsVisible()).toBeTrue();
-            await disconnect();
         });
 
         it('should hide scroll buttons when tab label is updated and tabs no longer overflow the container', async () => {
-            const { tabsPageObject, disconnect } = await setupInstance();
             await tabsPageObject.setTabsWidth(550);
             await tabsPageObject.addTab('New Tab With Extremely Long Name');
             expect(tabsPageObject.areScrollButtonsVisible()).toBeTrue();
             await tabsPageObject.updateTabLabel(6, 'Tab 6');
             expect(tabsPageObject.areScrollButtonsVisible()).toBeFalse();
-            await disconnect();
         });
     });
 });


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

- Adds `beforeEach` and `afterEach` execution for the helper
- Adds `this` context support during function execution which fixed Angular usage

Partially addresses https://github.com/ni/nimble/issues/2702

## 👩‍💻 Implementation

See above

## 🧪 Testing

Additional test cases added for beforeEach execution.

Looks like the CI caught and recovered an intermittency! [See build](https://github.com/ni/nimble/actions/runs/18174187006/job/51736032162?pr=2715#step:17:602). Excerpt: 

```
[test-concurrent:nimble-components] [test-webkit] LOG LOG: 'Test "Table detaching and reattaching maintains scroll position if data length is increased while not attached #SkipFirefox" failed, attempting retry 1 cleanup'
[test-concurrent:nimble-components] [test-webkit] LOG LOG: 'Test "Table detaching and reattaching maintains scroll position if data length is increased while not attached #SkipFirefox" failed, attempting retry 1 setup'
[test-concurrent:nimble-components] [test-webkit] LOG LOG: 'Test "Table detaching and reattaching maintains scroll position if data length is increased while not attached #SkipFirefox" failed, attempting retry 1 run in 1000ms'
```

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
