### PR TITLE
Renovate disable npm major updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,13 +35,18 @@
       "enabled": true,
       "matchPackageNames": [
         "!/^@angular/",
+        "!/@types/jasmine",
         "!/apache-arrow/",
         "!/beachball/",
         "!/comlink/",
         "!/eslint/",
+        "!/jasmine/",
+        "!/jasmine-core/",
         "!/ng-packagr/",
         "!/playwright/",
         "!/typescript/",
+        "!/vite/",
+        "!/yargs/",
         "!/zone.js/"
       ]
     },

--- a/change/@ni-nimble-components-32615f4e-bb40-4a12-9600-02c0b33be371.json
+++ b/change/@ni-nimble-components-32615f4e-bb40-4a12-9600-02c0b33be371.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "update dev deps",
+  "packageName": "@ni/nimble-components",
+  "email": "1588923+rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@ni-spright-components-e940b2bb-dc86-4df3-b015-9dc1323fec75.json
+++ b/change/@ni-spright-components-e940b2bb-dc86-4df3-b015-9dc1323fec75.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "update dev deps",
+  "packageName": "@ni/spright-components",
+  "email": "1588923+rajsite@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13601,44 +13601,146 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.1.tgz",
+      "integrity": "sha512-vN61cP9COzctyhBqKUOh9YHqU70hYPnaHqNpXdBzM9PcwIpfPAvNK06hjm4gEJEGuvy4GBairO6uU32+FKpS4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "4.1.2",
+        "chalk": "5.6.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
-        "supports-color": "8.1.1",
+        "shell-quote": "1.8.4",
+        "supports-color": "10.2.2",
         "tree-kill": "1.2.2",
-        "yargs": "17.7.2"
+        "yargs": "18.0.0"
       },
       "bin": {
-        "conc": "dist/bin/concurrently.js",
-        "concurrently": "dist/bin/concurrently.js"
+        "conc": "dist/bin/index.js",
+        "concurrently": "dist/bin/index.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
-    "node_modules/concurrently/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+    "node_modules/concurrently/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/concurrently/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-flag": "^4.0.0"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/config-chain": {
@@ -30491,9 +30593,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -35106,7 +35208,7 @@
         "@rollup/plugin-terser": "^1.0.0",
         "@types/jasmine": "^5.1.4",
         "@types/offscreencanvas": "^2019.7.3",
-        "concurrently": "^9.0.0",
+        "concurrently": "^10.0.0",
         "jasmine-core": "^5.1.2",
         "karma": "^6.3.0",
         "karma-chrome-launcher": "^3.1.0",
@@ -35298,7 +35400,7 @@
         "@rollup/plugin-replace": "^6.0.0",
         "@rollup/plugin-terser": "^1.0.0",
         "@types/jasmine": "^5.1.4",
-        "concurrently": "^9.0.0",
+        "concurrently": "^10.0.0",
         "jasmine-core": "^5.1.2",
         "karma": "^6.3.0",
         "karma-chrome-launcher": "^3.1.0",

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -97,7 +97,7 @@
     "@rollup/plugin-terser": "^1.0.0",
     "@types/jasmine": "^5.1.4",
     "@types/offscreencanvas": "^2019.7.3",
-    "concurrently": "^9.0.0",
+    "concurrently": "^10.0.0",
     "jasmine-core": "^5.1.2",
     "karma": "^6.3.0",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/spright-components/package.json
+++ b/packages/spright-components/package.json
@@ -57,7 +57,7 @@
     "@rollup/plugin-replace": "^6.0.0",
     "@rollup/plugin-terser": "^1.0.0",
     "@types/jasmine": "^5.1.4",
-    "concurrently": "^9.0.0",
+    "concurrently": "^10.0.0",
     "jasmine-core": "^5.1.2",
     "karma": "^6.3.0",
     "karma-chrome-launcher": "^3.1.0",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The following package updates are skipped for the described reason and disabled for renovate updates:
- Angular 21 [story](https://dev.azure.com/ni/DevCentral/_workitems/edit/3758756)
  - gates `@angular/*`, `eslint`, `ng-packagr`, `typescript`, `vite`,  `zone.js`
- `jasmine`, `jasmine-core`, `@jasmine/types` conflicts with `karma-jasmine` https://github.com/karma-runner/karma-jasmine/issues/333
- `yargs` v18: https://github.com/ni/nimble/issues/2627
- `beachball` v2.65.x: https://github.com/ni/nimble/issues/2948

## 👩‍💻 Implementation

- Disable the manually handled renovate updates
- Update concurrently to supersede #2970

## 🧪 Testing

Rely on CI

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
