### PR TITLE
Add breakpoint icons to Spright and update arrow icon in Nimble

### DIFF
--- a/change/@ni-nimble-tokens-3dfd7d43-8f62-4c7e-a290-c22611537feb.json
+++ b/change/@ni-nimble-tokens-3dfd7d43-8f62-4c7e-a290-c22611537feb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update `nimble-icon-arrow-right-thin`",
+  "packageName": "@ni/nimble-tokens",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-spright-angular-1799340e-46e9-4a7d-8fcf-eb437c8fe4fd.json
+++ b/change/@ni-spright-angular-1799340e-46e9-4a7d-8fcf-eb437c8fe4fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add new breakpoint icons",
+  "packageName": "@ni/spright-angular",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-spright-blazor-dbea899e-d2fd-4afe-897d-c74022c0434e.json
+++ b/change/@ni-spright-blazor-dbea899e-d2fd-4afe-897d-c74022c0434e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add new breakpoint icons",
+  "packageName": "@ni/spright-blazor",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-spright-components-a722c073-4ab7-40e7-aee4-427edc82fa13.json
+++ b/change/@ni-spright-components-a722c073-4ab7-40e7-aee4-427edc82fa13.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add new breakpoint icons",
+  "packageName": "@ni/spright-components",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-spright-react-7d63061e-0d29-4680-be98-63c9d5b481db.json
+++ b/change/@ni-spright-react-7d63061e-0d29-4680-be98-63c9d5b481db.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add new breakpoint icons",
+  "packageName": "@ni/spright-react",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/angular-workspace/spright-angular/icons/breakpoint-conditional/ng-package.json
+++ b/packages/angular-workspace/spright-angular/icons/breakpoint-conditional/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+        "entryFile": "spright-icon-breakpoint-conditional.directive.ts"
+    }
+}

--- a/packages/angular-workspace/spright-angular/icons/breakpoint-conditional/spright-icon-breakpoint-conditional.directive.ts
+++ b/packages/angular-workspace/spright-angular/icons/breakpoint-conditional/spright-icon-breakpoint-conditional.directive.ts
@@ -1,0 +1,16 @@
+import { Directive } from '@angular/core';
+import { type IconBreakpointConditional, iconBreakpointConditionalTag } from '@ni/spright-components/dist/esm/icons/breakpoint-conditional';
+import '@ni/spright-components/dist/esm/icons/breakpoint-conditional';
+import { SprightIconBaseDirective } from '@ni/spright-angular/icon-base';
+
+export { type IconBreakpointConditional, iconBreakpointConditionalTag };
+
+/**
+ * Spright breakpoint conditional icon directive
+ */
+@Directive({
+    selector: 'spright-icon-breakpoint-conditional',
+    standalone: true
+})
+export class SprightIconBreakpointConditionalDirective extends SprightIconBaseDirective {
+}

--- a/packages/angular-workspace/spright-angular/icons/breakpoint-disabled/ng-package.json
+++ b/packages/angular-workspace/spright-angular/icons/breakpoint-disabled/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+        "entryFile": "spright-icon-breakpoint-disabled.directive.ts"
+    }
+}

--- a/packages/angular-workspace/spright-angular/icons/breakpoint-disabled/spright-icon-breakpoint-disabled.directive.ts
+++ b/packages/angular-workspace/spright-angular/icons/breakpoint-disabled/spright-icon-breakpoint-disabled.directive.ts
@@ -1,0 +1,16 @@
+import { Directive } from '@angular/core';
+import { type IconBreakpointDisabled, iconBreakpointDisabledTag } from '@ni/spright-components/dist/esm/icons/breakpoint-disabled';
+import '@ni/spright-components/dist/esm/icons/breakpoint-disabled';
+import { SprightIconBaseDirective } from '@ni/spright-angular/icon-base';
+
+export { type IconBreakpointDisabled, iconBreakpointDisabledTag };
+
+/**
+ * Spright breakpoint disabled icon directive
+ */
+@Directive({
+    selector: 'spright-icon-breakpoint-disabled',
+    standalone: true
+})
+export class SprightIconBreakpointDisabledDirective extends SprightIconBaseDirective {
+}

--- a/packages/angular-workspace/spright-angular/icons/breakpoint-enabled/ng-package.json
+++ b/packages/angular-workspace/spright-angular/icons/breakpoint-enabled/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+        "entryFile": "spright-icon-breakpoint-enabled.directive.ts"
+    }
+}

--- a/packages/angular-workspace/spright-angular/icons/breakpoint-enabled/spright-icon-breakpoint-enabled.directive.ts
+++ b/packages/angular-workspace/spright-angular/icons/breakpoint-enabled/spright-icon-breakpoint-enabled.directive.ts
@@ -1,0 +1,16 @@
+import { Directive } from '@angular/core';
+import { type IconBreakpointEnabled, iconBreakpointEnabledTag } from '@ni/spright-components/dist/esm/icons/breakpoint-enabled';
+import '@ni/spright-components/dist/esm/icons/breakpoint-enabled';
+import { SprightIconBaseDirective } from '@ni/spright-angular/icon-base';
+
+export { type IconBreakpointEnabled, iconBreakpointEnabledTag };
+
+/**
+ * Spright breakpoint enabled icon directive
+ */
+@Directive({
+    selector: 'spright-icon-breakpoint-enabled',
+    standalone: true
+})
+export class SprightIconBreakpointEnabledDirective extends SprightIconBaseDirective {
+}

--- a/packages/angular-workspace/spright-angular/icons/breakpoint-execution-pointer/ng-package.json
+++ b/packages/angular-workspace/spright-angular/icons/breakpoint-execution-pointer/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+        "entryFile": "spright-icon-breakpoint-execution-pointer.directive.ts"
+    }
+}

--- a/packages/angular-workspace/spright-angular/icons/breakpoint-execution-pointer/spright-icon-breakpoint-execution-pointer.directive.ts
+++ b/packages/angular-workspace/spright-angular/icons/breakpoint-execution-pointer/spright-icon-breakpoint-execution-pointer.directive.ts
@@ -1,0 +1,16 @@
+import { Directive } from '@angular/core';
+import { type IconBreakpointExecutionPointer, iconBreakpointExecutionPointerTag } from '@ni/spright-components/dist/esm/icons/breakpoint-execution-pointer';
+import '@ni/spright-components/dist/esm/icons/breakpoint-execution-pointer';
+import { SprightIconBaseDirective } from '@ni/spright-angular/icon-base';
+
+export { type IconBreakpointExecutionPointer, iconBreakpointExecutionPointerTag };
+
+/**
+ * Spright breakpoint execution pointer icon directive
+ */
+@Directive({
+    selector: 'spright-icon-breakpoint-execution-pointer',
+    standalone: true
+})
+export class SprightIconBreakpointExecutionPointerDirective extends SprightIconBaseDirective {
+}

--- a/packages/angular-workspace/spright-angular/icons/breakpoint-hit-disabled/ng-package.json
+++ b/packages/angular-workspace/spright-angular/icons/breakpoint-hit-disabled/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+        "entryFile": "spright-icon-breakpoint-hit-disabled.directive.ts"
+    }
+}

--- a/packages/angular-workspace/spright-angular/icons/breakpoint-hit-disabled/spright-icon-breakpoint-hit-disabled.directive.ts
+++ b/packages/angular-workspace/spright-angular/icons/breakpoint-hit-disabled/spright-icon-breakpoint-hit-disabled.directive.ts
@@ -1,0 +1,16 @@
+import { Directive } from '@angular/core';
+import { type IconBreakpointHitDisabled, iconBreakpointHitDisabledTag } from '@ni/spright-components/dist/esm/icons/breakpoint-hit-disabled';
+import '@ni/spright-components/dist/esm/icons/breakpoint-hit-disabled';
+import { SprightIconBaseDirective } from '@ni/spright-angular/icon-base';
+
+export { type IconBreakpointHitDisabled, iconBreakpointHitDisabledTag };
+
+/**
+ * Spright breakpoint hit disabled icon directive
+ */
+@Directive({
+    selector: 'spright-icon-breakpoint-hit-disabled',
+    standalone: true
+})
+export class SprightIconBreakpointHitDisabledDirective extends SprightIconBaseDirective {
+}

--- a/packages/angular-workspace/spright-angular/icons/breakpoint-hit/ng-package.json
+++ b/packages/angular-workspace/spright-angular/icons/breakpoint-hit/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+        "entryFile": "spright-icon-breakpoint-hit.directive.ts"
+    }
+}

--- a/packages/angular-workspace/spright-angular/icons/breakpoint-hit/spright-icon-breakpoint-hit.directive.ts
+++ b/packages/angular-workspace/spright-angular/icons/breakpoint-hit/spright-icon-breakpoint-hit.directive.ts
@@ -1,0 +1,16 @@
+import { Directive } from '@angular/core';
+import { type IconBreakpointHit, iconBreakpointHitTag } from '@ni/spright-components/dist/esm/icons/breakpoint-hit';
+import '@ni/spright-components/dist/esm/icons/breakpoint-hit';
+import { SprightIconBaseDirective } from '@ni/spright-angular/icon-base';
+
+export { type IconBreakpointHit, iconBreakpointHitTag };
+
+/**
+ * Spright breakpoint hit icon directive
+ */
+@Directive({
+    selector: 'spright-icon-breakpoint-hit',
+    standalone: true
+})
+export class SprightIconBreakpointHitDirective extends SprightIconBaseDirective {
+}

--- a/packages/angular-workspace/spright-angular/icons/breakpoint-hover/ng-package.json
+++ b/packages/angular-workspace/spright-angular/icons/breakpoint-hover/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+        "entryFile": "spright-icon-breakpoint-hover.directive.ts"
+    }
+}

--- a/packages/angular-workspace/spright-angular/icons/breakpoint-hover/spright-icon-breakpoint-hover.directive.ts
+++ b/packages/angular-workspace/spright-angular/icons/breakpoint-hover/spright-icon-breakpoint-hover.directive.ts
@@ -1,0 +1,16 @@
+import { Directive } from '@angular/core';
+import { type IconBreakpointHover, iconBreakpointHoverTag } from '@ni/spright-components/dist/esm/icons/breakpoint-hover';
+import '@ni/spright-components/dist/esm/icons/breakpoint-hover';
+import { SprightIconBaseDirective } from '@ni/spright-angular/icon-base';
+
+export { type IconBreakpointHover, iconBreakpointHoverTag };
+
+/**
+ * Spright breakpoint hover icon directive
+ */
+@Directive({
+    selector: 'spright-icon-breakpoint-hover',
+    standalone: true
+})
+export class SprightIconBreakpointHoverDirective extends SprightIconBaseDirective {
+}

--- a/packages/blazor-workspace/CodeAnalysisDictionary.xml
+++ b/packages/blazor-workspace/CodeAnalysisDictionary.xml
@@ -4,6 +4,7 @@
         <Recognized>
             <Word>args</Word>
             <Word>blazor</Word>
+            <Word>breakpoint</Word>
             <Word>bool</Word>
             <Word>clearable</Word>
             <Word>combobox</Word>

--- a/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointConditional.razor
+++ b/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointConditional.razor
@@ -1,0 +1,5 @@
+@namespace SprightBlazor
+@inherits SprightIconBase
+<spright-icon-breakpoint-conditional
+    @attributes="AdditionalAttributes">
+</spright-icon-breakpoint-conditional>

--- a/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointConditional.razor.cs
+++ b/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointConditional.razor.cs
@@ -1,0 +1,5 @@
+namespace SprightBlazor;
+
+public partial class SprightIconBreakpointConditional : SprightIconBase
+{
+}

--- a/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointDisabled.razor
+++ b/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointDisabled.razor
@@ -1,0 +1,5 @@
+@namespace SprightBlazor
+@inherits SprightIconBase
+<spright-icon-breakpoint-disabled
+    @attributes="AdditionalAttributes">
+</spright-icon-breakpoint-disabled>

--- a/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointDisabled.razor.cs
+++ b/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointDisabled.razor.cs
@@ -1,0 +1,5 @@
+namespace SprightBlazor;
+
+public partial class SprightIconBreakpointDisabled : SprightIconBase
+{
+}

--- a/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointEnabled.razor
+++ b/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointEnabled.razor
@@ -1,0 +1,5 @@
+@namespace SprightBlazor
+@inherits SprightIconBase
+<spright-icon-breakpoint-enabled
+    @attributes="AdditionalAttributes">
+</spright-icon-breakpoint-enabled>

--- a/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointEnabled.razor.cs
+++ b/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointEnabled.razor.cs
@@ -1,0 +1,5 @@
+namespace SprightBlazor;
+
+public partial class SprightIconBreakpointEnabled : SprightIconBase
+{
+}

--- a/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointExecutionPointer.razor
+++ b/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointExecutionPointer.razor
@@ -1,0 +1,5 @@
+@namespace SprightBlazor
+@inherits SprightIconBase
+<spright-icon-breakpoint-execution-pointer
+    @attributes="AdditionalAttributes">
+</spright-icon-breakpoint-execution-pointer>

--- a/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointExecutionPointer.razor.cs
+++ b/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointExecutionPointer.razor.cs
@@ -1,0 +1,5 @@
+namespace SprightBlazor;
+
+public partial class SprightIconBreakpointExecutionPointer : SprightIconBase
+{
+}

--- a/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointHit.razor
+++ b/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointHit.razor
@@ -1,0 +1,5 @@
+@namespace SprightBlazor
+@inherits SprightIconBase
+<spright-icon-breakpoint-hit
+    @attributes="AdditionalAttributes">
+</spright-icon-breakpoint-hit>

--- a/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointHit.razor.cs
+++ b/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointHit.razor.cs
@@ -1,0 +1,5 @@
+namespace SprightBlazor;
+
+public partial class SprightIconBreakpointHit : SprightIconBase
+{
+}

--- a/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointHitDisabled.razor
+++ b/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointHitDisabled.razor
@@ -1,0 +1,5 @@
+@namespace SprightBlazor
+@inherits SprightIconBase
+<spright-icon-breakpoint-hit-disabled
+    @attributes="AdditionalAttributes">
+</spright-icon-breakpoint-hit-disabled>

--- a/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointHitDisabled.razor.cs
+++ b/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointHitDisabled.razor.cs
@@ -1,0 +1,5 @@
+namespace SprightBlazor;
+
+public partial class SprightIconBreakpointHitDisabled : SprightIconBase
+{
+}

--- a/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointHover.razor
+++ b/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointHover.razor
@@ -1,0 +1,5 @@
+@namespace SprightBlazor
+@inherits SprightIconBase
+<spright-icon-breakpoint-hover
+    @attributes="AdditionalAttributes">
+</spright-icon-breakpoint-hover>

--- a/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointHover.razor.cs
+++ b/packages/blazor-workspace/SprightBlazor/Source/Icons/SprightIconBreakpointHover.razor.cs
@@ -1,0 +1,5 @@
+namespace SprightBlazor;
+
+public partial class SprightIconBreakpointHover : SprightIconBase
+{
+}

--- a/packages/nimble-tokens/CONTRIBUTING.md
+++ b/packages/nimble-tokens/CONTRIBUTING.md
@@ -73,7 +73,7 @@ These steps require access to Adobe Illustrator and Perforce so will typically b
 
 2. Confirm the new icon files will build correctly by running: `npm run build -w @ni/nimble-tokens`.
 3. Generate and build icon components by running `npm run build -w @ni/nimble-components`. This step will report an error at this point but is necessary to enable the next step.
-4. Add metadata for the new icons to `nimble-components/src/icon-base/tests/icon-metadata.ts`.
+4. Add metadata for the new icons to `nimble-components/src/icon-svg/tests/icon-metadata.ts`.
 5. Run `npm run build -w @ni/nimble-components` again. It should now succeed.
 6. Preview the built files by running: `npm run storybook`, and review the **Icons** story to confirm that your changes appear correctly. Inspect the icons in each **Severity** and ensure their color changes.
 7. Publish a PR with your changes. If there are any new icons, set `changeType` and `dependentChangeType` to minor in the beachball change file.

--- a/packages/nimble-tokens/dist/icons/svg/arrow-right-thin_16x16.svg
+++ b/packages/nimble-tokens/dist/icons/svg/arrow-right-thin_16x16.svg
@@ -1,11 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-  <defs>
-    <style>
-      .cls-1 {
-        fill: #161617;
-      }
-    </style>
-  </defs>
   <polygon class="cls-1" points="7.97 4.37 7.29 5.49 10.38 7.35 2 7.35 2 8.65 10.38 8.65 7.29 10.51 7.97 11.63 14 8 7.97 4.37"/>
 </svg>

--- a/packages/nimble-tokens/dist/icons/svg/arrow-right-thin_16x16.svg
+++ b/packages/nimble-tokens/dist/icons/svg/arrow-right-thin_16x16.svg
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-	<polygon class="cls-1"
-		points="7.83105 4.38647 7.12451 5.51306 10.25311 7.35004 2 7.35046 2 8.64996 10.3653 8.6496 7.48907 10.52771 8.25653 11.61346 13.87549 8 7.83105 4.38647"/>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #161617;
+      }
+    </style>
+  </defs>
+  <polygon class="cls-1" points="7.97 4.37 7.29 5.49 10.38 7.35 2 7.35 2 8.65 10.38 8.65 7.29 10.51 7.97 11.63 14 8 7.97 4.37"/>
 </svg>

--- a/packages/react-workspace/spright-react/src/icons/breakpoint-conditional/index.ts
+++ b/packages/react-workspace/spright-react/src/icons/breakpoint-conditional/index.ts
@@ -1,0 +1,8 @@
+'use client';
+
+import { IconBreakpointConditional, iconBreakpointConditionalTag } from '@ni/spright-components/dist/esm/icons/breakpoint-conditional';
+import { wrap } from '../../utilities/react-wrapper';
+
+export type { IconBreakpointConditional };
+export { iconBreakpointConditionalTag };
+export const SprightIconBreakpointConditional = wrap(IconBreakpointConditional);

--- a/packages/react-workspace/spright-react/src/icons/breakpoint-disabled/index.ts
+++ b/packages/react-workspace/spright-react/src/icons/breakpoint-disabled/index.ts
@@ -1,0 +1,8 @@
+'use client';
+
+import { IconBreakpointDisabled, iconBreakpointDisabledTag } from '@ni/spright-components/dist/esm/icons/breakpoint-disabled';
+import { wrap } from '../../utilities/react-wrapper';
+
+export type { IconBreakpointDisabled };
+export { iconBreakpointDisabledTag };
+export const SprightIconBreakpointDisabled = wrap(IconBreakpointDisabled);

--- a/packages/react-workspace/spright-react/src/icons/breakpoint-enabled/index.ts
+++ b/packages/react-workspace/spright-react/src/icons/breakpoint-enabled/index.ts
@@ -1,0 +1,8 @@
+'use client';
+
+import { IconBreakpointEnabled, iconBreakpointEnabledTag } from '@ni/spright-components/dist/esm/icons/breakpoint-enabled';
+import { wrap } from '../../utilities/react-wrapper';
+
+export type { IconBreakpointEnabled };
+export { iconBreakpointEnabledTag };
+export const SprightIconBreakpointEnabled = wrap(IconBreakpointEnabled);

--- a/packages/react-workspace/spright-react/src/icons/breakpoint-execution-pointer/index.ts
+++ b/packages/react-workspace/spright-react/src/icons/breakpoint-execution-pointer/index.ts
@@ -1,0 +1,8 @@
+'use client';
+
+import { IconBreakpointExecutionPointer, iconBreakpointExecutionPointerTag } from '@ni/spright-components/dist/esm/icons/breakpoint-execution-pointer';
+import { wrap } from '../../utilities/react-wrapper';
+
+export type { IconBreakpointExecutionPointer };
+export { iconBreakpointExecutionPointerTag };
+export const SprightIconBreakpointExecutionPointer = wrap(IconBreakpointExecutionPointer);

--- a/packages/react-workspace/spright-react/src/icons/breakpoint-hit-disabled/index.ts
+++ b/packages/react-workspace/spright-react/src/icons/breakpoint-hit-disabled/index.ts
@@ -1,0 +1,8 @@
+'use client';
+
+import { IconBreakpointHitDisabled, iconBreakpointHitDisabledTag } from '@ni/spright-components/dist/esm/icons/breakpoint-hit-disabled';
+import { wrap } from '../../utilities/react-wrapper';
+
+export type { IconBreakpointHitDisabled };
+export { iconBreakpointHitDisabledTag };
+export const SprightIconBreakpointHitDisabled = wrap(IconBreakpointHitDisabled);

--- a/packages/react-workspace/spright-react/src/icons/breakpoint-hit/index.ts
+++ b/packages/react-workspace/spright-react/src/icons/breakpoint-hit/index.ts
@@ -1,0 +1,8 @@
+'use client';
+
+import { IconBreakpointHit, iconBreakpointHitTag } from '@ni/spright-components/dist/esm/icons/breakpoint-hit';
+import { wrap } from '../../utilities/react-wrapper';
+
+export type { IconBreakpointHit };
+export { iconBreakpointHitTag };
+export const SprightIconBreakpointHit = wrap(IconBreakpointHit);

--- a/packages/react-workspace/spright-react/src/icons/breakpoint-hover/index.ts
+++ b/packages/react-workspace/spright-react/src/icons/breakpoint-hover/index.ts
@@ -1,0 +1,8 @@
+'use client';
+
+import { IconBreakpointHover, iconBreakpointHoverTag } from '@ni/spright-components/dist/esm/icons/breakpoint-hover';
+import { wrap } from '../../utilities/react-wrapper';
+
+export type { IconBreakpointHover };
+export { iconBreakpointHoverTag };
+export const SprightIconBreakpointHover = wrap(IconBreakpointHover);

--- a/packages/spright-components/src/icon-base/tests/icon-metadata.ts
+++ b/packages/spright-components/src/icon-base/tests/icon-metadata.ts
@@ -10,6 +10,9 @@ export const iconMetadata: {
     readonly [key in IconName]: IconMetadata;
 } = {
     /* eslint-disable @typescript-eslint/naming-convention */
+    IconBreakpointConditional: {
+        tags: ['debug']
+    },
     IconNigelChat: {
         tags: ['nigel', 'chat', 'ai']
     },

--- a/packages/spright-components/src/icon-base/tests/icon-metadata.ts
+++ b/packages/spright-components/src/icon-base/tests/icon-metadata.ts
@@ -22,10 +22,10 @@ export const iconMetadata: {
     IconBreakpointExecutionPointer: {
         tags: ['debug']
     },
-    IconBreakpointHitDisabled: {
+    IconBreakpointHit: {
         tags: ['debug']
     },
-    IconBreakpointHit: {
+    IconBreakpointHitDisabled: {
         tags: ['debug']
     },
     IconBreakpointHover: {
@@ -37,11 +37,11 @@ export const iconMetadata: {
     IconWorkItemCalendarWeek: {
         tags: ['reservation', 'booking', 'schedule', 'time slot']
     },
-    IconWorkItemForklift: {
-        tags: ['logistics', 'delivery', 'transport', 'shipping']
-    },
     IconWorkItemCalipers: {
         tags: ['calibration', 'quality', 'measurement', 'standards']
+    },
+    IconWorkItemForklift: {
+        tags: ['logistics', 'delivery', 'transport', 'shipping']
     },
     IconWorkItemRectangleCheckLines: {
         tags: ['testing', 'verification', 'quality assurance', 'checklist']

--- a/packages/spright-components/src/icon-base/tests/icon-metadata.ts
+++ b/packages/spright-components/src/icon-base/tests/icon-metadata.ts
@@ -13,6 +13,24 @@ export const iconMetadata: {
     IconBreakpointConditional: {
         tags: ['debug']
     },
+    IconBreakpointDisabled: {
+        tags: ['debug']
+    },
+    IconBreakpointEnabled: {
+        tags: ['debug']
+    },
+    IconBreakpointExecutionPointer: {
+        tags: ['debug']
+    },
+    IconBreakpointHitDisabled: {
+        tags: ['debug']
+    },
+    IconBreakpointHit: {
+        tags: ['debug']
+    },
+    IconBreakpointHover: {
+        tags: ['debug']
+    },
     IconNigelChat: {
         tags: ['nigel', 'chat', 'ai']
     },

--- a/packages/spright-components/src/icons/all-icons.ts
+++ b/packages/spright-components/src/icons/all-icons.ts
@@ -1,4 +1,10 @@
 export { IconBreakpointConditional } from './breakpoint-conditional';
+export { IconBreakpointDisabled } from './breakpoint-disabled';
+export { IconBreakpointEnabled } from './breakpoint-enabled';
+export { IconBreakpointExecutionPointer } from './breakpoint-execution-pointer';
+export { IconBreakpointHitDisabled } from './breakpoint-hit-disabled';
+export { IconBreakpointHit } from './breakpoint-hit';
+export { IconBreakpointHover } from './breakpoint-hover';
 export { IconNigelChat } from './nigel-chat';
 export { IconWorkItemCalendarWeek } from './work-item-calendar-week';
 export { IconWorkItemCalipers } from './work-item-calipers';

--- a/packages/spright-components/src/icons/all-icons.ts
+++ b/packages/spright-components/src/icons/all-icons.ts
@@ -1,3 +1,4 @@
+export { IconBreakpointConditional } from './breakpoint-conditional';
 export { IconNigelChat } from './nigel-chat';
 export { IconWorkItemCalendarWeek } from './work-item-calendar-week';
 export { IconWorkItemCalipers } from './work-item-calipers';

--- a/packages/spright-components/src/icons/breakpoint-conditional/icon-data.ts
+++ b/packages/spright-components/src/icons/breakpoint-conditional/icon-data.ts
@@ -1,0 +1,11 @@
+export const iconData = `<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs>
+    <style>
+      .breakpoint-conditional-0 {
+        fill: #c42126;
+      }
+    </style>
+  </defs>
+  <path class="breakpoint-conditional-0" d="M8,3c-2.76,0-5,2.24-5,5s2.24,5,5,5,5-2.24,5-5-2.24-5-5-5ZM11,9h-2v2h-2v-2h-2v-2h2v-2h2v2h2v2Z"/>
+</svg>`;

--- a/packages/spright-components/src/icons/breakpoint-conditional/index.ts
+++ b/packages/spright-components/src/icons/breakpoint-conditional/index.ts
@@ -1,0 +1,32 @@
+import { Icon } from '@ni/nimble-components/dist/esm/icon-base';
+import { styles } from '@ni/nimble-components/dist/esm/icon-svg/styles';
+import { html } from '@ni/fast-element';
+import { DesignSystem } from '@ni/fast-foundation';
+import { iconData } from './icon-data';
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'spright-icon-breakpoint-conditional': IconBreakpointConditional;
+    }
+}
+
+/**
+ * Spright breakpoint conditional icon.
+ */
+export class IconBreakpointConditional extends Icon {}
+
+const template = html<IconBreakpointConditional>`
+    <div class="icon" aria-hidden="true" :innerHTML="${() => iconData}"></div>
+`;
+
+const sprightIconBreakpointConditional = IconBreakpointConditional.compose({
+    baseName: 'icon-breakpoint-conditional',
+    template,
+    styles
+});
+
+DesignSystem.getOrCreate()
+    .withPrefix('spright')
+    .register(sprightIconBreakpointConditional());
+
+export const iconBreakpointConditionalTag = 'spright-icon-breakpoint-conditional';

--- a/packages/spright-components/src/icons/breakpoint-disabled/icon-data.ts
+++ b/packages/spright-components/src/icons/breakpoint-disabled/icon-data.ts
@@ -1,0 +1,12 @@
+export const iconData = `<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs>
+    <style>
+      .breakpoint-disabled-0 {
+        fill: #161617;
+        opacity: .3;
+      }
+    </style>
+  </defs>
+  <circle class="breakpoint-disabled-0" cx="8" cy="8" r="5"/>
+</svg>`;

--- a/packages/spright-components/src/icons/breakpoint-disabled/index.ts
+++ b/packages/spright-components/src/icons/breakpoint-disabled/index.ts
@@ -1,0 +1,32 @@
+import { Icon } from '@ni/nimble-components/dist/esm/icon-base';
+import { styles } from '@ni/nimble-components/dist/esm/icon-svg/styles';
+import { html } from '@ni/fast-element';
+import { DesignSystem } from '@ni/fast-foundation';
+import { iconData } from './icon-data';
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'spright-icon-breakpoint-disabled': IconBreakpointDisabled;
+    }
+}
+
+/**
+ * Spright breakpoint disabled icon.
+ */
+export class IconBreakpointDisabled extends Icon {}
+
+const template = html<IconBreakpointDisabled>`
+    <div class="icon" aria-hidden="true" :innerHTML="${() => iconData}"></div>
+`;
+
+const sprightIconBreakpointDisabled = IconBreakpointDisabled.compose({
+    baseName: 'icon-breakpoint-disabled',
+    template,
+    styles
+});
+
+DesignSystem.getOrCreate()
+    .withPrefix('spright')
+    .register(sprightIconBreakpointDisabled());
+
+export const iconBreakpointDisabledTag = 'spright-icon-breakpoint-disabled';

--- a/packages/spright-components/src/icons/breakpoint-enabled/icon-data.ts
+++ b/packages/spright-components/src/icons/breakpoint-enabled/icon-data.ts
@@ -1,0 +1,11 @@
+export const iconData = `<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs>
+    <style>
+      .breakpoint-enabled-0 {
+        fill: #c42126;
+      }
+    </style>
+  </defs>
+  <circle class="breakpoint-enabled-0" cx="8" cy="8" r="5"/>
+</svg>`;

--- a/packages/spright-components/src/icons/breakpoint-enabled/index.ts
+++ b/packages/spright-components/src/icons/breakpoint-enabled/index.ts
@@ -1,0 +1,32 @@
+import { Icon } from '@ni/nimble-components/dist/esm/icon-base';
+import { styles } from '@ni/nimble-components/dist/esm/icon-svg/styles';
+import { html } from '@ni/fast-element';
+import { DesignSystem } from '@ni/fast-foundation';
+import { iconData } from './icon-data';
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'spright-icon-breakpoint-enabled': IconBreakpointEnabled;
+    }
+}
+
+/**
+ * Spright breakpoint enabled icon.
+ */
+export class IconBreakpointEnabled extends Icon {}
+
+const template = html<IconBreakpointEnabled>`
+    <div class="icon" aria-hidden="true" :innerHTML="${() => iconData}"></div>
+`;
+
+const sprightIconBreakpointEnabled = IconBreakpointEnabled.compose({
+    baseName: 'icon-breakpoint-enabled',
+    template,
+    styles
+});
+
+DesignSystem.getOrCreate()
+    .withPrefix('spright')
+    .register(sprightIconBreakpointEnabled());
+
+export const iconBreakpointEnabledTag = 'spright-icon-breakpoint-enabled';

--- a/packages/spright-components/src/icons/breakpoint-execution-pointer/icon-data.ts
+++ b/packages/spright-components/src/icons/breakpoint-execution-pointer/icon-data.ts
@@ -1,0 +1,11 @@
+export const iconData = `<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs>
+    <style>
+      .breakpoint-execution-pointer-0 {
+        fill: #161617;
+      }
+    </style>
+  </defs>
+  <polygon class="breakpoint-execution-pointer-0" points="7.97 4.37 7.29 5.49 9.8 7 2 7 2 9 9.8 9 7.29 10.51 7.97 11.63 14 8 7.97 4.37"/>
+</svg>`;

--- a/packages/spright-components/src/icons/breakpoint-execution-pointer/index.ts
+++ b/packages/spright-components/src/icons/breakpoint-execution-pointer/index.ts
@@ -1,0 +1,32 @@
+import { Icon } from '@ni/nimble-components/dist/esm/icon-base';
+import { styles } from '@ni/nimble-components/dist/esm/icon-svg/styles';
+import { html } from '@ni/fast-element';
+import { DesignSystem } from '@ni/fast-foundation';
+import { iconData } from './icon-data';
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'spright-icon-breakpoint-execution-pointer': IconBreakpointExecutionPointer;
+    }
+}
+
+/**
+ * Spright breakpoint execution pointer icon.
+ */
+export class IconBreakpointExecutionPointer extends Icon {}
+
+const template = html<IconBreakpointExecutionPointer>`
+    <div class="icon" aria-hidden="true" :innerHTML="${() => iconData}"></div>
+`;
+
+const sprightIconBreakpointExecutionPointer = IconBreakpointExecutionPointer.compose({
+    baseName: 'icon-breakpoint-execution-pointer',
+    template,
+    styles
+});
+
+DesignSystem.getOrCreate()
+    .withPrefix('spright')
+    .register(sprightIconBreakpointExecutionPointer());
+
+export const iconBreakpointExecutionPointerTag = 'spright-icon-breakpoint-execution-pointer';

--- a/packages/spright-components/src/icons/breakpoint-hit-disabled/icon-data.ts
+++ b/packages/spright-components/src/icons/breakpoint-hit-disabled/icon-data.ts
@@ -1,0 +1,16 @@
+export const iconData = `<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs>
+    <style>
+      .breakpoint-hit-disabled-0 {
+        opacity: .3;
+      }
+
+      .breakpoint-hit-disabled-0, .breakpoint-hit-disabled-1 {
+        fill: #161617;
+      }
+    </style>
+  </defs>
+  <path class="breakpoint-hit-disabled-0" d="M3.36,6.25c.71-1.89,2.5-3.25,4.64-3.25s3.98,1.4,4.67,3.33l-4.96-2.99-1.45,2.4.84.51h-3.75ZM7.71,12.66l-1.45-2.4.84-.51h-3.75c.71,1.89,2.5,3.25,4.64,3.25s3.98-1.4,4.67-3.33l-4.96,2.99Z"/>
+  <polygon class="breakpoint-hit-disabled-1" points="7.97 4.37 7.29 5.49 9.8 7 2 7 2 9 9.8 9 7.29 10.51 7.97 11.63 14 8 7.97 4.37"/>
+</svg>`;

--- a/packages/spright-components/src/icons/breakpoint-hit-disabled/index.ts
+++ b/packages/spright-components/src/icons/breakpoint-hit-disabled/index.ts
@@ -1,0 +1,32 @@
+import { Icon } from '@ni/nimble-components/dist/esm/icon-base';
+import { styles } from '@ni/nimble-components/dist/esm/icon-svg/styles';
+import { html } from '@ni/fast-element';
+import { DesignSystem } from '@ni/fast-foundation';
+import { iconData } from './icon-data';
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'spright-icon-breakpoint-hit-disabled': IconBreakpointHitDisabled;
+    }
+}
+
+/**
+ * Spright breakpoint hit disabled icon.
+ */
+export class IconBreakpointHitDisabled extends Icon {}
+
+const template = html<IconBreakpointHitDisabled>`
+    <div class="icon" aria-hidden="true" :innerHTML="${() => iconData}"></div>
+`;
+
+const sprightIconBreakpointHitDisabled = IconBreakpointHitDisabled.compose({
+    baseName: 'icon-breakpoint-hit-disabled',
+    template,
+    styles
+});
+
+DesignSystem.getOrCreate()
+    .withPrefix('spright')
+    .register(sprightIconBreakpointHitDisabled());
+
+export const iconBreakpointHitDisabledTag = 'spright-icon-breakpoint-hit-disabled';

--- a/packages/spright-components/src/icons/breakpoint-hit/icon-data.ts
+++ b/packages/spright-components/src/icons/breakpoint-hit/icon-data.ts
@@ -1,0 +1,16 @@
+export const iconData = `<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs>
+    <style>
+      .breakpoint-hit-0 {
+        fill: #c42126;
+      }
+
+      .breakpoint-hit-1 {
+        fill: #161617;
+      }
+    </style>
+  </defs>
+  <path class="breakpoint-hit-0" d="M3.36,6.25c.71-1.89,2.5-3.25,4.64-3.25s3.98,1.4,4.67,3.33l-4.96-2.99-1.45,2.4.84.51h-3.75ZM7.71,12.66l-1.45-2.4.84-.51h-3.75c.71,1.89,2.5,3.25,4.64,3.25s3.98-1.4,4.67-3.33l-4.96,2.99Z"/>
+  <polygon class="breakpoint-hit-1" points="7.97 4.37 7.29 5.49 9.8 7 2 7 2 9 9.8 9 7.29 10.51 7.97 11.63 14 8 7.97 4.37"/>
+</svg>`;

--- a/packages/spright-components/src/icons/breakpoint-hit/index.ts
+++ b/packages/spright-components/src/icons/breakpoint-hit/index.ts
@@ -1,0 +1,32 @@
+import { Icon } from '@ni/nimble-components/dist/esm/icon-base';
+import { styles } from '@ni/nimble-components/dist/esm/icon-svg/styles';
+import { html } from '@ni/fast-element';
+import { DesignSystem } from '@ni/fast-foundation';
+import { iconData } from './icon-data';
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'spright-icon-breakpoint-hit': IconBreakpointHit;
+    }
+}
+
+/**
+ * Spright breakpoint hit icon.
+ */
+export class IconBreakpointHit extends Icon {}
+
+const template = html<IconBreakpointHit>`
+    <div class="icon" aria-hidden="true" :innerHTML="${() => iconData}"></div>
+`;
+
+const sprightIconBreakpointHit = IconBreakpointHit.compose({
+    baseName: 'icon-breakpoint-hit',
+    template,
+    styles
+});
+
+DesignSystem.getOrCreate()
+    .withPrefix('spright')
+    .register(sprightIconBreakpointHit());
+
+export const iconBreakpointHitTag = 'spright-icon-breakpoint-hit';

--- a/packages/spright-components/src/icons/breakpoint-hover/icon-data.ts
+++ b/packages/spright-components/src/icons/breakpoint-hover/icon-data.ts
@@ -1,0 +1,12 @@
+export const iconData = `<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs>
+    <style>
+      .breakpoint-hover-0 {
+        fill: #c42126;
+        opacity: .3;
+      }
+    </style>
+  </defs>
+  <circle class="breakpoint-hover-0" cx="8" cy="8" r="5"/>
+</svg>`;

--- a/packages/spright-components/src/icons/breakpoint-hover/index.ts
+++ b/packages/spright-components/src/icons/breakpoint-hover/index.ts
@@ -1,0 +1,32 @@
+import { Icon } from '@ni/nimble-components/dist/esm/icon-base';
+import { styles } from '@ni/nimble-components/dist/esm/icon-svg/styles';
+import { html } from '@ni/fast-element';
+import { DesignSystem } from '@ni/fast-foundation';
+import { iconData } from './icon-data';
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'spright-icon-breakpoint-hover': IconBreakpointHover;
+    }
+}
+
+/**
+ * Spright breakpoint hover icon.
+ */
+export class IconBreakpointHover extends Icon {}
+
+const template = html<IconBreakpointHover>`
+    <div class="icon" aria-hidden="true" :innerHTML="${() => iconData}"></div>
+`;
+
+const sprightIconBreakpointHover = IconBreakpointHover.compose({
+    baseName: 'icon-breakpoint-hover',
+    template,
+    styles
+});
+
+DesignSystem.getOrCreate()
+    .withPrefix('spright')
+    .register(sprightIconBreakpointHover());
+
+export const iconBreakpointHoverTag = 'spright-icon-breakpoint-hover';


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #2962

## 👩‍💻 Implementation

1. Add new breakpoint icons to Spright. See discussion on linked issue for rationale (special purpose and colored).
2. Added framework wrappers as these are not generated automaticaly for Spright icons
3. Update right arrow Nimble icon with new data
4. Minor related docs and code analysis dictionary updates

## 🧪 Testing

Storybook inspection

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
