### PR TITLE
Add docs for OK library project name prefix

### DIFF
--- a/change/@ni-ok-components-5ec6f238-fd6a-4b89-ad8f-c7c4da376564.json
+++ b/change/@ni-ok-components-5ec6f238-fd6a-4b89-ad8f-c7c4da376564.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update OK contributing docs for project name",
+  "packageName": "@ni/ok-components",
+  "email": "1588923+rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/ok-components/CONTRIBUTING.md
+++ b/packages/ok-components/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Code in Ok packages is owned the contributing team.
 
 The Design System team will maintain infrastructure like pipelines and dependency updates. However, if an Ok component results in excessive build times, complexity during dependency updates, test instability, or is a burden on the state of the monorepo the contributing team is expected to address issues. Failing to do so will lead to components having tests disabled, build removed, and ultimately deletion from the repository.
 
-Each set of contribution should have a short, usually 2-3 letters, project name prefix. The project name will be used to name folders to place source in each library and is used for tag / class names. Project names could be correlated to owning R&D team, project effort, or experimenting individual. For example, a project such as LabVIEW may put a collection of components under the project `lv` or personally owned components for John Doe may use a project prefix of `jd`. Reference the example project with project name `ex` in each OK library for an example of how to organize Ok contributions.
+Each set of contributions should have a short, usually 2-3 letters, project name prefix. The project name will be used to name folders to place source in each library and is used for tag / class names. Project names could be correlated to owning R&D team, project effort, or experimenting individual. For example, a project such as LabVIEW may put a collection of components under the project `lv` or personally owned components for John Doe may use a project prefix of `jd`. Reference the example project with project name `ex` in each OK library for an example of how to organize Ok contributions.
 
 ## Code quality
 

--- a/packages/ok-components/CONTRIBUTING.md
+++ b/packages/ok-components/CONTRIBUTING.md
@@ -8,6 +8,8 @@ Code in Ok packages is owned the contributing team.
 
 The Design System team will maintain infrastructure like pipelines and dependency updates. However, if an Ok component results in excessive build times, complexity during dependency updates, test instability, or is a burden on the state of the monorepo the contributing team is expected to address issues. Failing to do so will lead to components having tests disabled, build removed, and ultimately deletion from the repository.
 
+Each set of contribution should have a short, usually 2-3 letters, project name prefix. The project name will be used to name folders to place source in each library and is used for tag / class names. Project names could be correlated to owning R&D team, project effort, or experimenting individual. For example, a project such as LabVIEW may put a collection of components under the project `lv` or personally owned components for John Doe may use a project prefix of `jd`. Reference the example project with project name `ex` in each OK library for an example of how to organize Ok contributions.
+
 ## Code quality
 
 Code should adhere to NI and Nimble standards for quality and test coverage. The contributing team is ultimately responsible for aligning with those practices and is encouraged to reach out to Nimble developers with questions or for feedback.


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Adds documentation of OK library project name prefixes. Resolves #2935

## 👩‍💻 Implementation

Added docs to OK components Contributing.md

## 🧪 Testing

NA

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
