### PR TITLE
Storybook dark mode workarounds

### DIFF
--- a/packages/storybook/.storybook/manager-head.html
+++ b/packages/storybook/.storybook/manager-head.html
@@ -35,5 +35,16 @@
     .sb-bar button[class*="selected"] svg {
         fill: #f5f5f5 !important;
     }
-</style>
 
+    /* top-level html and loading spinner are not theme aware*/
+    @media (prefers-color-scheme: dark) {
+        body {
+            background-color: black;
+            color: white;
+        }
+
+        #main-preview-heading + div > div:first-child {
+            background-color: black;
+        }
+    }
+</style>

--- a/packages/storybook/.storybook/preview.css
+++ b/packages/storybook/.storybook/preview.css
@@ -4,9 +4,14 @@ by the storybook.ts createStory helpers */
     display: contents;
 }
 
-/* doc pages skeleton not theme aware
+/* doc pages loading skeleton not theme aware
 see: https://github.com/storybookjs/storybook/discussions/26088 */
 @media (prefers-color-scheme: dark) {
+    body {
+        background-color: black;
+        color: white;
+    }
+
     .sb-wrapper,
     .sb-previewBlock_body,
     .sb-previewBlock_header {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Makes the following responsive to prefers-color-scheme:
- top level manager body
- top level manager spinner
- preview page body
- preview page spinner already had  workaroud

## 👩‍💻 Implementation

see above

## 🧪 Testing

Manual with chrome simulated network throttling

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
