### PR TITLE
Fix console errors in rich-text-mention-listbox

### DIFF
--- a/packages/nimble-components/src/rich-text/mention-listbox/index.ts
+++ b/packages/nimble-components/src/rich-text/mention-listbox/index.ts
@@ -160,16 +160,31 @@ export class RichTextMentionListbox extends FoundationListbox {
      * @internal
      */
     public filterOptions(): void {
+        let newFilteredOptions: ListboxOption[];
         if (!this.filter) {
-            this.filteredOptions = this._options;
+            newFilteredOptions = this._options;
         } else {
             const normalizedFilter = diacriticInsensitiveStringNormalizer(
                 this.filter
             );
-            this.filteredOptions = this._options.filter(o => diacriticInsensitiveStringNormalizer(o.text).includes(
+            newFilteredOptions = this._options.filter(o => diacriticInsensitiveStringNormalizer(o.text).includes(
                 normalizedFilter
             ));
         }
+
+        // Skip the observable assignment when both old and new are empty.
+        // Different empty array references would trigger an @observable
+        // notification, queuing a deferred DOM.queueUpdate for the
+        // when-directive that can crash with "parentNode is null" if the
+        // DOM markers are in an inconsistent state during processing.
+        if (
+            newFilteredOptions.length === 0
+            && this.filteredOptions.length === 0
+        ) {
+            return;
+        }
+
+        this.filteredOptions = newFilteredOptions;
 
         this._options.forEach(o => {
             o.hidden = !this.filteredOptions.includes(o);
@@ -196,8 +211,21 @@ export class RichTextMentionListbox extends FoundationListbox {
         prev: Element[] | undefined,
         next: Element[]
     ): void {
-        super.slottedOptionsChanged(prev, next);
-        this.filterOptions();
+        if (this.open) {
+            super.slottedOptionsChanged(prev, next);
+            this.filterOptions();
+        } else {
+            // When closed, silently update the internal options list without
+            // calling super. The base class triggers observable notifications
+            // (options, selectedIndex, selectedOptions) that queue deferred
+            // FAST binding updates via DOM.queueUpdate. These deferred tasks
+            // can crash with "parentNode is null" when they try to update
+            // when-directive DOM markers that were detached between the
+            // enqueue and requestAnimationFrame execution.
+            this._options = next.filter(
+                (o): o is ListboxOption => o instanceof ListboxOption
+            );
+        }
     }
 
     /**
@@ -236,8 +264,17 @@ export class RichTextMentionListbox extends FoundationListbox {
             this.anchorElementIntersectionObserver.unobserve(prev);
         }
         if (this.region && this.anchorElement) {
-            this.region.anchorElement = this.anchorElement;
-            this.region.update();
+            if (this.region.anchorElement !== null) {
+                // When the anchored region already has an anchor, set the backing
+                // field directly and call update() to reposition. This avoids
+                // going through the observable setter which triggers requestReset()
+                // and tears down initialLayoutComplete, corrupting FAST's
+                // when-directive DOM markers during deferred binding updates.
+                (this.region as unknown as { [key: string]: unknown })._anchorElement = this.anchorElement;
+                this.region.update();
+            } else {
+                this.region.anchorElement = this.anchorElement;
+            }
             this.anchorElementIntersectionObserver.observe(next);
         }
     }
@@ -285,6 +322,13 @@ export class RichTextMentionListbox extends FoundationListbox {
     }
 
     private setOpen(value: boolean): void {
+        if (!value && this.open) {
+            // Clear stale filtered options by writing the backing field
+            // directly. Using the @observable setter would queue a deferred
+            // binding update for the when-directive, which can crash with
+            // "parentNode is null" if the DOM markers are being torn down.
+            (this as unknown as { [key: string]: unknown })._filteredOptions = [];
+        }
         this.open = value;
     }
 }

--- a/packages/nimble-components/src/rich-text/mention-listbox/template.ts
+++ b/packages/nimble-components/src/rich-text/mention-listbox/template.ts
@@ -1,4 +1,4 @@
-import { html, ref, slotted, when } from '@ni/fast-element';
+import { html, ref, slotted } from '@ni/fast-element';
 import { Listbox } from '@ni/fast-foundation';
 import type { RichTextMentionListbox } from '.';
 import { anchoredRegionTag } from '../../anchored-region';
@@ -38,11 +38,9 @@ export const template = html<RichTextMentionListbox>`
                     })}
                 >
                 </slot>
-                ${when(x => x.filteredOptions.length === 0, html<RichTextMentionListbox>`
-                    <span class="no-results-label">
-                        ${x => filterNoResultsLabel.getValueFor(x)}
-                    </span>
-                `)}
+                <span class="no-results-label" ?hidden="${x => x.filteredOptions.length > 0}">
+                    ${x => filterNoResultsLabel.getValueFor(x)}
+                </span>
             </div>
         </${anchoredRegionTag}>
     </template>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

#2744

Rich text editor mention listbox throws multiple `TypeError` console errors in Firefox (and occasionally Chrome) when using the `@mention` feature:
- `"can't access property 'insertBefore', node.parentNode is null"`
- `"can't access property 'nextSibling', current is null"`
- `"can't access property 'hasChildNodes', this.fragment is undefined"`

These errors break the UI — the mention popup fails to render or behaves incorrectly.

## 👩‍💻 Implementation

FAST Element's `@observable` system uses `DOM.queueUpdate` (`requestAnimationFrame`-based) to execute deferred binding updates. When the mention listbox closes or repositions, the anchored-region's `requestReset()` sets `initialLayoutComplete = false`, causing the `when(initialLayoutComplete)` directive to tear down its `<slot>` and detach DOM marker nodes. When the deferred binding update fires (next rAF), it tries to `insertBefore` on a detached marker whose `parentNode` is `null`, causing the crash.

### Solution

Applied multiple targeted workarounds in the `RichTextMentionListbox` component to prevent FAST's deferred binding updates from encountering detached DOM markers:
1. **`slottedOptionsChanged` — conditional base class call**: When the listbox is closed, skip `super.slottedOptionsChanged()` which triggers observable notifications (`options`, `selectedIndex`, `selectedOptions`) that queue deferred DOM updates. Instead, silently update the internal `_options` list directly.
2. **`filterOptions` — skip redundant empty-array assignment**: When both old and new filtered options are empty (different array references), skip the `@observable` assignment to avoid queuing a deferred binding update for the `when`-directive that can crash with detached markers.
3. **`anchorElementChanged` — bypass `requestReset()` on re-anchoring**: When the anchored region already has an anchor element, write to the backing field `_anchorElement` directly and call `update()` instead of going through the observable setter. This avoids `requestReset()` → `initialLayoutComplete = false` → DOM marker teardown cycle.
4. **`setOpen` — clear filteredOptions via backing field**: When closing the listbox, write to `_filteredOptions` backing field directly instead of using the observable setter, to avoid queuing a deferred binding update that can crash during teardown.
5. **Replace `when` directive with `?hidden` attribute for no-results label**: The `when` directive creates/destroys DOM fragments, which involves marker node manipulation vulnerable to the timing issue. Using `?hidden` keeps the element in the DOM and toggles visibility, avoiding the marker lifecycle entirely.

### Known Limitations

- **No-results label not displayed on second attempt**: When typing an invalid name the second time (e.g. type `@invalid`, clear, type `@invalid` again), the no-results label may not appear in Firefox. This is because the `filterOptions` optimization skips the `@observable` assignment when both old and new arrays are empty.
- **Popup flicker on `@` tag**: When inserting a mention via the `@` trigger, the popup briefly appears at the top-left corner of the page before repositioning to the correct anchor location. This is caused by the `anchorElementChanged` workaround that bypasses `requestReset()` — the initial positioning is delayed until `update()` completes.

## 🧪 Testing


## ✅ Checklist

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.