### PR TITLE
Update fast dependency to fix bug in Firefox

### DIFF
--- a/change/@ni-nimble-components-9fdd80b4-da0b-4489-a454-d16a1f4449b1.json
+++ b/change/@ni-nimble-components-9fdd80b4-da0b-4489-a454-d16a1f4449b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update fast dependency to fix view bug in Firefox",
+  "packageName": "@ni/nimble-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-ok-components-f49ced02-34a7-4fe2-b538-70cb8c8aaacd.json
+++ b/change/@ni-ok-components-f49ced02-34a7-4fe2-b538-70cb8c8aaacd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update fast dependency to fix view bug in Firefox",
+  "packageName": "@ni/ok-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-spright-components-02b5f67f-03aa-464f-a086-8f9ecbb6474c.json
+++ b/change/@ni-spright-components-02b5f67f-03aa-464f-a086-8f9ecbb6474c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update fast dependency to fix view bug in Firefox",
+  "packageName": "@ni/spright-components",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8075,18 +8075,18 @@
       "license": "MIT"
     },
     "node_modules/@ni/fast-element": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@ni/fast-element/-/fast-element-10.1.0.tgz",
-      "integrity": "sha512-gFqkNPOJFEGFo05V1mKbVw/3n1eU2b1hAVO3HNczdnqAderVlxW+kaEI5NLiH8pdyk3OFbyAjEfURpDWGlr5Pg==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@ni/fast-element/-/fast-element-10.1.1.tgz",
+      "integrity": "sha512-HsUjqkK54ktgZ3QmdPmUKhWeEcadWnwc0LYuwWxEkL7C7XYT4Q2KZE3OfF7GfthgmnYWwIRY5YZyxVGmMrYvIQ==",
       "license": "MIT"
     },
     "node_modules/@ni/fast-foundation": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/@ni/fast-foundation/-/fast-foundation-10.2.2.tgz",
-      "integrity": "sha512-+fd5fX+JaUegIVSuNri4VutdYLJrnnrcdomGqR4Y0ofkYgHLZEu4fayKfxn/kwRW2GLdYmmy/aqZXQY09JUB/w==",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/@ni/fast-foundation/-/fast-foundation-10.2.3.tgz",
+      "integrity": "sha512-5qQTVibDQ6dp3yTLPypjTr7VPSJRMqIpLLFFDZh0k1GpC6d1c1kOK7gYJ2ouflnhd2Y3bCJGZGHY3Q3xLAXdHA==",
       "license": "MIT",
       "dependencies": {
-        "@ni/fast-element": "^10.1.0",
+        "@ni/fast-element": "^10.1.1",
         "@ni/fast-web-utilities": "^10.0.4",
         "tabbable": "^6.2.0",
         "tslib": "^2.8.1"
@@ -8759,6 +8759,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
@@ -8801,6 +8802,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8822,6 +8824,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8843,6 +8846,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8864,6 +8868,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8885,6 +8890,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8906,6 +8912,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8927,6 +8934,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8948,6 +8956,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8969,6 +8978,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8990,6 +9000,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -9011,6 +9022,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -9032,6 +9044,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -9053,6 +9066,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -9067,7 +9081,8 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@parcel/watcher/node_modules/picomatch": {
       "version": "4.0.4",
@@ -9076,6 +9091,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16846,6 +16862,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "prr": "~1.0.1"
       },
@@ -20206,6 +20223,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "bin": {
         "image-size": "bin/image-size.js"
       },
@@ -22532,6 +22550,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -22546,6 +22565,7 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -27573,6 +27593,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.3",
         "sax": "^1.2.4"
@@ -27591,6 +27612,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -29765,7 +29787,8 @@
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -37497,8 +37520,8 @@
       "license": "MIT",
       "dependencies": {
         "@ni/fast-colors": "^10.0.0",
-        "@ni/fast-element": "^10.1.0",
-        "@ni/fast-foundation": "^10.2.2",
+        "@ni/fast-element": "^10.1.1",
+        "@ni/fast-foundation": "^10.2.3",
         "@ni/fast-web-utilities": "^10.0.0",
         "@ni/nimble-tokens": "^8.17.0",
         "@ni/unit-format": "^1.0.3",
@@ -37581,8 +37604,8 @@
       "version": "0.3.10",
       "license": "MIT",
       "dependencies": {
-        "@ni/fast-element": "^10.1.0",
-        "@ni/fast-foundation": "^10.2.2",
+        "@ni/fast-element": "^10.1.1",
+        "@ni/fast-foundation": "^10.2.3",
         "@ni/fast-web-utilities": "^10.0.0",
         "@ni/nimble-components": "^35.5.6",
         "@ni/spright-components": "^6.15.5",
@@ -37719,8 +37742,8 @@
       "version": "6.15.5",
       "license": "MIT",
       "dependencies": {
-        "@ni/fast-element": "^10.1.0",
-        "@ni/fast-foundation": "^10.2.2",
+        "@ni/fast-element": "^10.1.1",
+        "@ni/fast-foundation": "^10.2.3",
         "@ni/fast-web-utilities": "^10.0.0",
         "@ni/nimble-components": "^35.5.6",
         "@ni/nimble-tokens": "^8.17.0",
@@ -37760,8 +37783,8 @@
       "devDependencies": {
         "@chromatic-com/storybook": "^5.0.1",
         "@ni-private/eslint-config-nimble": "*",
-        "@ni/fast-element": "^10.1.0",
-        "@ni/fast-foundation": "^10.2.2",
+        "@ni/fast-element": "^10.1.1",
+        "@ni/fast-foundation": "^10.2.3",
         "@ni/fast-web-utilities": "^10.0.0",
         "@ni/nimble-components": "*",
         "@ni/nimble-react": "*",

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -46,8 +46,8 @@
   "customElements": "dist/custom-elements.json",
   "dependencies": {
     "@ni/fast-colors": "^10.0.0",
-    "@ni/fast-element": "^10.1.0",
-    "@ni/fast-foundation": "^10.2.2",
+    "@ni/fast-element": "^10.1.1",
+    "@ni/fast-foundation": "^10.2.3",
     "@ni/fast-web-utilities": "^10.0.0",
     "@ni/nimble-tokens": "^8.17.0",
     "@ni/unit-format": "^1.0.3",

--- a/packages/nimble-components/src/table/components/row/index.ts
+++ b/packages/nimble-components/src/table/components/row/index.ts
@@ -215,11 +215,6 @@ export class TableRow<
         column: TableColumn
     ): void {
         this.menuOpen = event.detail.newState;
-        // Workaround for Firefox issue when action menus opened on different rows
-        // See: https://github.com/ni/nimble/issues/2744
-        if (!event.detail.newState) {
-            this.currentActionMenuColumn = undefined;
-        }
         this.emitActionMenuToggleEvent(
             'row-action-menu-toggle',
             event.detail,

--- a/packages/ok-components/package.json
+++ b/packages/ok-components/package.json
@@ -39,8 +39,8 @@
   "homepage": "https://github.com/ni/nimble#readme",
   "customElements": "dist/custom-elements.json",
   "dependencies": {
-    "@ni/fast-element": "^10.1.0",
-    "@ni/fast-foundation": "^10.2.2",
+    "@ni/fast-element": "^10.1.1",
+    "@ni/fast-foundation": "^10.2.3",
     "@ni/fast-web-utilities": "^10.0.0",
     "@ni/nimble-components": "^35.5.6",
     "@ni/spright-components": "^6.15.5",

--- a/packages/spright-components/package.json
+++ b/packages/spright-components/package.json
@@ -39,8 +39,8 @@
   "homepage": "https://github.com/ni/nimble#readme",
   "customElements": "dist/custom-elements.json",
   "dependencies": {
-    "@ni/fast-element": "^10.1.0",
-    "@ni/fast-foundation": "^10.2.2",
+    "@ni/fast-element": "^10.1.1",
+    "@ni/fast-foundation": "^10.2.3",
     "@ni/fast-web-utilities": "^10.0.0",
     "@ni/nimble-components": "^35.5.6",
     "@ni/nimble-tokens": "^8.17.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -24,8 +24,8 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^5.0.1",
     "@ni-private/eslint-config-nimble": "*",
-    "@ni/fast-element": "^10.1.0",
-    "@ni/fast-foundation": "^10.2.2",
+    "@ni/fast-element": "^10.1.1",
+    "@ni/fast-foundation": "^10.2.3",
     "@ni/fast-web-utilities": "^10.0.0",
     "@ni/nimble-components": "*",
     "@ni/nimble-react": "*",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

This PR pulls in the fix from ni/fast: https://github.com/ni/fast/pull/40

Specifically, this resolves an issue in Firefox that we were seeing in nimble with the `nimble-table` and `nimble-rich-text-editor` where certain interactions (i.e. opening the context menu in the table and using at-mentions in the rich text editor) would leave the component/browser in a bad state. See #2744 

As part of this change, I also reverted a workaround that had previously been put into the table to avoid the issue opening and closing context menus.

## 👩‍💻 Implementation

- Update `@ni/fast-element` and `@ni/fast-foundation` in all packages within the repository
- Remove workaround from table

## 🧪 Testing

Manually tested the table and rich-text-editor in firefox

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
