### PR TITLE
Disable RichTextEditor keyboard shortcut tests on WebKit

### DIFF
--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor.spec.ts
@@ -208,7 +208,8 @@ describe('RichTextEditor', () => {
         });
     });
 
-    describe('keyboard shortcuts should update the checked state of the buttons', () => {
+    // #SkipWebkit: Fails on Mac (both Playwright-Webkit + Safari) - https://github.com/ni/nimble/issues/2957
+    describe('keyboard shortcuts should update the checked state of the buttons #SkipWebkit', () => {
         parameterizeSpec(formattingButtons, (spec, name, value) => {
             spec(`"${name}" button keyboard shortcut check`, async () => {
                 expect(


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

See #2957 

Disabling tests on WebKit (`#SkipWebkit`) as they fail on Mac.

## 🧪 Testing

PR build

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
