### PR TITLE
Remove DStavilaNI as owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,8 +15,8 @@
 /packages/angular-workspace/spright-angular @rajsite @atmgrifter00
 /packages/blazor-workspace @rajsite @atmgrifter00 @msmithNI
 /packages/nimble-components @rajsite @jattasNI
-/packages/nimble-components/build/generate-workers @rajsite @jattasNI @DStavilaNI @munteannatan
-/packages/nimble-components/src/wafer-map @rajsite @jattasNI @DStavilaNI @munteannatan
+/packages/nimble-components/build/generate-workers @rajsite @jattasNI @munteannatan
+/packages/nimble-components/src/wafer-map @rajsite @jattasNI @munteannatan
 /packages/nimble-components/src/rich-text @rajsite @jattasNI @vivinkrishna-ni
 /packages/nimble-components/src/rich-text-mention @rajsite @jattasNI @vivinkrishna-ni
 /packages/nimble-tokens @rajsite @jattasNI @fredvisser


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

I noticed that #2727 was reporting errors in the CODEOWNERS file. Some of these are because `@DenisStavila` is listed as an owner but doesn't have write access to this repo because he left the company.

## 👩‍💻 Implementation

Remove user as owner.

I also granted write access to other new owners from #2727 who are all still at the company.

## 🧪 Testing

No CODEOWNERS errors reported in this PR.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
