### PR TITLE
Blazor lint fixes from VS 2026

### DIFF
--- a/packages/blazor-workspace/Examples/Demo.Shared/Pages/ComponentsDemo.razor
+++ b/packages/blazor-workspace/Examples/Demo.Shared/Pages/ComponentsDemo.razor
@@ -79,7 +79,7 @@
             <NimbleCardButton>
                 <span class="card-button-content">Card Button</span>
             </NimbleCardButton>
-            <NimbleCardButton selected>
+            <NimbleCardButton Selected="true">
                 <span class="card-button-content">Selected Card Button</span>
             </NimbleCardButton>
         </div>
@@ -102,7 +102,7 @@
         <div class="sub-container">
             <div class="container-label">Dialog</div>
             <NimbleButton Appearance="ButtonAppearance.Outline" @onclick="OpenDialogAsync">Open Dialog</NimbleButton>
-            <NimbleTextField readonly Value="@DialogClosedReason">Closed reason</NimbleTextField>
+            <NimbleTextField ReadOnly="true" Value="@DialogClosedReason">Closed reason</NimbleTextField>
             <NimbleDialog TCloseReason="DialogResult" @ref="_dialog">
                 <span slot="title">Have a nice day</span>
                 <div>And also a nice week</div>
@@ -118,7 +118,7 @@
                 <NimbleListOption Value="@DrawerLocation.Left.ToString()">Drawer: Left-side</NimbleListOption>
                 <NimbleListOption Value="@DrawerLocation.Right.ToString()">Drawer: Right-side</NimbleListOption>
             </NimbleSelect>
-            <NimbleTextField readonly Value="@DrawerClosedReason">Closed reason</NimbleTextField>
+            <NimbleTextField ReadOnly="true" Value="@DrawerClosedReason">Closed reason</NimbleTextField>
             <NimbleDrawer TCloseReason="DialogResult" Location="_drawerLocation" @ref="_drawer">
                 <header>Have a nice day</header>
                 <section>And also a nice week</section>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests.Acceptance.Client/Program.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests.Acceptance.Client/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 
 namespace NimbleBlazor.Tests.Acceptance.Client;
+
 internal static class Program
 {
     public static async Task Main(string[] args)

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleListOptionGroupTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleListOptionGroupTests.cs
@@ -4,6 +4,7 @@ using Bunit;
 using Xunit;
 
 namespace NimbleBlazor.Tests.Unit.Components;
+
 public class NimbleListOptionGroupTests
 {
     [Fact]


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Installed VS 2026 with .NET 10 and new lint errors appeared when trying to build Nimble which is on .NET 8 🤷

## 👩‍💻 Implementation

Address lint errors

## 🧪 Testing

Rely on CI

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
