### PR TITLE
Update chat welcome icon with designer feedback

### DIFF
--- a/change/@ni-spright-components-92d0e2e0-8c82-478e-915f-8909e0f54a1e.json
+++ b/change/@ni-spright-components-92d0e2e0-8c82-478e-915f-8909e0f54a1e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update chat welcome icon with designer feedback",
+  "packageName": "@ni/spright-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/spright-components/src/icons/nigel-chat/icon-data.ts
+++ b/packages/spright-components/src/icons/nigel-chat/icon-data.ts
@@ -1,3 +1,6 @@
+// Visual Design is iterating on this icon for NI Connect 2026; it's likely we will get different
+// icons for dark and light mode in future but for now they like the dark icon even on light background.
+// Both exports use the same visual but with unique IDs to avoid collisions when both are in the DOM.
 export const nigelChatLightData = `<?xml version="1.0" encoding="UTF-8"?>
 <svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 16 16">
   <defs>
@@ -11,10 +14,10 @@ export const nigelChatLightData = `<?xml version="1.0" encoding="UTF-8"?>
       }
     </style>
     <linearGradient id="nigel-chat-gradient-light-1" x1="11.84" y1="6.19" x2="4.84" y2="13.18" gradientTransform="translate(0 18) scale(1 -1)" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#023325"/>
-      <stop offset="1" stop-color="#004f38"/>
+      <stop offset="0" stop-color="#00ad7c"/>
+      <stop offset="1" stop-color="#32eb96"/>
     </linearGradient>
-    <linearGradient id="nigel-chat-gradient-light-0" x1="10.25" y1="-146.82" x2="6.95" y2="-150.11" gradientTransform="translate(0 156)" xlink:href="#nigel-chat-gradient-light-1"/>
+    <linearGradient id="nigel-chat-gradient-light-0" x1="10.25" y1="-658.82" x2="6.95" y2="-662.11" gradientTransform="translate(0 668)" xlink:href="#nigel-chat-gradient-light-1"/>
   </defs>
   <path class="nigel-chat-light-1" d="M14.21,7.52l-.11-.06c-2.36-1.29-4.3-3.23-5.59-5.59l-.06-.11c-.19-.36-.7-.36-.9,0l-.06.11c-1.29,2.36-3.23,4.3-5.59,5.59l-.11.06c-.36.19-.36.7,0,.9l.11.06c2.36,1.29,4.3,3.23,5.59,5.59l.06.11c.19.36.7.36.9,0l.06-.11c1.29-2.36,3.23-4.3,5.59-5.59l.11-.06c.36-.19.36-.7,0-.9ZM12.5,7.88l-.08.04c-1.58.87-2.89,2.17-3.75,3.75l-.04.08c-.13.24-.47.24-.6,0l-.04-.08c-.87-1.58-2.17-2.89-3.75-3.75l-.08-.04c-.24-.13-.24-.47,0-.6l.08-.04c1.58-.87,2.89-2.17,3.75-3.75l.04-.08c.13-.24.47-.24.6,0l.04.08c.87,1.58,2.17,2.89,3.75,3.75l.08.04c.24.13.24.47,0,.6Z"/>
   <path class="nigel-chat-light-0" d="M11.36,7.6l-.03.02c-1.12.61-2.04,1.53-2.65,2.65l-.02.03c-.1.18-.35.18-.45,0l-.02-.03c-.61-1.12-1.53-2.04-2.65-2.65l-.03-.02c-.18-.1-.18-.35,0-.45l.03-.02c1.12-.61,2.04-1.53,2.65-2.65l.02-.03c.1-.18.35-.18.45,0l.02.03c.61,1.12,1.53,2.04,2.65,2.65l.03.02c.18.1.18.35,0,.45Z"/>

--- a/packages/spright-components/src/icons/nigel-chat/template.ts
+++ b/packages/spright-components/src/icons/nigel-chat/template.ts
@@ -1,10 +1,8 @@
 import { html } from '@ni/fast-element';
 import type { IconNigelChat } from '.';
-import { nigelChatDarkData } from './icon-data';
+import { nigelChatLightData, nigelChatDarkData } from './icon-data';
 
-// Visual Design is iterating on this icon for NI Connect 2026; it's likely we will get different
-// icons for dark and light mode in future but for now they like the dark icon even on light background
 export const template = html<IconNigelChat>`
-    <div class="icon light-icon" aria-hidden="true" :innerHTML="${() => nigelChatDarkData}"></div>
+    <div class="icon light-icon" aria-hidden="true" :innerHTML="${() => nigelChatLightData}"></div>
     <div class="icon dark-icon" aria-hidden="true" :innerHTML="${() => nigelChatDarkData}"></div>
 `;

--- a/packages/spright-components/src/icons/nigel-chat/template.ts
+++ b/packages/spright-components/src/icons/nigel-chat/template.ts
@@ -1,8 +1,10 @@
 import { html } from '@ni/fast-element';
 import type { IconNigelChat } from '.';
-import { nigelChatLightData, nigelChatDarkData } from './icon-data';
+import { nigelChatDarkData } from './icon-data';
 
+// Visual Design is iterating on this icon for NI Connect 2026; it's likely we will get different
+// icons for dark and light mode in future but for now they like the dark icon even on light background
 export const template = html<IconNigelChat>`
-    <div class="icon light-icon" aria-hidden="true" :innerHTML="${() => nigelChatLightData}"></div>
+    <div class="icon light-icon" aria-hidden="true" :innerHTML="${() => nigelChatDarkData}"></div>
     <div class="icon dark-icon" aria-hidden="true" :innerHTML="${() => nigelChatDarkData}"></div>
 `;


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

I showed the results of #2949 to designers and they said there's a new decision to use the dark mode icon in both dark and light mode.

## 👩‍💻 Implementation

Use the dark mode icon in both dark and light mode. I'm keeping the infrastructure to switch icons because I suspect there will be more iteration on this decision.

## 🧪 Testing

Storybook inspection

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
