### PR TITLE
Update CODEOWNERS for xliff-to-json-converter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,7 +23,7 @@
 /packages/site @rajsite @jattasNI
 /packages/spright-components @rajsite @jattasNI
 /packages/storybook/.storybook @rajsite @jattasNI @fredvisser
-/packages/xliff-to-json-converter @rajsite @TrevorKarjanis @jattasNI
+/packages/xliff-to-json-converter @rajsite @jattasNI
 
 # Specs (placed after packages to have higher precedence for spec files contained in packages)
 specs @rajsite @jattasNI @atmgrifter00 @mollykreis


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

`@TrevorKarjanis` is no longer a maintainer for this repo.

## 👩‍💻 Implementation

Removed `@TrevorKarjanis` from CODEOWNERS for xliff-to-json-converter.

## 🧪 Testing

N/A

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [X] I have updated the project documentation to reflect my changes or determined no changes are needed.
