### PR TITLE
Pinned dep update: Apache.Arrow NuGet to 23.0.0

### DIFF
--- a/change/@ni-nimble-blazor-964ae161-5a44-4c0c-990b-5cb96cb8f686.json
+++ b/change/@ni-nimble-blazor-964ae161-5a44-4c0c-990b-5cb96cb8f686.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update Apache.Arrow NuGet to latest (23.0.0)",
+  "packageName": "@ni/nimble-blazor",
+  "email": "20709258+msmithNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-blazor-964ae161-5a44-4c0c-990b-5cb96cb8f686.json
+++ b/change/@ni-nimble-blazor-964ae161-5a44-4c0c-990b-5cb96cb8f686.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Update Apache.Arrow NuGet to latest (23.0.0)",
+  "comment": "Deps update (Apache.Arrow NuGet to latest/23.0.0)",
   "packageName": "@ni/nimble-blazor",
   "email": "20709258+msmithNI@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/blazor-workspace/Examples/Demo.Client/packages.lock.json
+++ b/packages/blazor-workspace/Examples/Demo.Client/packages.lock.json
@@ -61,8 +61,16 @@
       },
       "Apache.Arrow": {
         "type": "Transitive",
-        "resolved": "22.1.0",
-        "contentHash": "mTdHWGsNCWpKyQxqyNcSS+q4BtBTSOUfhdG+Lwo6eAOznCLSwrZQ5VKtDG2G8VrUp1ul4DwWHefoBS1umjO/VQ=="
+        "resolved": "23.0.0",
+        "contentHash": "cU4Zm7byFwnb82Ea9ZRvVnq2nJNf/TF9j+rj/MHlvu9RBYMqYtu4sJaR1JmMh3MmSIuwMafVg7PfJxPAMv9dGw==",
+        "dependencies": {
+          "Apache.Arrow.Scalars": "23.0.0"
+        }
+      },
+      "Apache.Arrow.Scalars": {
+        "type": "Transitive",
+        "resolved": "23.0.0",
+        "contentHash": "i53VmQ505ASXsStf7y29Z5qvhN6PGgFGNb6UUU7z1WmbzEgSjKQuIJkKKVbh+K5rtXRiKyr1Ah3Rmvbeb2BEHQ=="
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -361,7 +369,7 @@
       "nimbleblazor": {
         "type": "Project",
         "dependencies": {
-          "Apache.Arrow": "[22.1.0, 22.1.0]",
+          "Apache.Arrow": "[23.0.0, 23.0.0]",
           "Microsoft.AspNetCore.Components.Web": "[8.0.26, )"
         }
       },

--- a/packages/blazor-workspace/Examples/Demo.Hybrid/packages.lock.json
+++ b/packages/blazor-workspace/Examples/Demo.Hybrid/packages.lock.json
@@ -54,8 +54,16 @@
       },
       "Apache.Arrow": {
         "type": "Transitive",
-        "resolved": "22.1.0",
-        "contentHash": "mTdHWGsNCWpKyQxqyNcSS+q4BtBTSOUfhdG+Lwo6eAOznCLSwrZQ5VKtDG2G8VrUp1ul4DwWHefoBS1umjO/VQ=="
+        "resolved": "23.0.0",
+        "contentHash": "cU4Zm7byFwnb82Ea9ZRvVnq2nJNf/TF9j+rj/MHlvu9RBYMqYtu4sJaR1JmMh3MmSIuwMafVg7PfJxPAMv9dGw==",
+        "dependencies": {
+          "Apache.Arrow.Scalars": "23.0.0"
+        }
+      },
+      "Apache.Arrow.Scalars": {
+        "type": "Transitive",
+        "resolved": "23.0.0",
+        "contentHash": "i53VmQ505ASXsStf7y29Z5qvhN6PGgFGNb6UUU7z1WmbzEgSjKQuIJkKKVbh+K5rtXRiKyr1Ah3Rmvbeb2BEHQ=="
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -368,7 +376,7 @@
       "nimbleblazor": {
         "type": "Project",
         "dependencies": {
-          "Apache.Arrow": "[22.1.0, 22.1.0]",
+          "Apache.Arrow": "[23.0.0, 23.0.0]",
           "Microsoft.AspNetCore.Components.Web": "[8.0.26, )"
         }
       },

--- a/packages/blazor-workspace/Examples/Demo.Server/packages.lock.json
+++ b/packages/blazor-workspace/Examples/Demo.Server/packages.lock.json
@@ -30,8 +30,16 @@
       },
       "Apache.Arrow": {
         "type": "Transitive",
-        "resolved": "22.1.0",
-        "contentHash": "mTdHWGsNCWpKyQxqyNcSS+q4BtBTSOUfhdG+Lwo6eAOznCLSwrZQ5VKtDG2G8VrUp1ul4DwWHefoBS1umjO/VQ=="
+        "resolved": "23.0.0",
+        "contentHash": "cU4Zm7byFwnb82Ea9ZRvVnq2nJNf/TF9j+rj/MHlvu9RBYMqYtu4sJaR1JmMh3MmSIuwMafVg7PfJxPAMv9dGw==",
+        "dependencies": {
+          "Apache.Arrow.Scalars": "23.0.0"
+        }
+      },
+      "Apache.Arrow.Scalars": {
+        "type": "Transitive",
+        "resolved": "23.0.0",
+        "contentHash": "i53VmQ505ASXsStf7y29Z5qvhN6PGgFGNb6UUU7z1WmbzEgSjKQuIJkKKVbh+K5rtXRiKyr1Ah3Rmvbeb2BEHQ=="
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -273,7 +281,7 @@
       "nimbleblazor": {
         "type": "Project",
         "dependencies": {
-          "Apache.Arrow": "[22.1.0, 22.1.0]",
+          "Apache.Arrow": "[23.0.0, 23.0.0]",
           "Microsoft.AspNetCore.Components.Web": "[8.0.26, )"
         }
       },

--- a/packages/blazor-workspace/Examples/Demo.Shared/packages.lock.json
+++ b/packages/blazor-workspace/Examples/Demo.Shared/packages.lock.json
@@ -44,8 +44,16 @@
       },
       "Apache.Arrow": {
         "type": "Transitive",
-        "resolved": "22.1.0",
-        "contentHash": "mTdHWGsNCWpKyQxqyNcSS+q4BtBTSOUfhdG+Lwo6eAOznCLSwrZQ5VKtDG2G8VrUp1ul4DwWHefoBS1umjO/VQ=="
+        "resolved": "23.0.0",
+        "contentHash": "cU4Zm7byFwnb82Ea9ZRvVnq2nJNf/TF9j+rj/MHlvu9RBYMqYtu4sJaR1JmMh3MmSIuwMafVg7PfJxPAMv9dGw==",
+        "dependencies": {
+          "Apache.Arrow.Scalars": "23.0.0"
+        }
+      },
+      "Apache.Arrow.Scalars": {
+        "type": "Transitive",
+        "resolved": "23.0.0",
+        "contentHash": "i53VmQ505ASXsStf7y29Z5qvhN6PGgFGNb6UUU7z1WmbzEgSjKQuIJkKKVbh+K5rtXRiKyr1Ah3Rmvbeb2BEHQ=="
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -263,7 +271,7 @@
       "nimbleblazor": {
         "type": "Project",
         "dependencies": {
-          "Apache.Arrow": "[22.1.0, 22.1.0]",
+          "Apache.Arrow": "[23.0.0, 23.0.0]",
           "Microsoft.AspNetCore.Components.Web": "[8.0.26, )"
         }
       },

--- a/packages/blazor-workspace/NimbleBlazor/NimbleBlazor.csproj
+++ b/packages/blazor-workspace/NimbleBlazor/NimbleBlazor.csproj
@@ -54,7 +54,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Apache.Arrow" Version="[22.1.0]" />
+    <PackageReference Include="Apache.Arrow" Version="[23.0.0]" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.26" />
     <PackageReference Include="NI.CSharp.Analyzers" Version="2.0.35" PrivateAssets="all" />
   </ItemGroup>

--- a/packages/blazor-workspace/NimbleBlazor/packages.lock.json
+++ b/packages/blazor-workspace/NimbleBlazor/packages.lock.json
@@ -4,9 +4,12 @@
     "net8.0": {
       "Apache.Arrow": {
         "type": "Direct",
-        "requested": "[22.1.0, 22.1.0]",
-        "resolved": "22.1.0",
-        "contentHash": "mTdHWGsNCWpKyQxqyNcSS+q4BtBTSOUfhdG+Lwo6eAOznCLSwrZQ5VKtDG2G8VrUp1ul4DwWHefoBS1umjO/VQ=="
+        "requested": "[23.0.0, 23.0.0]",
+        "resolved": "23.0.0",
+        "contentHash": "cU4Zm7byFwnb82Ea9ZRvVnq2nJNf/TF9j+rj/MHlvu9RBYMqYtu4sJaR1JmMh3MmSIuwMafVg7PfJxPAMv9dGw==",
+        "dependencies": {
+          "Apache.Arrow.Scalars": "23.0.0"
+        }
       },
       "Microsoft.AspNetCore.Components.Web": {
         "type": "Direct",
@@ -35,6 +38,11 @@
           "Roslynator.Analyzers": "4.1.1",
           "StyleCop.Analyzers": "1.2.0-beta.556"
         }
+      },
+      "Apache.Arrow.Scalars": {
+        "type": "Transitive",
+        "resolved": "23.0.0",
+        "contentHash": "i53VmQ505ASXsStf7y29Z5qvhN6PGgFGNb6UUU7z1WmbzEgSjKQuIJkKKVbh+K5rtXRiKyr1Ah3Rmvbeb2BEHQ=="
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",

--- a/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Acceptance/packages.lock.json
+++ b/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Acceptance/packages.lock.json
@@ -101,8 +101,16 @@
       },
       "Apache.Arrow": {
         "type": "Transitive",
-        "resolved": "22.1.0",
-        "contentHash": "mTdHWGsNCWpKyQxqyNcSS+q4BtBTSOUfhdG+Lwo6eAOznCLSwrZQ5VKtDG2G8VrUp1ul4DwWHefoBS1umjO/VQ=="
+        "resolved": "23.0.0",
+        "contentHash": "cU4Zm7byFwnb82Ea9ZRvVnq2nJNf/TF9j+rj/MHlvu9RBYMqYtu4sJaR1JmMh3MmSIuwMafVg7PfJxPAMv9dGw==",
+        "dependencies": {
+          "Apache.Arrow.Scalars": "23.0.0"
+        }
+      },
+      "Apache.Arrow.Scalars": {
+        "type": "Transitive",
+        "resolved": "23.0.0",
+        "contentHash": "i53VmQ505ASXsStf7y29Z5qvhN6PGgFGNb6UUU7z1WmbzEgSjKQuIJkKKVbh+K5rtXRiKyr1Ah3Rmvbeb2BEHQ=="
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -650,7 +658,7 @@
       "nimbleblazor": {
         "type": "Project",
         "dependencies": {
-          "Apache.Arrow": "[22.1.0, 22.1.0]",
+          "Apache.Arrow": "[23.0.0, 23.0.0]",
           "Microsoft.AspNetCore.Components.Web": "[8.0.26, )"
         }
       }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests.Acceptance.Client/packages.lock.json
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests.Acceptance.Client/packages.lock.json
@@ -43,8 +43,16 @@
       },
       "Apache.Arrow": {
         "type": "Transitive",
-        "resolved": "22.1.0",
-        "contentHash": "mTdHWGsNCWpKyQxqyNcSS+q4BtBTSOUfhdG+Lwo6eAOznCLSwrZQ5VKtDG2G8VrUp1ul4DwWHefoBS1umjO/VQ=="
+        "resolved": "23.0.0",
+        "contentHash": "cU4Zm7byFwnb82Ea9ZRvVnq2nJNf/TF9j+rj/MHlvu9RBYMqYtu4sJaR1JmMh3MmSIuwMafVg7PfJxPAMv9dGw==",
+        "dependencies": {
+          "Apache.Arrow.Scalars": "23.0.0"
+        }
+      },
+      "Apache.Arrow.Scalars": {
+        "type": "Transitive",
+        "resolved": "23.0.0",
+        "contentHash": "i53VmQ505ASXsStf7y29Z5qvhN6PGgFGNb6UUU7z1WmbzEgSjKQuIJkKKVbh+K5rtXRiKyr1Ah3Rmvbeb2BEHQ=="
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -321,7 +329,7 @@
       "nimbleblazor": {
         "type": "Project",
         "dependencies": {
-          "Apache.Arrow": "[22.1.0, 22.1.0]",
+          "Apache.Arrow": "[23.0.0, 23.0.0]",
           "Microsoft.AspNetCore.Components.Web": "[8.0.26, )"
         }
       }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests.Acceptance/packages.lock.json
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests.Acceptance/packages.lock.json
@@ -95,8 +95,16 @@
       },
       "Apache.Arrow": {
         "type": "Transitive",
-        "resolved": "22.1.0",
-        "contentHash": "mTdHWGsNCWpKyQxqyNcSS+q4BtBTSOUfhdG+Lwo6eAOznCLSwrZQ5VKtDG2G8VrUp1ul4DwWHefoBS1umjO/VQ=="
+        "resolved": "23.0.0",
+        "contentHash": "cU4Zm7byFwnb82Ea9ZRvVnq2nJNf/TF9j+rj/MHlvu9RBYMqYtu4sJaR1JmMh3MmSIuwMafVg7PfJxPAMv9dGw==",
+        "dependencies": {
+          "Apache.Arrow.Scalars": "23.0.0"
+        }
+      },
+      "Apache.Arrow.Scalars": {
+        "type": "Transitive",
+        "resolved": "23.0.0",
+        "contentHash": "i53VmQ505ASXsStf7y29Z5qvhN6PGgFGNb6UUU7z1WmbzEgSjKQuIJkKKVbh+K5rtXRiKyr1Ah3Rmvbeb2BEHQ=="
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -684,7 +692,7 @@
       "nimbleblazor": {
         "type": "Project",
         "dependencies": {
-          "Apache.Arrow": "[22.1.0, 22.1.0]",
+          "Apache.Arrow": "[23.0.0, 23.0.0]",
           "Microsoft.AspNetCore.Components.Web": "[8.0.26, )"
         }
       },

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/packages.lock.json
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/packages.lock.json
@@ -125,8 +125,16 @@
       },
       "Apache.Arrow": {
         "type": "Transitive",
-        "resolved": "22.1.0",
-        "contentHash": "mTdHWGsNCWpKyQxqyNcSS+q4BtBTSOUfhdG+Lwo6eAOznCLSwrZQ5VKtDG2G8VrUp1ul4DwWHefoBS1umjO/VQ=="
+        "resolved": "23.0.0",
+        "contentHash": "cU4Zm7byFwnb82Ea9ZRvVnq2nJNf/TF9j+rj/MHlvu9RBYMqYtu4sJaR1JmMh3MmSIuwMafVg7PfJxPAMv9dGw==",
+        "dependencies": {
+          "Apache.Arrow.Scalars": "23.0.0"
+        }
+      },
+      "Apache.Arrow.Scalars": {
+        "type": "Transitive",
+        "resolved": "23.0.0",
+        "contentHash": "i53VmQ505ASXsStf7y29Z5qvhN6PGgFGNb6UUU7z1WmbzEgSjKQuIJkKKVbh+K5rtXRiKyr1Ah3Rmvbeb2BEHQ=="
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -525,7 +533,7 @@
       "nimbleblazor": {
         "type": "Project",
         "dependencies": {
-          "Apache.Arrow": "[22.1.0, 22.1.0]",
+          "Apache.Arrow": "[23.0.0, 23.0.0]",
           "Microsoft.AspNetCore.Components.Web": "[8.0.26, )"
         }
       }

--- a/packages/blazor-workspace/Tests/OkBlazor.Tests.Acceptance/packages.lock.json
+++ b/packages/blazor-workspace/Tests/OkBlazor.Tests.Acceptance/packages.lock.json
@@ -95,8 +95,16 @@
       },
       "Apache.Arrow": {
         "type": "Transitive",
-        "resolved": "22.1.0",
-        "contentHash": "mTdHWGsNCWpKyQxqyNcSS+q4BtBTSOUfhdG+Lwo6eAOznCLSwrZQ5VKtDG2G8VrUp1ul4DwWHefoBS1umjO/VQ=="
+        "resolved": "23.0.0",
+        "contentHash": "cU4Zm7byFwnb82Ea9ZRvVnq2nJNf/TF9j+rj/MHlvu9RBYMqYtu4sJaR1JmMh3MmSIuwMafVg7PfJxPAMv9dGw==",
+        "dependencies": {
+          "Apache.Arrow.Scalars": "23.0.0"
+        }
+      },
+      "Apache.Arrow.Scalars": {
+        "type": "Transitive",
+        "resolved": "23.0.0",
+        "contentHash": "i53VmQ505ASXsStf7y29Z5qvhN6PGgFGNb6UUU7z1WmbzEgSjKQuIJkKKVbh+K5rtXRiKyr1Ah3Rmvbeb2BEHQ=="
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -664,7 +672,7 @@
       "nimbleblazor": {
         "type": "Project",
         "dependencies": {
-          "Apache.Arrow": "[22.1.0, 22.1.0]",
+          "Apache.Arrow": "[23.0.0, 23.0.0]",
           "Microsoft.AspNetCore.Components.Web": "[8.0.26, )"
         }
       },

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests.Acceptance/packages.lock.json
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests.Acceptance/packages.lock.json
@@ -95,8 +95,16 @@
       },
       "Apache.Arrow": {
         "type": "Transitive",
-        "resolved": "22.1.0",
-        "contentHash": "mTdHWGsNCWpKyQxqyNcSS+q4BtBTSOUfhdG+Lwo6eAOznCLSwrZQ5VKtDG2G8VrUp1ul4DwWHefoBS1umjO/VQ=="
+        "resolved": "23.0.0",
+        "contentHash": "cU4Zm7byFwnb82Ea9ZRvVnq2nJNf/TF9j+rj/MHlvu9RBYMqYtu4sJaR1JmMh3MmSIuwMafVg7PfJxPAMv9dGw==",
+        "dependencies": {
+          "Apache.Arrow.Scalars": "23.0.0"
+        }
+      },
+      "Apache.Arrow.Scalars": {
+        "type": "Transitive",
+        "resolved": "23.0.0",
+        "contentHash": "i53VmQ505ASXsStf7y29Z5qvhN6PGgFGNb6UUU7z1WmbzEgSjKQuIJkKKVbh+K5rtXRiKyr1Ah3Rmvbeb2BEHQ=="
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -664,7 +672,7 @@
       "nimbleblazor": {
         "type": "Project",
         "dependencies": {
-          "Apache.Arrow": "[22.1.0, 22.1.0]",
+          "Apache.Arrow": "[23.0.0, 23.0.0]",
           "Microsoft.AspNetCore.Components.Web": "[8.0.26, )"
         }
       },


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Updating pinned dependency versions as outlined in #1747 

comlink / Playwright / Apache Arrow JS versions are already up-to-date.

## 👩‍💻 Implementation

Update pinned Apache.Arrow NuGet version to 23.0.0

## 🧪 Testing

PR build + ran Blazor example app (Storybook) to see wafer map

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
