### PR TITLE
Storybook preview page dark mode

### DIFF
--- a/packages/storybook/.storybook/preview.css
+++ b/packages/storybook/.storybook/preview.css
@@ -9,13 +9,11 @@ see: https://github.com/storybookjs/storybook/discussions/26088 */
 @media (prefers-color-scheme: dark) {
     .sb-wrapper,
     .sb-previewBlock_body,
-    .sb-previewBlock_header
-    {
-        background-color:black;
+    .sb-previewBlock_header {
+        background-color: black;
     }
 
-    .sb-argstableBlock-body td
-    {
+    .sb-argstableBlock-body td {
         background: gray;
     }
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The preview page is not theme aware (multiple issues shown but tackling the skeleton loader on the docs page):
   
![sb-skeleton](https://github.com/user-attachments/assets/daf853ef-b5bf-4e8e-bc41-7f55a34701ff)

## 👩‍💻 Implementation

Put in a manual `prefers-color-theme` check and made the colors darker

![sb-skeleton-fix](https://github.com/user-attachments/assets/12f9d018-79ac-4126-88f5-2986826be43b)

## 🧪 Testing

Rely on ni CI changes

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
