### PR TITLE
Scrollable stepper

### DIFF
--- a/change/@ni-nimble-components-0acd0006-3e8d-40e6-bece-c51f1e6b2b44.json
+++ b/change/@ni-nimble-components-0acd0006-3e8d-40e6-bece-c51f1e6b2b44.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Implement scrollable stepper",
+  "packageName": "@ni/nimble-components",
+  "email": "1588923+rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/anchor-step/template.ts
+++ b/packages/nimble-components/src/anchor-step/template.ts
@@ -8,6 +8,7 @@ import { iconTriangleFilledTag } from '../icons/triangle-filled';
 import { iconCheckTag } from '../icons/check';
 import type { StepPattern } from '../patterns/step/types';
 import { popupIconCurrentLabel, popupIconErrorLabel, popupIconWarningLabel, popupIconCompletedLabel } from '../label-provider/core/label-tokens';
+import { StepperOrientation } from '../stepper/types';
 
 export const template: FoundationElementTemplate<
 ViewTemplate<AnchorStep>,
@@ -16,7 +17,7 @@ AnchorOptions
     <template slot="step">
         <li class="
             container
-            ${x => (x.stepInternals.orientation === 'vertical' ? 'vertical' : '')}
+            ${x => (x.stepInternals.orientation === StepperOrientation.vertical ? 'vertical' : '')}
             ${x => (x.stepInternals.last ? 'last' : '')}
         ">
             <a

--- a/packages/nimble-components/src/step/template.ts
+++ b/packages/nimble-components/src/step/template.ts
@@ -8,6 +8,7 @@ import { iconTriangleFilledTag } from '../icons/triangle-filled';
 import { Severity } from '../patterns/severity/types';
 import { popupIconCompletedLabel, popupIconCurrentLabel, popupIconErrorLabel, popupIconWarningLabel } from '../label-provider/core/label-tokens';
 import type { StepPattern } from '../patterns/step/types';
+import { StepperOrientation } from '../stepper/types';
 
 export const template: FoundationElementTemplate<
 ViewTemplate<Step>,
@@ -16,7 +17,7 @@ ButtonOptions
     <template slot="step">
         <li class="
             container
-            ${x => (x.stepInternals.orientation === 'vertical' ? 'vertical' : '')}
+            ${x => (x.stepInternals.orientation === StepperOrientation.vertical ? 'vertical' : '')}
             ${x => (x.stepInternals.last ? 'last' : '')}
         ">
             <button

--- a/packages/nimble-components/src/stepper/index.ts
+++ b/packages/nimble-components/src/stepper/index.ts
@@ -18,9 +18,7 @@ export class Stepper extends FoundationElement {
     @attr
     public orientation: StepperOrientation = StepperOrientation.horizontal;
 
-    /**
-     * @internal
-     */
+    /** @internal */
     @observable
     public showScrollButtons = false;
 
@@ -28,23 +26,17 @@ export class Stepper extends FoundationElement {
     @observable
     public steps?: (StepPattern)[];
 
-    /**
-     * @internal
-     */
+    /** @internal */
     public list!: HTMLElement;
 
-    /**
-     * @internal
-     */
+    /** @internal */
     public readonly startScrollButton?: HTMLElement;
 
     private listIntersectionObserver?: IntersectionObserver;
 
-    /**
-     * @internal
-     */
+    /** @internal */
     public onScrollStartClick(): void {
-        if (this.orientation === StepperOrientation.horizontal) {
+        if (this.isHorizontal()) {
             this.list.scrollBy({
                 left: -this.list.clientWidth,
                 behavior: 'smooth'
@@ -57,11 +49,9 @@ export class Stepper extends FoundationElement {
         }
     }
 
-    /**
-     * @internal
-     */
+    /** @internal */
     public onScrollEndClick(): void {
-        if (this.orientation === StepperOrientation.horizontal) {
+        if (this.isHorizontal()) {
             this.list.scrollBy({
                 left: this.list.clientWidth,
                 behavior: 'smooth'
@@ -74,6 +64,7 @@ export class Stepper extends FoundationElement {
         }
     }
 
+    /** @internal */
     public override connectedCallback(): void {
         super.connectedCallback();
         // Steps fill parent container so can't rely on a resize observer to track their space usage.
@@ -87,9 +78,15 @@ export class Stepper extends FoundationElement {
         });
     }
 
+    /** @internal */
     public override disconnectedCallback(): void {
         super.disconnectedCallback();
         this.listIntersectionObserver?.disconnect();
+    }
+
+    /** @internal */
+    public isHorizontal(): boolean {
+        return this.orientation !== StepperOrientation.vertical;
     }
 
     private orientationChanged(): void {
@@ -110,26 +107,27 @@ export class Stepper extends FoundationElement {
         }
         const lastIndex = this.steps.length - 1;
         this.steps.forEach((step, index) => {
-            step.stepInternals.orientation = this.orientation;
+            step.stepInternals.orientation = this.isHorizontal()
+                ? StepperOrientation.horizontal
+                : StepperOrientation.vertical;
             step.stepInternals.last = index === lastIndex;
             step.stepInternals.position = index + 1;
         });
     }
 
     private handleListOverflow(): void {
-        const isHorizontal = this.orientation === StepperOrientation.horizontal;
-        let listVisibleSize = isHorizontal
+        let listVisibleSize = this.isHorizontal()
             ? this.list.clientWidth
             : this.list.clientHeight;
         if (listVisibleSize !== undefined) {
-            const buttonSize = isHorizontal
+            const buttonSize = this.isHorizontal()
                 ? this.startScrollButton?.clientWidth ?? 0
                 : this.startScrollButton?.clientHeight ?? 0;
             listVisibleSize = Math.ceil(listVisibleSize);
             if (this.showScrollButtons) {
                 listVisibleSize += buttonSize * 2;
             }
-            const listScrollSize = isHorizontal
+            const listScrollSize = this.isHorizontal()
                 ? this.list.scrollWidth
                 : this.list.scrollHeight;
             this.showScrollButtons = listVisibleSize < listScrollSize;

--- a/packages/nimble-components/src/stepper/index.ts
+++ b/packages/nimble-components/src/stepper/index.ts
@@ -39,14 +39,7 @@ export class Stepper extends FoundationElement {
      */
     public readonly startScrollButton?: HTMLElement;
 
-    private readonly listResizeObserver: ResizeObserver;
-
-    public constructor() {
-        super();
-        this.listResizeObserver = new ResizeObserver(_ => {
-            this.handleListOverflow();
-        });
-    }
+    private listIntersectionObserver?: IntersectionObserver;
 
     /**
      * @internal
@@ -84,12 +77,25 @@ export class Stepper extends FoundationElement {
 
     public override connectedCallback(): void {
         super.connectedCallback();
-        this.listResizeObserver.observe(this.list);
+        // Unlike other scrollable implementations, the steps fill the space
+        // of the container instead of the container sized to the items.
+        // We can't rely on the resizing of the container so instead
+        // track intersection of all steps inside the container.
+        // Found in manual testing that can get in states of partial occlusion
+        // before tabbing / using arrow keys triggers an intersection change.
+        // Hopefully the reliable solution is container scroll state queries when available:
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Conditional_rules/Container_scroll-state_queries
+        this.listIntersectionObserver = new IntersectionObserver(_ => {
+            this.handleListOverflow();
+        }, {
+            root: this.list,
+            threshold: 1.0
+        });
     }
 
     public override disconnectedCallback(): void {
         super.disconnectedCallback();
-        this.listResizeObserver.disconnect();
+        this.listIntersectionObserver?.disconnect();
     }
 
     private orientationChanged(): void {
@@ -98,7 +104,10 @@ export class Stepper extends FoundationElement {
 
     private stepsChanged(): void {
         this.updateStepInternals();
-        this.handleListOverflow();
+        this.listIntersectionObserver?.disconnect();
+        if (this.steps) {
+            this.steps.forEach(step => this.listIntersectionObserver?.observe(step));
+        }
     }
 
     private updateStepInternals(): void {

--- a/packages/nimble-components/src/stepper/index.ts
+++ b/packages/nimble-components/src/stepper/index.ts
@@ -29,7 +29,6 @@ export class Stepper extends FoundationElement {
     public steps?: (StepPattern)[];
 
     /**
-     * A reference to the list element
      * @internal
      */
     public list!: HTMLElement;
@@ -77,14 +76,9 @@ export class Stepper extends FoundationElement {
 
     public override connectedCallback(): void {
         super.connectedCallback();
-        // Unlike other scrollable implementations, the steps fill the space
-        // of the container instead of the container sized to the items.
-        // We can't rely on the resizing of the container so instead
-        // track intersection of all steps inside the container.
-        // Found in manual testing that can get in states of partial occlusion
-        // before tabbing / using arrow keys triggers an intersection change.
-        // Hopefully the reliable solution is container scroll state queries when available:
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Conditional_rules/Container_scroll-state_queries
+        // Steps fill parent container so can't rely on a resize observer to track their space usage.
+        // Instead directly track each step's occlusion with intersection observer which is more compute intensive.
+        // When available can switch to container scroll state queries, see: https://github.com/ni/nimble/issues/2922
         this.listIntersectionObserver = new IntersectionObserver(_ => {
             this.handleListOverflow();
         }, {

--- a/packages/nimble-components/src/stepper/index.ts
+++ b/packages/nimble-components/src/stepper/index.ts
@@ -18,9 +18,79 @@ export class Stepper extends FoundationElement {
     @attr
     public orientation: StepperOrientation = StepperOrientation.horizontal;
 
+    /**
+     * @internal
+     */
+    @observable
+    public showScrollButtons = false;
+
     /** @internal */
     @observable
     public steps?: (StepPattern)[];
+
+    /**
+     * A reference to the list element
+     * @internal
+     */
+    public list!: HTMLElement;
+
+    /**
+     * @internal
+     */
+    public readonly startScrollButton?: HTMLElement;
+
+    private readonly listResizeObserver: ResizeObserver;
+
+    public constructor() {
+        super();
+        this.listResizeObserver = new ResizeObserver(_ => {
+            this.handleListOverflow();
+        });
+    }
+
+    /**
+     * @internal
+     */
+    public onScrollStartClick(): void {
+        if (this.orientation === StepperOrientation.horizontal) {
+            this.list.scrollBy({
+                left: -this.list.clientWidth,
+                behavior: 'smooth'
+            });
+        } else {
+            this.list.scrollBy({
+                top: -this.list.clientHeight,
+                behavior: 'smooth'
+            });
+        }
+    }
+
+    /**
+     * @internal
+     */
+    public onScrollEndClick(): void {
+        if (this.orientation === StepperOrientation.horizontal) {
+            this.list.scrollBy({
+                left: this.list.clientWidth,
+                behavior: 'smooth'
+            });
+        } else {
+            this.list.scrollBy({
+                top: this.list.clientHeight,
+                behavior: 'smooth'
+            });
+        }
+    }
+
+    public override connectedCallback(): void {
+        super.connectedCallback();
+        this.listResizeObserver.observe(this.list);
+    }
+
+    public override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this.listResizeObserver.disconnect();
+    }
 
     private orientationChanged(): void {
         this.updateStepInternals();
@@ -28,6 +98,7 @@ export class Stepper extends FoundationElement {
 
     private stepsChanged(): void {
         this.updateStepInternals();
+        this.handleListOverflow();
     }
 
     private updateStepInternals(): void {
@@ -40,6 +111,26 @@ export class Stepper extends FoundationElement {
             step.stepInternals.last = index === lastIndex;
             step.stepInternals.position = index + 1;
         });
+    }
+
+    private handleListOverflow(): void {
+        const isHorizontal = this.orientation === StepperOrientation.horizontal;
+        let listVisibleSize = isHorizontal
+            ? this.list.clientWidth
+            : this.list.clientHeight;
+        if (listVisibleSize !== undefined) {
+            const buttonSize = isHorizontal
+                ? this.startScrollButton?.clientWidth ?? 0
+                : this.startScrollButton?.clientHeight ?? 0;
+            listVisibleSize = Math.ceil(listVisibleSize);
+            if (this.showScrollButtons) {
+                listVisibleSize += buttonSize * 2;
+            }
+            const listScrollSize = isHorizontal
+                ? this.list.scrollWidth
+                : this.list.scrollHeight;
+            this.showScrollButtons = listVisibleSize < listScrollSize;
+        }
     }
 }
 

--- a/packages/nimble-components/src/stepper/styles.ts
+++ b/packages/nimble-components/src/stepper/styles.ts
@@ -1,21 +1,67 @@
 import { css } from '@ni/fast-element';
 import { display } from '../utilities/style/display';
-import { smallPadding } from '../theme-provider/design-tokens';
+import { controlHeight, smallPadding } from '../theme-provider/design-tokens';
 
 export const styles = css`
     ${display('inline-flex')}
 
     :host {
         border: none;
-        gap: ${smallPadding};
     }
 
     :host([orientation="vertical"]) {
         flex-direction: column;
     }
 
-    ol {
-        display: contents;
+    .scroll-button.start {
+        width: ${controlHeight};
+        height: ${controlHeight};
+        margin-right: ${smallPadding};
+        margin-bottom: 0px;
+    }
+
+    :host([orientation="vertical"]) .scroll-button.start {
+        margin-right: 0px;
+        margin-bottom: ${smallPadding};
+    }
+
+    .list {
+        flex-grow: 1;
+        display: inline-flex;
+        gap: ${smallPadding};
+        scrollbar-width: none;
+        padding: 0;
+        margin: 0;
+
+        flex-direction: row;
+        overflow-x: scroll;
+        overflow-y: hidden;
+        width: max-content;
+        max-width: 100%;
+        height: auto;
+        max-height: none;
+    }
+
+    :host([orientation="vertical"]) .list {
+        flex-direction: column;
+        overflow-x: hidden;
+        overflow-y: scroll;
+        width: auto;
+        max-width: none;
+        height: max-content;
+        max-height: 100%;
+    }
+
+    .scroll-button.end {
+        width: ${controlHeight};
+        height: ${controlHeight};
+        margin-left: ${smallPadding};
+        margin-top: 0px;
+    }
+
+    :host([orientation="vertical"]) .scroll-button.end {
+        margin-left: 0px;
+        margin-top: ${smallPadding};
     }
 
     slot[name="step"]::slotted(*) {

--- a/packages/nimble-components/src/stepper/template.ts
+++ b/packages/nimble-components/src/stepper/template.ts
@@ -11,7 +11,6 @@ import { iconArrowExpanderRightTag } from '../icons/arrow-expander-right';
 import { iconArrowExpanderUpTag } from '../icons/arrow-expander-up';
 import { iconArrowExpanderDownTag } from '../icons/arrow-expander-down';
 
-// prettier-ignore
 export const template = html<Stepper>`
     ${when(x => x.showScrollButtons, html<Stepper>`
         <${buttonTag}

--- a/packages/nimble-components/src/stepper/template.ts
+++ b/packages/nimble-components/src/stepper/template.ts
@@ -21,8 +21,11 @@ export const template = html<Stepper>`
             ${ref('startScrollButton')}
         >
             ${x => scrollForwardLabel.getValueFor(x)}
-            ${when(x => x.orientation === 'horizontal', html`<${iconArrowExpanderLeftTag} slot="start"></${iconArrowExpanderLeftTag}>`)}
-            ${when(x => x.orientation === 'vertical', html`<${iconArrowExpanderUpTag} slot="start"></${iconArrowExpanderUpTag}>`)}
+            ${when(
+                x => x.isHorizontal(),
+                html`<${iconArrowExpanderLeftTag} slot="start"></${iconArrowExpanderLeftTag}>`,
+                html`<${iconArrowExpanderUpTag} slot="start"></${iconArrowExpanderUpTag}>`
+            )}
         </${buttonTag}>
     `)}
     <ol ${ref('list')} class="list"><slot
@@ -37,8 +40,11 @@ export const template = html<Stepper>`
             @click="${x => x.onScrollEndClick()}"
         >
             ${x => scrollBackwardLabel.getValueFor(x)}
-            ${when(x => x.orientation === 'horizontal', html`<${iconArrowExpanderRightTag} slot="start"></${iconArrowExpanderRightTag}>`)}
-            ${when(x => x.orientation === 'vertical', html`<${iconArrowExpanderDownTag} slot="start"></${iconArrowExpanderDownTag}>`)}
+            ${when(
+                x => x.isHorizontal(),
+                html`<${iconArrowExpanderRightTag} slot="start"></${iconArrowExpanderRightTag}>`,
+                html`<${iconArrowExpanderDownTag} slot="start"></${iconArrowExpanderDownTag}>`
+            )}
         </${buttonTag}>
     `)}
 `;

--- a/packages/nimble-components/src/stepper/template.ts
+++ b/packages/nimble-components/src/stepper/template.ts
@@ -1,7 +1,45 @@
-import { html, slotted } from '@ni/fast-element';
+import { html, ref, slotted, when } from '@ni/fast-element';
 import type { Stepper } from '.';
+import { buttonTag } from '../button';
+import { ButtonAppearance } from '../button/types';
+import {
+    scrollBackwardLabel,
+    scrollForwardLabel
+} from '../label-provider/core/label-tokens';
+import { iconArrowExpanderLeftTag } from '../icons/arrow-expander-left';
+import { iconArrowExpanderRightTag } from '../icons/arrow-expander-right';
+import { iconArrowExpanderUpTag } from '../icons/arrow-expander-up';
+import { iconArrowExpanderDownTag } from '../icons/arrow-expander-down';
 
-export const template = html<Stepper>`<ol><slot
-        name="step"
-        ${slotted('steps')}
-    ></slot></ol>`;
+// prettier-ignore
+export const template = html<Stepper>`
+    ${when(x => x.showScrollButtons, html<Stepper>`
+        <${buttonTag}
+            content-hidden
+            class="scroll-button start"
+            appearance="${ButtonAppearance.ghost}"
+            @click="${x => x.onScrollStartClick()}"
+            ${ref('startScrollButton')}
+        >
+            ${x => scrollForwardLabel.getValueFor(x)}
+            ${when(x => x.orientation === 'horizontal', html`<${iconArrowExpanderLeftTag} slot="start"></${iconArrowExpanderLeftTag}>`)}
+            ${when(x => x.orientation === 'vertical', html`<${iconArrowExpanderUpTag} slot="start"></${iconArrowExpanderUpTag}>`)}
+        </${buttonTag}>
+    `)}
+    <ol ${ref('list')} class="list"><slot
+            name="step"
+            ${slotted('steps')}
+        ></slot></ol>
+    ${when(x => x.showScrollButtons, html<Stepper>`
+        <${buttonTag}
+            content-hidden
+            class="scroll-button end"
+            appearance="${ButtonAppearance.ghost}"
+            @click="${x => x.onScrollEndClick()}"
+        >
+            ${x => scrollBackwardLabel.getValueFor(x)}
+            ${when(x => x.orientation === 'horizontal', html`<${iconArrowExpanderRightTag} slot="start"></${iconArrowExpanderRightTag}>`)}
+            ${when(x => x.orientation === 'vertical', html`<${iconArrowExpanderDownTag} slot="start"></${iconArrowExpanderDownTag}>`)}
+        </${buttonTag}>
+    `)}
+`;

--- a/packages/nimble-components/src/stepper/testing/stepper.pageobject.ts
+++ b/packages/nimble-components/src/stepper/testing/stepper.pageobject.ts
@@ -69,11 +69,11 @@ export class StepperPageObject {
         await waitForUpdatesAsync();
     }
 
-    public async addStep(label?: string): Promise<void> {
+    public async addStep(title?: string): Promise<void> {
         const step = document.createElement(stepTag);
         step.appendChild(Object.assign(document.createElement('span'), {
             slot: 'title',
-            textContent: label
+            textContent: title ?? ''
         }));
         this.element.appendChild(step);
         await waitForUpdatesAsync();
@@ -88,5 +88,23 @@ export class StepperPageObject {
         steps[index]!.remove();
         await waitForUpdatesAsync();
         await waitForUpdatesAsync(); // wait for overflow check queued by stepsChanged
+    }
+
+    public async updateStepTitle(
+        index: number,
+        title: string
+    ): Promise<void> {
+        const steps = this.element.steps;
+        if (!steps || index >= steps.length) {
+            throw new Error(`Step with index ${index} not found`);
+        }
+        const step = steps[index]!;
+        const titleSlot = step.querySelector('[slot="title"]');
+        if (!titleSlot) {
+            throw new Error(`No slot="title" element found to update for step with index ${index}`);
+        }
+        titleSlot.textContent = title;
+        await waitForUpdatesAsync();
+        await waitForUpdatesAsync();
     }
 }

--- a/packages/nimble-components/src/stepper/testing/stepper.pageobject.ts
+++ b/packages/nimble-components/src/stepper/testing/stepper.pageobject.ts
@@ -1,0 +1,92 @@
+import type { Button } from '../../button';
+import { waitForUpdatesAsync } from '../../testing/async-helpers';
+import { waitTimeout } from '../../utilities/testing/component';
+import type { Stepper } from '..';
+import { stepTag } from '../../step';
+import { StepperOrientation } from '../types';
+
+/**
+ * Page object for the `nimble-stepper`
+ */
+export class StepperPageObject {
+    public constructor(protected readonly element: Stepper) {}
+
+    public async setStepperScrollAxisSize(size: number): Promise<void> {
+        if (this.element.orientation === StepperOrientation.horizontal) {
+            this.element.style.width = `${size}px`;
+        } else {
+            this.element.style.height = `${size}px`;
+        }
+        await waitForUpdatesAsync();
+        await waitForUpdatesAsync(); // wait for the resize observer to fire
+    }
+
+    public async clickScrollStartButton(): Promise<void> {
+        const startButton = this.element.shadowRoot!.querySelector<Button>(
+            '.scroll-button.start'
+        );
+        if (!startButton) {
+            throw new Error('Scroll start button not found');
+        }
+        startButton.click();
+        await waitForUpdatesAsync();
+        await waitTimeout(50); // let animation run
+    }
+
+    public async clickScrollEndButton(): Promise<void> {
+        const endButton = this.element.shadowRoot!.querySelector<Button>(
+            '.scroll-button.end'
+        );
+        if (!endButton) {
+            throw new Error('Scroll end button not found');
+        }
+        endButton.click();
+        await waitForUpdatesAsync();
+        await waitTimeout(50); // let animation run
+    }
+
+    public areScrollButtonsVisible(): boolean {
+        return (
+            this.element.shadowRoot!.querySelectorAll(
+                '.scroll-button'
+            ).length > 0
+        );
+    }
+
+    public getStepperViewScrollOffset(): number {
+        const list = this.element.shadowRoot!.querySelector('.list')!;
+        return this.element.orientation === 'horizontal'
+            ? list.scrollLeft
+            : list.scrollTop;
+    }
+
+    public async scrollStepIntoViewByIndex(index: number): Promise<void> {
+        const steps = this.element.steps;
+        if (!steps || index >= steps.length) {
+            throw new Error(`Step with index ${index} not found`);
+        }
+        steps[index]!.scrollIntoView();
+        await waitForUpdatesAsync();
+    }
+
+    public async addStep(label?: string): Promise<void> {
+        const step = document.createElement(stepTag);
+        step.appendChild(Object.assign(document.createElement('span'), {
+            slot: 'title',
+            textContent: label
+        }));
+        this.element.appendChild(step);
+        await waitForUpdatesAsync();
+        await waitForUpdatesAsync(); // wait for overflow check queued by stepsChanged
+    }
+
+    public async removeStepByIndex(index: number): Promise<void> {
+        const steps = this.element.steps;
+        if (!steps || index >= steps.length) {
+            throw new Error(`Step with index ${index} not found`);
+        }
+        steps[index]!.remove();
+        await waitForUpdatesAsync();
+        await waitForUpdatesAsync(); // wait for overflow check queued by stepsChanged
+    }
+}

--- a/packages/nimble-components/src/stepper/tests/stepper.spec.ts
+++ b/packages/nimble-components/src/stepper/tests/stepper.spec.ts
@@ -250,8 +250,8 @@ describe('Stepper', () => {
                         });
 
                         it('should hide scroll buttons when the steps no longer overflow the container', async () => {
-                            await stepperPageObject.setStepperScrollAxisSize(200);
-                            await stepperPageObject.setStepperScrollAxisSize(3000);
+                            await stepperPageObject.setStepperScrollAxisSize(200); // first stepper overflow
+                            await stepperPageObject.setStepperScrollAxisSize(3000); // then stepper fit
                             expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
                         });
 

--- a/packages/nimble-components/src/stepper/tests/stepper.spec.ts
+++ b/packages/nimble-components/src/stepper/tests/stepper.spec.ts
@@ -11,6 +11,8 @@ import { AnchorStepPageObject } from '../../anchor-step/testing/anchor-step.page
 import type { StepBasePageObject } from '../../patterns/step/testing/step-base.pageobject';
 import { Severity } from '../../patterns/severity/types';
 import { waitForUpdatesAsync } from '../../testing/async-helpers';
+import { StepperPageObject } from '../testing/stepper.pageobject';
+import { StepperOrientation } from '../types';
 
 describe('Stepper', () => {
     it('can construct an element instance', () => {
@@ -200,6 +202,110 @@ describe('Stepper', () => {
                     await waitForUpdatesAsync();
                     expect(model.stepPageObject.getSelectedStateLabel()).toBe('Custom current');
                 });
+            });
+        });
+    });
+    const orientationTests = [
+        { name: StepperOrientation.horizontal },
+        { name: StepperOrientation.vertical },
+    ] as const;
+    parameterizeSuite(orientationTests, (suite, name, value) => {
+        suite(`Scroll buttons (${name})`, () => {
+            let stepperPageObject: StepperPageObject;
+            let element: Stepper;
+            let connect: () => Promise<void>;
+            let disconnect: () => Promise<void>;
+
+            async function setupScroll(): Promise<Fixture<Stepper>> {
+                return await fixture<Stepper>(
+                    html`
+                        <${stepperTag} orientation="${value.name}">
+                            <${stepTag}></${stepTag}>
+                            <${stepTag}></${stepTag}>
+                            <${stepTag}></${stepTag}>
+                            <${stepTag}></${stepTag}>
+                            <${stepTag}></${stepTag}>
+                            <${stepTag}></${stepTag}>
+                        </${stepperTag}>
+                    `
+                );
+            }
+
+            beforeEach(async () => {
+                ({ element, connect, disconnect } = await setupScroll());
+                await connect();
+                stepperPageObject = new StepperPageObject(element);
+            });
+
+            afterEach(async () => {
+                await disconnect();
+            });
+
+            it('should not show scroll buttons when the steps fit within the container', () => {
+                expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
+            });
+
+            it('should show scroll buttons when the steps overflow the container', async () => {
+                await stepperPageObject.setStepperScrollAxisSize(200);
+                expect(stepperPageObject.areScrollButtonsVisible()).toBeTrue();
+            });
+
+            it('should hide scroll buttons when the steps no longer overflow the container', async () => {
+                await stepperPageObject.setStepperScrollAxisSize(200);
+                await stepperPageObject.setStepperScrollAxisSize(3000);
+                expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
+            });
+
+            it('should scroll forward when the end scroll button is clicked', async () => {
+                await stepperPageObject.setStepperScrollAxisSize(200);
+                await stepperPageObject.clickScrollEndButton();
+                expect(
+                    stepperPageObject.getStepperViewScrollOffset()
+                ).toBeGreaterThan(0);
+            });
+
+            it('should scroll backward when the start scroll button is clicked', async () => {
+                await stepperPageObject.setStepperScrollAxisSize(200);
+                await stepperPageObject.scrollStepIntoViewByIndex(5);
+                const currentScrollOffset = stepperPageObject.getStepperViewScrollOffset();
+                await stepperPageObject.clickScrollStartButton();
+                expect(
+                    stepperPageObject.getStepperViewScrollOffset()
+                ).toBeLessThan(currentScrollOffset);
+            });
+
+            it('should not scroll backward when already at the start', async () => {
+                await stepperPageObject.setStepperScrollAxisSize(200);
+                await stepperPageObject.clickScrollStartButton();
+                expect(stepperPageObject.getStepperViewScrollOffset()).toBe(0);
+            });
+
+            it('should show scroll buttons when a new step is added and steps overflow the container', async () => {
+                await stepperPageObject.setStepperScrollAxisSize(400);
+                expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
+                // Labels impact horizontal size but not really vertical
+                // Add several steps to cause vertical overflow
+                await stepperPageObject.addStep();
+                await stepperPageObject.addStep();
+                await stepperPageObject.addStep();
+                await stepperPageObject.addStep();
+                expect(stepperPageObject.areScrollButtonsVisible()).toBeTrue();
+            });
+
+            it('should hide scroll buttons when a step is removed and steps no longer overflow the container', async () => {
+                await stepperPageObject.setStepperScrollAxisSize(400);
+                // Labels impact horizontal size but not really vertical
+                // Add several steps to cause vertical overflow
+                await stepperPageObject.addStep();
+                await stepperPageObject.addStep();
+                await stepperPageObject.addStep();
+                await stepperPageObject.addStep();
+                expect(stepperPageObject.areScrollButtonsVisible()).toBeTrue();
+                await stepperPageObject.removeStepByIndex(9);
+                await stepperPageObject.removeStepByIndex(8);
+                await stepperPageObject.removeStepByIndex(7);
+                await stepperPageObject.removeStepByIndex(6);
+                expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
             });
         });
     });

--- a/packages/nimble-components/src/stepper/tests/stepper.spec.ts
+++ b/packages/nimble-components/src/stepper/tests/stepper.spec.ts
@@ -203,109 +203,111 @@ describe('Stepper', () => {
                     expect(model.stepPageObject.getSelectedStateLabel()).toBe('Custom current');
                 });
             });
-        });
-    });
-    const orientationTests = [
-        { name: StepperOrientation.horizontal },
-        { name: StepperOrientation.vertical },
-    ] as const;
-    parameterizeSuite(orientationTests, (suite, name, value) => {
-        suite(`Scroll buttons (${name})`, () => {
-            let stepperPageObject: StepperPageObject;
-            let element: Stepper;
-            let connect: () => Promise<void>;
-            let disconnect: () => Promise<void>;
+            const orientationTests = [
+                { name: StepperOrientation.horizontal },
+                { name: StepperOrientation.vertical },
+            ] as const;
+            parameterizeSuite(orientationTests, (orientationSuite, orientationName) => {
+                orientationSuite(`orientation (${orientationName})`, () => {
+                    describe('step buttons', () => {
+                        let stepperPageObject: StepperPageObject;
+                        let element: Stepper;
+                        let connect: () => Promise<void>;
+                        let disconnect: () => Promise<void>;
 
-            async function setupScroll(): Promise<Fixture<Stepper>> {
-                return await fixture<Stepper>(
-                    html`
-                        <${stepperTag} orientation="${value.name}">
-                            <${stepTag}></${stepTag}>
-                            <${stepTag}></${stepTag}>
-                            <${stepTag}></${stepTag}>
-                            <${stepTag}></${stepTag}>
-                            <${stepTag}></${stepTag}>
-                            <${stepTag}></${stepTag}>
-                        </${stepperTag}>
-                    `
-                );
-            }
+                        async function setupScroll(): Promise<Fixture<Stepper>> {
+                            return await fixture<Stepper>(
+                                html`
+                                    <${stepperTag} orientation="${orientationName}">
+                                        <${value.stepTypeTag}></${value.stepTypeTag}>
+                                        <${value.stepTypeTag}></${value.stepTypeTag}>
+                                        <${value.stepTypeTag}></${value.stepTypeTag}>
+                                        <${value.stepTypeTag}></${value.stepTypeTag}>
+                                        <${value.stepTypeTag}></${value.stepTypeTag}>
+                                        <${value.stepTypeTag}></${value.stepTypeTag}>
+                                    </${stepperTag}>
+                                `
+                            );
+                        }
 
-            beforeEach(async () => {
-                ({ element, connect, disconnect } = await setupScroll());
-                await connect();
-                stepperPageObject = new StepperPageObject(element);
-            });
+                        beforeEach(async () => {
+                            ({ element, connect, disconnect } = await setupScroll());
+                            await connect();
+                            stepperPageObject = new StepperPageObject(element);
+                        });
 
-            afterEach(async () => {
-                await disconnect();
-            });
+                        afterEach(async () => {
+                            await disconnect();
+                        });
 
-            it('should not show scroll buttons when the steps fit within the container', () => {
-                expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
-            });
+                        it('should not show scroll buttons when the steps fit within the container', () => {
+                            expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
+                        });
 
-            it('should show scroll buttons when the steps overflow the container', async () => {
-                await stepperPageObject.setStepperScrollAxisSize(200);
-                expect(stepperPageObject.areScrollButtonsVisible()).toBeTrue();
-            });
+                        it('should show scroll buttons when the steps overflow the container', async () => {
+                            await stepperPageObject.setStepperScrollAxisSize(200);
+                            expect(stepperPageObject.areScrollButtonsVisible()).toBeTrue();
+                        });
 
-            it('should hide scroll buttons when the steps no longer overflow the container', async () => {
-                await stepperPageObject.setStepperScrollAxisSize(200);
-                await stepperPageObject.setStepperScrollAxisSize(3000);
-                expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
-            });
+                        it('should hide scroll buttons when the steps no longer overflow the container', async () => {
+                            await stepperPageObject.setStepperScrollAxisSize(200);
+                            await stepperPageObject.setStepperScrollAxisSize(3000);
+                            expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
+                        });
 
-            it('should scroll forward when the end scroll button is clicked', async () => {
-                await stepperPageObject.setStepperScrollAxisSize(200);
-                await stepperPageObject.clickScrollEndButton();
-                expect(
-                    stepperPageObject.getStepperViewScrollOffset()
-                ).toBeGreaterThan(0);
-            });
+                        it('should scroll forward when the end scroll button is clicked', async () => {
+                            await stepperPageObject.setStepperScrollAxisSize(200);
+                            await stepperPageObject.clickScrollEndButton();
+                            expect(
+                                stepperPageObject.getStepperViewScrollOffset()
+                            ).toBeGreaterThan(0);
+                        });
 
-            it('should scroll backward when the start scroll button is clicked', async () => {
-                await stepperPageObject.setStepperScrollAxisSize(200);
-                await stepperPageObject.scrollStepIntoViewByIndex(5);
-                const currentScrollOffset = stepperPageObject.getStepperViewScrollOffset();
-                await stepperPageObject.clickScrollStartButton();
-                expect(
-                    stepperPageObject.getStepperViewScrollOffset()
-                ).toBeLessThan(currentScrollOffset);
-            });
+                        it('should scroll backward when the start scroll button is clicked', async () => {
+                            await stepperPageObject.setStepperScrollAxisSize(200);
+                            await stepperPageObject.scrollStepIntoViewByIndex(5);
+                            const currentScrollOffset = stepperPageObject.getStepperViewScrollOffset();
+                            await stepperPageObject.clickScrollStartButton();
+                            expect(
+                                stepperPageObject.getStepperViewScrollOffset()
+                            ).toBeLessThan(currentScrollOffset);
+                        });
 
-            it('should not scroll backward when already at the start', async () => {
-                await stepperPageObject.setStepperScrollAxisSize(200);
-                await stepperPageObject.clickScrollStartButton();
-                expect(stepperPageObject.getStepperViewScrollOffset()).toBe(0);
-            });
+                        it('should not scroll backward when already at the start', async () => {
+                            await stepperPageObject.setStepperScrollAxisSize(200);
+                            await stepperPageObject.clickScrollStartButton();
+                            expect(stepperPageObject.getStepperViewScrollOffset()).toBe(0);
+                        });
 
-            it('should show scroll buttons when a new step is added and steps overflow the container', async () => {
-                await stepperPageObject.setStepperScrollAxisSize(400);
-                expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
-                // Labels impact horizontal size but not really vertical
-                // Add several steps to cause vertical overflow
-                await stepperPageObject.addStep();
-                await stepperPageObject.addStep();
-                await stepperPageObject.addStep();
-                await stepperPageObject.addStep();
-                expect(stepperPageObject.areScrollButtonsVisible()).toBeTrue();
-            });
+                        it('should show scroll buttons when a new step is added and steps overflow the container', async () => {
+                            await stepperPageObject.setStepperScrollAxisSize(400);
+                            expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
+                            // Labels impact horizontal size but not really vertical size
+                            // Add several steps to cause vertical overflow
+                            await stepperPageObject.addStep();
+                            await stepperPageObject.addStep();
+                            await stepperPageObject.addStep();
+                            await stepperPageObject.addStep();
+                            expect(stepperPageObject.areScrollButtonsVisible()).toBeTrue();
+                        });
 
-            it('should hide scroll buttons when a step is removed and steps no longer overflow the container', async () => {
-                await stepperPageObject.setStepperScrollAxisSize(400);
-                // Labels impact horizontal size but not really vertical
-                // Add several steps to cause vertical overflow
-                await stepperPageObject.addStep();
-                await stepperPageObject.addStep();
-                await stepperPageObject.addStep();
-                await stepperPageObject.addStep();
-                expect(stepperPageObject.areScrollButtonsVisible()).toBeTrue();
-                await stepperPageObject.removeStepByIndex(9);
-                await stepperPageObject.removeStepByIndex(8);
-                await stepperPageObject.removeStepByIndex(7);
-                await stepperPageObject.removeStepByIndex(6);
-                expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
+                        it('should hide scroll buttons when a step is removed and steps no longer overflow the container', async () => {
+                            await stepperPageObject.setStepperScrollAxisSize(400);
+                            // Labels impact horizontal size but not really vertical size
+                            // Add several steps to cause vertical overflow
+                            await stepperPageObject.addStep();
+                            await stepperPageObject.addStep();
+                            await stepperPageObject.addStep();
+                            await stepperPageObject.addStep();
+                            expect(stepperPageObject.areScrollButtonsVisible()).toBeTrue();
+                            await stepperPageObject.removeStepByIndex(9);
+                            await stepperPageObject.removeStepByIndex(8);
+                            await stepperPageObject.removeStepByIndex(7);
+                            await stepperPageObject.removeStepByIndex(6);
+                            expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
+                        });
+                    });
+                });
             });
         });
     });

--- a/packages/nimble-components/src/stepper/tests/stepper.spec.ts
+++ b/packages/nimble-components/src/stepper/tests/stepper.spec.ts
@@ -219,12 +219,12 @@ describe('Stepper', () => {
                             return await fixture<Stepper>(
                                 html`
                                     <${stepperTag} orientation="${orientationName}">
-                                        <${value.stepTypeTag}></${value.stepTypeTag}>
-                                        <${value.stepTypeTag}></${value.stepTypeTag}>
-                                        <${value.stepTypeTag}></${value.stepTypeTag}>
-                                        <${value.stepTypeTag}></${value.stepTypeTag}>
-                                        <${value.stepTypeTag}></${value.stepTypeTag}>
-                                        <${value.stepTypeTag}></${value.stepTypeTag}>
+                                        <${value.stepTypeTag}><span slot="title"></span></${value.stepTypeTag}>
+                                        <${value.stepTypeTag}><span slot="title"></span></${value.stepTypeTag}>
+                                        <${value.stepTypeTag}><span slot="title"></span></${value.stepTypeTag}>
+                                        <${value.stepTypeTag}><span slot="title"></span></${value.stepTypeTag}>
+                                        <${value.stepTypeTag}><span slot="title"></span></${value.stepTypeTag}>
+                                        <${value.stepTypeTag}><span slot="title"></span></${value.stepTypeTag}>
                                     </${stepperTag}>
                                 `
                             );
@@ -255,14 +255,6 @@ describe('Stepper', () => {
                             expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
                         });
 
-                        it('should scroll forward when the end scroll button is clicked', async () => {
-                            await stepperPageObject.setStepperScrollAxisSize(200);
-                            await stepperPageObject.clickScrollEndButton();
-                            expect(
-                                stepperPageObject.getStepperViewScrollOffset()
-                            ).toBeGreaterThan(0);
-                        });
-
                         it('should scroll backward when the start scroll button is clicked', async () => {
                             await stepperPageObject.setStepperScrollAxisSize(200);
                             await stepperPageObject.scrollStepIntoViewByIndex(5);
@@ -279,11 +271,29 @@ describe('Stepper', () => {
                             expect(stepperPageObject.getStepperViewScrollOffset()).toBe(0);
                         });
 
+                        it('should scroll forward when the end scroll button is clicked', async () => {
+                            await stepperPageObject.setStepperScrollAxisSize(200);
+                            await stepperPageObject.clickScrollEndButton();
+                            expect(
+                                stepperPageObject.getStepperViewScrollOffset()
+                            ).toBeGreaterThan(0);
+                        });
+
+                        it('should not scroll forward when already at the end', async () => {
+                            await stepperPageObject.setStepperScrollAxisSize(200);
+                            await stepperPageObject.scrollStepIntoViewByIndex(5);
+                            const currentScrollOffset = stepperPageObject.getStepperViewScrollOffset();
+                            await stepperPageObject.clickScrollEndButton();
+                            expect(stepperPageObject.getStepperViewScrollOffset()).toBe(
+                                currentScrollOffset
+                            );
+                        });
+
                         it('should show scroll buttons when a new step is added and steps overflow the container', async () => {
                             await stepperPageObject.setStepperScrollAxisSize(400);
                             expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
-                            // Labels impact horizontal size but not really vertical size
-                            // Add several steps to cause vertical overflow
+                            // Title impact horizontal size but not vertical size
+                            // Add several steps to cause either horizontal or vertical overflow
                             await stepperPageObject.addStep();
                             await stepperPageObject.addStep();
                             await stepperPageObject.addStep();
@@ -293,8 +303,8 @@ describe('Stepper', () => {
 
                         it('should hide scroll buttons when a step is removed and steps no longer overflow the container', async () => {
                             await stepperPageObject.setStepperScrollAxisSize(400);
-                            // Labels impact horizontal size but not really vertical size
-                            // Add several steps to cause vertical overflow
+                            // Title impact horizontal size but not vertical size
+                            // Add several steps to cause either horizontal or vertical overflow
                             await stepperPageObject.addStep();
                             await stepperPageObject.addStep();
                             await stepperPageObject.addStep();
@@ -306,6 +316,29 @@ describe('Stepper', () => {
                             await stepperPageObject.removeStepByIndex(6);
                             expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
                         });
+
+                        // Title contents only impact overflow in horizontal orientation
+                        if (orientationName === StepperOrientation.horizontal) {
+                            it('should show scroll buttons when step title is updated and steps overflow the container', async () => {
+                                await stepperPageObject.setStepperScrollAxisSize(450);
+                                expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
+                                await stepperPageObject.updateStepTitle(
+                                    0,
+                                    'New Item With Extremely Long Name'
+                                );
+                                expect(stepperPageObject.areScrollButtonsVisible()).toBeTrue();
+                            });
+
+                            it('should hide scroll buttons when step title is updated and steps no longer overflow the container', async () => {
+                                await stepperPageObject.setStepperScrollAxisSize(550);
+                                await stepperPageObject.addStep(
+                                    'New Item With Extremely Long Name'
+                                );
+                                expect(stepperPageObject.areScrollButtonsVisible()).toBeTrue();
+                                await stepperPageObject.updateStepTitle(6, 'Item 6');
+                                expect(stepperPageObject.areScrollButtonsVisible()).toBeFalse();
+                            });
+                        }
                     });
                 });
             });

--- a/packages/storybook/src/nimble/stepper/stepper-matrix.stories.ts
+++ b/packages/storybook/src/nimble/stepper/stepper-matrix.stories.ts
@@ -11,7 +11,7 @@ import {
 } from '../../utilities/matrix';
 import { createStory } from '../../utilities/storybook';
 import { hiddenWrapper } from '../../utilities/hidden';
-import { orientationStates, type OrientationStates } from './types';
+import { sizeStates, type SizeStates } from './types';
 
 const metadata: Meta = {
     title: 'Tests/Stepper',
@@ -23,17 +23,19 @@ const metadata: Meta = {
 export default metadata;
 
 const component = (
-    [orientationName, orientation]: OrientationStates
+    [sizeName, orientation, sizeStyle]: SizeStates,
 ): ViewTemplate => html`
-<div style="display: inline-flex; flex-direction: row; gap: 16px;">
-    <div style="padding-right: 16px;">${orientationName}</div>
-    <${stepperTag} orientation=${() => orientation}>
-        <${stepTag}><span slot="title">Step 1</span><span slot="subtitle">first</span></${stepTag}>
-        <${stepTag}><span slot="title">Step 2</span><span slot="subtitle">last</span></${stepTag}>
+<div style="display: inline-flex; flex-direction: column; gap: 16px;">
+    <div style="padding-right: 16px;">${sizeName}</div>
+    <${stepperTag} orientation=${() => orientation} style="${sizeStyle}">
+        <${stepTag}><span slot="title">Step 1 and a decent amount of text</span><span slot="subtitle">first</span></${stepTag}>
+        <${stepTag}><span slot="title">Step 2 and a decent amount of text</span><span slot="subtitle">first</span></${stepTag}>
+        <${stepTag}><span slot="title">Step 3 and a decent amount of text</span><span slot="subtitle">first</span></${stepTag}>
     </${stepperTag}>
-    <${stepperTag} orientation=${() => orientation}>
-        <${anchorStepTag} href="#" target="_self"><span slot="title">Anchor Step 1</span><span slot="subtitle">first</span></${anchorStepTag}>
-        <${anchorStepTag} href="#" target="_self"><span slot="title">Anchor Step 2</span><span slot="subtitle">last</span></${anchorStepTag}>
+    <${stepperTag} orientation=${() => orientation} style="${sizeStyle}">
+        <${anchorStepTag} href="#" target="_self"><span slot="title">Anchor Step 1 and a decent amount of text</span><span slot="subtitle">first</span></${anchorStepTag}>
+        <${anchorStepTag} href="#" target="_self"><span slot="title">Anchor Step 2 and a decent amount of text</span><span slot="subtitle">first</span></${anchorStepTag}>
+        <${anchorStepTag} href="#" target="_self"><span slot="title">Anchor Step 3 and a decent amount of text</span><span slot="subtitle">first</span></${anchorStepTag}>
     </${stepperTag}>
 </div>
 `;
@@ -46,7 +48,7 @@ export const themeMatrix: StoryFn = createMatrixThemeStory(html`
             color: var(${bodyFontColor.cssCustomProperty});
         ">
     ${createMatrix(component, [
-        orientationStates
+        sizeStates
     ])}
     </div>
 `);

--- a/packages/storybook/src/nimble/stepper/stepper.stories.ts
+++ b/packages/storybook/src/nimble/stepper/stepper.stories.ts
@@ -226,9 +226,31 @@ const severity: readonly StepSetItem[] = [
     { title: 'Share results', subtitle: 'Reveal who is responsible', selected: true },
 ];
 
+const many = Array.from({ length: 20 }).map((_x, i, arr) => ({
+    title: `Step ${i + 1}`,
+    subtitle: `On step ${i + 1} of ${arr.length}`,
+}));
+
+const wide = [
+    {
+        title: 'Step 1 that is too long and should probably be shorter but is not and sometimes you have to pick which battles to fight and which to let go of',
+        subtitle: 'On step 1 of 3'
+    },
+    {
+        title: 'Page 2 that is also long but not too long',
+        subtitle: 'On step 2 of 3',
+    },
+    {
+        title: 'Short',
+        subtitle: 'On step 3 of 3',
+    }
+] as const;
+
 const stepSets: { [key in ExampleStepType]: readonly StepSetItem[] } = {
     [ExampleStepType.simple]: simple,
     [ExampleStepType.severity]: severity,
+    [ExampleStepType.many]: many,
+    [ExampleStepType.wide]: wide,
 };
 type StepSet = StepSetItem;
 
@@ -243,9 +265,14 @@ export const stepper: StoryObj<StepperArgs> = {
         componentName: stepperTag,
         statusLink: 'https://github.com/ni/nimble/issues/624'
     })}
+    <style class="code-hide">
+        ${stepperTag} {
+            max-width: 100%;
+            max-height: 500px;
+        }
+    </style>
     <${stepperTag}
         orientation="${x => x.orientation}"
-        style="width: 860px;"
     >
         ${repeat(x => stepSets[x.stepType], html<StepSet>`
             <${stepTag}
@@ -271,6 +298,8 @@ export const stepper: StoryObj<StepperArgs> = {
                 labels: {
                     [ExampleStepType.simple]: 'Simple default step items',
                     [ExampleStepType.severity]: 'Steps with various severities',
+                    [ExampleStepType.many]: 'Many steps',
+                    [ExampleStepType.wide]: 'Wide steps',
                 }
             },
         },

--- a/packages/storybook/src/nimble/stepper/stepper.stories.ts
+++ b/packages/storybook/src/nimble/stepper/stepper.stories.ts
@@ -245,6 +245,7 @@ export const stepper: StoryObj<StepperArgs> = {
     })}
     <${stepperTag}
         orientation="${x => x.orientation}"
+        style="width: 860px;"
     >
         ${repeat(x => stepSets[x.stepType], html<StepSet>`
             <${stepTag}

--- a/packages/storybook/src/nimble/stepper/types.ts
+++ b/packages/storybook/src/nimble/stepper/types.ts
@@ -1,5 +1,4 @@
 import { Severity } from '@ni/nimble-components/dist/esm/patterns/severity/types';
-import { StepperOrientation } from '@ni/nimble-components/dist/esm/stepper/types';
 
 export const ExampleStepType = {
     simple: 'simple',
@@ -36,12 +35,6 @@ export type StepContentStates = (typeof stepContentStates)[number];
 export const stepContentStateShort = stepContentStates[2];
 export const stepContentStateStepIndicator = stepContentStates[5];
 
-export const orientationStates = [
-    ['Horizontal', StepperOrientation.horizontal],
-    ['Vertical', StepperOrientation.vertical],
-] as const;
-export type OrientationStates = (typeof orientationStates)[number];
-
 export const stepLayoutStates = [
     ['First Horizontal', false, 'horizontal'],
     ['Last Horizontal', true, 'horizontal'],
@@ -64,3 +57,13 @@ export const stepManipulationState = {
     readOnly: stepManipulationStates[2],
     readOnlyDisabled: stepManipulationStates[3],
 } as const;
+
+export const sizeStates = [
+    ['horizontal', 'horizontal', 'width: min-content;'],
+    ['horizontal small', 'horizontal', 'width: 250px;'],
+    ['horizontal large', 'horizontal', 'width: 1000px;'],
+    ['vertical', 'vertical', 'width: min-content;'],
+    ['vertical small', 'vertical', 'height: 140px;'],
+    ['vertical large', 'vertical', 'height: 300px;'],
+] as const;
+export type SizeStates = (typeof sizeStates)[number];

--- a/packages/storybook/src/nimble/stepper/types.ts
+++ b/packages/storybook/src/nimble/stepper/types.ts
@@ -4,6 +4,8 @@ import { StepperOrientation } from '@ni/nimble-components/dist/esm/stepper/types
 export const ExampleStepType = {
     simple: 'simple',
     severity: 'severity',
+    many: 'many',
+    wide: 'wide'
 } as const;
 export type ExampleStepType = (typeof ExampleStepType)[keyof typeof ExampleStepType];
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Implements scrollable stepper pattern similar to breadcrumbs and tabs.

## 👩‍💻 Implementation

Follows the pattern established in #2695 reasonably closely with the following differences:
- Implements both horizontal and vertical scrollable behavior based on orientation
- Uses an interaction observer instead of a resize observer (comments in source go into more detail)

## 🧪 Testing

- Duplicates the same test patterns and matrix tests
- Similar pattern for storybook tests

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
