### PR TITLE
Fix visual styling for the Blazor checkbox wrapper

### DIFF
--- a/change/@ni-nimble-angular-15482ba9-3501-43b0-b4f1-74ad0aba1df2.json
+++ b/change/@ni-nimble-angular-15482ba9-3501-43b0-b4f1-74ad0aba1df2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add appearance-indeterminate property to nimble checkbox",
+  "packageName": "@ni/nimble-angular",
+  "email": "5265744+hellovolcano@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-blazor-febf4a46-996f-49e6-9627-d93d610074c2.json
+++ b/change/@ni-nimble-blazor-febf4a46-996f-49e6-9627-d93d610074c2.json
@@ -1,6 +1,6 @@
 {
   "type": "major",
-  "comment": "Add Appearance-Indeterminate property for checkbox",
+  "comment": "Add AppearanceIndeterminate property for checkbox",
   "packageName": "@ni/nimble-blazor",
   "email": "5265744+hellovolcano@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@ni-nimble-blazor-febf4a46-996f-49e6-9627-d93d610074c2.json
+++ b/change/@ni-nimble-blazor-febf4a46-996f-49e6-9627-d93d610074c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add Appearance-Indeterminate property for blazor wrapper",
+  "packageName": "@ni/nimble-blazor",
+  "email": "5265744+hellovolcano@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-nimble-blazor-febf4a46-996f-49e6-9627-d93d610074c2.json
+++ b/change/@ni-nimble-blazor-febf4a46-996f-49e6-9627-d93d610074c2.json
@@ -1,6 +1,6 @@
 {
-  "type": "patch",
-  "comment": "Add Appearance-Indeterminate property for blazor wrapper",
+  "type": "major",
+  "comment": "Add Appearance-Indeterminate property for checkbox",
   "packageName": "@ni/nimble-blazor",
   "email": "5265744+hellovolcano@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@ni-nimble-components-d78016f3-bfed-48e6-b02e-55c176163add.json
+++ b/change/@ni-nimble-components-d78016f3-bfed-48e6-b02e-55c176163add.json
@@ -1,6 +1,6 @@
 {
-  "type": "patch",
-  "comment": "Add Appearance-Indeterminate property for blazor wrapper",
+  "type": "minor",
+  "comment": "Add Appearance-Indeterminate property for checkbox",
   "packageName": "@ni/nimble-components",
   "email": "5265744+hellovolcano@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@ni-nimble-components-d78016f3-bfed-48e6-b02e-55c176163add.json
+++ b/change/@ni-nimble-components-d78016f3-bfed-48e6-b02e-55c176163add.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add Appearance-Indeterminate property for checkbox",
+  "comment": "Add appearance-indeterminate property for checkbox",
   "packageName": "@ni/nimble-components",
   "email": "5265744+hellovolcano@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@ni-nimble-components-d78016f3-bfed-48e6-b02e-55c176163add.json
+++ b/change/@ni-nimble-components-d78016f3-bfed-48e6-b02e-55c176163add.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add Appearance-Indeterminate property for blazor wrapper",
+  "packageName": "@ni/nimble-components",
+  "email": "5265744+hellovolcano@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/angular-workspace/nimble-angular/src/directives/checkbox/nimble-checkbox.directive.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/checkbox/nimble-checkbox.directive.ts
@@ -53,5 +53,13 @@ export class NimbleCheckboxDirective {
         this.renderer.setProperty(this.elementRef.nativeElement, 'errorVisible', toBooleanProperty(value));
     }
 
+    public get appearanceIndeterminate(): boolean {
+        return this.elementRef.nativeElement.appearanceIndeterminate;
+    }
+
+    @Input('appearance-indeterminate') public set appearanceIndeterminate(value: BooleanValueOrAttribute) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'appearanceIndeterminate', toBooleanProperty(value));
+    }
+
     public constructor(private readonly renderer: Renderer2, private readonly elementRef: ElementRef<Checkbox>) {}
 }

--- a/packages/angular-workspace/nimble-angular/src/directives/checkbox/tests/nimble-checkbox.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/checkbox/tests/nimble-checkbox.directive.spec.ts
@@ -68,6 +68,11 @@ describe('Nimble checkbox', () => {
             expect(directive.errorText).toBeUndefined();
             expect(nativeElement.errorText).toBeUndefined();
         });
+
+        it('has expected defaults for appearanceIndeterminate', () => {
+            expect(directive.appearanceIndeterminate).toBeFalse();
+            expect(nativeElement.appearanceIndeterminate).toBeFalse();
+        });
     });
 
     describe('with template string values', () => {
@@ -77,6 +82,7 @@ describe('Nimble checkbox', () => {
                     disabled
                     checked
                     indeterminate
+                    appearance-indeterminate
                     error-visible
                     error-text="Error message">
                 </nimble-checkbox>`,
@@ -126,6 +132,11 @@ describe('Nimble checkbox', () => {
             expect(directive.errorText).toBe('Error message');
             expect(nativeElement.errorText).toBe('Error message');
         });
+
+        it('will use template string values for appearanceIndeterminate', () => {
+            expect(directive.appearanceIndeterminate).toBeTrue();
+            expect(nativeElement.appearanceIndeterminate).toBeTrue();
+        });
     });
 
     describe('with property bound values', () => {
@@ -135,6 +146,7 @@ describe('Nimble checkbox', () => {
                     [disabled]="disabled"
                     [checked]="checked"
                     [indeterminate]="indeterminate"
+                    [appearance-indeterminate]="appearanceIndeterminate"
                     [error-text]="errorText"
                     [error-visible]="errorVisible">
                 </nimble-checkbox>
@@ -147,6 +159,7 @@ describe('Nimble checkbox', () => {
             public disabled = false;
             public checked = false;
             public indeterminate = false;
+            public appearanceIndeterminate = false;
             public errorText = 'initial value';
             public errorVisible = false;
         }
@@ -220,6 +233,17 @@ describe('Nimble checkbox', () => {
             expect(directive.errorVisible).toBeTrue();
             expect(nativeElement.errorVisible).toBeTrue();
         });
+
+        it('can be configured with property binding for appearanceIndeterminate', () => {
+            expect(directive.appearanceIndeterminate).toBeFalse();
+            expect(nativeElement.appearanceIndeterminate).toBeFalse();
+
+            fixture.componentInstance.appearanceIndeterminate = true;
+            fixture.detectChanges();
+
+            expect(directive.appearanceIndeterminate).toBeTrue();
+            expect(nativeElement.appearanceIndeterminate).toBeTrue();
+        });
     });
 
     describe('with attribute bound values', () => {
@@ -228,6 +252,7 @@ describe('Nimble checkbox', () => {
                 <nimble-checkbox #checkbox
                     [attr.disabled]="disabled"
                     [attr.checked]="checked"
+                    [attr.appearance-indeterminate]="appearanceIndeterminate"
                     [attr.error-text]="errorText"
                     [attr.error-visible]="errorVisible">
                 </nimble-checkbox>
@@ -239,6 +264,7 @@ describe('Nimble checkbox', () => {
             @ViewChild('checkbox', { read: ElementRef }) public elementRef: ElementRef<Checkbox>;
             public disabled: BooleanValueOrAttribute = null;
             public checked: BooleanValueOrAttribute = null;
+            public appearanceIndeterminate: BooleanValueOrAttribute = null;
             public errorText = 'initial value';
             public errorVisible: BooleanValueOrAttribute = null;
         }
@@ -300,6 +326,17 @@ describe('Nimble checkbox', () => {
 
             expect(directive.errorVisible).toBeTrue();
             expect(nativeElement.errorVisible).toBeTrue();
+        });
+
+        it('can be configured with attribute binding for appearanceIndeterminate', () => {
+            expect(directive.appearanceIndeterminate).toBeFalse();
+            expect(nativeElement.appearanceIndeterminate).toBeFalse();
+
+            fixture.componentInstance.appearanceIndeterminate = '';
+            fixture.detectChanges();
+
+            expect(directive.appearanceIndeterminate).toBeTrue();
+            expect(nativeElement.appearanceIndeterminate).toBeTrue();
         });
 
         // indeterminate property does not have a matching attribute

--- a/packages/blazor-workspace/NimbleBlazor/Source/Checkbox/NimbleCheckbox.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Checkbox/NimbleCheckbox.razor
@@ -3,7 +3,7 @@
 <nimble-checkbox disabled="@Disabled"
     current-checked="@BindConverter.FormatValue(CurrentValue)"
     @onnimblecheckedchange="(__value) => CurrentValue = __value.Checked"
-    indeterminate="@Indeterminate"
+    appearance-indeterminate="@AppearanceIndeterminate"
     required="@Required"
     readonly="@ReadOnly"
     error-visible="@ErrorVisible"

--- a/packages/blazor-workspace/NimbleBlazor/Source/Checkbox/NimbleCheckbox.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Checkbox/NimbleCheckbox.razor.cs
@@ -12,7 +12,7 @@ public partial class NimbleCheckbox : NimbleInputBase<bool>
     public bool? Required { get; set; }
 
     [Parameter]
-    public bool? Indeterminate { get; set; }
+    public bool? AppearanceIndeterminate { get; set; }
 
     [Parameter]
     public bool? ReadOnly { get; set; }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleCheckboxTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleCheckboxTests.cs
@@ -47,6 +47,14 @@ public class NimbleCheckboxTests
         Assert.Contains("error-visible", checkbox.Markup);
     }
 
+    [Fact]
+    public void NimbleCheckboxAppearanceIndeterminate_AttributeIsSet()
+    {
+        var checkbox = RenderNimbleCheckboxWithPropertySet(x => x.AppearanceIndeterminate, true);
+
+        Assert.Contains("appearance-indeterminate", checkbox.Markup);
+    }
+
     private IRenderedComponent<NimbleCheckbox> RenderNimbleCheckboxWithPropertySet<TProperty>(Expression<Func<NimbleCheckbox, TProperty>> propertyGetter, TProperty propertyValue)
     {
         var context = new TestContext();

--- a/packages/nimble-components/src/checkbox/index.ts
+++ b/packages/nimble-components/src/checkbox/index.ts
@@ -28,6 +28,14 @@ export class Checkbox extends mixinErrorPattern(FoundationCheckbox) {
     public override tabIndex!: number;
 
     /**
+     * @public
+     * @remarks
+     * HTML Attribute: appearance-indeterminate
+     */
+    @attr({ attribute: 'appearance-indeterminate', mode: 'boolean' })
+    public appearanceIndeterminate = false;
+
+    /**
      * @internal
      */
     public get resolvedTabindex(): string | undefined {

--- a/packages/nimble-components/src/checkbox/styles.ts
+++ b/packages/nimble-components/src/checkbox/styles.ts
@@ -118,7 +118,7 @@ export const styles = css`
         fill: ${borderColor};
     }
 
-    :host(.checked:not(.indeterminate)) slot[name='checked-indicator'] {
+    :host(.checked:not(.indeterminate):not([appearance-indeterminate])) slot[name='checked-indicator'] {
         display: contents;
     }
 
@@ -132,7 +132,8 @@ export const styles = css`
         overflow: visible;
     }
 
-    :host(.indeterminate) slot[name='indeterminate-indicator'] {
+    :host(.indeterminate) slot[name='indeterminate-indicator'],
+    :host([appearance-indeterminate]) slot[name='indeterminate-indicator'] {
         display: contents;
     }
 

--- a/packages/nimble-components/src/checkbox/tests/checkbox.spec.ts
+++ b/packages/nimble-components/src/checkbox/tests/checkbox.spec.ts
@@ -36,4 +36,31 @@ describe('Checkbox', () => {
 
         await disconnect();
     });
+
+    it('should show indeterminate indicator when appearance-indeterminate is set', async () => {
+        const { element, connect, disconnect } = await setup();
+        await connect();
+
+        element.appearanceIndeterminate = true;
+        await waitForUpdatesAsync();
+
+        expect(element.hasAttribute('appearance-indeterminate')).toBeTrue();
+
+        await disconnect();
+    });
+
+    it('should not clear appearance-indeterminate on user click', async () => {
+        const { element, connect, disconnect } = await setup();
+        await connect();
+
+        element.appearanceIndeterminate = true;
+        await waitForUpdatesAsync();
+
+        element.click();
+        await waitForUpdatesAsync();
+
+        expect(element.appearanceIndeterminate).toBeTrue();
+
+        await disconnect();
+    });
 });

--- a/packages/storybook/src/nimble/checkbox/checkbox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/checkbox/checkbox-matrix.stories.ts
@@ -54,6 +54,7 @@ const component = (
     ?error-visible="${() => errorVisible}"
     error-text="${() => errorText}"
     :indeterminate="${() => indeterminate}"
+    ?appearance-indeterminate="${() => indeterminate}"
     style="width: 350px; margin: var(${standardPadding.cssCustomProperty});"
 >
     ${checkedName} ${indeterminateName} ${disabledName} ${errorName} ${extraText}

--- a/packages/storybook/src/nimble/checkbox/checkbox.stories.ts
+++ b/packages/storybook/src/nimble/checkbox/checkbox.stories.ts
@@ -66,6 +66,7 @@ const metadata: Meta<CheckboxArgs> = {
 <details>
 <summary>Usage details</summary>
 The \`indeterminate\` state is not automatically changed when the user interactively changes the checked state. Client applications that use \`indeterminate\` state are responsible for subscribing to the \`change\` event to respond to this situation.
+Blazor clients should use the \`appearance-indeterminate\` attribute to set the indeterminate visual state instead of the \`indeterminate\` property.
 </details>`,
             table: { category: apiCategory.nonAttributeProperties }
         },

--- a/packages/storybook/src/nimble/checkbox/checkbox.stories.ts
+++ b/packages/storybook/src/nimble/checkbox/checkbox.stories.ts
@@ -23,6 +23,16 @@ interface CheckboxArgs {
     errorText: string;
 }
 
+const indeterminateDescription = `Whether the checkbox is in the indeterminate (i.e. partially checked) state. Configured programmatically, not by attribute.
+
+<details>
+    <summary>Usage details</summary>
+
+    The \`indeterminate\` state is not automatically changed when the user interactively changes the checked state. Client applications that use \`indeterminate\` state are responsible for subscribing to the \`change\` event to respond to this situation.<br><br>
+    Blazor clients should use the \`appearance-indeterminate\` attribute to set the indeterminate visual state instead of the \`indeterminate\` property.
+</details>
+`;
+
 const metadata: Meta<CheckboxArgs> = {
     title: 'Components/Checkbox',
     decorators: [withActions<HtmlRenderer>],
@@ -61,13 +71,7 @@ const metadata: Meta<CheckboxArgs> = {
             table: { category: apiCategory.nonAttributeProperties }
         },
         indeterminate: {
-            description: `Whether the checkbox is in the indeterminate (i.e. partially checked) state. Configured programmatically, not by attribute.
-
-<details>
-<summary>Usage details</summary>
-The `indeterminate` state is not automatically changed when the user interactively changes the checked state. Client applications that use `indeterminate` state are responsible for subscribing to the \`change\` event to respond to this situation.
-Blazor clients should use the `appearance-indeterminate` attribute to set the indeterminate visual state instead of the `indeterminate` property.
-</details>`,
+            description: indeterminateDescription,
             table: { category: apiCategory.nonAttributeProperties }
         },
         appearanceIndeterminate: {

--- a/packages/storybook/src/nimble/checkbox/checkbox.stories.ts
+++ b/packages/storybook/src/nimble/checkbox/checkbox.stories.ts
@@ -65,8 +65,8 @@ const metadata: Meta<CheckboxArgs> = {
 
 <details>
 <summary>Usage details</summary>
-The \`indeterminate\` state is not automatically changed when the user interactively changes the checked state. Client applications that use \`indeterminate\` state are responsible for subscribing to the \`change\` event to respond to this situation.
-Blazor clients should use the \`appearance-indeterminate\` attribute to set the indeterminate visual state instead of the \`indeterminate\` property.
+The `indeterminate` state is not automatically changed when the user interactively changes the checked state. Client applications that use `indeterminate` state are responsible for subscribing to the \`change\` event to respond to this situation.
+Blazor clients should use the `appearance-indeterminate` attribute to set the indeterminate visual state instead of the `indeterminate` property.
 </details>`,
             table: { category: apiCategory.nonAttributeProperties }
         },

--- a/packages/storybook/src/nimble/checkbox/checkbox.stories.ts
+++ b/packages/storybook/src/nimble/checkbox/checkbox.stories.ts
@@ -16,6 +16,7 @@ interface CheckboxArgs {
     checked: boolean;
     checkedProperty: undefined;
     indeterminate: boolean;
+    appearanceIndeterminate: boolean;
     disabled: boolean;
     change: undefined;
     errorVisible: boolean;
@@ -35,6 +36,7 @@ const metadata: Meta<CheckboxArgs> = {
             ?checked="${x => x.checked}"
             ?disabled="${x => x.disabled}"
             :indeterminate="${x => x.indeterminate}"
+            ?appearance-indeterminate="${x => x.appearanceIndeterminate}"
             ?error-visible="${x => x.errorVisible}"
             error-text="${x => x.errorText}"
         >
@@ -67,6 +69,12 @@ The \`indeterminate\` state is not automatically changed when the user interacti
 </details>`,
             table: { category: apiCategory.nonAttributeProperties }
         },
+        appearanceIndeterminate: {
+            name: 'appearance-indeterminate',
+            description:
+                'Whether the checkbox should display the indeterminate (partially checked) visual appearance. Unlike the `indeterminate` property, this attribute is not cleared on user interaction, giving the application full control over the visual state.',
+            table: { category: apiCategory.attributes }
+        },
         disabled: {
             description: disabledDescription({ componentName: 'checkbox' }),
             table: { category: apiCategory.attributes }
@@ -92,6 +100,7 @@ The \`indeterminate\` state is not automatically changed when the user interacti
         label: 'Checkbox label',
         checked: false,
         indeterminate: false,
+        appearanceIndeterminate: false,
         disabled: false,
         errorVisible: false,
         errorText: 'Value is invalid'


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

<!---
Provide some background and a description of your work.
What problem does this change solve?

Include links to issues, work items, or other discussions.
-->

Setting the indeterminate state of blazor checkbox to true does not correctly update the visual state. 

#2543 

## 👩‍💻 Implementation

Add a new optional indeterminate-appearance property to the nimble checkbox to allow blazor clients to set the indeterminate style.

## 🧪 Testing

<!---
Detail the testing done to ensure this submission meets requirements. 

Include automated/manual test additions or modifications, testing done on a local build, private CI run results, and additional testing not covered by automatic pull request validation. If any functionality is not covered by automated testing, provide justification.
-->

Tests passing
Ran auto tests
Manual testing

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
