### PR TITLE
Add containerBackgroundColor token

### DIFF
--- a/change/@ni-nimble-components-6f2fd8a9-af5a-4834-8141-e1db3237aa7f.json
+++ b/change/@ni-nimble-components-6f2fd8a9-af5a-4834-8141-e1db3237aa7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "adding the containerBackgroundColor token",
+  "packageName": "@ni/nimble-components",
+  "email": "1458528+fredvisser@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/theme-provider/design-token-comments.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-comments.ts
@@ -6,6 +6,7 @@ export const comments: { readonly [key in TokenName]: string } = {
     actionRgbPartialColor:
         'DEPRECATED: *-partial tokens are used with rgba() to set color transparency in component stylesheets',
     applicationBackgroundColor: 'Primary background color for the application',
+    containerBackgroundColor: 'Background color for container surfaces layered above the application background',
     dividerBackgroundColor: 'Background color for static / non-movable dividers',
     dividerBackgroundDynamicColor: 'Background color for dynamic / movable dividers',
     headerBackgroundColor: 'Background color for application headers',

--- a/packages/nimble-components/src/theme-provider/design-token-comments.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-comments.ts
@@ -6,7 +6,7 @@ export const comments: { readonly [key in TokenName]: string } = {
     actionRgbPartialColor:
         'DEPRECATED: *-partial tokens are used with rgba() to set color transparency in component stylesheets',
     applicationBackgroundColor: 'Primary background color for the application',
-    containerBackgroundColor: 'Background color for container surfaces layered above the application background',
+    containerBackgroundColor: 'Background color for block-appearance component container surfaces, such as cards',
     dividerBackgroundColor: 'Background color for static / non-movable dividers',
     dividerBackgroundDynamicColor: 'Background color for dynamic / movable dividers',
     headerBackgroundColor: 'Background color for application headers',

--- a/packages/nimble-components/src/theme-provider/design-token-names.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-names.ts
@@ -10,6 +10,7 @@ type TokenName = keyof typeof TokensNamespace;
 export const tokenNames: { readonly [key in TokenName]: string } = {
     actionRgbPartialColor: 'action-rgb-partial-color',
     applicationBackgroundColor: 'application-background-color',
+    containerBackgroundColor: 'container-background-color',
     dividerBackgroundColor: 'divider-background-color',
     dividerBackgroundDynamicColor: 'divider-background-dynamic-color',
     headerBackgroundColor: 'header-background-color',

--- a/packages/nimble-components/src/theme-provider/design-token-values.ts
+++ b/packages/nimble-components/src/theme-provider/design-token-values.ts
@@ -170,6 +170,7 @@ const alias = {
 export const tokenValues = {
     actionRgbPartialColor: hexToRgbPartialThemeColor(createThemeColor(Black91, Black15, White)),
     applicationBackgroundColor: createThemeColor(White, Black85, ForestGreen),
+    containerBackgroundColor: hexToRgbaCssThemeColor(createThemeColor(Black91, Black15, White), 0.07, 0.1, 0.1),
     headerBackgroundColor: createThemeColor(Black7, Black88, ForestGreen),
     sectionBackgroundColor: createThemeColor(Black15, Black80, ForestGreen),
     sectionBackgroundImage: createThemeColor(

--- a/packages/nimble-components/src/theme-provider/design-tokens.ts
+++ b/packages/nimble-components/src/theme-provider/design-tokens.ts
@@ -7,6 +7,7 @@ import { tokenValues, type ThemeColor } from './design-token-values';
 // #region color tokens
 export const actionRgbPartialColor = createThemeColorToken(tokenNames.actionRgbPartialColor, tokenValues.actionRgbPartialColor);
 export const applicationBackgroundColor = createThemeColorToken(tokenNames.applicationBackgroundColor, tokenValues.applicationBackgroundColor);
+export const containerBackgroundColor = createThemeColorToken(tokenNames.containerBackgroundColor, tokenValues.containerBackgroundColor);
 export const headerBackgroundColor = createThemeColorToken(tokenNames.headerBackgroundColor, tokenValues.headerBackgroundColor);
 export const sectionBackgroundColor = createThemeColorToken(tokenNames.sectionBackgroundColor, tokenValues.sectionBackgroundColor);
 export const sectionBackgroundImage = createThemeColorToken(tokenNames.sectionBackgroundImage, tokenValues.sectionBackgroundImage);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Block appearance on the [container/card design](https://www.figma.com/design/PO9mFOu5BCl8aJvFchEeuN/Nimble_Components?node-id=5069-8503&m=dev) calls for a container background color that isn't currently represented by a token.

## 👩‍💻 Implementation

Pulled colors from the Figma design and mapped to our base tokens.

Used `container` naming vs `card` naming, preferring the affinity to the `applicationBackgroundColor` and `sectionBackgroundColor` vs calling it a `cardBackgroundColor` or `cardFillColor`.

Opinions welcome

## 🧪 Testing

Manual Storybook token review

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
