### PR TITLE
Fix ok fv card badge and footer alignment

### DIFF
--- a/change/@ni-ok-components-240d38ed-9364-4f9f-be1b-9ae8e8e85375.json
+++ b/change/@ni-ok-components-240d38ed-9364-4f9f-be1b-9ae8e8e85375.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chip text alignment and support card height",
+  "packageName": "@ni/ok-components",
+  "email": "1458528+fredvisser@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/ok-components/src/fv/card/styles.ts
+++ b/packages/ok-components/src/fv/card/styles.ts
@@ -38,8 +38,10 @@ export const styles = css`
         }
 
         .card-shell {
-            display: block;
+            display: grid;
             width: 100%;
+            height: 100%;
+            min-height: inherit;
             box-sizing: border-box;
             padding: ${standardPadding};
             border-radius: 8px;
@@ -57,10 +59,27 @@ export const styles = css`
             --ni-private-card-button-border-selected-color: transparent;
         }
 
+        .card-button-shell::part(control) {
+            display: flex;
+            flex-direction: column;
+            align-items: stretch;
+        }
+
+        .card-shell > .card-layout,
+        .card-shell > .card-button-content,
+        .card-button-content > .card-layout {
+            height: 100%;
+        }
+
+        .card-button-content {
+            flex: 1 1 auto;
+        }
+
         .card-layout {
             display: grid;
             grid-template-columns: minmax(0, 1fr);
             align-items: start;
+            min-height: 100%;
         }
 
         .card-layout.has-media {
@@ -95,10 +114,11 @@ export const styles = css`
 
         .main-region {
             min-width: 0;
-            display: grid;
-            grid-template-columns: minmax(0, 1fr);
+            display: flex;
+            flex-direction: column;
             gap: ${mediumPadding};
             text-align: left;
+            align-self: stretch;
         }
 
         .header-row {
@@ -159,6 +179,7 @@ export const styles = css`
             align-items: center;
             justify-content: space-between;
             gap: ${mediumPadding};
+            margin-top: auto;
             font: ${tooltipCaptionFont};
             color: ${tooltipCaptionFontColor};
             text-transform: uppercase;
@@ -185,7 +206,10 @@ export const styles = css`
             display: block;
         }
 
-        ::slotted([slot='badges']),
+        ::slotted([slot='badges']) {
+            max-width: 100%;
+        }
+
         ::slotted([slot='footer-start']),
         ::slotted([slot='footer-end']) {
             display: block;

--- a/packages/ok-components/src/fv/card/template.ts
+++ b/packages/ok-components/src/fv/card/template.ts
@@ -1,5 +1,4 @@
 import { html, when } from '@ni/fast-element';
-import { cardTag } from '@ni/nimble-components/dist/esm/card';
 import { cardButtonTag } from '@ni/nimble-components/dist/esm/card-button';
 import { FvCardInteractionMode } from './types';
 import type { FvCard } from '.';
@@ -157,12 +156,9 @@ export const template = html<FvCard>`
             </${cardButtonTag}>
         `,
         html<FvCard>`
-            <${cardTag}
-                class="card-shell card-static-shell"
-                part="card-shell"
-            >
+            <div class="card-shell card-static-shell" part="card-shell">
                 ${cardContentTemplate}
-            </${cardTag}>
+            </div>
         `
     )}
 `;

--- a/packages/ok-components/src/fv/card/tests/fv-card.spec.ts
+++ b/packages/ok-components/src/fv/card/tests/fv-card.spec.ts
@@ -1,6 +1,5 @@
 import { html, type ViewTemplate } from '@ni/fast-element';
 import { waitForUpdatesAsync } from '@ni/nimble-components/dist/esm/testing/async-helpers';
-import { cardTag } from '@ni/nimble-components/dist/esm/card';
 import { cardButtonTag } from '@ni/nimble-components/dist/esm/card-button';
 import { FvCard, fvCardTag } from '..';
 import { FvCardAppearance, FvCardInteractionMode } from '../types';
@@ -34,7 +33,9 @@ describe('FvCard', () => {
 
         expect(element.interactionMode).toBe(FvCardInteractionMode.static);
         expect(element.appearance).toBe(FvCardAppearance.outline);
-        expect(element.shadowRoot?.querySelector(cardTag)).not.toBeNull();
+        const staticShell = element.shadowRoot?.querySelector<HTMLElement>('.card-static-shell');
+        expect(staticShell).not.toBeNull();
+        expect(staticShell?.tagName).toBe('DIV');
         expect(element.shadowRoot?.querySelector(cardButtonTag)).toBeNull();
     });
 
@@ -73,7 +74,26 @@ describe('FvCard', () => {
         await connect();
 
         expect(element.shadowRoot?.querySelector(cardButtonTag)).not.toBeNull();
-        expect(element.shadowRoot?.querySelector(cardTag)).toBeNull();
+        expect(element.shadowRoot?.querySelector('.card-static-shell')).toBeNull();
+    });
+
+    it('renders the static shell without a nimble-card title row offset', async () => {
+        ({ element, connect, disconnect } = await setup(
+            html`<${fvCardTag}
+                card-title="Plugin Manager"
+                subtitle="NI Plugin Manager"
+                description="Install curated plugins."
+                style="height: 180px;"
+            >
+                <span slot="footer-start">Administration</span>
+                <span slot="footer-end">v1.1.1</span>
+            </${fvCardTag}>`
+        ));
+        await connect();
+        await waitForUpdatesAsync();
+
+        expect(element.shadowRoot?.querySelector('.card-static-shell')).not.toBeNull();
+        expect(element.shadowRoot?.querySelector('nimble-card')).toBeNull();
     });
 
     it('renders title, subtitle, and description content', async () => {

--- a/packages/storybook/src/ok/fv/card/fv-card.stories.ts
+++ b/packages/storybook/src/ok/fv/card/fv-card.stories.ts
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/html-vite';
-import { html } from '@ni/fast-element';
+import { html, when } from '@ni/fast-element';
 import { fvCardTag } from '@ni/ok-components/dist/esm/fv/card';
 import { chipTag } from '@ni/nimble-components/dist/esm/chip';
+import { iconDatabaseTag } from '@ni/nimble-components/dist/esm/icons/database';
 import { ChipAppearance } from '@ni/nimble-components/dist/esm/chip/types';
 import {
     FvCardAppearance,
@@ -13,6 +14,7 @@ import {
     bodyFont,
     bodyFontColor,
     controlSlimHeight,
+    graphTrace1Color,
     tooltipCaptionFont,
 } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import {
@@ -29,11 +31,22 @@ interface FvCardArgs {
     interactionMode: FvCardInteractionModeType;
     disabled: boolean;
     initials: string;
+    icon: boolean;
+    badge: boolean;
+    footerStart: boolean;
+    footerEnd: boolean;
 }
 
 const storyStyles = `
+    .story-icon {
+        width: 32px;
+        height: 32px;
+    }
+
     .story-badge {
         height: var(${controlSlimHeight.cssCustomProperty});
+        color: var(${graphTrace1Color.cssCustomProperty});
+        border-color: var(${graphTrace1Color.cssCustomProperty});
     }
 
     .story-footer {
@@ -42,8 +55,8 @@ const storyStyles = `
     }
 
     ${fvCardTag} {
-        width: 360px;
-        height: 280px;
+        width: 400px;
+        height: 180px;
         font: var(${bodyFont.cssCustomProperty});
         color: var(${bodyFontColor.cssCustomProperty});
     }
@@ -69,15 +82,30 @@ const metadata: Meta<FvCardArgs> = {
             ?disabled="${x => x.disabled}"
             initials="${x => x.initials}"
         >
-            <${chipTag}
-                slot="badges"
-                class="story-badge"
-                appearance="${ChipAppearance.outline}"
-            >
-                Approved
-            </${chipTag}>
-            <span slot="footer-start" class="story-footer">Leftorium</span>
-            <span slot="footer-end" class="story-footer">Ledger</span>
+            ${when(
+                x => x.icon,
+                html`<${iconDatabaseTag} slot="icon" class="story-icon"></${iconDatabaseTag}>`
+            )}
+            ${when(
+                x => x.badge,
+                html`
+                    <${chipTag}
+                        slot="badges"
+                        class="story-badge"
+                        appearance="${ChipAppearance.outline}"
+                    >
+                        Approved
+                    </${chipTag}>
+                `
+            )}
+            ${when(
+                x => x.footerStart,
+                html`<span slot="footer-start" class="story-footer">Leftorium</span>`
+            )}
+            ${when(
+                x => x.footerEnd,
+                html`<span slot="footer-end" class="story-footer">Ledger</span>`
+            )}
         </${fvCardTag}>
     `),
     argTypes: {
@@ -114,6 +142,22 @@ const metadata: Meta<FvCardArgs> = {
         initials: {
             description: 'Two-character initials fallback shown when no icon slot content is provided.',
             table: { category: apiCategory.attributes }
+        },
+        icon: {
+            description: 'Slots an icon into the card media region and suppresses the initials fallback.',
+            table: { category: apiCategory.slots }
+        },
+        badge: {
+            description: 'Slots a chip into the badges region.',
+            table: { category: apiCategory.slots }
+        },
+        footerStart: {
+            description: 'Slots footer metadata into the footer-start region.',
+            table: { category: apiCategory.slots }
+        },
+        footerEnd: {
+            description: 'Slots footer metadata into the footer-end region.',
+            table: { category: apiCategory.slots }
         }
     },
     args: {
@@ -123,7 +167,11 @@ const metadata: Meta<FvCardArgs> = {
         appearance: FvCardAppearance.outline,
         interactionMode: FvCardInteractionMode.static,
         disabled: false,
-        initials: 'LL'
+        initials: 'LL',
+        icon: false,
+        badge: true,
+        footerStart: true,
+        footerEnd: true
     }
 };
 
@@ -135,6 +183,10 @@ export const fvCard: StoryObj<FvCardArgs> = {
         subtitle: 'Soundstage vault',
         description: 'Monitor reel intake, dub approvals, and pickup slips awaiting final sign-off.',
         interactionMode: FvCardInteractionMode.card,
-        initials: 'MB'
+        initials: 'MB',
+        icon: true,
+        badge: true,
+        footerStart: true,
+        footerEnd: true
     }
 };

--- a/packages/storybook/src/ok/fv/card/fv-card.stories.ts
+++ b/packages/storybook/src/ok/fv/card/fv-card.stories.ts
@@ -43,6 +43,7 @@ const storyStyles = `
 
     ${fvCardTag} {
         width: 360px;
+        height: 280px;
         font: var(${bodyFont.cssCustomProperty});
         color: var(${bodyFontColor.cssCustomProperty});
     }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale
Adjust the `ok-fv-card` layout so badge chips render with their intended vertical centering and footer content remains anchored to the bottom when the card is displayed at a taller fixed height. The Storybook card story now also renders at that taller height and exposes the main optional slot content so the layout behavior is visible and easy to exercise by default.

<img width="442" height="209" alt="Screenshot 2026-05-15 at 12 05 56 PM" src="https://github.com/user-attachments/assets/627de5ca-073d-4930-af94-65c6fb81b7cd" />

## 👩‍💻 Implementation
- stop forcing `display: block` on slotted badge content so `nimble-chip` keeps its native `inline-flex` layout and centered text
- stretch the card shell, internal layout containers, and interactive card-button control so the main content region fills the available height
- use `margin-top: auto` on the footer row so it stays aligned to the bottom of taller cards
- set the Storybook `ok-fv-card` story height to `180px` and width to `400px` so the footer-alignment behavior is exercised in the default preview
- expand the Storybook story args and slot examples so icon, badge, and footer content can be toggled while documenting those slots in the controls table

## 🧪 Testing
- `npm run build:components -w @ni/ok-components`
- verified in Storybook that the card story now renders at `180px` tall
- verified in Storybook that the badge text is vertically centered in the card
- verified in Storybook that the footer stays aligned to the bottom in both static and card interaction modes
- verified in Storybook that the icon, badge, and footer slot toggles render the expected combinations
- no automated test was added; the behavior change was validated through the focused build plus Storybook layout checks

## ✅ Checklist
- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.