### PR TITLE
 Fix Firefox crash in anchored-region by replacing when directive with CSS-based slot visibility

### DIFF
--- a/change/@ni-nimble-components-01bb6111-fa96-46dd-8351-53d8d2e79be4.json
+++ b/change/@ni-nimble-components-01bb6111-fa96-46dd-8351-53d8d2e79be4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Firefox crash in rich test mention list box by having a custom anchored region template",
+  "packageName": "@ni/nimble-components",
+  "email": "123377523+vivinkrishna-ni@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/anchored-region/index.ts
+++ b/packages/nimble-components/src/anchored-region/index.ts
@@ -1,8 +1,8 @@
 import {
     DesignSystem,
-    AnchoredRegion as FoundationAnchoredRegion,
-    anchoredRegionTemplate as template
+    AnchoredRegion as FoundationAnchoredRegion
 } from '@ni/fast-foundation';
+import { template } from './template';
 import { styles } from './styles';
 
 declare global {

--- a/packages/nimble-components/src/anchored-region/styles.ts
+++ b/packages/nimble-components/src/anchored-region/styles.ts
@@ -15,4 +15,12 @@ export const styles = css`
         display: block;
         visibility: hidden;
     }
+
+    :host(.loaded) slot {
+        display: contents;
+    }
+
+    slot {
+        display: none;
+    }
 `;

--- a/packages/nimble-components/src/anchored-region/template.ts
+++ b/packages/nimble-components/src/anchored-region/template.ts
@@ -1,0 +1,8 @@
+import { html } from '@ni/fast-element';
+import type { AnchoredRegion } from '.';
+
+export const template = html<AnchoredRegion>`
+    <template class="${x => (x.initialLayoutComplete ? 'loaded' : '')}">
+        <slot></slot>
+    </template>
+`;

--- a/packages/nimble-components/src/anchored-region/tests/anchored-region.spec.ts
+++ b/packages/nimble-components/src/anchored-region/tests/anchored-region.spec.ts
@@ -1,9 +1,87 @@
+import { html } from '@ni/fast-element';
+import { fixture, type Fixture } from '../../utilities/tests/fixture';
 import { AnchoredRegion, anchoredRegionTag } from '..';
+import { waitForUpdatesAsync } from '../../testing/async-helpers';
+
+async function setup(): Promise<Fixture<AnchoredRegion>> {
+    return await fixture<AnchoredRegion>(
+        html`<${anchoredRegionTag}></${anchoredRegionTag}>`
+    );
+}
 
 describe('Anchored Region', () => {
+    let element: AnchoredRegion;
+    let connect: () => Promise<void>;
+    let disconnect: () => Promise<void>;
+    let parent: HTMLElement;
+
     it('can construct an element instance', () => {
         expect(document.createElement(anchoredRegionTag)).toBeInstanceOf(
             AnchoredRegion
         );
+    });
+
+    describe('slot visibility', () => {
+        async function waitUntilLoaded(
+            region: AnchoredRegion
+        ): Promise<void> {
+            await waitForUpdatesAsync();
+            await new Promise<void>(resolve => {
+                region.addEventListener('loaded', () => {
+                    resolve();
+                });
+            });
+        }
+
+        beforeEach(async () => {
+            ({ element, connect, disconnect, parent } = await setup());
+
+            const anchor = document.createElement('button');
+            anchor.id = 'anchor';
+            parent.insertBefore(anchor, element);
+
+            element.setAttribute('anchor', 'anchor');
+            element.setAttribute(
+                'vertical-positioning-mode',
+                'locktodefault'
+            );
+            element.setAttribute(
+                'horizontal-positioning-mode',
+                'locktodefault'
+            );
+        });
+
+        afterEach(async () => {
+            await disconnect();
+        });
+
+        it('should hide slot content before region is loaded', async () => {
+            await connect();
+
+            const slot = element.shadowRoot!.querySelector('slot')!;
+            expect(getComputedStyle(slot).display).toBe('none');
+        });
+
+        it('should not have "loaded" class before initial layout is complete', async () => {
+            await connect();
+
+            expect(element.classList.contains('loaded')).toBeFalse();
+        });
+
+        it('should add "loaded" class after region is loaded', async () => {
+            await connect();
+            await waitUntilLoaded(element);
+
+            expect(element.classList.contains('loaded')).toBeTrue();
+        });
+
+        it('should show slot content after region is loaded', async () => {
+            await connect();
+            await waitUntilLoaded(element);
+            await waitForUpdatesAsync();
+
+            const slot = element.shadowRoot!.querySelector('slot')!;
+            expect(getComputedStyle(slot).display).toBe('contents');
+        });
     });
 });


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

#2744 

In Firefox, using `@mention` in the `rich-text-editor` causes an error in the FAST element, breaking the page.

The root cause is the foundation's [`anchoredRegionTemplate` using a `when` directive](https://github.com/ni/fast/blob/b6d033d38166955c0544173346056475721504fe/packages/web-components/fast-foundation/src/anchored-region/anchored-region.template.ts#L14) to conditionally add/remove the `<slot>` from the shadow DOM based on `initialLayoutComplete`. When `initialLayoutComplete` transitions, `updateContentTarget` calls `view.remove()` on the view containing the `<slot>`. Removing the `<slot>` triggers a slotchange microtask (per the DOM spec). In Firefox, this microtask runs between iterations of FAST's `process()` loop, causing interleaved binding updates that call `view.remove()` a second time on the same view, crashing because the view's nodes have already been moved into the fragment.

Chrome processes these microtasks in a different order that avoids the double-remove.

## 👩‍💻 Implementation

<!---
Describe how the change addresses the problem. Consider factors such as complexity, alternative solutions, performance impact, etc. 

Consider listing files with important changes or comment on them directly in the pull request.
-->

Replaced the foundation's `anchoredRegionTemplate` (which uses a `when` directive) with a local nimble template that keeps the `<slot>` always present in the DOM:

- Always renders `<slot></slot>` without a `when` directive. The `loaded` class is still applied via the `initialLayoutComplete` binding on the host.
- Added slot display toggle styles to control visibility through CSS instead of DOM manipulation.
- Switched from importing `anchoredRegionTemplate` from `@ni/fast-foundation` to the local template.
- This eliminates the `updateContentTarget` / `view.remove()` cycle entirely. No DOM mutations on the `<slot>`, no slotchange events, no race condition.

## 🧪 Testing

<!---
Detail the testing done to ensure this submission meets requirements. 

Include automated/manual test additions or modifications, testing done on a local build, private CI run results, and additional testing not covered by automatic pull request validation. If any functionality is not covered by automated testing, provide justification.
-->

- Added tests for the newly updated anchored region template and style updates.
- Manually tested in the storybook, where no console error is thrown, and the app is not frozen. It is also related to the fix in the FAST library: https://github.com/ni/fast/pull/39

### Known Issue

When entering characters after entering `@` that do not match any user in the list, it shows the `No items found` option in the list for the first time. However, when reproducing the same behavior, it shows nothing when finding no options. This is again reproducible only in the Firefox browser.

![no-result-issue](https://github.com/user-attachments/assets/6fc55138-9dd5-49d0-8a5b-f7bed1757c9e)

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.