### PR TITLE
Mark all react components as 'use client'

### DIFF
--- a/change/@ni-nimble-react-89ce99f4-0fd5-42de-8eff-3a1ef4a7dfdf.json
+++ b/change/@ni-nimble-react-89ce99f4-0fd5-42de-8eff-3a1ef4a7dfdf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Mark all react components as 'use client'",
+  "packageName": "@ni/nimble-react",
+  "email": "1588923+rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-ok-react-2efa87ea-384e-4d32-993f-c6f2843e94d8.json
+++ b/change/@ni-ok-react-2efa87ea-384e-4d32-993f-c6f2843e94d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Mark all react components as 'use client'",
+  "packageName": "@ni/ok-react",
+  "email": "1588923+rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-spright-react-9a7b311f-550a-4d49-ba22-2fc2145b697a.json
+++ b/change/@ni-spright-react-9a7b311f-550a-4d49-ba22-2fc2145b697a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Mark all react components as 'use client'",
+  "packageName": "@ni/spright-react",
+  "email": "1588923+rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-workspace/nimble-react/build/generate-icons.mjs
+++ b/packages/react-workspace/nimble-react/build/generate-icons.mjs
@@ -39,7 +39,9 @@ for (const key of Object.keys(icons)) {
 
     fileCount += 1;
 
-    const iconReactWrapperContent = `${generatedFilePrefix}
+    const iconReactWrapperContent = `'use client';
+
+${generatedFilePrefix}
 import { ${className}, ${tagName} } from '@ni/nimble-components/dist/esm/icons/${fileName}';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/anchor-button/index.ts
+++ b/packages/react-workspace/nimble-react/src/anchor-button/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { AnchorButton, anchorButtonTag } from '@ni/nimble-components/dist/esm/anchor-button';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/anchor-menu-item/index.ts
+++ b/packages/react-workspace/nimble-react/src/anchor-menu-item/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { AnchorMenuItem, anchorMenuItemTag } from '@ni/nimble-components/dist/esm/anchor-menu-item';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/anchor-step/index.ts
+++ b/packages/react-workspace/nimble-react/src/anchor-step/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { AnchorStep, anchorStepTag } from '@ni/nimble-components/dist/esm/anchor-step';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/anchor-tab/index.ts
+++ b/packages/react-workspace/nimble-react/src/anchor-tab/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { AnchorTab, anchorTabTag } from '@ni/nimble-components/dist/esm/anchor-tab';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/anchor-tabs/index.ts
+++ b/packages/react-workspace/nimble-react/src/anchor-tabs/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { AnchorTabs, anchorTabsTag } from '@ni/nimble-components/dist/esm/anchor-tabs';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/anchor-tree-item/index.ts
+++ b/packages/react-workspace/nimble-react/src/anchor-tree-item/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { AnchorTreeItem, anchorTreeItemTag } from '@ni/nimble-components/dist/esm/anchor-tree-item';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/anchor/index.ts
+++ b/packages/react-workspace/nimble-react/src/anchor/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Anchor, anchorTag } from '@ni/nimble-components/dist/esm/anchor';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/anchored-region/index.ts
+++ b/packages/react-workspace/nimble-react/src/anchored-region/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { AnchoredRegion, anchoredRegionTag } from '@ni/nimble-components/dist/esm/anchored-region';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/banner/index.ts
+++ b/packages/react-workspace/nimble-react/src/banner/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Banner, bannerTag } from '@ni/nimble-components/dist/esm/banner';
 import type { BannerToggleEventDetail } from '@ni/nimble-components/dist/esm/banner/types';
 import { wrap, type EventName } from '../utilities/react-wrapper';

--- a/packages/react-workspace/nimble-react/src/breadcrumb-item/index.ts
+++ b/packages/react-workspace/nimble-react/src/breadcrumb-item/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { BreadcrumbItem, breadcrumbItemTag } from '@ni/nimble-components/dist/esm/breadcrumb-item';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/breadcrumb/index.ts
+++ b/packages/react-workspace/nimble-react/src/breadcrumb/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Breadcrumb, breadcrumbTag } from '@ni/nimble-components/dist/esm/breadcrumb';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/button/index.ts
+++ b/packages/react-workspace/nimble-react/src/button/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Button, buttonTag } from '@ni/nimble-components/dist/esm/button';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/card-button/index.ts
+++ b/packages/react-workspace/nimble-react/src/card-button/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { CardButton, cardButtonTag } from '@ni/nimble-components/dist/esm/card-button';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/card/index.ts
+++ b/packages/react-workspace/nimble-react/src/card/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Card, cardTag } from '@ni/nimble-components/dist/esm/card';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/checkbox/index.ts
+++ b/packages/react-workspace/nimble-react/src/checkbox/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Checkbox, checkboxTag } from '@ni/nimble-components/dist/esm/checkbox';
 import { wrap, type EventName } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/chip/index.ts
+++ b/packages/react-workspace/nimble-react/src/chip/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Chip, chipTag } from '@ni/nimble-components/dist/esm/chip';
 import { wrap, type EventName } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/combobox/index.ts
+++ b/packages/react-workspace/nimble-react/src/combobox/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Combobox, comboboxTag } from '@ni/nimble-components/dist/esm/combobox';
 import { wrap, type EventName } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/dialog/index.ts
+++ b/packages/react-workspace/nimble-react/src/dialog/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Dialog, UserDismissed as DialogUserDismissed, dialogTag } from '@ni/nimble-components/dist/esm/dialog';
 import type { RefAttributes, RefObject } from 'react';
 import { wrap } from '../utilities/react-wrapper';

--- a/packages/react-workspace/nimble-react/src/drawer/index.ts
+++ b/packages/react-workspace/nimble-react/src/drawer/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Drawer, UserDismissed as DrawerUserDismissed, drawerTag } from '@ni/nimble-components/dist/esm/drawer';
 import { DrawerLocation } from '@ni/nimble-components/dist/esm/drawer/types';
 import type { RefAttributes, RefObject } from 'react';

--- a/packages/react-workspace/nimble-react/src/label-provider/core/index.ts
+++ b/packages/react-workspace/nimble-react/src/label-provider/core/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { LabelProviderCore, labelProviderCoreTag } from '@ni/nimble-components/dist/esm/label-provider/core';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/label-provider/rich-text/index.ts
+++ b/packages/react-workspace/nimble-react/src/label-provider/rich-text/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { LabelProviderRichText, labelProviderRichTextTag } from '@ni/nimble-components/dist/esm/label-provider/rich-text';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/label-provider/table/index.ts
+++ b/packages/react-workspace/nimble-react/src/label-provider/table/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { LabelProviderTable, labelProviderTableTag } from '@ni/nimble-components/dist/esm/label-provider/table';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/list-option-group/index.ts
+++ b/packages/react-workspace/nimble-react/src/list-option-group/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { ListOptionGroup, listOptionGroupTag } from '@ni/nimble-components/dist/esm/list-option-group';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/list-option/index.ts
+++ b/packages/react-workspace/nimble-react/src/list-option/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { ListOption, listOptionTag } from '@ni/nimble-components/dist/esm/list-option';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/mapping/empty/index.ts
+++ b/packages/react-workspace/nimble-react/src/mapping/empty/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { MappingEmpty, mappingEmptyTag } from '@ni/nimble-components/dist/esm/mapping/empty';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/mapping/icon/index.ts
+++ b/packages/react-workspace/nimble-react/src/mapping/icon/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { MappingIcon, mappingIconTag } from '@ni/nimble-components/dist/esm/mapping/icon';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/mapping/spinner/index.ts
+++ b/packages/react-workspace/nimble-react/src/mapping/spinner/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { MappingSpinner, mappingSpinnerTag } from '@ni/nimble-components/dist/esm/mapping/spinner';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/mapping/text/index.ts
+++ b/packages/react-workspace/nimble-react/src/mapping/text/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { MappingText, mappingTextTag } from '@ni/nimble-components/dist/esm/mapping/text';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/mapping/user/index.ts
+++ b/packages/react-workspace/nimble-react/src/mapping/user/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { MappingUser, mappingUserTag } from '@ni/nimble-components/dist/esm/mapping/user';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/menu-button/index.ts
+++ b/packages/react-workspace/nimble-react/src/menu-button/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { MenuButton, menuButtonTag } from '@ni/nimble-components/dist/esm/menu-button';
 import type { MenuButtonToggleEventDetail } from '@ni/nimble-components/dist/esm/menu-button/types';
 import { wrap, type EventName } from '../utilities/react-wrapper';

--- a/packages/react-workspace/nimble-react/src/menu-item/index.ts
+++ b/packages/react-workspace/nimble-react/src/menu-item/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { MenuItem, menuItemTag } from '@ni/nimble-components/dist/esm/menu-item';
 import { wrap, type EventName } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/menu/index.ts
+++ b/packages/react-workspace/nimble-react/src/menu/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Menu, menuTag } from '@ni/nimble-components/dist/esm/menu';
 import { wrap, type EventName } from '../utilities/react-wrapper';
 import type { MenuItemChangeEvent } from '../menu-item';

--- a/packages/react-workspace/nimble-react/src/number-field/index.ts
+++ b/packages/react-workspace/nimble-react/src/number-field/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { NumberField, numberFieldTag } from '@ni/nimble-components/dist/esm/number-field';
 import { wrap, type EventName } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/radio-group/index.ts
+++ b/packages/react-workspace/nimble-react/src/radio-group/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { RadioGroup, radioGroupTag } from '@ni/nimble-components/dist/esm/radio-group';
 import { wrap, type EventName } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/radio/index.ts
+++ b/packages/react-workspace/nimble-react/src/radio/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Radio, radioTag } from '@ni/nimble-components/dist/esm/radio';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/rich-text-mention/users/index.ts
+++ b/packages/react-workspace/nimble-react/src/rich-text-mention/users/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { RichTextMentionUsers, richTextMentionUsersTag } from '@ni/nimble-components/dist/esm/rich-text-mention/users';
 import type { MentionUpdateEventDetail } from '@ni/nimble-components/dist/esm/rich-text-mention/base/types';
 import { wrap, type EventName } from '../../utilities/react-wrapper';

--- a/packages/react-workspace/nimble-react/src/rich-text/editor/index.ts
+++ b/packages/react-workspace/nimble-react/src/rich-text/editor/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { RichTextEditor, richTextEditorTag } from '@ni/nimble-components/dist/esm/rich-text/editor';
 import { wrap, type EventName } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/rich-text/viewer/index.ts
+++ b/packages/react-workspace/nimble-react/src/rich-text/viewer/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { RichTextViewer, richTextViewerTag } from '@ni/nimble-components/dist/esm/rich-text/viewer';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/select/index.ts
+++ b/packages/react-workspace/nimble-react/src/select/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Select, selectTag } from '@ni/nimble-components/dist/esm/select';
 import type { SelectFilterInputEventDetail } from '@ni/nimble-components/dist/esm/select/types';
 import { wrap, type EventName } from '../utilities/react-wrapper';

--- a/packages/react-workspace/nimble-react/src/spinner/index.ts
+++ b/packages/react-workspace/nimble-react/src/spinner/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Spinner, spinnerTag } from '@ni/nimble-components/dist/esm/spinner';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/step/index.ts
+++ b/packages/react-workspace/nimble-react/src/step/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Step, stepTag } from '@ni/nimble-components/dist/esm/step';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/stepper/index.ts
+++ b/packages/react-workspace/nimble-react/src/stepper/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Stepper, stepperTag } from '@ni/nimble-components/dist/esm/stepper';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/switch/index.ts
+++ b/packages/react-workspace/nimble-react/src/switch/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Switch, switchTag } from '@ni/nimble-components/dist/esm/switch';
 import { wrap, type EventName } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/tab-panel/index.ts
+++ b/packages/react-workspace/nimble-react/src/tab-panel/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { TabPanel, tabPanelTag } from '@ni/nimble-components/dist/esm/tab-panel';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/tab/index.ts
+++ b/packages/react-workspace/nimble-react/src/tab/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Tab, tabTag } from '@ni/nimble-components/dist/esm/tab';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/table-column/anchor/index.ts
+++ b/packages/react-workspace/nimble-react/src/table-column/anchor/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { TableColumnAnchor, tableColumnAnchorTag } from '@ni/nimble-components/dist/esm/table-column/anchor';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/table-column/date-text/index.ts
+++ b/packages/react-workspace/nimble-react/src/table-column/date-text/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { TableColumnDateText, tableColumnDateTextTag } from '@ni/nimble-components/dist/esm/table-column/date-text';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/table-column/duration-text/index.ts
+++ b/packages/react-workspace/nimble-react/src/table-column/duration-text/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { TableColumnDurationText, tableColumnDurationTextTag } from '@ni/nimble-components/dist/esm/table-column/duration-text';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/table-column/mapping/index.ts
+++ b/packages/react-workspace/nimble-react/src/table-column/mapping/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { TableColumnMapping, tableColumnMappingTag } from '@ni/nimble-components/dist/esm/table-column/mapping';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/table-column/menu-button/index.ts
+++ b/packages/react-workspace/nimble-react/src/table-column/menu-button/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { TableColumnMenuButton, tableColumnMenuButtonTag } from '@ni/nimble-components/dist/esm/table-column/menu-button';
 import type { MenuButtonColumnToggleEventDetail } from '@ni/nimble-components/dist/esm/table-column/menu-button/types';
 import { wrap, type EventName } from '../../utilities/react-wrapper';

--- a/packages/react-workspace/nimble-react/src/table-column/number-text/index.ts
+++ b/packages/react-workspace/nimble-react/src/table-column/number-text/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { TableColumnNumberText, tableColumnNumberTextTag } from '@ni/nimble-components/dist/esm/table-column/number-text';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/table-column/text/index.ts
+++ b/packages/react-workspace/nimble-react/src/table-column/text/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { TableColumnText, tableColumnTextTag } from '@ni/nimble-components/dist/esm/table-column/text';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/table/index.ts
+++ b/packages/react-workspace/nimble-react/src/table/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Table, tableTag } from '@ni/nimble-components/dist/esm/table';
 import type {
     TableActionMenuToggleEventDetail,

--- a/packages/react-workspace/nimble-react/src/tabs-toolbar/index.ts
+++ b/packages/react-workspace/nimble-react/src/tabs-toolbar/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { TabsToolbar, tabsToolbarTag } from '@ni/nimble-components/dist/esm/tabs-toolbar';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/tabs/index.ts
+++ b/packages/react-workspace/nimble-react/src/tabs/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Tabs, tabsTag } from '@ni/nimble-components/dist/esm/tabs';
 import { wrap, type EventName } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/text-area/index.ts
+++ b/packages/react-workspace/nimble-react/src/text-area/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { TextArea, textAreaTag } from '@ni/nimble-components/dist/esm/text-area';
 import { wrap, type EventName } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/text-field/index.ts
+++ b/packages/react-workspace/nimble-react/src/text-field/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { TextField, textFieldTag } from '@ni/nimble-components/dist/esm/text-field';
 import { wrap, type EventName } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/theme-provider/index.ts
+++ b/packages/react-workspace/nimble-react/src/theme-provider/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { ThemeProvider, themeProviderTag } from '@ni/nimble-components/dist/esm/theme-provider';
 import { Theme } from '@ni/nimble-components/dist/esm/theme-provider/types';
 import { wrap } from '../utilities/react-wrapper';

--- a/packages/react-workspace/nimble-react/src/toggle-button/index.ts
+++ b/packages/react-workspace/nimble-react/src/toggle-button/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { ToggleButton, toggleButtonTag } from '@ni/nimble-components/dist/esm/toggle-button';
 import { wrap, type EventName } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/toolbar/index.ts
+++ b/packages/react-workspace/nimble-react/src/toolbar/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Toolbar, toolbarTag } from '@ni/nimble-components/dist/esm/toolbar';
 import { wrap } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/tooltip/index.ts
+++ b/packages/react-workspace/nimble-react/src/tooltip/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Tooltip, tooltipTag } from '@ni/nimble-components/dist/esm/tooltip';
 import { wrap, type EventName } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/tree-item/index.ts
+++ b/packages/react-workspace/nimble-react/src/tree-item/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { TreeItem, treeItemTag } from '@ni/nimble-components/dist/esm/tree-item';
 import { wrap, type EventName } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/nimble-react/src/tree-view/index.ts
+++ b/packages/react-workspace/nimble-react/src/tree-view/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { TreeView, treeViewTag } from '@ni/nimble-components/dist/esm/tree-view';
 import { wrap, type EventName } from '../utilities/react-wrapper';
 import type { TreeItemExpandedChangeEvent, TreeItemSelectedChangeEvent } from '../tree-item';

--- a/packages/react-workspace/nimble-react/src/wafer-map/index.ts
+++ b/packages/react-workspace/nimble-react/src/wafer-map/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { WaferMap, waferMapTag } from '@ni/nimble-components/dist/esm/wafer-map';
 import { wrap, type EventName } from '../utilities/react-wrapper';
 

--- a/packages/react-workspace/ok-react/src/ex/button/index.ts
+++ b/packages/react-workspace/ok-react/src/ex/button/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { ExButton } from '@ni/ok-components/dist/esm/ex/button';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/ok-react/src/fv/accordion-item/index.ts
+++ b/packages/react-workspace/ok-react/src/fv/accordion-item/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { FvAccordionItem, fvAccordionItemTag } from '@ni/ok-components/dist/esm/fv/accordion-item';
 import { FvAccordionItemAppearance } from '@ni/ok-components/dist/esm/fv/accordion-item/types';
 import { wrap } from '../../utilities/react-wrapper';

--- a/packages/react-workspace/spright-react/src/chat/conversation/index.ts
+++ b/packages/react-workspace/spright-react/src/chat/conversation/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { ChatConversation } from '@ni/spright-components/dist/esm/chat/conversation';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/spright-react/src/chat/input/index.ts
+++ b/packages/react-workspace/spright-react/src/chat/input/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { ChatInput } from '@ni/spright-components/dist/esm/chat/input';
 import type { ChatInputSendEventDetail } from '@ni/spright-components/dist/esm/chat/input/types';
 import { wrap, type EventName } from '../../utilities/react-wrapper';

--- a/packages/react-workspace/spright-react/src/chat/message/inbound/index.ts
+++ b/packages/react-workspace/spright-react/src/chat/message/inbound/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { ChatMessageInbound } from '@ni/spright-components/dist/esm/chat/message/inbound';
 import { wrap } from '../../../utilities/react-wrapper';
 

--- a/packages/react-workspace/spright-react/src/chat/message/index.ts
+++ b/packages/react-workspace/spright-react/src/chat/message/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { ChatMessage } from '@ni/spright-components/dist/esm/chat/message';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/spright-react/src/chat/message/outbound/index.ts
+++ b/packages/react-workspace/spright-react/src/chat/message/outbound/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { ChatMessageOutbound } from '@ni/spright-components/dist/esm/chat/message/outbound';
 import { wrap } from '../../../utilities/react-wrapper';
 

--- a/packages/react-workspace/spright-react/src/chat/message/system/index.ts
+++ b/packages/react-workspace/spright-react/src/chat/message/system/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { ChatMessageSystem } from '@ni/spright-components/dist/esm/chat/message/system';
 import { wrap } from '../../../utilities/react-wrapper';
 

--- a/packages/react-workspace/spright-react/src/chat/message/welcome/index.ts
+++ b/packages/react-workspace/spright-react/src/chat/message/welcome/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { ChatMessageWelcome } from '@ni/spright-components/dist/esm/chat/message/welcome';
 import { wrap } from '../../../utilities/react-wrapper';
 

--- a/packages/react-workspace/spright-react/src/icons/nigel-chat/index.ts
+++ b/packages/react-workspace/spright-react/src/icons/nigel-chat/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { IconNigelChat, iconNigelChatTag } from '@ni/spright-components/dist/esm/icons/nigel-chat';
 import { wrap } from '../../utilities/react-wrapper';
 

--- a/packages/react-workspace/spright-react/src/rectangle/index.ts
+++ b/packages/react-workspace/spright-react/src/rectangle/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Rectangle } from '@ni/spright-components/dist/esm/rectangle';
 import { wrap } from '../utilities/react-wrapper';
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Nimble components rely on running client side so mark all the Nimble / Spright / Ok components with [`'use client';`](https://react.dev/reference/rsc/use-client)

## 👩‍💻 Implementation

- Update each file and the icon build script to be marked as `use client`

## 🧪 Testing

- Rely on CI to avoid regressions
- Manual testing from React Server Components (RSC) and Next.JS users

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
