### PR TITLE
Migrate Angular templates to control flow syntax

### DIFF
--- a/packages/angular-workspace/example-client-app/src/app/app.component.html
+++ b/packages/angular-workspace/example-client-app/src/app/app.component.html
@@ -5,7 +5,9 @@
     <div class="example-root">
         <div class="header">
             <nimble-select class="theme-select" appearance="frameless" [(ngModel)]="theme">
-                <nimble-list-option *ngFor="let item of themes" [ngValue]="item">{{ item | titlecase}} Theme</nimble-list-option>
+                @for (item of themes; track item) {
+                    <nimble-list-option [ngValue]="item">{{ item | titlecase}} Theme</nimble-list-option>
+                }
             </nimble-select>
         </div>
         <div class="content-container-wrapper">

--- a/packages/angular-workspace/example-client-app/src/app/customapp/chat-conversation-section.component.ts
+++ b/packages/angular-workspace/example-client-app/src/app/customapp/chat-conversation-section.component.ts
@@ -34,7 +34,9 @@ import type { ChatInputSendEventDetail } from '@ni/spright-angular/chat/input';
                     <nimble-button slot="end" appearance="block">Order a tab</nimble-button>
                     <nimble-button slot="end" appearance="block">Check core temperature</nimble-button>
                 </spright-chat-message-inbound>
-                <spright-chat-message-outbound *ngFor="let message of chatUserMessages"><span>{{message}}</span></spright-chat-message-outbound>
+                @for (message of chatUserMessages; track message) {
+                    <spright-chat-message-outbound><span>{{message}}</span></spright-chat-message-outbound>
+                }
                 <spright-chat-input slot="input" placeholder="Type here" (send)="onChatInputSend($event)"></spright-chat-input>
                 <span slot="end">
                     AI-generated content may be incorrect.

--- a/packages/angular-workspace/example-client-app/src/app/customapp/combobox-section.component.ts
+++ b/packages/angular-workspace/example-client-app/src/app/customapp/combobox-section.component.ts
@@ -12,7 +12,9 @@ interface ComboboxItem {
         <example-sub-container label="Combobox">
             <nimble-combobox aria-label="Combobox" [(ngModel)]="comboboxSelectedOption" (ngModelChange)="onComboboxChange($event)" appearance="underline" autocomplete="both" placeholder="Select value...">
                 Underline Combobox
-                <nimble-list-option *ngFor="let item of comboboxItems" [ngValue]="item">{{ item ? item.first : '' }}</nimble-list-option>
+                @for (item of comboboxItems; track item) {
+                    <nimble-list-option [ngValue]="item">{{ item ? item.first : '' }}</nimble-list-option>
+                }
             </nimble-combobox>
             <div>
                 <span>
@@ -21,11 +23,15 @@ interface ComboboxItem {
             </div>
             <nimble-combobox aria-label="Combobox" [(ngModel)]="comboboxSelectedOption" (ngModelChange)="onComboboxChange($event)" appearance="outline" autocomplete="both" placeholder="Select value...">
                 Outline Combobox
-                <nimble-list-option *ngFor="let item of comboboxItems" [ngValue]="item">{{ item ? item.first : '' }}</nimble-list-option>
+                @for (item of comboboxItems; track item) {
+                    <nimble-list-option [ngValue]="item">{{ item ? item.first : '' }}</nimble-list-option>
+                }
             </nimble-combobox>
             <nimble-combobox aria-label="Combobox" [(ngModel)]="comboboxSelectedOption" (ngModelChange)="onComboboxChange($event)" appearance="block" autocomplete="both" placeholder="Select value...">
                 Block Combobox
-                <nimble-list-option *ngFor="let item of comboboxItems" [ngValue]="item">{{ item ? item.first : '' }}</nimble-list-option>
+                @for (item of comboboxItems; track item) {
+                    <nimble-list-option [ngValue]="item">{{ item ? item.first : '' }}</nimble-list-option>
+                }
             </nimble-combobox>
         </example-sub-container>
     `,

--- a/packages/angular-workspace/example-client-app/src/app/customapp/select-section.component.ts
+++ b/packages/angular-workspace/example-client-app/src/app/customapp/select-section.component.ts
@@ -49,7 +49,9 @@ interface ComboboxItem {
             <example-sub-container label="Select with dynamic options">
                 <nimble-select #dynamicSelect appearance="underline" filter-mode="manual" [(ngModel)]="dynamicSelectValue" (filter-input)="onDynamicSelectFilterInput($event)" [compareWith]="dynamicSelectCompareWith">
                     <nimble-list-option hidden selected disabled [ngValue]="dynamicSelectPlaceholderValue">Select an option</nimble-list-option>
-                    <nimble-list-option *ngFor="let item of dynamicSelectItems" [ngValue]="item" [hidden]="shouldHideItem(item)">{{ item.first }} {{ item.last }}</nimble-list-option>
+                    @for (item of dynamicSelectItems; track item) {
+                        <nimble-list-option [ngValue]="item" [hidden]="shouldHideItem(item)">{{ item.first }} {{ item.last }}</nimble-list-option>
+                    }
                 </nimble-select>
             </example-sub-container>
         </example-sub-container>

--- a/packages/angular-workspace/example-client-app/src/app/customapp/sub-container/sub-container.component.ts
+++ b/packages/angular-workspace/example-client-app/src/app/customapp/sub-container/sub-container.component.ts
@@ -4,7 +4,9 @@ import { Component, Input } from '@angular/core';
     selector: 'example-sub-container',
     template: `
         <div class="sub-container">
-            <div class="container-label" *ngIf="label">{{ label }}</div>
+            @if (label) {
+                <div class="container-label">{{ label }}</div>
+            }
             <ng-content></ng-content>
         </div>
     `,

--- a/packages/angular-workspace/example-client-app/src/app/customapp/table-section.component.ts
+++ b/packages/angular-workspace/example-client-app/src/app/customapp/table-section.component.ts
@@ -103,10 +103,14 @@ interface SimpleTableRecord extends TableRecord {
                 </nimble-menu>
 
                 <nimble-menu slot="color-menu">
-                    <nimble-menu-item *ngFor="let color of possibleColors" (change)="onColorSelected(color)">
-                        <nimble-icon-check *ngIf="color === currentColor" slot="start"></nimble-icon-check>
-                        {{ color }}
-                    </nimble-menu-item>
+                    @for (color of possibleColors; track color) {
+                        <nimble-menu-item (change)="onColorSelected(color)">
+                            @if (color === currentColor) {
+                                <nimble-icon-check slot="start"></nimble-icon-check>
+                            }
+                            {{ color }}
+                        </nimble-menu-item>
+                    }
                 </nimble-menu>
             </nimble-table>
             <nimble-button class="add-table-row-button" (click)="addTableRows(10)">Add rows</nimble-button>

--- a/packages/angular-workspace/nimble-angular/src/directives/combobox/tests/nimble-combobox-control-value-accessor.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/combobox/tests/nimble-combobox-control-value-accessor.directive.spec.ts
@@ -31,9 +31,13 @@ describe('Nimble combobox control value accessor', () => {
         @Component({
             template: `
                 <nimble-combobox #combobox [(ngModel)]="selectedOption" (ngModelChange)="onModelValueChange($event)" [compareWith]="compareWith" [disabled]="selectDisabled" autocomplete="none">
-                    <nimble-list-option *ngFor="let option of selectOptions" [ngValue]="option">{{ option?.name ?? nullValueString }}</nimble-list-option>
+                    @for (option of selectOptions; track option) {
+                        <nimble-list-option [ngValue]="option">{{ option?.name ?? nullValueString }}</nimble-list-option>
+                    }
                     <nimble-list-option [ngValue]="dynamicOption">{{ dynamicOption?.name }}</nimble-list-option>
-                    <nimble-list-option *ngIf="showFirstSharedOption" [ngValue]="sharedOption">{{ sharedOption?.name }}</nimble-list-option>
+                    @if (showFirstSharedOption) {
+                        <nimble-list-option [ngValue]="sharedOption">{{ sharedOption?.name }}</nimble-list-option>
+                    }
                     <nimble-list-option #lastOption [ngValue]="sharedOption">{{ sharedOption?.otherName }}</nimble-list-option>
                 </nimble-combobox>
              `,
@@ -328,9 +332,13 @@ describe('Nimble combobox control value accessor', () => {
             template: `
                 <form [formGroup]="form">
                     <nimble-combobox #combobox [formControl]="selectedOption" [compareWith]="compareWith" autocomplete="none">
-                        <nimble-list-option *ngFor="let option of selectOptions" [ngValue]="option">{{ option?.name ?? nullValueString }}</nimble-list-option>
+                        @for (option of selectOptions; track option) {
+                            <nimble-list-option [ngValue]="option">{{ option?.name ?? nullValueString }}</nimble-list-option>
+                        }
                         <nimble-list-option [ngValue]="dynamicOption">{{ dynamicOption?.name }}</nimble-list-option>
-                        <nimble-list-option *ngIf="showFirstSharedOption" [ngValue]="sharedOption">{{ sharedOption?.name }}</nimble-list-option>
+                        @if (showFirstSharedOption) {
+                            <nimble-list-option [ngValue]="sharedOption">{{ sharedOption?.name }}</nimble-list-option>
+                        }
                         <nimble-list-option #lastOption [ngValue]="sharedOption">{{ sharedOption?.otherName }}</nimble-list-option>
                     </nimble-combobox>
                 </form>

--- a/packages/angular-workspace/nimble-angular/src/directives/combobox/tests/nimble-combobox.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/combobox/tests/nimble-combobox.directive.spec.ts
@@ -546,7 +546,9 @@ describe('Nimble combobox', () => {
         @Component({
             template: `
                 <nimble-combobox #combobox>
-                    <nimble-list-option *ngFor="let option of autoCompleteOptions" [ngValue]="option">{{ option.name }}</nimble-list-option>
+                    @for (option of autoCompleteOptions; track option) {
+                        <nimble-list-option [ngValue]="option">{{ option.name }}</nimble-list-option>
+                    }
                 </nimble-combobox>
             `,
             standalone: false

--- a/packages/angular-workspace/nimble-angular/src/directives/radio/tests/nimble-radio-control-value-accessor.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/radio/tests/nimble-radio-control-value-accessor.directive.spec.ts
@@ -16,9 +16,11 @@ describe('Nimble radio control value accessor', () => {
         @Component({
             template: `
                 <nimble-radio-group #radioGroup name="options">
-                    <nimble-radio *ngFor="let button of radios" [value]="button.value" [(ngModel)]="selectedRadio" (ngModelChange)="onModelValueChange($event)">
-                        {{ button.name }}
-                    </nimble-radio>
+                    @for (button of radios; track button) {
+                        <nimble-radio [value]="button.value" [(ngModel)]="selectedRadio" (ngModelChange)="onModelValueChange($event)">
+                            {{ button.name }}
+                        </nimble-radio>
+                    }
                 </nimble-radio-group>
              `,
             standalone: false
@@ -113,9 +115,11 @@ describe('Nimble radio control value accessor', () => {
             template: `
                 <form [formGroup]="form">
                     <nimble-radio-group #radioGroup>
-                        <nimble-radio *ngFor="let option of radios" [value]="option.value" [formControl]="selectedRadio">
-                            {{ option.name }}
-                        </nimble-radio>
+                        @for (option of radios; track option) {
+                            <nimble-radio [value]="option.value" [formControl]="selectedRadio">
+                                {{ option.name }}
+                            </nimble-radio>
+                        }
                     </nimble-radio-group>
                 </form>
                 `,

--- a/packages/angular-workspace/nimble-angular/src/directives/select/tests/nimble-select-control-value-accessor.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/select/tests/nimble-select-control-value-accessor.directive.spec.ts
@@ -13,10 +13,11 @@ describe('Nimble select control value accessor', () => {
         @Component({
             template: `
                 <nimble-select #select [(ngModel)]="selectedOption" (ngModelChange)="onModelValueChange($event)" [compareWith]="compareWith" [disabled]="selectDisabled">
-                    <nimble-list-option *ngFor="let option of selectOptions"
-                        [ngValue]="option">
-                        {{ option.name }}
-                    </nimble-list-option>
+                    @for (option of selectOptions; track option) {
+                        <nimble-list-option [ngValue]="option">
+                            {{ option.name }}
+                        </nimble-list-option>
+                    }
                 </nimble-select>
              `,
             standalone: false
@@ -122,10 +123,11 @@ describe('Nimble select control value accessor', () => {
         @Component({
             template: `
                 <nimble-select #select [(ngModel)]="selectedOption">
-                    <nimble-list-option *ngFor="let option of selectOptions"
-                        [value]="option.value">
-                        {{ option.name }}
-                    </nimble-list-option>
+                    @for (option of selectOptions; track option) {
+                        <nimble-list-option [value]="option.value">
+                            {{ option.name }}
+                        </nimble-list-option>
+                    }
                 </nimble-select>
              `,
             standalone: false
@@ -195,10 +197,11 @@ describe('Nimble select control value accessor', () => {
             template: `
                 <form [formGroup]='form'>
                     <nimble-select #select formControlName="selectValue">
-                        <nimble-list-option *ngFor="let option of selectOptions"
-                            [ngValue]="option">
-                            {{ option.name }}
-                        </nimble-list-option>
+                        @for (option of selectOptions; track option) {
+                            <nimble-list-option [ngValue]="option">
+                                {{ option.name }}
+                            </nimble-list-option>
+                        }
                     </nimble-select>
                 </form>
              `,
@@ -265,10 +268,11 @@ describe('Nimble select control value accessor', () => {
             template: `
                 <form [formGroup]='form'>
                     <nimble-select #select formControlName="selectValue">
-                        <nimble-list-option *ngFor="let option of selectOptions"
-                            [ngValue]="option">
-                            {{ option.name }}
-                        </nimble-list-option>
+                        @for (option of selectOptions; track option) {
+                            <nimble-list-option [ngValue]="option">
+                                {{ option.name }}
+                            </nimble-list-option>
+                        }
                     </nimble-select>
                 </form>
              `,
@@ -348,10 +352,11 @@ describe('Nimble select control value accessor', () => {
                 <form [formGroup]='form'>
                     <nimble-select #select formControlName="selectValue">
                         <nimble-list-option-group label="Group 1">
-                            <nimble-list-option *ngFor="let option of selectOptions"
-                                [ngValue]="option">
-                                {{ option.name }}
-                            </nimble-list-option>
+                            @for (option of selectOptions; track option) {
+                                <nimble-list-option [ngValue]="option">
+                                    {{ option.name }}
+                                </nimble-list-option>
+                            }
                         </nimble-list-option-group>
                     </nimble-select>
                 </form>
@@ -420,10 +425,11 @@ describe('Nimble select control value accessor', () => {
                 <form [formGroup]='form'>
                     <nimble-select #select formControlName="selectValue">
                         <nimble-list-option-group label="Group 1">
-                            <nimble-list-option *ngFor="let option of selectOptions"
-                                [ngValue]="option">
-                                {{ option.name }}
-                            </nimble-list-option>
+                            @for (option of selectOptions; track option) {
+                                <nimble-list-option [ngValue]="option">
+                                    {{ option.name }}
+                                </nimble-list-option>
+                            }
                         </nimble-list-option-group>
                     </nimble-select>
                 </form>

--- a/packages/eslint-config-nimble/angular.js
+++ b/packages/eslint-config-nimble/angular.js
@@ -97,6 +97,8 @@ export const angularTypescriptNimbleConfig = defineConfig([
 export const angularTemplateNimbleConfigOverrides = defineConfig([
     {
         rules: {
+            '@angular-eslint/template/prefer-control-flow': 'error',
+
             // Enable i18n template checking for the purpose of making sure to capture updates for the lint rules
             '@angular-eslint/template/i18n': [
                 'error',


### PR DESCRIPTION



# Pull Request

## 🤨 Rationale

The Angular `*ngIf`/`*ngFor` syntax is deprecated in Angular 20 and should be replaced with `@if`/`@for`.

## 👩‍💻 Implementation

Used copilot to:
- update example client app and nimble-angular directive tests. 
- ignore thirdparty forked directives
- enable `@angular-eslint/template/prefer-control-flow` lint rule

## 🧪 Testing

1. Spot checked copilot's work manually
1. Verified that the lint rule is working (using old syntax cause lint errors)
1. Verified table example in example app


## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
