### PR TITLE
bUnit semantic matchers

### DIFF
--- a/packages/blazor-workspace/BlazorWorkspace.slnx
+++ b/packages/blazor-workspace/BlazorWorkspace.slnx
@@ -7,6 +7,7 @@
   </Folder>
   <Folder Name="/Tests/">
     <Project Path="Tests/BlazorWorkspace.Testing.Acceptance/BlazorWorkspace.Testing.Acceptance.csproj" />
+    <Project Path="Tests/BlazorWorkspace.Testing.Unit/BlazorWorkspace.Testing.Unit.csproj" />
     <Project Path="Tests/NimbleBlazor.Tests.Acceptance.Client/NimbleBlazor.Tests.Acceptance.Client.csproj" />
     <Project Path="Tests/NimbleBlazor.Tests.Acceptance/NimbleBlazor.Tests.Acceptance.csproj" />
     <Project Path="Tests/NimbleBlazor.Tests/NimbleBlazor.Tests.csproj" />

--- a/packages/blazor-workspace/CodeAnalysisDictionary.xml
+++ b/packages/blazor-workspace/CodeAnalysisDictionary.xml
@@ -6,6 +6,7 @@
             <Word>blazor</Word>
             <Word>bool</Word>
             <Word>breakpoint</Word>
+            <Word>bunit</Word>
             <Word>clearable</Word>
             <Word>combobox</Word>
             <Word>dropdown</Word>

--- a/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/BlazorWorkspace.Testing.Unit.csproj
+++ b/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/BlazorWorkspace.Testing.Unit.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <Nullable>enable</Nullable>
+    <RootNamespace>BlazorWorkspace.Testing.Unit</RootNamespace>
+    <AssemblyName>BlazorWorkspace.Testing.Unit</AssemblyName>
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\CodeAnalysisDictionary.xml" Link="CodeAnalysisDictionary.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="bunit" Version="2.7.2" />
+    <PackageReference Include="NI.CSharp.Analyzers" Version="2.0.35" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+  </ItemGroup>
+
+</Project>

--- a/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/BunitTestBase.cs
+++ b/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/BunitTestBase.cs
@@ -1,0 +1,20 @@
+using Bunit;
+
+namespace BlazorWorkspace.Testing.Unit;
+
+/// <summary>
+/// Base class for bUnit-based unit tests. Provides a <see cref="BunitContext"/>
+/// pre-configured with loose JS interop so derived test classes can call
+/// <c>Render&lt;TComponent&gt;()</c> directly without repeating setup boilerplate.
+/// </summary>
+public abstract class BunitTestBase : BunitContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BunitTestBase"/> class with
+    /// loose JS interop configured.
+    /// </summary>
+    protected BunitTestBase()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+}

--- a/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/RenderedComponentExtensions.cs
+++ b/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/RenderedComponentExtensions.cs
@@ -1,0 +1,66 @@
+using System.Linq;
+using AngleSharp.Dom;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Xunit;
+
+namespace BlazorWorkspace.Testing.Unit;
+
+/// <summary>
+/// Extension methods for <see cref="IRenderedComponent{TComponent}"/> used to make
+/// markup assertions terser and more stable than raw string comparisons.
+/// </summary>
+public static class RenderedComponentExtensions
+{
+    /// <summary>
+    /// Returns the first rendered DOM element of the component. Useful for asserting
+    /// against a component's root element attributes (for example, with
+    /// <c>GetAttribute</c> / <c>HasAttribute</c>) without needing to know its tag name.
+    /// </summary>
+    /// <typeparam name="TComponent">The component type.</typeparam>
+    /// <param name="renderedComponent">The rendered component.</param>
+    /// <returns>The component's first rendered <see cref="IElement"/>.</returns>
+    public static IElement RootElement<TComponent>(this IRenderedComponent<TComponent> renderedComponent)
+        where TComponent : IComponent
+    {
+        return renderedComponent.Nodes.OfType<IElement>().First();
+    }
+
+    /// <summary>
+    /// Asserts that the component's root element has an attribute with the expected value,
+    /// or that the attribute is absent when <paramref name="expectedAttributeValue"/> is
+    /// <see langword="null"/>. This provides a stable, semantic alternative to substring or
+    /// regular-expression matching against raw markup.
+    /// </summary>
+    /// <typeparam name="TComponent">The component type.</typeparam>
+    /// <param name="renderedComponent">The rendered component.</param>
+    /// <param name="attributeName">The name of the attribute to assert against.</param>
+    /// <param name="expectedAttributeValue">
+    /// The expected attribute value, or <see langword="null"/> to assert the attribute is absent.
+    /// </param>
+    public static void AssertAttribute<TComponent>(this IRenderedComponent<TComponent> renderedComponent, string attributeName, string? expectedAttributeValue)
+        where TComponent : IComponent
+    {
+        var element = renderedComponent.RootElement();
+        if (expectedAttributeValue is null)
+        {
+            Assert.False(element.HasAttribute(attributeName), $"Expected attribute '{attributeName}' to be absent, but it was present.");
+        }
+        else
+        {
+            Assert.Equal(expectedAttributeValue, element.GetAttribute(attributeName));
+        }
+    }
+
+    /// <summary>
+    /// Asserts that the component's root element has the specified boolean attribute present.
+    /// </summary>
+    /// <typeparam name="TComponent">The component type.</typeparam>
+    /// <param name="renderedComponent">The rendered component.</param>
+    /// <param name="attributeName">The name of the boolean attribute to assert is present.</param>
+    public static void AssertHasAttribute<TComponent>(this IRenderedComponent<TComponent> renderedComponent, string attributeName)
+        where TComponent : IComponent
+    {
+        Assert.True(renderedComponent.RootElement().HasAttribute(attributeName), $"Expected attribute '{attributeName}' to be present, but it was absent.");
+    }
+}

--- a/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/packages.lock.json
+++ b/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/packages.lock.json
@@ -22,22 +22,6 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
         }
       },
-      "coverlet.collector": {
-        "type": "Direct",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "27jXSV/0DbVqF5jDrAxuQFZ9oaz6gmG03p8ttxAFk+X0M4woFYj7MoWDLCna5EGLb0CE6OE7X6ZH3Wt5smTtaA=="
-      },
-      "Microsoft.NET.Test.Sdk": {
-        "type": "Direct",
-        "requested": "[18.6.0, )",
-        "resolved": "18.6.0",
-        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
-        "dependencies": {
-          "Microsoft.CodeCoverage": "18.6.0",
-          "Microsoft.TestPlatform.TestHost": "18.6.0"
-        }
-      },
       "NI.CSharp.Analyzers": {
         "type": "Direct",
         "requested": "[2.0.35, )",
@@ -63,21 +47,6 @@
           "xunit.core": "[2.9.3]"
         }
       },
-      "xunit.extensibility.execution": {
-        "type": "Direct",
-        "requested": "[2.9.3, )",
-        "resolved": "2.9.3",
-        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
-        "dependencies": {
-          "xunit.extensibility.core": "[2.9.3]"
-        }
-      },
-      "xunit.runner.visualstudio": {
-        "type": "Direct",
-        "requested": "[3.1.5, )",
-        "resolved": "3.1.5",
-        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
-      },
       "AngleSharp": {
         "type": "Transitive",
         "resolved": "1.4.0",
@@ -102,28 +71,28 @@
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "t+q60N2/+UIBnkuLRJWv1r02fhuwPI1fqUh0xnuWIjsVsU1szYcic0/LW+BcZ4ZaO3mMVVJP3H/F9bwfJgGboA==",
+        "resolved": "10.0.0",
+        "contentHash": "8qUwBAtUj9kX8RwqEPGJu3zGM/GlwF2bR9gsxk/+kiSmCB6aDYlYF7E2gM9VOYS9NDF6zxTSEgJxwD9kFbu8Sw==",
         "dependencies": {
-          "Microsoft.AspNetCore.Metadata": "10.0.8",
-          "Microsoft.Extensions.Diagnostics": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
+          "Microsoft.AspNetCore.Metadata": "10.0.0",
+          "Microsoft.Extensions.Diagnostics": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
         }
       },
       "Microsoft.AspNetCore.Components": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "307/ua6dEQ+XQBAVJf9I9OG1QIDmhReRMiNA/XCff54t+qP7ZhjJ8/tKsRZ5tBlgrGaRr6zLmMAS17j34eLAgA==",
+        "resolved": "10.0.0",
+        "contentHash": "ljLBmYTPkIe/WhOn/y3kpMCJ4A/xg76H/SRm9XkoOBqlM96Ntcbr+WFJqV/0bEqjaUqQYIMITPnJXrVJ242cWQ==",
         "dependencies": {
-          "Microsoft.AspNetCore.Authorization": "10.0.8",
-          "Microsoft.AspNetCore.Components.Analyzers": "10.0.8"
+          "Microsoft.AspNetCore.Authorization": "10.0.0",
+          "Microsoft.AspNetCore.Components.Analyzers": "10.0.0"
         }
       },
       "Microsoft.AspNetCore.Components.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "2bQ1wHeawWxqTlxHdSVAmPZxe6ZBElj4TdvzkTV4ji28kvCHurL0CWTdlFh+q1650hXkm9Zb1nz5AKt/xitaUw=="
+        "resolved": "10.0.0",
+        "contentHash": "5j9dQ/U51yLLKo8hKJOU7uTPppPsjLTua0PFzRotaePcmz7M9W7pM69pBXDEgkBfGD1tp2ufH0zHRHkwg1ikDg=="
       },
       "Microsoft.AspNetCore.Components.Authorization": {
         "type": "Transitive",
@@ -136,23 +105,23 @@
       },
       "Microsoft.AspNetCore.Components.Forms": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "vgvzcw0YdXTA3rynequip502h34cqEfucQEBJCbzLlkoM8tEYWh7635AKmXz8HFZh/JnwFbR5m1Awm/U4fn7ag==",
+        "resolved": "10.0.0",
+        "contentHash": "5kMwH8DqYFfUpyMNv+IzIoDHxR8fHTPKeJeFNAyjY5tMxo3yyM7ezmuYNcVt9QJ+6K2soHQjBnCvFs8yNd3UGQ==",
         "dependencies": {
-          "Microsoft.AspNetCore.Components": "10.0.8",
-          "Microsoft.Extensions.Validation": "10.0.8"
+          "Microsoft.AspNetCore.Components": "10.0.0",
+          "Microsoft.Extensions.Validation": "10.0.0"
         }
       },
       "Microsoft.AspNetCore.Components.Web": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "r3SkaADmYqGAVrk2lhy+/kVsU2eBTRTXi0uCDppZX/VaX8m3ENtBd749XT8wGQyhfYr8MT6rC9WDXI1mmPHrGg==",
+        "resolved": "10.0.0",
+        "contentHash": "TAv9+cOrU27YPKuHE7AlG2UBWtTWivvcDHmfdN2yngzQFtas+3p2IBDAF6odNfOJiW3Cs1lHwzqLAoNw5Sc59Q==",
         "dependencies": {
-          "Microsoft.AspNetCore.Components": "10.0.8",
-          "Microsoft.AspNetCore.Components.Forms": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8",
-          "Microsoft.JSInterop": "10.0.8"
+          "Microsoft.AspNetCore.Components": "10.0.0",
+          "Microsoft.AspNetCore.Components.Forms": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0",
+          "Microsoft.JSInterop": "10.0.0"
         }
       },
       "Microsoft.AspNetCore.Components.WebAssembly": {
@@ -178,8 +147,8 @@
       },
       "Microsoft.AspNetCore.Metadata": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "N+d8MnpnEhKnbkCZzrV5jyPLpMOA9eSxP91We8B8QRSlt5NnyWDk1deEn8JpErDbyiQBAwhbvkxLofIOijRwTw=="
+        "resolved": "10.0.0",
+        "contentHash": "uMXReBNxJKabrdoxHn4LNDTlGQFGDPtntlVvqo/b0HaxJzeDAIMFXJJ64mufJCNRuQU/Pus8ngcTZErvnsh7vg=="
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
@@ -207,11 +176,6 @@
         "resolved": "10.0.100",
         "contentHash": "uj9VuyvqylnNueJfU7u2PkI/hEMpZl8Wg9BXyI0eatNEldU5jDYPdwsM8aDL18+1oLovju25MiqOPaGRBnG72A=="
       },
-      "Microsoft.CodeCoverage": {
-        "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
-      },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.0",
@@ -234,28 +198,28 @@
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "ehZcoPbjzWzS4XFvuz7R3V55SmpdkyMqFURLH3yXaN9NtXd9tR6CGB7pd49HYtCkenl+G7ctXSFLhNI08xLfRg==",
+        "resolved": "10.0.0",
+        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "I63esIFbL3h5pSt7gXpXOlmcwDmYBUoYNEglKfDPFUqtYvSV84f2l28hO2lfVXsV0wdlplgAM7IVz16matapSg==",
+        "resolved": "10.0.0",
+        "contentHash": "d2kDKnCsJvY7mBVhcjPSp9BkJk48DsaHPg5u+Oy4f8XaOqnEedRy/USyvnpHL92wpJ6DrTPy7htppUUzskbCXQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.8"
+          "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "R3NN1X+kVu14uoxLEW6sBSQyhogDSbaOQzILnCtuXxBN4hx22AgjWPwZX6v/suERFkEDgU1lk12AglHTrUxhlw==",
+        "resolved": "10.0.0",
+        "contentHash": "tMF9wNh+hlyYDWB8mrFCQHQmWHlRosol1b/N2Jrefy1bFLnuTlgSYmPyHNmz8xVQgs7DpXytBRWxGhG+mSTp0g==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
         }
       },
       "Microsoft.Extensions.Configuration.FileExtensions": {
@@ -283,34 +247,34 @@
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "daf62xHIrq8pnE709hgaZZN9tSam9TGGepWe1+bE6V3GEuVwJiMs6ib+38lfMCyAJAHiX0vapxBhsuMSV7U+cg==",
+        "resolved": "10.0.0",
+        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "21nbDV60SRPWGIivsyl6lqBeEJNG1sginhhfWgRrr3Ais7aQ12To25OAHQxgoiJkjqy1aQ6RxpZBGYuTi7Ge6A=="
+        "resolved": "10.0.0",
+        "contentHash": "L3AdmZ1WOK4XXT5YFPEwyt0ep6l8lGIPs7F5OOBZc77Zqeo01Of7XXICy47628sdVl0v/owxYJTe86DTgFwKCA=="
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "uduyw9d3Fi+sbredO5drA1S44AQS2FRNFyn72UmB2vmQIO1qaXprpp1U/2lYhYi8yFdVERfY9sy/pxw/qPOU9w==",
+        "resolved": "10.0.0",
+        "contentHash": "xjkxIPgrT0mKTfBwb+CVqZnRchyZgzKIfDQOp8z+WUC6vPe3WokIf71z+hJPkH0YBUYJwa7Z/al1R087ib9oiw==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.8"
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
         }
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "+f4C5g78QCGNyxzUfrTYsB7qYx06Zca0e88s3qFlea9/lQhgPImYdNprlgzl1uHhRU3fVHLfmbijayU2sJEZ6w==",
+        "resolved": "10.0.0",
+        "contentHash": "SfK89ytD61S7DgzorFljSkUeluC1ncn6dtZgwc0ot39f/BEYWBl5jpgvodxduoYAs1d9HG8faCDRZxE95UMo2A==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
         }
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
@@ -353,51 +317,51 @@
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "fdVadZmsC8jRP0KvKy8mO8f6GV/HyBvElfcSxEhd+5FM5boAw/01iSaCto5G3G37ApJira4A3pNaVvBv8cUiLQ==",
+        "resolved": "10.0.0",
+        "contentHash": "FU/IfjDfwaMuKr414SSQNTIti/69bHEMb+QKrskRb26oVqpx3lNFXMjs/RC9ZUuhBhcwDM2BwOgoMw+PZ+beqQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
         }
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "VBD+131DpTNCNDfA4kIyKTiCySvJGNhwibdWBSdFRu7GMfXLXcXODkgA+KStKbbhzraLglZWUN4nXyHgW4JIRA==",
+        "resolved": "10.0.0",
+        "contentHash": "8oCAgXOow5XDrY9HaXX1QmH3ORsyZO/ANVHBlhLyCeWTH5Sg4UuqZeOTWJi6484M+LqSx0RqQXDJtdYy2BNiLQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "VOapXeO3lhBH0zYoyAH7tjapuo4V5pTHlevPpiSHueEquAajqd5nF0mttm+h/uE/exwAEuM5s26SzOJtletE3w==",
+        "resolved": "10.0.0",
+        "contentHash": "tL9cSl3maS5FPzp/3MtlZI21ExWhni0nnUCF8HY4npTsINw45n9SNDbkKXBMtFyUFGSsQep25fHIDN4f/Vp3AQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "OBPo4nYhMyIbtueoC10CBm6AGAbo/A9IV8QQ/6ryZS7VvmqpGT7hunazeHLxFawRzn3oLOq4jhqhpBX4tfswWQ=="
+        "resolved": "10.0.0",
+        "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
       },
       "Microsoft.Extensions.Validation": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "CekWvF0+2NUol7aixnG/o7Iy2VCwN6Y3UcTmsDx++oiJlJ6M0ppfymwJ58yANRXRElN3WkHUynIeb+FuNE/3Ww==",
+        "resolved": "10.0.0",
+        "contentHash": "viIKcmaf1akdhx77c+dLkODvhL+HyonHNpBsicndoi47zvbSeHJEWPOk188NnFCh+dCUz7Icld1jPMbS5E2fqw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
         }
       },
       "Microsoft.JSInterop": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "eGKB3++3SDqRY86Y5prnI0bSceM5dJR03agFPQR8j9eL61HhBYzn3DLt3pVWJAS3t98hwJWuJA+NxB7Q8d4UJA=="
+        "resolved": "10.0.0",
+        "contentHash": "Qfs4KtmfMUQ/BtD4jdt753kiAa7frm1QVms8UHiFArOokoXBkBOOKE2N5APdt3BlAdTSFJNiuDFfgDzVq/3EZg=="
       },
       "Microsoft.JSInterop.WebAssembly": {
         "type": "Transitive",
@@ -407,29 +371,10 @@
           "Microsoft.JSInterop": "10.0.0"
         }
       },
-      "Microsoft.TestPlatform.ObjectModel": {
-        "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA=="
-      },
-      "Microsoft.TestPlatform.TestHost": {
-        "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "em1eLz5Q46+hsCtAXdXggWAPd9gQyT4ngdsQ7k1eWvQgpsjtS/wAOJ/5TteieFdiAvrEq1iVn00LtusAxRaVmQ==",
-        "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.6.0",
-          "Newtonsoft.Json": "13.0.3"
-        }
-      },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Transitive",
         "resolved": "17.10.48",
         "contentHash": "xwvwT91oqFjLgQykUp6y/JPYxz8LchbfJKrLVatfczWddXKng8DAo8RiiIodt+pRdsVXP9Ud02GtJoY7ifdXPQ=="
-      },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "Roslynator.Analyzers": {
         "type": "Transitive",
@@ -481,18 +426,12 @@
           "xunit.abstractions": "2.0.3"
         }
       },
-      "blazorworkspace.testing.unit": {
-        "type": "Project",
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
         "dependencies": {
-          "NI.CSharp.Analyzers": "[2.0.35, )",
-          "bunit": "[2.7.2, )",
-          "xunit": "[2.9.3, )"
-        }
-      },
-      "sprightblazor": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.AspNetCore.Components.Web": "[10.0.8, )"
+          "xunit.extensibility.core": "[2.9.3]"
         }
       }
     },
@@ -515,22 +454,6 @@
           "Microsoft.Extensions.Localization.Abstractions": "8.0.22",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
-        }
-      },
-      "coverlet.collector": {
-        "type": "Direct",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "27jXSV/0DbVqF5jDrAxuQFZ9oaz6gmG03p8ttxAFk+X0M4woFYj7MoWDLCna5EGLb0CE6OE7X6ZH3Wt5smTtaA=="
-      },
-      "Microsoft.NET.Test.Sdk": {
-        "type": "Direct",
-        "requested": "[18.6.0, )",
-        "resolved": "18.6.0",
-        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
-        "dependencies": {
-          "Microsoft.CodeCoverage": "18.6.0",
-          "Microsoft.TestPlatform.TestHost": "18.6.0"
         }
       },
       "NI.CSharp.Analyzers": {
@@ -558,21 +481,6 @@
           "xunit.core": "[2.9.3]"
         }
       },
-      "xunit.extensibility.execution": {
-        "type": "Direct",
-        "requested": "[2.9.3, )",
-        "resolved": "2.9.3",
-        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
-        "dependencies": {
-          "xunit.extensibility.core": "[2.9.3]"
-        }
-      },
-      "xunit.runner.visualstudio": {
-        "type": "Direct",
-        "requested": "[3.1.5, )",
-        "resolved": "3.1.5",
-        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
-      },
       "AngleSharp": {
         "type": "Transitive",
         "resolved": "1.4.0",
@@ -597,27 +505,27 @@
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
-        "resolved": "8.0.27",
-        "contentHash": "daZ9zUoD/2DAmaRcoUbmjofar3bBGxp4kkluojz0smsMn0tIgjZ32tSdy29gcJQPiSskSHamPJWvIEq9rbGeUw==",
+        "resolved": "8.0.22",
+        "contentHash": "D7GY8e30UCkjQO9z2cQ1XT/+T1CSAae+KxojcI5SRb8iKmhVjMrAyspdslGMVhS5zOnPgObUp1666BriQmzv3g==",
         "dependencies": {
-          "Microsoft.AspNetCore.Metadata": "8.0.27",
+          "Microsoft.AspNetCore.Metadata": "8.0.22",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
       "Microsoft.AspNetCore.Components": {
         "type": "Transitive",
-        "resolved": "8.0.27",
-        "contentHash": "aPmh1gxSolzltCOzSbWCAG8958XIfgpeysrcmjrAeZZKDXvz8KVaEwaa5B23uFQJXCJvJ/ljodvZ0LruEOdJDQ==",
+        "resolved": "8.0.22",
+        "contentHash": "qlW2tz9umukb/XTA+D7p+OiOz6l10rtn0jwh2A46LN8VwikutX5HbCE3pdc1x7eG2LdSKb2OLOTpdhaDp4NB3g==",
         "dependencies": {
-          "Microsoft.AspNetCore.Authorization": "8.0.27",
-          "Microsoft.AspNetCore.Components.Analyzers": "8.0.27"
+          "Microsoft.AspNetCore.Authorization": "8.0.22",
+          "Microsoft.AspNetCore.Components.Analyzers": "8.0.22"
         }
       },
       "Microsoft.AspNetCore.Components.Analyzers": {
         "type": "Transitive",
-        "resolved": "8.0.27",
-        "contentHash": "RpGeV6fcFofyw+ntWAc9kW06eEBWLlxQz/f4vSzITu+Qax2r2lQ2TBhP3ygIWJk7xAC119/BNSPCfSL3LcO3Pg=="
+        "resolved": "8.0.22",
+        "contentHash": "Xf/+WuHI1obDwkxUb8w5P+JnaQJEau6r/fDkTvikUvTsMJOwsMAlaG67mJBx31z21jv2SGSPiOWLysBcLagcIQ=="
       },
       "Microsoft.AspNetCore.Components.Authorization": {
         "type": "Transitive",
@@ -630,22 +538,22 @@
       },
       "Microsoft.AspNetCore.Components.Forms": {
         "type": "Transitive",
-        "resolved": "8.0.27",
-        "contentHash": "naie9Yqav3v3FWdkkRE5BtjpHkck6ilEBhCNbEzvn7xYhYDFkhxlU/Ud6w3Z9iuIEnzbeIbQ2VZ/K4JrsT7BAA==",
+        "resolved": "8.0.22",
+        "contentHash": "QbuKgMz6oE2FR2kFvoYoXJljdp43IQoHXbqmILVPE9TJ80GlTvE6YLqqHdYInT8+gR7lP9r56AJg9n+RBGEhQA==",
         "dependencies": {
-          "Microsoft.AspNetCore.Components": "8.0.27"
+          "Microsoft.AspNetCore.Components": "8.0.22"
         }
       },
       "Microsoft.AspNetCore.Components.Web": {
         "type": "Transitive",
-        "resolved": "8.0.27",
-        "contentHash": "KZv1bM9qxMkzDPQUWQ6qXkcpmMKCP9/rbhFIBRXOWJNVoPABAaQVXdfktJ1842f9ep2vmb9JHu6yTIMP35dSMQ==",
+        "resolved": "8.0.22",
+        "contentHash": "b/ik4mgmL7ncHw9//7mOWnx/BwKdrNO4DUyu3xZuzSt5ABmj1BVTElOCzjLBEewCOCwUIk0LmOqDpzaoXyG/NA==",
         "dependencies": {
-          "Microsoft.AspNetCore.Components": "8.0.27",
-          "Microsoft.AspNetCore.Components.Forms": "8.0.27",
+          "Microsoft.AspNetCore.Components": "8.0.22",
+          "Microsoft.AspNetCore.Components.Forms": "8.0.22",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.Extensions.Primitives": "8.0.0",
-          "Microsoft.JSInterop": "8.0.27",
+          "Microsoft.JSInterop": "8.0.22",
           "System.IO.Pipelines": "8.0.0"
         }
       },
@@ -672,8 +580,8 @@
       },
       "Microsoft.AspNetCore.Metadata": {
         "type": "Transitive",
-        "resolved": "8.0.27",
-        "contentHash": "yW4wV3ad57ECSgTacIz5SiNbtlD41Qbcdvx7i3rUeXY369YIYhYHhVuuSBPZs80U/QUrfJW/UAX+XhS3g6bagQ=="
+        "resolved": "8.0.22",
+        "contentHash": "Ha5M7eC//ZyBzJTc7CmUs0RJkqfBRXc38xzewR8VqZov8jURWuyaSv2XNiokjt7H77cZjQ7sLL0I/RD5JnQ/nA=="
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
@@ -700,11 +608,6 @@
         "type": "Transitive",
         "resolved": "10.0.100",
         "contentHash": "uj9VuyvqylnNueJfU7u2PkI/hEMpZl8Wg9BXyI0eatNEldU5jDYPdwsM8aDL18+1oLovju25MiqOPaGRBnG72A=="
-      },
-      "Microsoft.CodeCoverage": {
-        "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
@@ -849,8 +752,8 @@
       },
       "Microsoft.JSInterop": {
         "type": "Transitive",
-        "resolved": "8.0.27",
-        "contentHash": "B6PkdHztY6iMUTwibDXE57h6s8SI/BTi8gb/7nWkoa+pH+rny4a6J9MfUEtlnewVbegoiiw4jrwHdfIK3TTwaQ=="
+        "resolved": "8.0.22",
+        "contentHash": "RmReQAbsJXtJZjQEAo2XrpZDplNmvLtysMRGbcQlLwY6A/3/HZ3Y0kR1K6aq9PK5wyF6S5AwRNny09H+L997/Q=="
       },
       "Microsoft.JSInterop.WebAssembly": {
         "type": "Transitive",
@@ -860,29 +763,10 @@
           "Microsoft.JSInterop": "8.0.22"
         }
       },
-      "Microsoft.TestPlatform.ObjectModel": {
-        "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA=="
-      },
-      "Microsoft.TestPlatform.TestHost": {
-        "type": "Transitive",
-        "resolved": "18.6.0",
-        "contentHash": "em1eLz5Q46+hsCtAXdXggWAPd9gQyT4ngdsQ7k1eWvQgpsjtS/wAOJ/5TteieFdiAvrEq1iVn00LtusAxRaVmQ==",
-        "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.6.0",
-          "Newtonsoft.Json": "13.0.3"
-        }
-      },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Transitive",
         "resolved": "17.10.48",
         "contentHash": "xwvwT91oqFjLgQykUp6y/JPYxz8LchbfJKrLVatfczWddXKng8DAo8RiiIodt+pRdsVXP9Ud02GtJoY7ifdXPQ=="
-      },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "Roslynator.Analyzers": {
         "type": "Transitive",
@@ -939,18 +823,12 @@
           "xunit.abstractions": "2.0.3"
         }
       },
-      "blazorworkspace.testing.unit": {
-        "type": "Project",
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
         "dependencies": {
-          "NI.CSharp.Analyzers": "[2.0.35, )",
-          "bunit": "[2.7.2, )",
-          "xunit": "[2.9.3, )"
-        }
-      },
-      "sprightblazor": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.AspNetCore.Components.Web": "[8.0.27, )"
+          "xunit.extensibility.core": "[2.9.3]"
         }
       }
     }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/NimbleBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/NimbleBlazor.Tests.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>NimbleBlazor.Tests</RootNamespace>
     <AssemblyName>NimbleBlazor.Tests</AssemblyName>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/NimbleBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/NimbleBlazor.Tests.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\NimbleBlazor\NimbleBlazor.csproj" />
+    <ProjectReference Include="..\BlazorWorkspace.Testing.Unit\BlazorWorkspace.Testing.Unit.csproj" />
   </ItemGroup>
 
 </Project>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorButtonTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorButtonTests.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
+
+#nullable enable
 
 namespace NimbleBlazor.Tests.Unit.Components;
 
@@ -13,21 +16,15 @@ public class NimbleAnchorButtonTests : NimbleAnchorBaseTests<NimbleAnchorButton>
     [Fact]
     public void NimbleAnchorButton_Render_HasAnchorButtonMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-anchor-button";
+        var button = Render<NimbleAnchorButton>();
 
-        var button = context.Render<NimbleAnchorButton>();
-
-        Assert.Contains(expectedMarkup, button.Markup);
+        Assert.NotNull(button.Find("nimble-anchor-button"));
     }
 
     [Fact]
     public void NimbleAnchorButton_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleAnchorButton>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleAnchorButton>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -39,23 +36,21 @@ public class NimbleAnchorButtonTests : NimbleAnchorBaseTests<NimbleAnchorButton>
     {
         var button = RenderWithPropertySet(x => x.Appearance, value);
 
-        Assert.Contains(expectedAttribute, button.Markup);
+        button.AssertAttribute("appearance", expectedAttribute);
     }
 
     [Theory]
-    [InlineData(ButtonAppearanceVariant.Default, "<nimble-anchor-button>")]
-    [InlineData(ButtonAppearanceVariant.Primary, "appearance-variant=\"primary\"")]
-    public void ButtonAppearanceVariant_AttributeIsSet(ButtonAppearanceVariant value, string expectedMarkup)
+    [InlineData(ButtonAppearanceVariant.Default, null)]
+    [InlineData(ButtonAppearanceVariant.Primary, "primary")]
+    public void ButtonAppearanceVariant_AttributeIsSet(ButtonAppearanceVariant value, string? expectedValue)
     {
         var button = RenderWithPropertySet(x => x.AppearanceVariant, value);
 
-        Assert.Contains(expectedMarkup, button.Markup);
+        button.AssertAttribute("appearance-variant", expectedValue);
     }
 
     private IRenderedComponent<NimbleAnchorButton> RenderWithPropertySet<TProperty>(Expression<Func<NimbleAnchorButton, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleAnchorButton>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleAnchorButton>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorButtonTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorButtonTests.cs
@@ -4,8 +4,6 @@ using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
-#nullable enable
-
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorMenuItemTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorMenuItemTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -13,21 +14,15 @@ public class NimbleAnchorMenuItemTests : NimbleAnchorBaseTests<NimbleAnchorMenuI
     [Fact]
     public void NimbleAnchorMenuItem_Render_HasAnchorMenuItemMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-anchor-menu-item";
+        var menuItem = Render<NimbleAnchorMenuItem>();
 
-        var menuItem = context.Render<NimbleAnchorMenuItem>();
-
-        Assert.Contains(expectedMarkup, menuItem.Markup);
+        Assert.NotNull(menuItem.Find("nimble-anchor-menu-item"));
     }
 
     [Fact]
     public void NimbleAnchorMenuItem_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleAnchorMenuItem>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleAnchorMenuItem>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -36,13 +31,11 @@ public class NimbleAnchorMenuItemTests : NimbleAnchorBaseTests<NimbleAnchorMenuI
     {
         var anchorMenuItem = RenderWithPropertySet(x => x.Disabled, true);
 
-        Assert.Contains("disabled", anchorMenuItem.Markup);
+        anchorMenuItem.AssertHasAttribute("disabled");
     }
 
     private IRenderedComponent<NimbleAnchorMenuItem> RenderWithPropertySet<TProperty>(Expression<Func<NimbleAnchorMenuItem, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleAnchorMenuItem>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleAnchorMenuItem>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorStepTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorStepTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -13,33 +14,27 @@ public class NimbleAnchorStepTests : NimbleAnchorBaseTests<NimbleAnchorStep>
     [Fact]
     public void NimbleAnchorStep_Render_HasAnchorStepMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-anchor-step";
+        var anchorStep = Render<NimbleAnchorStep>();
 
-        var anchorStep = context.Render<NimbleAnchorStep>();
-
-        Assert.Contains(expectedMarkup, anchorStep.Markup);
+        Assert.NotNull(anchorStep.Find("nimble-anchor-step"));
     }
 
     [Fact]
     public void NimbleAnchorStep_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleAnchorStep>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleAnchorStep>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
     [Theory]
-    [InlineData(AnchorStepSeverity.Error, "severity=\"error\"")]
-    [InlineData(AnchorStepSeverity.Warning, "severity=\"warning\"")]
-    [InlineData(AnchorStepSeverity.Success, "severity=\"success\"")]
+    [InlineData(AnchorStepSeverity.Error, "error")]
+    [InlineData(AnchorStepSeverity.Warning, "warning")]
+    [InlineData(AnchorStepSeverity.Success, "success")]
     public void AnchorAnchorStepSeverity_AttributeIsSet(AnchorStepSeverity value, string expectedAttribute)
     {
         var anchorStep = RenderWithPropertySet(x => x.Severity, value);
 
-        Assert.Contains(expectedAttribute, anchorStep.Markup);
+        anchorStep.AssertAttribute("severity", expectedAttribute);
     }
 
     [Fact]
@@ -47,7 +42,7 @@ public class NimbleAnchorStepTests : NimbleAnchorBaseTests<NimbleAnchorStep>
     {
         var anchorStep = RenderWithPropertySet(x => x.Severity, AnchorStepSeverity.Default);
 
-        Assert.DoesNotContain("severity", anchorStep.Markup);
+        anchorStep.AssertAttribute("severity", null);
     }
 
     [Fact]
@@ -55,7 +50,7 @@ public class NimbleAnchorStepTests : NimbleAnchorBaseTests<NimbleAnchorStep>
     {
         var anchorStep = RenderWithPropertySet(x => x.Disabled, true);
 
-        Assert.Contains("disabled", anchorStep.Markup);
+        anchorStep.AssertHasAttribute("disabled");
     }
 
     [Fact]
@@ -63,7 +58,7 @@ public class NimbleAnchorStepTests : NimbleAnchorBaseTests<NimbleAnchorStep>
     {
         var anchorStep = RenderWithPropertySet(x => x.ReadOnly, true);
 
-        Assert.Contains("readonly", anchorStep.Markup);
+        anchorStep.AssertHasAttribute("readonly");
     }
 
     [Fact]
@@ -71,13 +66,11 @@ public class NimbleAnchorStepTests : NimbleAnchorBaseTests<NimbleAnchorStep>
     {
         var anchorStep = RenderWithPropertySet(x => x.Selected, true);
 
-        Assert.Contains("selected", anchorStep.Markup);
+        anchorStep.AssertHasAttribute("selected");
     }
 
     private IRenderedComponent<NimbleAnchorStep> RenderWithPropertySet<TProperty>(Expression<Func<NimbleAnchorStep, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleAnchorStep>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleAnchorStep>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorTabTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorTabTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -13,21 +14,15 @@ public class NimbleAnchorTabTests : NimbleAnchorBaseTests<NimbleAnchorTab>
     [Fact]
     public void NimbleAnchorTab_Render_HasAnchorTabMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-anchor-tab";
+        var menuItem = Render<NimbleAnchorTab>();
 
-        var menuItem = context.Render<NimbleAnchorTab>();
-
-        Assert.Contains(expectedMarkup, menuItem.Markup);
+        Assert.NotNull(menuItem.Find("nimble-anchor-tab"));
     }
 
     [Fact]
     public void NimbleAnchorTab_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleAnchorTab>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleAnchorTab>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -36,13 +31,11 @@ public class NimbleAnchorTabTests : NimbleAnchorBaseTests<NimbleAnchorTab>
     {
         var anchorTab = RenderWithPropertySet(x => x.Disabled, true);
 
-        Assert.Contains("disabled", anchorTab.Markup);
+        anchorTab.AssertHasAttribute("disabled");
     }
 
     private IRenderedComponent<NimbleAnchorTab> RenderWithPropertySet<TProperty>(Expression<Func<NimbleAnchorTab, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleAnchorTab>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleAnchorTab>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorTabsTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorTabsTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using AngleSharp.Dom;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,25 +9,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleAnchorTabs"/>
 /// </summary>
-public class NimbleAnchorTabsTests
+public class NimbleAnchorTabsTests : BunitTestBase
 {
     [Fact]
     public void NimbleAnchorTabsRendered_HasTabsMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-anchor-tabs";
-        var tabs = context.Render<NimbleAnchorTabs>();
+        var tabs = Render<NimbleAnchorTabs>();
 
-        Assert.Contains(expectedMarkup, tabs.Markup);
+        Assert.NotNull(tabs.Find("nimble-anchor-tabs"));
     }
 
     [Fact]
     public void NimbleAnchorTabs_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleAnchorTabs>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleAnchorTabs>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -45,7 +41,7 @@ public class NimbleAnchorTabsTests
     {
         var tabs = RenderTabsWithContent();
 
-        Assert.Contains("activeid", tabs.Markup);
+        tabs.AssertAttribute("activeid", "tab1");
     }
 
     [Fact]
@@ -53,14 +49,14 @@ public class NimbleAnchorTabsTests
     {
         var tabs = RenderTabsWithContent();
 
+        // The disabled attribute is rendered on a child nimble-anchor-tab, not the root
+        // nimble-anchor-tabs element, so the root-scoped assertion helpers cannot be used here.
         Assert.Contains("disabled", tabs.Markup);
     }
 
     private IRenderedComponent<NimbleAnchorTabs> RenderTabsWithContent()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleAnchorTabs>(AddChildContentToTabs);
+        return Render<NimbleAnchorTabs>(AddChildContentToTabs);
     }
 
     private void AddChildContentToTabs(ComponentParameterCollectionBuilder<NimbleAnchorTabs> parameters)

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorTabsTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorTabsTests.cs
@@ -48,9 +48,6 @@ public class NimbleAnchorTabsTests : BunitTestBase
     public void NimbleAnchorTabsWithChildContent_HasDisabledMarkup()
     {
         var tabs = RenderTabsWithContent();
-
-        // The disabled attribute is rendered on a child nimble-anchor-tab, not the root
-        // nimble-anchor-tabs element, so the root-scoped assertion helpers cannot be used here.
         Assert.Contains("disabled", tabs.Markup);
     }
 

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorTests.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
+
+#nullable enable
 
 namespace NimbleBlazor.Tests.Unit.Components;
 
@@ -13,32 +16,26 @@ public class NimbleAnchorTests : NimbleAnchorBaseTests<NimbleAnchor>
     [Fact]
     public void NimbleAnchor_Rendered_HasAnchorMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-anchor";
+        var anchor = Render<NimbleAnchor>();
 
-        var anchor = context.Render<NimbleAnchor>();
-
-        Assert.Contains(expectedMarkup, anchor.Markup);
+        Assert.NotNull(anchor.Find("nimble-anchor"));
     }
 
     [Fact]
     public void NimbleAnchor_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleAnchor>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleAnchor>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
     [Theory]
-    [InlineData(AnchorAppearance.Default, "<nimble-anchor>")]
-    [InlineData(AnchorAppearance.Prominent, "appearance=\"prominent\"")]
-    public void AnchorAppearance_AttributeIsSet(AnchorAppearance value, string expectedMarkup)
+    [InlineData(AnchorAppearance.Default, null)]
+    [InlineData(AnchorAppearance.Prominent, "prominent")]
+    public void AnchorAppearance_AttributeIsSet(AnchorAppearance value, string? expectedValue)
     {
         var anchor = RenderWithPropertySet(x => x.Appearance, value);
 
-        Assert.Contains(expectedMarkup, anchor.Markup);
+        anchor.AssertAttribute("appearance", expectedValue);
     }
 
     [Fact]
@@ -46,7 +43,7 @@ public class NimbleAnchorTests : NimbleAnchorBaseTests<NimbleAnchor>
     {
         var anchor = RenderWithPropertySet(x => x.ContentEditable, "true");
 
-        Assert.Contains("contenteditable=\"true\"", anchor.Markup);
+        anchor.AssertAttribute("contenteditable", "true");
     }
 
     [Fact]
@@ -54,13 +51,11 @@ public class NimbleAnchorTests : NimbleAnchorBaseTests<NimbleAnchor>
     {
         var anchor = RenderWithPropertySet(x => x.UnderlineHidden, true);
 
-        Assert.Contains("underline-hidden", anchor.Markup);
+        anchor.AssertHasAttribute("underline-hidden");
     }
 
     private IRenderedComponent<NimbleAnchor> RenderWithPropertySet<TProperty>(Expression<Func<NimbleAnchor, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleAnchor>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleAnchor>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorTests.cs
@@ -4,8 +4,6 @@ using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
-#nullable enable
-
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorTreeItemTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleAnchorTreeItemTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -13,21 +14,15 @@ public class NimbleAnchorTreeItemTests : NimbleAnchorBaseTests<NimbleAnchorTreeI
     [Fact]
     public void NimbleAnchorTreeItem_Render_HasAnchorTreeItemMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-anchor-tree-item";
+        var menuItem = Render<NimbleAnchorTreeItem>();
 
-        var menuItem = context.Render<NimbleAnchorTreeItem>();
-
-        Assert.Contains(expectedMarkup, menuItem.Markup);
+        Assert.NotNull(menuItem.Find("nimble-anchor-tree-item"));
     }
 
     [Fact]
     public void NimbleAnchorTreeItem_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleAnchorTreeItem>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleAnchorTreeItem>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -36,7 +31,7 @@ public class NimbleAnchorTreeItemTests : NimbleAnchorBaseTests<NimbleAnchorTreeI
     {
         var anchorTreeItem = RenderWithPropertySet(x => x.Selected, true);
 
-        Assert.Contains("selected", anchorTreeItem.Markup);
+        anchorTreeItem.AssertHasAttribute("selected");
     }
 
     [Fact]
@@ -44,13 +39,11 @@ public class NimbleAnchorTreeItemTests : NimbleAnchorBaseTests<NimbleAnchorTreeI
     {
         var anchorTreeItem = RenderWithPropertySet(x => x.Disabled, true);
 
-        Assert.Contains("disabled", anchorTreeItem.Markup);
+        anchorTreeItem.AssertHasAttribute("disabled");
     }
 
     private IRenderedComponent<NimbleAnchorTreeItem> RenderWithPropertySet<TProperty>(Expression<Func<NimbleAnchorTreeItem, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleAnchorTreeItem>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleAnchorTreeItem>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleBannerTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleBannerTests.cs
@@ -1,52 +1,47 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
+
+#nullable enable
 
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>
 /// Tests for <see cref="NimbleBanner"/>.
 /// </summary>
-public class NimbleBannerTests
+public class NimbleBannerTests : BunitTestBase
 {
     [Fact]
     public void NimbleBanner_Render_HasBannerMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-banner";
+        var banner = Render<NimbleBanner>();
 
-        var banner = context.Render<NimbleBanner>();
-
-        Assert.Contains(expectedMarkup, banner.Markup);
+        Assert.NotNull(banner.Find("nimble-banner"));
     }
 
     [Fact]
     public void NimbleBanner_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleBanner>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleBanner>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
     [Theory]
-    [InlineData(BannerSeverity.Default, "<nimble-banner((?!severity).)*>")]
-    [InlineData(BannerSeverity.Error, "severity=\"error\"")]
-    [InlineData(BannerSeverity.Warning, "severity=\"warning\"")]
-    [InlineData(BannerSeverity.Information, "severity=\"information\"")]
-    public void BannerSeverity_AttributeIsSet(BannerSeverity value, string expectedMarkupRegEx)
+    [InlineData(BannerSeverity.Default, null)]
+    [InlineData(BannerSeverity.Error, "error")]
+    [InlineData(BannerSeverity.Warning, "warning")]
+    [InlineData(BannerSeverity.Information, "information")]
+    public void BannerSeverity_AttributeIsSet(BannerSeverity value, string? expectedAttribute)
     {
         var banner = RenderWithPropertySet(x => x.Severity, value);
 
-        Assert.Matches(expectedMarkupRegEx, banner.Markup);
+        banner.AssertAttribute("severity", expectedAttribute);
     }
 
     private IRenderedComponent<NimbleBanner> RenderWithPropertySet<TProperty>(Expression<Func<NimbleBanner, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleBanner>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleBanner>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleBannerTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleBannerTests.cs
@@ -4,8 +4,6 @@ using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
-#nullable enable
-
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleBreadcrumbTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleBreadcrumbTests.cs
@@ -4,8 +4,6 @@ using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
-#nullable enable
-
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleBreadcrumbTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleBreadcrumbTests.cs
@@ -1,62 +1,53 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
+
+#nullable enable
 
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>
 /// Tests for <see cref="NimbleBreadcrumb"/>
 /// </summary>
-public class NimbleBreadcrumbTests
+public class NimbleBreadcrumbTests : BunitTestBase
 {
     [Fact]
     public void NimbleBreadcrumb_Rendered_HasBreadcrumbMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-breadcrumb";
+        var breadcrumb = Render<NimbleBreadcrumb>();
 
-        var breadcrumb = context.Render<NimbleBreadcrumb>();
-
-        Assert.Contains(expectedMarkup, breadcrumb.Markup);
+        Assert.NotNull(breadcrumb.Find("nimble-breadcrumb"));
     }
 
     [Fact]
     public void NimbleBreadcrumb_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleBreadcrumb>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleBreadcrumb>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
     [Fact]
     public void NimbleBreadcrumbItem_Rendered_HasBreadcrumbItemMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-breadcrumb-item";
+        var breadcrumbItem = Render<NimbleBreadcrumbItem>();
 
-        var breadcrumbItem = context.Render<NimbleBreadcrumbItem>();
-
-        Assert.Contains(expectedMarkup, breadcrumbItem.Markup);
+        Assert.NotNull(breadcrumbItem.Find("nimble-breadcrumb-item"));
     }
 
     [Theory]
-    [InlineData(BreadcrumbAppearance.Default, "<nimble-breadcrumb>")]
-    [InlineData(BreadcrumbAppearance.Prominent, "appearance=\"prominent\"")]
-    public void BreadcrumbAppearance_AttributeIsSet(BreadcrumbAppearance value, string expectedAttribute)
+    [InlineData(BreadcrumbAppearance.Default, null)]
+    [InlineData(BreadcrumbAppearance.Prominent, "prominent")]
+    public void BreadcrumbAppearance_AttributeIsSet(BreadcrumbAppearance value, string? expectedAttribute)
     {
         var breadcrumb = RenderWithPropertySet(x => x.Appearance, value);
 
-        Assert.Contains(expectedAttribute, breadcrumb.Markup);
+        breadcrumb.AssertAttribute("appearance", expectedAttribute);
     }
 
     private IRenderedComponent<NimbleBreadcrumb> RenderWithPropertySet<TProperty>(Expression<Func<NimbleBreadcrumb, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleBreadcrumb>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleBreadcrumb>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleButtonTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleButtonTests.cs
@@ -1,33 +1,30 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
+
+#nullable enable
 
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>
 /// Tests for <see cref="NimbleButton"/>.
 /// </summary>
-public class NimbleButtonTests
+public class NimbleButtonTests : BunitTestBase
 {
     [Fact]
     public void NimbleButton_Render_HasButtonMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-button";
+        var button = Render<NimbleButton>();
 
-        var button = context.Render<NimbleButton>();
-
-        Assert.Contains(expectedMarkup, button.Markup);
+        Assert.NotNull(button.Find("nimble-button"));
     }
 
     [Fact]
     public void NimbleButton_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleButton>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleButton>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -39,24 +36,22 @@ public class NimbleButtonTests
     {
         var button = RenderWithPropertySet(x => x.Appearance, value);
 
-        Assert.Contains(expectedAttribute, button.Markup);
+        button.AssertAttribute("appearance", expectedAttribute);
     }
 
     [Theory]
-    [InlineData(ButtonAppearanceVariant.Default, "<nimble-button>")]
-    [InlineData(ButtonAppearanceVariant.Primary, "appearance-variant=\"primary\"")]
-    [InlineData(ButtonAppearanceVariant.Accent, "appearance-variant=\"accent\"")]
-    public void ButtonAppearanceVariant_AttributeIsSet(ButtonAppearanceVariant value, string expectedAttribute)
+    [InlineData(ButtonAppearanceVariant.Default, null)]
+    [InlineData(ButtonAppearanceVariant.Primary, "primary")]
+    [InlineData(ButtonAppearanceVariant.Accent, "accent")]
+    public void ButtonAppearanceVariant_AttributeIsSet(ButtonAppearanceVariant value, string? expectedAttribute)
     {
         var button = RenderWithPropertySet(x => x.AppearanceVariant, value);
 
-        Assert.Contains(expectedAttribute, button.Markup);
+        button.AssertAttribute("appearance-variant", expectedAttribute);
     }
 
     private IRenderedComponent<NimbleButton> RenderWithPropertySet<TProperty>(Expression<Func<NimbleButton, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleButton>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleButton>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleButtonTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleButtonTests.cs
@@ -4,8 +4,6 @@ using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
-#nullable enable
-
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleCardButtonTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleCardButtonTests.cs
@@ -1,3 +1,4 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -6,26 +7,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleCardButton"/>.
 /// </summary>
-public class NimbleCardButtonTests
+public class NimbleCardButtonTests : BunitTestBase
 {
     [Fact]
     public void NimbleCardButton_Render_HasButtonMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-card-button";
+        var cardButton = Render<NimbleCardButton>();
 
-        var cardButton = context.Render<NimbleCardButton>();
-
-        Assert.Contains(expectedMarkup, cardButton.Markup);
+        Assert.NotNull(cardButton.Find("nimble-card-button"));
     }
 
     [Fact]
     public void NimbleCardButton_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleCardButton>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleCardButton>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleCardTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleCardTests.cs
@@ -1,3 +1,4 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -6,26 +7,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleCard"/>
 /// </summary>
-public class NimbleCardTests
+public class NimbleCardTests : BunitTestBase
 {
     [Fact]
     public void NimbleCard_Rendered_HasCardMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-card";
+        var card = Render<NimbleCard>();
 
-        var card = context.Render<NimbleCard>();
-
-        Assert.Contains(expectedMarkup, card.Markup);
+        Assert.NotNull(card.Find("nimble-card"));
     }
 
     [Fact]
     public void NimbleCard_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleCard>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleCard>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleCheckboxTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleCheckboxTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,26 +9,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleCheckbox"/>
 /// </summary>
-public class NimbleCheckboxTests
+public class NimbleCheckboxTests : BunitTestBase
 {
     [Fact]
     public void NimbleCheckbox_Rendered_HasCheckboxMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-checkbox";
+        var checkbox = Render<NimbleCheckbox>();
 
-        var checkbox = context.Render<NimbleCheckbox>();
-
-        Assert.Contains(expectedMarkup, checkbox.Markup);
+        Assert.NotNull(checkbox.Find("nimble-checkbox"));
     }
 
     [Fact]
     public void NimbleCheckbox_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleCheckbox>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleCheckbox>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -36,7 +31,7 @@ public class NimbleCheckboxTests
     {
         var checkbox = RenderNimbleCheckboxWithPropertySet(x => x.ErrorText, "bad value");
 
-        Assert.Contains("error-text=\"bad value\"", checkbox.Markup);
+        checkbox.AssertAttribute("error-text", "bad value");
     }
 
     [Fact]
@@ -44,7 +39,7 @@ public class NimbleCheckboxTests
     {
         var checkbox = RenderNimbleCheckboxWithPropertySet(x => x.ErrorVisible, true);
 
-        Assert.Contains("error-visible", checkbox.Markup);
+        checkbox.AssertHasAttribute("error-visible");
     }
 
     [Fact]
@@ -52,13 +47,11 @@ public class NimbleCheckboxTests
     {
         var checkbox = RenderNimbleCheckboxWithPropertySet(x => x.AppearanceIndeterminate, true);
 
-        Assert.Contains("appearance-indeterminate", checkbox.Markup);
+        checkbox.AssertHasAttribute("appearance-indeterminate");
     }
 
     private IRenderedComponent<NimbleCheckbox> RenderNimbleCheckboxWithPropertySet<TProperty>(Expression<Func<NimbleCheckbox, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleCheckbox>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleCheckbox>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleChipTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleChipTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,43 +9,35 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleChip"/>.
 /// </summary>
-public class NimbleChipTests
+public class NimbleChipTests : BunitTestBase
 {
     [Fact]
     public void NimbleChip_Render_HasChipMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-chip";
+        var chip = Render<NimbleChip>();
 
-        var chip = context.Render<NimbleChip>();
-
-        Assert.Contains(expectedMarkup, chip.Markup);
+        Assert.NotNull(chip.Find("nimble-chip"));
     }
 
     [Fact]
     public void NimbleChip_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleChip>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleChip>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
     [Theory]
-    [InlineData(ChipAppearance.Outline, "appearance=\"outline\"")]
-    [InlineData(ChipAppearance.Block, "appearance=\"block\"")]
-    public void ChipAppearance_AttributeIsSet(ChipAppearance value, string expectedMarkup)
+    [InlineData(ChipAppearance.Outline, "outline")]
+    [InlineData(ChipAppearance.Block, "block")]
+    public void ChipAppearance_AttributeIsSet(ChipAppearance value, string expectedAttribute)
     {
         var chip = RenderWithPropertySet(x => x.Appearance, value);
 
-        Assert.Contains(expectedMarkup, chip.Markup);
+        chip.AssertAttribute("appearance", expectedAttribute);
     }
 
     private IRenderedComponent<NimbleChip> RenderWithPropertySet<TProperty>(Expression<Func<NimbleChip, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleChip>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleChip>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleComboboxTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleComboboxTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,26 +9,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleCombobox"/>
 /// </summary>
-public class NimbleComboboxTests
+public class NimbleComboboxTests : BunitTestBase
 {
     [Fact]
     public void NimbleCombobox_Rendered_HasComboboxMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-combobox";
+        var combobox = Render<NimbleCombobox>();
 
-        var combobox = context.Render<NimbleCombobox>();
-
-        Assert.Contains(expectedMarkup, combobox.Markup);
+        Assert.NotNull(combobox.Find("nimble-combobox"));
     }
 
     [Fact]
     public void NimbleCombobox_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleCombobox>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleCombobox>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -38,7 +33,7 @@ public class NimbleComboboxTests
     {
         var combobox = RenderWithPropertySet(x => x.Position, value);
 
-        Assert.Contains(expectedAttribute, combobox.Markup);
+        combobox.AssertAttribute("position", expectedAttribute);
     }
 
     [Theory]
@@ -50,7 +45,7 @@ public class NimbleComboboxTests
     {
         var combobox = RenderWithPropertySet(x => x.AutoComplete, value);
 
-        Assert.Contains(expectedAttribute, combobox.Markup);
+        combobox.AssertAttribute("autocomplete", expectedAttribute);
     }
 
     [Theory]
@@ -62,7 +57,7 @@ public class NimbleComboboxTests
     {
         var combobox = RenderWithPropertySet(x => x.Appearance, value);
 
-        Assert.Contains(expectedAttribute, combobox.Markup);
+        combobox.AssertAttribute("appearance", expectedAttribute);
     }
 
     [Fact]
@@ -71,7 +66,7 @@ public class NimbleComboboxTests
         var placeholder = "Combobox value...";
         var combobox = RenderWithPropertySet(x => x.Placeholder, placeholder);
 
-        Assert.Contains("placeholder", combobox.Markup);
+        combobox.AssertAttribute("placeholder", placeholder);
     }
 
     [Fact]
@@ -79,7 +74,7 @@ public class NimbleComboboxTests
     {
         var combobox = RenderWithPropertySet(x => x.ErrorText, "bad number");
 
-        Assert.Contains("error-text=\"bad number\"", combobox.Markup);
+        combobox.AssertAttribute("error-text", "bad number");
     }
 
     [Fact]
@@ -87,7 +82,7 @@ public class NimbleComboboxTests
     {
         var combobox = RenderWithPropertySet(x => x.ErrorVisible, true);
 
-        Assert.Contains("error-visible", combobox.Markup);
+        combobox.AssertHasAttribute("error-visible");
     }
 
     [Fact]
@@ -95,7 +90,7 @@ public class NimbleComboboxTests
     {
         var combobox = RenderWithPropertySet(x => x.RequiredVisible, true);
 
-        Assert.Contains("required-visible", combobox.Markup);
+        combobox.AssertHasAttribute("required-visible");
     }
 
     [Fact]
@@ -103,7 +98,7 @@ public class NimbleComboboxTests
     {
         var combobox = RenderWithPropertySet(x => x.AppearanceReadOnly, true);
 
-        Assert.Contains("appearance-readonly", combobox.Markup);
+        combobox.AssertHasAttribute("appearance-readonly");
     }
 
     [Fact]
@@ -111,29 +106,24 @@ public class NimbleComboboxTests
     {
         var combobox = RenderWithPropertySet(x => x.FullBleed, true);
 
-        Assert.Contains("full-bleed", combobox.Markup);
+        combobox.AssertHasAttribute("full-bleed");
     }
 
     [Fact]
     public void ComboboxWithOption_HasListOptionMarkup()
     {
-        var expectedMarkup = "nimble-list-option";
         var combobox = RenderNimbleComboboxWithOption();
 
-        Assert.Contains(expectedMarkup, combobox.Markup);
+        Assert.NotNull(combobox.Find("nimble-list-option"));
     }
 
     private IRenderedComponent<NimbleCombobox> RenderWithPropertySet<TProperty>(Expression<Func<NimbleCombobox, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleCombobox>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleCombobox>(p => p.Add(propertyGetter, propertyValue));
     }
 
     private IRenderedComponent<NimbleCombobox> RenderNimbleComboboxWithOption()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleCombobox>(p => p.AddChildContent<NimbleListOption>());
+        return Render<NimbleCombobox>(p => p.AddChildContent<NimbleListOption>());
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleDialogTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleDialogTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Xunit;
@@ -9,25 +10,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleDialog"/>
 /// </summary>
-public class NimbleDialogTests
+public class NimbleDialogTests : BunitTestBase
 {
     [Fact]
     public void NimbleDialog_Rendered_HasDialogMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-dialog";
-        var dialog = context.Render<NimbleDialog<string>>();
+        var dialog = Render<NimbleDialog<string>>();
 
-        Assert.Contains(expectedMarkup, dialog.Markup);
+        Assert.NotNull(dialog.Find("nimble-dialog"));
     }
 
     [Fact]
     public void NimbleDialog_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleDialog<string>>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleDialog<string>>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -35,9 +31,8 @@ public class NimbleDialogTests
     public void NimbleDialog_WithChildContent_HasChildMarkup()
     {
         var dialog = RenderDialogWithContent<NimbleButton>();
-        var expectedMarkup = "nimble-button";
 
-        Assert.Contains(expectedMarkup, dialog.Markup);
+        Assert.NotNull(dialog.Find("nimble-button"));
     }
 
     [Fact]
@@ -45,7 +40,7 @@ public class NimbleDialogTests
     {
         var dialog = RenderDialogWithPropertySet(x => x.PreventDismiss, true);
 
-        Assert.Contains("prevent-dismiss", dialog.Markup);
+        dialog.AssertHasAttribute("prevent-dismiss");
     }
 
     [Fact]
@@ -53,7 +48,7 @@ public class NimbleDialogTests
     {
         var dialog = RenderDialogWithPropertySet(x => x.PreventDismiss, false);
 
-        Assert.DoesNotContain("prevent-dismiss", dialog.Markup);
+        dialog.AssertAttribute("prevent-dismiss", null);
     }
 
     [Fact]
@@ -61,7 +56,7 @@ public class NimbleDialogTests
     {
         var dialog = RenderDialogWithPropertySet(x => x.HeaderHidden, true);
 
-        Assert.Contains("header-hidden", dialog.Markup);
+        dialog.AssertHasAttribute("header-hidden");
     }
 
     [Fact]
@@ -69,7 +64,7 @@ public class NimbleDialogTests
     {
         var dialog = RenderDialogWithPropertySet(x => x.HeaderHidden, false);
 
-        Assert.DoesNotContain("header-hidden", dialog.Markup);
+        dialog.AssertAttribute("header-hidden", null);
     }
 
     [Fact]
@@ -77,7 +72,7 @@ public class NimbleDialogTests
     {
         var dialog = RenderDialogWithPropertySet(x => x.FooterHidden, true);
 
-        Assert.Contains("footer-hidden", dialog.Markup);
+        dialog.AssertHasAttribute("footer-hidden");
     }
 
     [Fact]
@@ -85,21 +80,17 @@ public class NimbleDialogTests
     {
         var dialog = RenderDialogWithPropertySet(x => x.FooterHidden, false);
 
-        Assert.DoesNotContain("footer-hidden", dialog.Markup);
+        dialog.AssertAttribute("footer-hidden", null);
     }
 
     private IRenderedComponent<NimbleDialog<string>> RenderDialogWithContent<TContent>()
         where TContent : IComponent
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleDialog<string>>(parameters => parameters.AddChildContent<TContent>());
+        return Render<NimbleDialog<string>>(parameters => parameters.AddChildContent<TContent>());
     }
 
     private IRenderedComponent<NimbleDialog<string>> RenderDialogWithPropertySet<TProperty>(Expression<Func<NimbleDialog<string>, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleDialog<string>>(parameters => parameters.Add(propertyGetter, propertyValue));
+        return Render<NimbleDialog<string>>(parameters => parameters.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleDrawerTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleDrawerTests.cs
@@ -1,3 +1,4 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Xunit;
@@ -7,25 +8,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleDrawer"/>
 /// </summary>
-public class NimbleDrawerTests
+public class NimbleDrawerTests : BunitTestBase
 {
     [Fact]
     public void NimbleDrawer_Rendered_HasDrawerMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-drawer";
-        var drawer = context.Render<NimbleDrawer<string>>();
+        var drawer = Render<NimbleDrawer<string>>();
 
-        Assert.Contains(expectedMarkup, drawer.Markup);
+        Assert.NotNull(drawer.Find("nimble-drawer"));
     }
 
     [Fact]
     public void NimbleDrawer_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleDrawer<string>>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleDrawer<string>>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -33,16 +29,13 @@ public class NimbleDrawerTests
     public void NimbleDrawer_WithChildContent_HasChildMarkup()
     {
         var drawer = RenderDrawerWithContent<NimbleButton>();
-        var expectedMarkup = "nimble-button";
 
-        Assert.Contains(expectedMarkup, drawer.Markup);
+        Assert.NotNull(drawer.Find("nimble-button"));
     }
 
     private IRenderedComponent<NimbleDrawer<string>> RenderDrawerWithContent<TContent>()
         where TContent : IComponent
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleDrawer<string>>(parameters => parameters.AddChildContent<TContent>());
+        return Render<NimbleDrawer<string>>(parameters => parameters.AddChildContent<TContent>());
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleIconCheckTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleIconCheckTests.cs
@@ -1,53 +1,48 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
+
+#nullable enable
 
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>
 /// Tests for <see cref="NimbleIconCheck"/>.
 /// </summary>
-public class NimbleIconCheckTests
+public class NimbleIconCheckTests : BunitTestBase
 {
     [Fact]
     public void NimbleIconCheck_Render_HasButtonMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-icon-check";
+        var icon = Render<NimbleIconCheck>();
 
-        var icon = context.Render<NimbleIconCheck>();
-
-        Assert.Contains(expectedMarkup, icon.Markup);
+        Assert.NotNull(icon.Find("nimble-icon-check"));
     }
 
     [Fact]
     public void NimbleIconCheck_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleIconCheck>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleIconCheck>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
     [Theory]
-    [InlineData(IconSeverity.Default, "<nimble-icon-check>")]
-    [InlineData(IconSeverity.Error, "severity=\"error\"")]
-    [InlineData(IconSeverity.Information, "severity=\"information\"")]
-    [InlineData(IconSeverity.Success, "severity=\"success\"")]
-    [InlineData(IconSeverity.Warning, "severity=\"warning\"")]
-    public void IconSeverity_AttributeIsSet(IconSeverity value, string expectedAttribute)
+    [InlineData(IconSeverity.Default, null)]
+    [InlineData(IconSeverity.Error, "error")]
+    [InlineData(IconSeverity.Information, "information")]
+    [InlineData(IconSeverity.Success, "success")]
+    [InlineData(IconSeverity.Warning, "warning")]
+    public void IconSeverity_AttributeIsSet(IconSeverity value, string? expectedAttribute)
     {
         var icon = RenderWithPropertySet(x => x.Severity, value);
 
-        Assert.Contains(expectedAttribute, icon.Markup);
+        icon.AssertAttribute("severity", expectedAttribute);
     }
 
     private IRenderedComponent<NimbleIconCheck> RenderWithPropertySet<TProperty>(Expression<Func<NimbleIconCheck, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleIconCheck>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleIconCheck>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleIconCheckTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleIconCheckTests.cs
@@ -4,8 +4,6 @@ using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
-#nullable enable
-
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleLabelProviderCoreTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleLabelProviderCoreTests.cs
@@ -1,3 +1,4 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -6,26 +7,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleLabelProviderCore"/>.
 /// </summary>
-public class NimbleLabelProviderCoreTests
+public class NimbleLabelProviderCoreTests : BunitTestBase
 {
     [Fact]
     public void NimbleLabelProviderCore_Render_HasLabelProviderMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-label-provider-core";
+        var themeProvider = Render<NimbleLabelProviderCore>();
 
-        var themeProvider = context.Render<NimbleLabelProviderCore>();
-
-        Assert.Contains(expectedMarkup, themeProvider.Markup);
+        Assert.NotNull(themeProvider.Find("nimble-label-provider-core"));
     }
 
     [Fact]
     public void NimbleLabelProviderCore_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleThemeProvider>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleThemeProvider>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -49,13 +44,11 @@ public class NimbleLabelProviderCoreTests
         var labelValue = propertyName + "UpdatedValue";
         var labelProvider = RenderNimbleLabelProvider(propertyName, labelValue);
 
-        Assert.Contains(labelValue, labelProvider.Markup);
+        labelProvider.AssertAttribute(AttributeHelpers.ConvertToAttributeString(propertyName), labelValue);
     }
 
     private IRenderedComponent<NimbleLabelProviderCore> RenderNimbleLabelProvider(string propertyName, string labelValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleLabelProviderCore>(parameters => parameters.AddUnmatched(propertyName, labelValue));
+        return Render<NimbleLabelProviderCore>(parameters => parameters.AddUnmatched(AttributeHelpers.ConvertToAttributeString(propertyName), labelValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleLabelProviderTableTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleLabelProviderTableTests.cs
@@ -1,3 +1,4 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -6,26 +7,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleLabelProviderTable"/>.
 /// </summary>
-public class NimbleLabelProviderTableTests
+public class NimbleLabelProviderTableTests : BunitTestBase
 {
     [Fact]
     public void NimbleLabelProviderTable_Render_HasLabelProviderMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-label-provider-table";
+        var themeProvider = Render<NimbleLabelProviderTable>();
 
-        var themeProvider = context.Render<NimbleLabelProviderTable>();
-
-        Assert.Contains(expectedMarkup, themeProvider.Markup);
+        Assert.NotNull(themeProvider.Find("nimble-label-provider-table"));
     }
 
     [Fact]
     public void NimbleLabelProviderTable_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleThemeProvider>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleThemeProvider>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -51,13 +46,11 @@ public class NimbleLabelProviderTableTests
         var labelValue = propertyName + "UpdatedValue";
         var labelProvider = RenderNimbleLabelProvider(propertyName, labelValue);
 
-        Assert.Contains(labelValue, labelProvider.Markup);
+        labelProvider.AssertAttribute(AttributeHelpers.ConvertToAttributeString(propertyName), labelValue);
     }
 
     private IRenderedComponent<NimbleLabelProviderTable> RenderNimbleLabelProvider(string propertyName, string labelValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleLabelProviderTable>(parameters => parameters.AddUnmatched(propertyName, labelValue));
+        return Render<NimbleLabelProviderTable>(parameters => parameters.AddUnmatched(AttributeHelpers.ConvertToAttributeString(propertyName), labelValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleListOptionGroupTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleListOptionGroupTests.cs
@@ -1,30 +1,25 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
 namespace NimbleBlazor.Tests.Unit.Components;
 
-public class NimbleListOptionGroupTests
+public class NimbleListOptionGroupTests : BunitTestBase
 {
     [Fact]
     public void NimbleListOptionGroup_Rendered_HasListOptionGroupMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-list-option-group";
+        var group = Render<NimbleListOptionGroup>();
 
-        var group = context.Render<NimbleListOptionGroup>();
-
-        Assert.Contains(expectedMarkup, group.Markup);
+        Assert.NotNull(group.Find("nimble-list-option-group"));
     }
 
     [Fact]
     public void NimbleListOptionGroup_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleListOptionGroup>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleListOptionGroup>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -33,7 +28,7 @@ public class NimbleListOptionGroupTests
     {
         var dialog = RenderWithPropertySet(x => x.Hidden, true);
 
-        Assert.Contains("hidden", dialog.Markup);
+        dialog.AssertHasAttribute("hidden");
     }
 
     [Fact]
@@ -41,7 +36,7 @@ public class NimbleListOptionGroupTests
     {
         var dialog = RenderWithPropertySet(x => x.Hidden, false);
 
-        Assert.DoesNotContain("hidden", dialog.Markup);
+        dialog.AssertAttribute("hidden", null);
     }
 
     [Fact]
@@ -49,13 +44,11 @@ public class NimbleListOptionGroupTests
     {
         var dialog = RenderWithPropertySet(x => x.Label, "foo");
 
-        Assert.Contains("label=\"foo\"", dialog.Markup);
+        dialog.AssertAttribute("label", "foo");
     }
 
     private IRenderedComponent<NimbleListOptionGroup> RenderWithPropertySet<TProperty>(Expression<Func<NimbleListOptionGroup, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleListOptionGroup>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleListOptionGroup>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMappingEmptyTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMappingEmptyTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,18 +9,14 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleMappingEmpty"/>
 /// </summary>
-public class NimbleMappingEmptyTests
+public class NimbleMappingEmptyTests : BunitTestBase
 {
     [Fact]
     public void NimbleMappingEmpty_Rendered_HasMappingTextMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-mapping-empty";
+        var element = Render<NimbleMappingEmpty<int>>();
 
-        var element = context.Render<NimbleMappingEmpty<int>>();
-
-        Assert.Contains(expectedMarkup, element.Markup);
+        Assert.NotNull(element.Find("nimble-mapping-empty"));
     }
 
     [Fact]
@@ -27,7 +24,7 @@ public class NimbleMappingEmptyTests
     {
         var element = RenderWithPropertySet<int, int>(x => x.Key, 1001);
 
-        Assert.Contains($"key=\"1001\"", element.Markup);
+        element.AssertAttribute("key", "1001");
     }
 
     [Fact]
@@ -35,13 +32,11 @@ public class NimbleMappingEmptyTests
     {
         var element = RenderWithPropertySet<int, string>(x => x.Text, "foo");
 
-        Assert.Contains($"text=\"foo\"", element.Markup);
+        element.AssertAttribute("text", "foo");
     }
 
     private IRenderedComponent<NimbleMappingEmpty<TKey>> RenderWithPropertySet<TKey, TProperty>(Expression<Func<NimbleMappingEmpty<TKey>, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleMappingEmpty<TKey>>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleMappingEmpty<TKey>>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMappingEmptyTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMappingEmptyTests.cs
@@ -30,7 +30,7 @@ public class NimbleMappingEmptyTests : BunitTestBase
     [Fact]
     public void NimbleMappingEmptyTextAttribute_HasCorrectMarkup()
     {
-        var element = RenderWithPropertySet<int, string>(x => x.Text, "foo");
+        var element = RenderWithPropertySet<int, string?>(x => x.Text, "foo");
 
         element.AssertAttribute("text", "foo");
     }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMappingIconTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMappingIconTests.cs
@@ -30,7 +30,7 @@ public class NimbleMappingIconTests : BunitTestBase
     [Fact]
     public void NimbleMappingIconTextAttribute_HasCorrectMarkup()
     {
-        var element = RenderWithPropertySet<int, string>(x => x.Text, "foo");
+        var element = RenderWithPropertySet<int, string?>(x => x.Text, "foo");
 
         element.AssertAttribute("text", "foo");
     }
@@ -38,7 +38,7 @@ public class NimbleMappingIconTests : BunitTestBase
     [Fact]
     public void NimbleMappingIconIconAttribute_HasCorrectMarkup()
     {
-        var element = RenderWithPropertySet<int, string>(x => x.Icon, "foo");
+        var element = RenderWithPropertySet<int, string?>(x => x.Icon, "foo");
 
         element.AssertAttribute("icon", "foo");
     }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMappingIconTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMappingIconTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,18 +9,14 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleMappingIcon"/>
 /// </summary>
-public class NimbleMappingIconTests
+public class NimbleMappingIconTests : BunitTestBase
 {
     [Fact]
     public void NimbleMappingIcon_Rendered_HasMappingIconMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-mapping-icon";
+        var element = Render<NimbleMappingIcon<int>>();
 
-        var element = context.Render<NimbleMappingIcon<int>>();
-
-        Assert.Contains(expectedMarkup, element.Markup);
+        Assert.NotNull(element.Find("nimble-mapping-icon"));
     }
 
     [Fact]
@@ -27,7 +24,7 @@ public class NimbleMappingIconTests
     {
         var element = RenderWithPropertySet<int, int>(x => x.Key, 1001);
 
-        Assert.Contains($"key=\"1001\"", element.Markup);
+        element.AssertAttribute("key", "1001");
     }
 
     [Fact]
@@ -35,7 +32,7 @@ public class NimbleMappingIconTests
     {
         var element = RenderWithPropertySet<int, string>(x => x.Text, "foo");
 
-        Assert.Contains($"text=\"foo\"", element.Markup);
+        element.AssertAttribute("text", "foo");
     }
 
     [Fact]
@@ -43,7 +40,7 @@ public class NimbleMappingIconTests
     {
         var element = RenderWithPropertySet<int, string>(x => x.Icon, "foo");
 
-        Assert.Contains($"icon=\"foo\"", element.Markup);
+        element.AssertAttribute("icon", "foo");
     }
 
     [Fact]
@@ -51,7 +48,7 @@ public class NimbleMappingIconTests
     {
         var element = RenderWithPropertySet<int, IconSeverity?>(x => x.Severity, IconSeverity.Success);
 
-        Assert.Contains($"severity=\"success\"", element.Markup);
+        element.AssertAttribute("severity", "success");
     }
 
     [Fact]
@@ -59,13 +56,11 @@ public class NimbleMappingIconTests
     {
         var element = RenderWithPropertySet<int, bool?>(x => x.TextHidden, true);
 
-        Assert.Contains($"text-hidden", element.Markup);
+        element.AssertHasAttribute("text-hidden");
     }
 
     private IRenderedComponent<NimbleMappingIcon<TKey>> RenderWithPropertySet<TKey, TProperty>(Expression<Func<NimbleMappingIcon<TKey>, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleMappingIcon<TKey>>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleMappingIcon<TKey>>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMappingSpinnerTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMappingSpinnerTests.cs
@@ -30,7 +30,7 @@ public class NimbleMappingSpinnerTests : BunitTestBase
     [Fact]
     public void NimbleMappingSpinnerTextAttribute_HasCorrectMarkup()
     {
-        var element = RenderWithPropertySet<int, string>(x => x.Text, "foo");
+        var element = RenderWithPropertySet<int, string?>(x => x.Text, "foo");
 
         element.AssertAttribute("text", "foo");
     }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMappingSpinnerTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMappingSpinnerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,18 +9,14 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleMappingSpinner"/>
 /// </summary>
-public class NimbleMappingSpinnerTests
+public class NimbleMappingSpinnerTests : BunitTestBase
 {
     [Fact]
     public void NimbleMappingSpinner_Rendered_HasMappingSpinnerMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-mapping-spinner";
+        var element = Render<NimbleMappingSpinner<int>>();
 
-        var element = context.Render<NimbleMappingSpinner<int>>();
-
-        Assert.Contains(expectedMarkup, element.Markup);
+        Assert.NotNull(element.Find("nimble-mapping-spinner"));
     }
 
     [Fact]
@@ -27,7 +24,7 @@ public class NimbleMappingSpinnerTests
     {
         var element = RenderWithPropertySet<int, int>(x => x.Key, 1001);
 
-        Assert.Contains($"key=\"1001\"", element.Markup);
+        element.AssertAttribute("key", "1001");
     }
 
     [Fact]
@@ -35,7 +32,7 @@ public class NimbleMappingSpinnerTests
     {
         var element = RenderWithPropertySet<int, string>(x => x.Text, "foo");
 
-        Assert.Contains($"text=\"foo\"", element.Markup);
+        element.AssertAttribute("text", "foo");
     }
 
     [Fact]
@@ -43,13 +40,11 @@ public class NimbleMappingSpinnerTests
     {
         var element = RenderWithPropertySet<int, bool?>(x => x.TextHidden, true);
 
-        Assert.Contains($"text-hidden", element.Markup);
+        element.AssertHasAttribute("text-hidden");
     }
 
     private IRenderedComponent<NimbleMappingSpinner<TKey>> RenderWithPropertySet<TKey, TProperty>(Expression<Func<NimbleMappingSpinner<TKey>, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleMappingSpinner<TKey>>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleMappingSpinner<TKey>>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMappingTextTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMappingTextTests.cs
@@ -30,7 +30,7 @@ public class NimbleMappingTextTests : BunitTestBase
     [Fact]
     public void NimbleMappingTextTextAttribute_HasCorrectMarkup()
     {
-        var element = RenderWithPropertySet<int, string>(x => x.Text, "foo");
+        var element = RenderWithPropertySet<int, string?>(x => x.Text, "foo");
 
         element.AssertAttribute("text", "foo");
     }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMappingTextTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMappingTextTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,18 +9,14 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleMappingText"/>
 /// </summary>
-public class NimbleMappingTextTests
+public class NimbleMappingTextTests : BunitTestBase
 {
     [Fact]
     public void NimbleMappingText_Rendered_HasMappingTextMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-mapping-text";
+        var element = Render<NimbleMappingText<int>>();
 
-        var element = context.Render<NimbleMappingText<int>>();
-
-        Assert.Contains(expectedMarkup, element.Markup);
+        Assert.NotNull(element.Find("nimble-mapping-text"));
     }
 
     [Fact]
@@ -27,7 +24,7 @@ public class NimbleMappingTextTests
     {
         var element = RenderWithPropertySet<int, int>(x => x.Key, 1001);
 
-        Assert.Contains($"key=\"1001\"", element.Markup);
+        element.AssertAttribute("key", "1001");
     }
 
     [Fact]
@@ -35,13 +32,11 @@ public class NimbleMappingTextTests
     {
         var element = RenderWithPropertySet<int, string>(x => x.Text, "foo");
 
-        Assert.Contains($"text=\"foo\"", element.Markup);
+        element.AssertAttribute("text", "foo");
     }
 
     private IRenderedComponent<NimbleMappingText<TKey>> RenderWithPropertySet<TKey, TProperty>(Expression<Func<NimbleMappingText<TKey>, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleMappingText<TKey>>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleMappingText<TKey>>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMenuButtonTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMenuButtonTests.cs
@@ -1,31 +1,28 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
+
+#nullable enable
 
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>
 /// Tests for <see cref="NimbleMenuButton"/>
 /// </summary>
-public class NimbleMenuButtonTests
+public class NimbleMenuButtonTests : BunitTestBase
 {
     [Fact]
     public void NimbleMenuButton_Rendered_HasButtonMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-menu-button";
+        var button = Render<NimbleMenuButton>();
 
-        var button = context.Render<NimbleMenuButton>();
-
-        Assert.Contains(expectedMarkup, button.Markup);
+        Assert.NotNull(button.Find("nimble-menu-button"));
     }
 
     [Fact]
     public void NimbleMenuButton_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleMenuButton>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleMenuButton>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -37,18 +34,18 @@ public class NimbleMenuButtonTests
     {
         var button = RenderNimbleMenuButton(value);
 
-        Assert.Contains(expectedAttribute, button.Markup);
+        button.AssertAttribute("appearance", expectedAttribute);
     }
 
     [Theory]
-    [InlineData(ButtonAppearanceVariant.Default, "<nimble-menu-button((?!appearance-variant).)*>")]
-    [InlineData(ButtonAppearanceVariant.Primary, "appearance-variant=\"primary\"")]
-    [InlineData(ButtonAppearanceVariant.Accent, "appearance-variant=\"accent\"")]
-    public void ButtonAppearanceVariant_AttributeIsSet(ButtonAppearanceVariant value, string expectedAttribute)
+    [InlineData(ButtonAppearanceVariant.Default, null)]
+    [InlineData(ButtonAppearanceVariant.Primary, "primary")]
+    [InlineData(ButtonAppearanceVariant.Accent, "accent")]
+    public void ButtonAppearanceVariant_AttributeIsSet(ButtonAppearanceVariant value, string? expectedAttribute)
     {
         var button = RenderNimbleMenuButton(value);
 
-        Assert.Matches(expectedAttribute, button.Markup);
+        button.AssertAttribute("appearance-variant", expectedAttribute);
     }
 
     [Theory]
@@ -59,27 +56,21 @@ public class NimbleMenuButtonTests
     {
         var button = RenderNimbleMenuButton(value);
 
-        Assert.Contains(expectedAttribute, button.Markup);
+        button.AssertAttribute("position", expectedAttribute);
     }
 
     private IRenderedComponent<NimbleMenuButton> RenderNimbleMenuButton(ButtonAppearance appearance)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleMenuButton>(p => p.Add(x => x.Appearance, appearance));
+        return Render<NimbleMenuButton>(p => p.Add(x => x.Appearance, appearance));
     }
 
     private IRenderedComponent<NimbleMenuButton> RenderNimbleMenuButton(ButtonAppearanceVariant appearanceVariant)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleMenuButton>(p => p.Add(x => x.AppearanceVariant, appearanceVariant));
+        return Render<NimbleMenuButton>(p => p.Add(x => x.AppearanceVariant, appearanceVariant));
     }
 
     private IRenderedComponent<NimbleMenuButton> RenderNimbleMenuButton(MenuButtonPosition position)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleMenuButton>(p => p.Add(x => x.Position, position));
+        return Render<NimbleMenuButton>(p => p.Add(x => x.Position, position));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMenuButtonTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMenuButtonTests.cs
@@ -2,8 +2,6 @@ using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
-#nullable enable
-
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMenuTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleMenuTests.cs
@@ -1,3 +1,4 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -6,26 +7,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleMenu"/>
 /// </summary>
-public class NimbleMenuTests
+public class NimbleMenuTests : BunitTestBase
 {
     [Fact]
     public void NimbleMenu_Rendered_HasMenuMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-menu";
+        var menu = Render<NimbleMenu>();
 
-        var menu = context.Render<NimbleMenu>();
-
-        Assert.Contains(expectedMarkup, menu.Markup);
+        Assert.NotNull(menu.Find("nimble-menu"));
     }
 
     [Fact]
     public void NimbleMenu_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleMenu>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleMenu>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleNumberFieldTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleNumberFieldTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,18 +9,16 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleNumberField"/>
 /// </summary>
-public class NimbleNumberFieldTests
+public class NimbleNumberFieldTests : BunitTestBase
 {
     private const string NumberFieldMarkup = "nimble-number-field";
 
     [Fact]
     public void NimbleNumberField_Rendered_HasNumberFieldMarkup()
     {
-        var context = new BunitContext();
+        var textField = Render<NimbleNumberField>();
 
-        var textField = context.Render<NimbleNumberField>();
-
-        Assert.Contains(NumberFieldMarkup, textField.Markup);
+        Assert.NotNull(textField.Find(NumberFieldMarkup));
     }
 
     [Theory]
@@ -29,8 +28,7 @@ public class NimbleNumberFieldTests
     [InlineData("1E+100")]
     public void Render_ChangeValue_HasMatchingValue(string value)
     {
-        var context = new BunitContext();
-        var field = context.Render<NimbleNumberField>();
+        var field = Render<NimbleNumberField>();
 
         field.Find(NumberFieldMarkup).Change(value);
 
@@ -41,8 +39,7 @@ public class NimbleNumberFieldTests
     [Fact]
     public void NimbleNumberField_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        var exception = Record.Exception(() => context.Render<NimbleNumberField>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleNumberField>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -55,7 +52,7 @@ public class NimbleNumberFieldTests
     {
         var numberField = RenderWithPropertySet(x => x.Appearance, value);
 
-        Assert.Contains(expectedAttribute, numberField.Markup);
+        numberField.AssertAttribute("appearance", expectedAttribute);
     }
 
     [Fact]
@@ -63,7 +60,7 @@ public class NimbleNumberFieldTests
     {
         var numberField = RenderWithPropertySet(x => x.Step, 2.3);
 
-        Assert.Contains("step=\"2.3\"", numberField.Markup);
+        numberField.AssertAttribute("step", "2.3");
     }
 
     [Fact]
@@ -71,7 +68,7 @@ public class NimbleNumberFieldTests
     {
         var numberField = RenderWithPropertySet(x => x.HideStep, true);
 
-        Assert.Contains("hide-step", numberField.Markup);
+        numberField.AssertHasAttribute("hide-step");
     }
 
     [Fact]
@@ -79,7 +76,7 @@ public class NimbleNumberFieldTests
     {
         var numberField = RenderWithPropertySet(x => x.Min, 2.3);
 
-        Assert.Contains("min=\"2.3\"", numberField.Markup);
+        numberField.AssertAttribute("min", "2.3");
     }
 
     [Fact]
@@ -87,7 +84,7 @@ public class NimbleNumberFieldTests
     {
         var numberField = RenderWithPropertySet(x => x.Max, 2.3);
 
-        Assert.Contains("max=\"2.3\"", numberField.Markup);
+        numberField.AssertAttribute("max", "2.3");
     }
 
     [Fact]
@@ -95,7 +92,7 @@ public class NimbleNumberFieldTests
     {
         var numberField = RenderWithPropertySet(x => x.Placeholder, "enter a value");
 
-        Assert.Contains("placeholder=\"enter a value\"", numberField.Markup);
+        numberField.AssertAttribute("placeholder", "enter a value");
     }
 
     [Fact]
@@ -103,7 +100,7 @@ public class NimbleNumberFieldTests
     {
         var numberField = RenderWithPropertySet(x => x.ErrorText, "bad number");
 
-        Assert.Contains("error-text=\"bad number\"", numberField.Markup);
+        numberField.AssertAttribute("error-text", "bad number");
     }
 
     [Fact]
@@ -111,7 +108,7 @@ public class NimbleNumberFieldTests
     {
         var numberField = RenderWithPropertySet(x => x.ErrorVisible, true);
 
-        Assert.Contains("error-visible", numberField.Markup);
+        numberField.AssertHasAttribute("error-visible");
     }
 
     [Fact]
@@ -119,7 +116,7 @@ public class NimbleNumberFieldTests
     {
         var numberField = RenderWithPropertySet(x => x.Disabled, true);
 
-        Assert.Contains("disabled", numberField.Markup);
+        numberField.AssertHasAttribute("disabled");
     }
 
     [Fact]
@@ -127,7 +124,7 @@ public class NimbleNumberFieldTests
     {
         var numberField = RenderWithPropertySet(x => x.ReadOnly, true);
 
-        Assert.Contains("readonly", numberField.Markup);
+        numberField.AssertHasAttribute("readonly");
     }
 
     [Fact]
@@ -135,7 +132,7 @@ public class NimbleNumberFieldTests
     {
         var numberField = RenderWithPropertySet(x => x.RequiredVisible, true);
 
-        Assert.Contains("required-visible", numberField.Markup);
+        numberField.AssertHasAttribute("required-visible");
     }
 
     [Fact]
@@ -143,7 +140,7 @@ public class NimbleNumberFieldTests
     {
         var numberField = RenderWithPropertySet(x => x.AppearanceReadOnly, true);
 
-        Assert.Contains("appearance-readonly", numberField.Markup);
+        numberField.AssertHasAttribute("appearance-readonly");
     }
 
     [Fact]
@@ -151,7 +148,7 @@ public class NimbleNumberFieldTests
     {
         var numberField = RenderWithPropertySet(x => x.FullBleed, true);
 
-        Assert.Contains("full-bleed", numberField.Markup);
+        numberField.AssertHasAttribute("full-bleed");
     }
 
     [Fact]
@@ -161,7 +158,7 @@ public class NimbleNumberFieldTests
         {
             var numberField = RenderWithPropertySet(x => x.Value, 1.5);
 
-            Assert.Contains("current-value=\"1.5\"", numberField.Markup);
+            numberField.AssertAttribute("current-value", "1.5");
         }
     }
 
@@ -172,7 +169,7 @@ public class NimbleNumberFieldTests
         {
             var numberField = RenderWithPropertySet(x => x.Step, 1.5);
 
-            Assert.Contains("step=\"1.5\"", numberField.Markup);
+            numberField.AssertAttribute("step", "1.5");
         }
     }
 
@@ -183,7 +180,7 @@ public class NimbleNumberFieldTests
         {
             var numberField = RenderWithPropertySet(x => x.Min, 1.5);
 
-            Assert.Contains("min=\"1.5\"", numberField.Markup);
+            numberField.AssertAttribute("min", "1.5");
         }
     }
 
@@ -194,14 +191,12 @@ public class NimbleNumberFieldTests
         {
             var numberField = RenderWithPropertySet(x => x.Max, 1.5);
 
-            Assert.Contains("max=\"1.5\"", numberField.Markup);
+            numberField.AssertAttribute("max", "1.5");
         }
     }
 
     private IRenderedComponent<NimbleNumberField> RenderWithPropertySet<TProperty>(Expression<Func<NimbleNumberField, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleNumberField>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleNumberField>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleRadioGroupTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleRadioGroupTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,26 +9,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleRadioGroup"/>
 /// </summary>
-public class NimbleRadioGroupTests
+public class NimbleRadioGroupTests : BunitTestBase
 {
     [Fact]
     public void NimbleRadioGroup_Rendered_HasRadioGroupMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-radio-group";
+        var radioGroup = Render<NimbleRadioGroup>();
 
-        var radioGroup = context.Render<NimbleRadioGroup>();
-
-        Assert.Contains(expectedMarkup, radioGroup.Markup);
+        Assert.NotNull(radioGroup.Find("nimble-radio-group"));
     }
 
     [Fact]
     public void NimbleRadioGroup_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleRadioGroup>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleRadioGroup>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -38,16 +33,15 @@ public class NimbleRadioGroupTests
     {
         var radioGroup = RenderNimbleRadioGroup(value);
 
-        Assert.Contains(expectedAttribute, radioGroup.Markup);
+        radioGroup.AssertAttribute("orientation", expectedAttribute);
     }
 
     [Fact]
     public void RadioGroupWithButton_HasRadioMarkup()
     {
-        var expectedMarkup = "nimble-radio";
         var select = RenderNimbleRadioGroupWithButton();
 
-        Assert.Contains(expectedMarkup, select.Markup);
+        Assert.NotNull(select.Find("nimble-radio"));
     }
 
     [Fact]
@@ -55,7 +49,7 @@ public class NimbleRadioGroupTests
     {
         var radioGroup = RenderNimbleRadioGroupWithPropertySet(x => x.Disabled, true);
 
-        Assert.Contains("disabled", radioGroup.Markup);
+        radioGroup.AssertHasAttribute("disabled");
     }
 
     [Fact]
@@ -63,7 +57,7 @@ public class NimbleRadioGroupTests
     {
         var radioGroup = RenderNimbleRadioGroupWithPropertySet(x => x.Name, "foo");
 
-        Assert.Contains("name", radioGroup.Markup);
+        radioGroup.AssertAttribute("name", "foo");
     }
 
     [Fact]
@@ -71,7 +65,7 @@ public class NimbleRadioGroupTests
     {
         var radioGroup = RenderNimbleRadioGroupWithPropertySet(x => x.ErrorText, "bad value");
 
-        Assert.Contains("error-text=\"bad value\"", radioGroup.Markup);
+        radioGroup.AssertAttribute("error-text", "bad value");
     }
 
     [Fact]
@@ -79,7 +73,7 @@ public class NimbleRadioGroupTests
     {
         var radioGroup = RenderNimbleRadioGroupWithPropertySet(x => x.ErrorVisible, true);
 
-        Assert.Contains("error-visible", radioGroup.Markup);
+        radioGroup.AssertHasAttribute("error-visible");
     }
 
     [Fact]
@@ -87,27 +81,21 @@ public class NimbleRadioGroupTests
     {
         var radioGroup = RenderNimbleRadioGroupWithPropertySet(x => x.RequiredVisible, true);
 
-        Assert.Contains("required-visible", radioGroup.Markup);
+        radioGroup.AssertHasAttribute("required-visible");
     }
 
     private IRenderedComponent<NimbleRadioGroup> RenderNimbleRadioGroupWithPropertySet<TProperty>(Expression<Func<NimbleRadioGroup, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleRadioGroup>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleRadioGroup>(p => p.Add(propertyGetter, propertyValue));
     }
 
     private IRenderedComponent<NimbleRadioGroup> RenderNimbleRadioGroupWithButton()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleRadioGroup>(p => p.AddChildContent<NimbleRadio>());
+        return Render<NimbleRadioGroup>(p => p.AddChildContent<NimbleRadio>());
     }
 
     private IRenderedComponent<NimbleRadioGroup> RenderNimbleRadioGroup(Orientation orientation)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleRadioGroup>(p => p.Add(x => x.Orientation, orientation));
+        return Render<NimbleRadioGroup>(p => p.Add(x => x.Orientation, orientation));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleRadioTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleRadioTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,26 +9,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleRadio"/>
 /// </summary>
-public class NimbleRadioTests
+public class NimbleRadioTests : BunitTestBase
 {
     [Fact]
     public void NimbleRadio_Rendered_HasRadioMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-radio";
+        var radio = Render<NimbleRadio>();
 
-        var radio = context.Render<NimbleRadio>();
-
-        Assert.Contains(expectedMarkup, radio.Markup);
+        Assert.NotNull(radio.Find("nimble-radio"));
     }
 
     [Fact]
     public void NimbleRadio_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleRadio>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleRadio>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -36,7 +31,7 @@ public class NimbleRadioTests
     {
         var radio = RenderNimbleRadioWithPropertySet(x => x.CurrentValue, "foo");
 
-        Assert.Contains("current-value", radio.Markup);
+        radio.AssertAttribute("current-value", "foo");
     }
 
     [Fact]
@@ -44,7 +39,7 @@ public class NimbleRadioTests
     {
         var radio = RenderNimbleRadioWithPropertySet(x => x.Disabled, true);
 
-        Assert.Contains("disabled", radio.Markup);
+        radio.AssertHasAttribute("disabled");
     }
 
     [Fact]
@@ -52,13 +47,11 @@ public class NimbleRadioTests
     {
         var radio = RenderNimbleRadioWithPropertySet(x => x.Name, "buttons");
 
-        Assert.Contains("name", radio.Markup);
+        radio.AssertAttribute("name", "buttons");
     }
 
     private IRenderedComponent<NimbleRadio> RenderNimbleRadioWithPropertySet<TProperty>(Expression<Func<NimbleRadio, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleRadio>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleRadio>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleRichTextViewerTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleRichTextViewerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,26 +9,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Test for <see cref="NimbleRichTextViewer"/>
 /// </summary>
-public class NimbleRichTextViewerTests
+public class NimbleRichTextViewerTests : BunitTestBase
 {
     [Fact]
     public void NimbleRichTextViewer_Rendered_HasRichTextViewerMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-rich-text-viewer";
+        var textField = Render<NimbleRichTextViewer>();
 
-        var textField = context.Render<NimbleRichTextViewer>();
-
-        Assert.Contains(expectedMarkup, textField.Markup);
+        Assert.NotNull(textField.Find("nimble-rich-text-viewer"));
     }
 
     [Fact]
     public void NimbleRichTextViewer_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleRichTextViewer>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleRichTextViewer>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -36,13 +31,11 @@ public class NimbleRichTextViewerTests
     {
         var richTextViewer = RenderWithPropertySet(x => x.Markdown, "**markdown string**");
 
-        Assert.Contains("markdown=\"**markdown string**\"", richTextViewer.Markup);
+        richTextViewer.AssertAttribute("markdown", "**markdown string**");
     }
 
     private IRenderedComponent<NimbleRichTextViewer> RenderWithPropertySet<TProperty>(Expression<Func<NimbleRichTextViewer, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleRichTextViewer>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleRichTextViewer>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleSelectTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleSelectTests.cs
@@ -1,33 +1,30 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
+
+#nullable enable
 
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>
 /// Tests for <see cref="NimbleSelect"/>
 /// </summary>
-public class NimbleSelectTests
+public class NimbleSelectTests : BunitTestBase
 {
     [Fact]
     public void NimbleSelect_Rendered_HasSelectMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-select";
+        var select = Render<NimbleSelect>();
 
-        var select = context.Render<NimbleSelect>();
-
-        Assert.Contains(expectedMarkup, select.Markup);
+        Assert.NotNull(select.Find("nimble-select"));
     }
 
     [Fact]
     public void NimbleSelect_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleSelect>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleSelect>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -38,7 +35,7 @@ public class NimbleSelectTests
     {
         var select = RenderWithPropertySet(x => x.Position, value);
 
-        Assert.Contains(expectedAttribute, select.Markup);
+        select.AssertAttribute("position", expectedAttribute);
     }
 
     [Fact]
@@ -46,7 +43,7 @@ public class NimbleSelectTests
     {
         var select = RenderWithPropertySet(x => x.ErrorText, "bad number");
 
-        Assert.Contains("error-text=\"bad number\"", select.Markup);
+        select.AssertAttribute("error-text", "bad number");
     }
 
     [Fact]
@@ -54,7 +51,7 @@ public class NimbleSelectTests
     {
         var select = RenderWithPropertySet(x => x.ErrorVisible, true);
 
-        Assert.Contains("error-visible", select.Markup);
+        select.AssertHasAttribute("error-visible");
     }
 
     [Fact]
@@ -62,16 +59,15 @@ public class NimbleSelectTests
     {
         var select = RenderWithPropertySet(x => x.RequiredVisible, true);
 
-        Assert.Contains("required-visible", select.Markup);
+        select.AssertHasAttribute("required-visible");
     }
 
     [Fact]
     public void SelectWithOption_HasListOptionMarkup()
     {
-        var expectedMarkup = "nimble-list-option";
         var select = RenderNimbleSelectWithOption();
 
-        Assert.Contains(expectedMarkup, select.Markup);
+        Assert.NotNull(select.Find("nimble-list-option"));
     }
 
     [Theory]
@@ -83,16 +79,15 @@ public class NimbleSelectTests
     {
         var select = RenderWithPropertySet(x => x.Appearance, value);
 
-        Assert.Contains(expectedAttribute, select.Markup);
+        select.AssertAttribute("appearance", expectedAttribute);
     }
 
     [Fact]
     public void Select_FilterModeStandardIsSet()
     {
-        var expectedContents = "filter-mode=\"standard\"";
         var select = RenderWithPropertySet(x => x.FilterMode, FilterMode.Standard);
 
-        Assert.Contains(expectedContents, select.Markup);
+        select.AssertAttribute("filter-mode", "standard");
     }
 
     [Fact]
@@ -100,7 +95,7 @@ public class NimbleSelectTests
     {
         var select = RenderWithPropertySet(x => x.FilterMode, FilterMode.None);
 
-        Assert.DoesNotContain("filter-mode", select.Markup);
+        select.AssertAttribute("filter-mode", null);
     }
 
     [Fact]
@@ -108,7 +103,7 @@ public class NimbleSelectTests
     {
         var select = RenderWithPropertySet(x => x.Clearable, true);
 
-        Assert.Contains("clearable", select.Markup);
+        select.AssertHasAttribute("clearable");
     }
 
     [Fact]
@@ -116,7 +111,7 @@ public class NimbleSelectTests
     {
         var select = RenderWithPropertySet(x => x.AppearanceReadOnly, true);
 
-        Assert.Contains("appearance-readonly", select.Markup);
+        select.AssertHasAttribute("appearance-readonly");
     }
 
     [Fact]
@@ -124,20 +119,16 @@ public class NimbleSelectTests
     {
         var select = RenderWithPropertySet(x => x.FullBleed, true);
 
-        Assert.Contains("full-bleed", select.Markup);
+        select.AssertHasAttribute("full-bleed");
     }
 
     private IRenderedComponent<NimbleSelect> RenderWithPropertySet<TProperty>(Expression<Func<NimbleSelect, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleSelect>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleSelect>(p => p.Add(propertyGetter, propertyValue));
     }
 
     private IRenderedComponent<NimbleSelect> RenderNimbleSelectWithOption()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleSelect>(p => p.AddChildContent<NimbleListOption>());
+        return Render<NimbleSelect>(p => p.AddChildContent<NimbleListOption>());
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleSelectTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleSelectTests.cs
@@ -4,8 +4,6 @@ using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
-#nullable enable
-
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleSpinnerTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleSpinnerTests.cs
@@ -1,50 +1,45 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
+
+#nullable enable
 
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>
 /// Tests for <see cref="NimbleSpinner"/>.
 /// </summary>
-public class NimbleSpinnerTests
+public class NimbleSpinnerTests : BunitTestBase
 {
     [Fact]
     public void NimbleSpinner_Render_HasSpinnerMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-spinner";
+        var spinner = Render<NimbleSpinner>();
 
-        var spinner = context.Render<NimbleSpinner>();
-
-        Assert.Contains(expectedMarkup, spinner.Markup);
+        Assert.NotNull(spinner.Find("nimble-spinner"));
     }
 
     [Fact]
     public void NimbleSpinner_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleSpinner>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleSpinner>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
     [Theory]
-    [InlineData(SpinnerAppearance.Default, "<nimble-spinner>")]
-    [InlineData(SpinnerAppearance.Accent, "appearance=\"accent\"")]
-    public void SpinnerAppearance_AttributeIsSet(SpinnerAppearance value, string expectedMarkup)
+    [InlineData(SpinnerAppearance.Default, null)]
+    [InlineData(SpinnerAppearance.Accent, "accent")]
+    public void SpinnerAppearance_AttributeIsSet(SpinnerAppearance value, string? expectedValue)
     {
         var spinner = RenderWithPropertySet(x => x.Appearance, value);
 
-        Assert.Contains(expectedMarkup, spinner.Markup);
+        spinner.AssertAttribute("appearance", expectedValue);
     }
 
     private IRenderedComponent<NimbleSpinner> RenderWithPropertySet<TProperty>(Expression<Func<NimbleSpinner, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleSpinner>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleSpinner>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleSpinnerTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleSpinnerTests.cs
@@ -4,8 +4,6 @@ using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
-#nullable enable
-
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleStepTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleStepTests.cs
@@ -1,45 +1,42 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
+
+#nullable enable
 
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>
 /// Tests for <see cref="NimbleStep"/>
 /// </summary>
-public class NimbleStepTests
+public class NimbleStepTests : BunitTestBase
 {
     [Fact]
     public void NimbleStep_Rendered_HasStepMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-step";
+        var step = Render<NimbleStep>();
 
-        var step = context.Render<NimbleStep>();
-
-        Assert.Contains(expectedMarkup, step.Markup);
+        Assert.NotNull(step.Find("nimble-step"));
     }
 
     [Fact]
     public void NimbleStep_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleStep>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleStep>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
     [Theory]
-    [InlineData(StepSeverity.Error, "severity=\"error\"")]
-    [InlineData(StepSeverity.Warning, "severity=\"warning\"")]
-    [InlineData(StepSeverity.Success, "severity=\"success\"")]
+    [InlineData(StepSeverity.Error, "error")]
+    [InlineData(StepSeverity.Warning, "warning")]
+    [InlineData(StepSeverity.Success, "success")]
     public void StepSeverity_AttributeIsSet(StepSeverity value, string expectedAttribute)
     {
         var step = RenderWithPropertySet(x => x.Severity, value);
 
-        Assert.Contains(expectedAttribute, step.Markup);
+        step.AssertAttribute("severity", expectedAttribute);
     }
 
     [Fact]
@@ -47,7 +44,7 @@ public class NimbleStepTests
     {
         var step = RenderWithPropertySet(x => x.Severity, StepSeverity.Default);
 
-        Assert.DoesNotContain("severity", step.Markup);
+        step.AssertAttribute("severity", null);
     }
 
     [Fact]
@@ -55,7 +52,7 @@ public class NimbleStepTests
     {
         var step = RenderWithPropertySet(x => x.Disabled, true);
 
-        Assert.Contains("disabled", step.Markup);
+        step.AssertHasAttribute("disabled");
     }
 
     [Fact]
@@ -63,7 +60,7 @@ public class NimbleStepTests
     {
         var step = RenderWithPropertySet(x => x.ReadOnly, true);
 
-        Assert.Contains("readonly", step.Markup);
+        step.AssertHasAttribute("readonly");
     }
 
     [Fact]
@@ -71,13 +68,11 @@ public class NimbleStepTests
     {
         var step = RenderWithPropertySet(x => x.Selected, true);
 
-        Assert.Contains("selected", step.Markup);
+        step.AssertHasAttribute("selected");
     }
 
     private IRenderedComponent<NimbleStep> RenderWithPropertySet<TProperty>(Expression<Func<NimbleStep, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleStep>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleStep>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleStepTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleStepTests.cs
@@ -4,8 +4,6 @@ using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
-#nullable enable
-
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleStepperTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleStepperTests.cs
@@ -1,7 +1,6 @@
 using System;
-using System.Linq;
 using System.Linq.Expressions;
-using AngleSharp.Dom;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -10,54 +9,43 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleStepper"/>
 /// </summary>
-public class NimbleStepperTests
+public class NimbleStepperTests : BunitTestBase
 {
     [Fact]
     public void NimbleStepper_Rendered_HasStepperMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-stepper";
+        var stepper = Render<NimbleStepper>();
 
-        var stepper = context.Render<NimbleStepper>();
-
-        Assert.Contains(expectedMarkup, stepper.Markup);
+        Assert.NotNull(stepper.Find("nimble-stepper"));
     }
 
     [Fact]
     public void NimbleStepper_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleStepper>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleStepper>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
     [Theory]
-    [InlineData(Orientation.Horizontal, "orientation=\"horizontal\"")]
-    [InlineData(Orientation.Vertical, "orientation=\"vertical\"")]
+    [InlineData(Orientation.Horizontal, "horizontal")]
+    [InlineData(Orientation.Vertical, "vertical")]
     public void StepperOrientation_AttributeIsSet(Orientation value, string expectedAttribute)
     {
         var stepper = RenderWithPropertySet(x => x.Orientation, value);
 
-        Assert.Contains(expectedAttribute, stepper.Markup);
+        stepper.AssertAttribute("orientation", expectedAttribute);
     }
 
     [Fact]
     public void NimbleStepperWithChildContent_HasChildMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var stepper = context.Render<NimbleStepper>(p => p.AddChildContent<NimbleStep>());
+        var stepper = Render<NimbleStepper>(p => p.AddChildContent<NimbleStep>());
 
-        var expectedMarkup = "nimble-step";
-        Assert.Contains(expectedMarkup, stepper.Markup);
+        Assert.NotNull(stepper.Find("nimble-step"));
     }
 
     private IRenderedComponent<NimbleStepper> RenderWithPropertySet<TProperty>(Expression<Func<NimbleStepper, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleStepper>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleStepper>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleSwitchTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleSwitchTests.cs
@@ -1,3 +1,4 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -6,26 +7,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleSwitch"/>
 /// </summary>
-public class NimbleSwitchTests
+public class NimbleSwitchTests : BunitTestBase
 {
     [Fact]
     public void NimbleSwitch_Rendered_HasSwitchMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-switch";
+        var switchComponent = Render<NimbleSwitch>();
 
-        var switchComponent = context.Render<NimbleSwitch>();
-
-        Assert.Contains(expectedMarkup, switchComponent.Markup);
+        Assert.NotNull(switchComponent.Find("nimble-switch"));
     }
 
     [Fact]
     public void NimbleSwitch_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleSwitch>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleSwitch>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnAnchorTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnAnchorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 #nullable enable
@@ -8,14 +9,12 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleTableColumnAnchor"/>
 /// </summary>
-public class NimbleTableColumnAnchorTests
+public class NimbleTableColumnAnchorTests : BunitTestBase
 {
     [Fact]
     public void NimbleTableColumnAnchor_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleTableColumnAnchor>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleTableColumnAnchor>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -24,8 +23,7 @@ public class NimbleTableColumnAnchorTests
     {
         var tableColumn = RenderWithPropertySet(x => x.LabelFieldName!, "FirstName");
 
-        var expectedMarkup = @"label-field-name=""FirstName""";
-        Assert.Contains(expectedMarkup, tableColumn.Markup);
+        tableColumn.AssertAttribute("label-field-name", "FirstName");
     }
 
     [Fact]
@@ -33,8 +31,7 @@ public class NimbleTableColumnAnchorTests
     {
         var tableColumn = RenderWithPropertySet(x => x.HrefFieldName!, "Link");
 
-        var expectedMarkup = @"href-field-name=""Link""";
-        Assert.Contains(expectedMarkup, tableColumn.Markup);
+        tableColumn.AssertAttribute("href-field-name", "Link");
     }
 
     [Fact]
@@ -42,8 +39,7 @@ public class NimbleTableColumnAnchorTests
     {
         var tableColumn = RenderWithPropertySet(x => x.Appearance!, AnchorAppearance.Prominent);
 
-        var expectedMarkup = @"appearance=""prominent""";
-        Assert.Contains(expectedMarkup, tableColumn.Markup);
+        tableColumn.AssertAttribute("appearance", "prominent");
     }
 
     [Fact]
@@ -51,8 +47,7 @@ public class NimbleTableColumnAnchorTests
     {
         var table = RenderWithPropertySet(x => x.Placeholder, "Custom placeholder");
 
-        var expectedMarkup = @"placeholder=""Custom placeholder""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("placeholder", "Custom placeholder");
     }
 
     [Fact]
@@ -60,8 +55,7 @@ public class NimbleTableColumnAnchorTests
     {
         var tableColumn = RenderWithPropertySet(x => x.UnderlineHidden, true);
 
-        var expectedMarkup = @"underline-hidden";
-        Assert.Contains(expectedMarkup, tableColumn.Markup);
+        tableColumn.AssertHasAttribute("underline-hidden");
     }
 
     [Fact]
@@ -69,8 +63,7 @@ public class NimbleTableColumnAnchorTests
     {
         var tableColumn = RenderWithPropertySet(x => x.HrefLang!, "en");
 
-        var expectedMarkup = @"hreflang=""en""";
-        Assert.Contains(expectedMarkup, tableColumn.Markup);
+        tableColumn.AssertAttribute("hreflang", "en");
     }
 
     [Fact]
@@ -78,8 +71,7 @@ public class NimbleTableColumnAnchorTests
     {
         var tableColumn = RenderWithPropertySet(x => x.Ping!, "foo");
 
-        var expectedMarkup = @"ping=""foo""";
-        Assert.Contains(expectedMarkup, tableColumn.Markup);
+        tableColumn.AssertAttribute("ping", "foo");
     }
 
     [Fact]
@@ -87,8 +79,7 @@ public class NimbleTableColumnAnchorTests
     {
         var tableColumn = RenderWithPropertySet(x => x.ReferrerPolicy!, "foo");
 
-        var expectedMarkup = @"referrerpolicy=""foo""";
-        Assert.Contains(expectedMarkup, tableColumn.Markup);
+        tableColumn.AssertAttribute("referrerpolicy", "foo");
     }
 
     [Fact]
@@ -96,8 +87,7 @@ public class NimbleTableColumnAnchorTests
     {
         var tableColumn = RenderWithPropertySet(x => x.Rel!, "foo");
 
-        var expectedMarkup = @"rel=""foo""";
-        Assert.Contains(expectedMarkup, tableColumn.Markup);
+        tableColumn.AssertAttribute("rel", "foo");
     }
 
     [Fact]
@@ -105,8 +95,7 @@ public class NimbleTableColumnAnchorTests
     {
         var tableColumn = RenderWithPropertySet(x => x.Target!, "foo");
 
-        var expectedMarkup = @"target=""foo""";
-        Assert.Contains(expectedMarkup, tableColumn.Markup);
+        tableColumn.AssertAttribute("target", "foo");
     }
 
     [Fact]
@@ -114,8 +103,7 @@ public class NimbleTableColumnAnchorTests
     {
         var tableColumn = RenderWithPropertySet(x => x.Type!, "foo");
 
-        var expectedMarkup = @"type=""foo""";
-        Assert.Contains(expectedMarkup, tableColumn.Markup);
+        tableColumn.AssertAttribute("type", "foo");
     }
 
     [Fact]
@@ -123,15 +111,12 @@ public class NimbleTableColumnAnchorTests
     {
         var tableColumn = RenderWithPropertySet(x => x.Download!, "foo");
 
-        var expectedMarkup = @"download=""foo""";
-        Assert.Contains(expectedMarkup, tableColumn.Markup);
+        tableColumn.AssertAttribute("download", "foo");
     }
 
     private IRenderedComponent<NimbleTableColumnAnchor> RenderWithPropertySet<TProperty>(Expression<Func<NimbleTableColumnAnchor, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleTableColumnAnchor>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleTableColumnAnchor>(p => p.Add(propertyGetter, propertyValue));
     }
 }
 

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnAnchorTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnAnchorTests.cs
@@ -3,7 +3,6 @@ using System.Linq.Expressions;
 using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
-#nullable enable
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnDateTextTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnDateTextTests.cs
@@ -3,7 +3,6 @@ using System.Linq.Expressions;
 using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
-#nullable enable
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnDateTextTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnDateTextTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 #nullable enable
@@ -8,14 +9,12 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleTableColumnDateText"/>
 /// </summary>
-public class NimbleTableColumnDateTextTests
+public class NimbleTableColumnDateTextTests : BunitTestBase
 {
     [Fact]
     public void NimbleTableColumnDateText_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleTableColumnDateText>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleTableColumnDateText>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -24,8 +23,7 @@ public class NimbleTableColumnDateTextTests
     {
         var table = RenderWithPropertySet(x => x.FieldName!, "FirstName");
 
-        var expectedMarkup = @"field-name=""FirstName""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("field-name", "FirstName");
     }
 
     [Fact]
@@ -33,135 +31,134 @@ public class NimbleTableColumnDateTextTests
     {
         var table = RenderWithPropertySet(x => x.Placeholder, "Custom placeholder");
 
-        var expectedMarkup = @"placeholder=""Custom placeholder""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("placeholder", "Custom placeholder");
     }
 
     [Theory]
-    [InlineData(DateTextFormat.Default, "<nimble-table-column-date-text((?!format).)*>")]
-    [InlineData(DateTextFormat.Custom, @"format=""custom""")]
-    public void NimbleTableColumnDateText_WithFormatAttribute_HasTableMarkup(DateTextFormat value, string expectedMarkupRegEx)
+    [InlineData(DateTextFormat.Default, null)]
+    [InlineData(DateTextFormat.Custom, "custom")]
+    public void NimbleTableColumnDateText_WithFormatAttribute_HasTableMarkup(DateTextFormat value, string? expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.Format, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("format", expectedAttributeValue);
     }
 
     [Theory]
-    [InlineData(LocaleMatcherAlgorithm.BestFit, @"custom-locale-matcher=""best fit""")]
-    [InlineData(LocaleMatcherAlgorithm.Lookup, @"custom-locale-matcher=""lookup""")]
-    public void NimbleTableColumnDateText_WithCustomLocaleMatcherAttribute_HasTableMarkup(LocaleMatcherAlgorithm value, string expectedMarkupRegEx)
+    [InlineData(LocaleMatcherAlgorithm.BestFit, "best fit")]
+    [InlineData(LocaleMatcherAlgorithm.Lookup, "lookup")]
+    public void NimbleTableColumnDateText_WithCustomLocaleMatcherAttribute_HasTableMarkup(LocaleMatcherAlgorithm value, string expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.CustomLocaleMatcher, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("custom-locale-matcher", expectedAttributeValue);
     }
 
     [Theory]
-    [InlineData(WeekdayFormat.Long, @"custom-weekday=""long""")]
-    [InlineData(WeekdayFormat.Short, @"custom-weekday=""short""")]
-    [InlineData(WeekdayFormat.Narrow, @"custom-weekday=""narrow""")]
-    public void NimbleTableColumnDateText_WithCustomWeekdayAttribute_HasTableMarkup(WeekdayFormat value, string expectedMarkupRegEx)
+    [InlineData(WeekdayFormat.Long, "long")]
+    [InlineData(WeekdayFormat.Short, "short")]
+    [InlineData(WeekdayFormat.Narrow, "narrow")]
+    public void NimbleTableColumnDateText_WithCustomWeekdayAttribute_HasTableMarkup(WeekdayFormat value, string expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.CustomWeekday, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("custom-weekday", expectedAttributeValue);
     }
 
     [Theory]
-    [InlineData(EraFormat.Long, @"custom-era=""long""")]
-    [InlineData(EraFormat.Short, @"custom-era=""short""")]
-    [InlineData(EraFormat.Narrow, @"custom-era=""narrow""")]
-    public void NimbleTableColumnDateText_WithCustomEraAttribute_HasTableMarkup(EraFormat value, string expectedMarkupRegEx)
+    [InlineData(EraFormat.Long, "long")]
+    [InlineData(EraFormat.Short, "short")]
+    [InlineData(EraFormat.Narrow, "narrow")]
+    public void NimbleTableColumnDateText_WithCustomEraAttribute_HasTableMarkup(EraFormat value, string expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.CustomEra, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("custom-era", expectedAttributeValue);
     }
 
     [Theory]
-    [InlineData(YearFormat.Numeric, @"custom-year=""numeric""")]
-    [InlineData(YearFormat.TwoDigit, @"custom-year=""2-digit""")]
-    public void NimbleTableColumnDateText_WithCustomYearAttribute_HasTableMarkup(YearFormat value, string expectedMarkupRegEx)
+    [InlineData(YearFormat.Numeric, "numeric")]
+    [InlineData(YearFormat.TwoDigit, "2-digit")]
+    public void NimbleTableColumnDateText_WithCustomYearAttribute_HasTableMarkup(YearFormat value, string expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.CustomYear, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("custom-year", expectedAttributeValue);
     }
 
     [Theory]
-    [InlineData(MonthFormat.Numeric, @"custom-month=""numeric""")]
-    [InlineData(MonthFormat.TwoDigit, @"custom-month=""2-digit""")]
-    [InlineData(MonthFormat.Long, @"custom-month=""long""")]
-    [InlineData(MonthFormat.Short, @"custom-month=""short""")]
-    [InlineData(MonthFormat.Narrow, @"custom-month=""narrow""")]
-    public void NimbleTableColumnDateText_WithCustomMonthAttribute_HasTableMarkup(MonthFormat value, string expectedMarkupRegEx)
+    [InlineData(MonthFormat.Numeric, "numeric")]
+    [InlineData(MonthFormat.TwoDigit, "2-digit")]
+    [InlineData(MonthFormat.Long, "long")]
+    [InlineData(MonthFormat.Short, "short")]
+    [InlineData(MonthFormat.Narrow, "narrow")]
+    public void NimbleTableColumnDateText_WithCustomMonthAttribute_HasTableMarkup(MonthFormat value, string expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.CustomMonth, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("custom-month", expectedAttributeValue);
     }
 
     [Theory]
-    [InlineData(DayFormat.Numeric, @"custom-day=""numeric""")]
-    [InlineData(DayFormat.TwoDigit, @"custom-day=""2-digit""")]
-    public void NimbleTableColumnDateText_WithCustomDayAttribute_HasTableMarkup(DayFormat value, string expectedMarkupRegEx)
+    [InlineData(DayFormat.Numeric, "numeric")]
+    [InlineData(DayFormat.TwoDigit, "2-digit")]
+    public void NimbleTableColumnDateText_WithCustomDayAttribute_HasTableMarkup(DayFormat value, string expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.CustomDay, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("custom-day", expectedAttributeValue);
     }
 
     [Theory]
-    [InlineData(HourFormat.Numeric, @"custom-hour=""numeric""")]
-    [InlineData(HourFormat.TwoDigit, @"custom-hour=""2-digit""")]
-    public void NimbleTableColumnDateText_WithCustomHourAttribute_HasTableMarkup(HourFormat value, string expectedMarkupRegEx)
+    [InlineData(HourFormat.Numeric, "numeric")]
+    [InlineData(HourFormat.TwoDigit, "2-digit")]
+    public void NimbleTableColumnDateText_WithCustomHourAttribute_HasTableMarkup(HourFormat value, string expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.CustomHour, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("custom-hour", expectedAttributeValue);
     }
 
     [Theory]
-    [InlineData(MinuteFormat.Numeric, @"custom-minute=""numeric""")]
-    [InlineData(MinuteFormat.TwoDigit, @"custom-minute=""2-digit""")]
-    public void NimbleTableColumnDateText_WithCustomMinuteAttribute_HasTableMarkup(MinuteFormat value, string expectedMarkupRegEx)
+    [InlineData(MinuteFormat.Numeric, "numeric")]
+    [InlineData(MinuteFormat.TwoDigit, "2-digit")]
+    public void NimbleTableColumnDateText_WithCustomMinuteAttribute_HasTableMarkup(MinuteFormat value, string expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.CustomMinute, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("custom-minute", expectedAttributeValue);
     }
 
     [Theory]
-    [InlineData(SecondFormat.Numeric, @"custom-second=""numeric""")]
-    [InlineData(SecondFormat.TwoDigit, @"custom-second=""2-digit""")]
-    public void NimbleTableColumnDateText_WithCustomSecondAttribute_HasTableMarkup(SecondFormat value, string expectedMarkupRegEx)
+    [InlineData(SecondFormat.Numeric, "numeric")]
+    [InlineData(SecondFormat.TwoDigit, "2-digit")]
+    public void NimbleTableColumnDateText_WithCustomSecondAttribute_HasTableMarkup(SecondFormat value, string expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.CustomSecond, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("custom-second", expectedAttributeValue);
     }
 
     [Theory]
-    [InlineData(TimeZoneNameFormat.Long, @"custom-time-zone-name=""long""")]
-    [InlineData(TimeZoneNameFormat.Short, @"custom-time-zone-name=""short""")]
-    [InlineData(TimeZoneNameFormat.LongGeneric, @"custom-time-zone-name=""longGeneric""")]
-    [InlineData(TimeZoneNameFormat.LongOffset, @"custom-time-zone-name=""longOffset""")]
-    [InlineData(TimeZoneNameFormat.ShortGeneric, @"custom-time-zone-name=""shortGeneric""")]
-    [InlineData(TimeZoneNameFormat.ShortOffset, @"custom-time-zone-name=""shortOffset""")]
-    public void NimbleTableColumnDateText_WithCustomTimeZoneNameAttribute_HasTableMarkup(TimeZoneNameFormat value, string expectedMarkupRegEx)
+    [InlineData(TimeZoneNameFormat.Long, "long")]
+    [InlineData(TimeZoneNameFormat.Short, "short")]
+    [InlineData(TimeZoneNameFormat.LongGeneric, "longGeneric")]
+    [InlineData(TimeZoneNameFormat.LongOffset, "longOffset")]
+    [InlineData(TimeZoneNameFormat.ShortGeneric, "shortGeneric")]
+    [InlineData(TimeZoneNameFormat.ShortOffset, "shortOffset")]
+    public void NimbleTableColumnDateText_WithCustomTimeZoneNameAttribute_HasTableMarkup(TimeZoneNameFormat value, string expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.CustomTimeZoneName, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("custom-time-zone-name", expectedAttributeValue);
     }
 
     [Theory]
-    [InlineData(FormatMatcherAlgorithm.BestFit, @"custom-format-matcher=""best fit""")]
-    [InlineData(FormatMatcherAlgorithm.Basic, @"custom-format-matcher=""basic""")]
-    public void NimbleTableColumnDateText_WithCustomFormatMatcherAttribute_HasTableMarkup(FormatMatcherAlgorithm value, string expectedMarkupRegEx)
+    [InlineData(FormatMatcherAlgorithm.BestFit, "best fit")]
+    [InlineData(FormatMatcherAlgorithm.Basic, "basic")]
+    public void NimbleTableColumnDateText_WithCustomFormatMatcherAttribute_HasTableMarkup(FormatMatcherAlgorithm value, string expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.CustomFormatMatcher, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("custom-format-matcher", expectedAttributeValue);
     }
 
     [Theory]
-    [InlineData(null, "<nimble-table-column-date-text((?!custom-hour12).)*>")]
-    [InlineData(true, @"custom-hour12=""true""")]
-    [InlineData(false, @"custom-hour12=""false""")]
-    public void NimbleTableColumnDateText_WithCustomHour12Attribute_HasTableMarkup(bool? value, string expectedMarkupRegEx)
+    [InlineData(null, null)]
+    [InlineData(true, "true")]
+    [InlineData(false, "false")]
+    public void NimbleTableColumnDateText_WithCustomHour12Attribute_HasTableMarkup(bool? value, string? expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.CustomHour12, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("custom-hour12", expectedAttributeValue);
     }
 
     [Fact]
@@ -169,8 +166,7 @@ public class NimbleTableColumnDateTextTests
     {
         var table = RenderWithPropertySet(x => x.CustomTimeZone, "America/New York");
 
-        var expectedMarkup = @"custom-time-zone=""America/New York""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("custom-time-zone", "America/New York");
     }
 
     [Fact]
@@ -178,18 +174,17 @@ public class NimbleTableColumnDateTextTests
     {
         var table = RenderWithPropertySet(x => x.CustomCalendar, "hebrew");
 
-        var expectedMarkup = @"custom-calendar=""hebrew""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("custom-calendar", "hebrew");
     }
 
     [Theory]
-    [InlineData(DayPeriodFormat.Long, @"custom-day-period=""long""")]
-    [InlineData(DayPeriodFormat.Short, @"custom-day-period=""short""")]
-    [InlineData(DayPeriodFormat.Narrow, @"custom-day-period=""narrow""")]
-    public void NimbleTableColumnDateText_WithCustomDayPeriodAttribute_HasTableMarkup(DayPeriodFormat value, string expectedMarkupRegEx)
+    [InlineData(DayPeriodFormat.Long, "long")]
+    [InlineData(DayPeriodFormat.Short, "short")]
+    [InlineData(DayPeriodFormat.Narrow, "narrow")]
+    public void NimbleTableColumnDateText_WithCustomDayPeriodAttribute_HasTableMarkup(DayPeriodFormat value, string expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.CustomDayPeriod, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("custom-day-period", expectedAttributeValue);
     }
 
     [Fact]
@@ -197,48 +192,45 @@ public class NimbleTableColumnDateTextTests
     {
         var table = RenderWithPropertySet(x => x.CustomNumberingSystem, "latn");
 
-        var expectedMarkup = @"custom-numbering-system=""latn""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("custom-numbering-system", "latn");
     }
 
     [Theory]
-    [InlineData(DateStyle.Full, @"custom-date-style=""full""")]
-    [InlineData(DateStyle.Medium, @"custom-date-style=""medium""")]
-    [InlineData(DateStyle.Long, @"custom-date-style=""long""")]
-    [InlineData(DateStyle.Short, @"custom-date-style=""short""")]
-    public void NimbleTableColumnDateText_WithCustomDateStyleAttribute_HasTableMarkup(DateStyle value, string expectedMarkupRegEx)
+    [InlineData(DateStyle.Full, "full")]
+    [InlineData(DateStyle.Medium, "medium")]
+    [InlineData(DateStyle.Long, "long")]
+    [InlineData(DateStyle.Short, "short")]
+    public void NimbleTableColumnDateText_WithCustomDateStyleAttribute_HasTableMarkup(DateStyle value, string expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.CustomDateStyle, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("custom-date-style", expectedAttributeValue);
     }
 
     [Theory]
-    [InlineData(TimeStyle.Full, @"custom-time-style=""full""")]
-    [InlineData(TimeStyle.Medium, @"custom-time-style=""medium""")]
-    [InlineData(TimeStyle.Long, @"custom-time-style=""long""")]
-    [InlineData(TimeStyle.Short, @"custom-time-style=""short""")]
-    public void NimbleTableColumnDateText_WithCustomTimeStyleAttribute_HasTableMarkup(TimeStyle value, string expectedMarkupRegEx)
+    [InlineData(TimeStyle.Full, "full")]
+    [InlineData(TimeStyle.Medium, "medium")]
+    [InlineData(TimeStyle.Long, "long")]
+    [InlineData(TimeStyle.Short, "short")]
+    public void NimbleTableColumnDateText_WithCustomTimeStyleAttribute_HasTableMarkup(TimeStyle value, string expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.CustomTimeStyle, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("custom-time-style", expectedAttributeValue);
     }
 
     [Theory]
-    [InlineData(HourCycleFormat.H11, @"custom-hour-cycle=""h11""")]
-    [InlineData(HourCycleFormat.H12, @"custom-hour-cycle=""h12""")]
-    [InlineData(HourCycleFormat.H23, @"custom-hour-cycle=""h23""")]
-    [InlineData(HourCycleFormat.H24, @"custom-hour-cycle=""h24""")]
-    public void NimbleTableColumnDateText_WithCustomHourCycleAttribute_HasTableMarkup(HourCycleFormat value, string expectedMarkupRegEx)
+    [InlineData(HourCycleFormat.H11, "h11")]
+    [InlineData(HourCycleFormat.H12, "h12")]
+    [InlineData(HourCycleFormat.H23, "h23")]
+    [InlineData(HourCycleFormat.H24, "h24")]
+    public void NimbleTableColumnDateText_WithCustomHourCycleAttribute_HasTableMarkup(HourCycleFormat value, string expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.CustomHourCycle, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("custom-hour-cycle", expectedAttributeValue);
     }
 
     private IRenderedComponent<NimbleTableColumnDateText> RenderWithPropertySet<TProperty>(Expression<Func<NimbleTableColumnDateText, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleTableColumnDateText>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleTableColumnDateText>(p => p.Add(propertyGetter, propertyValue));
     }
 }
 

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnDurationTextTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnDurationTextTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,14 +9,12 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleTableColumnDurationText"/>
 /// </summary>
-public class NimbleTableColumnDurationTextTests
+public class NimbleTableColumnDurationTextTests : BunitTestBase
 {
     [Fact]
     public void NimbleTableColumnDurationText_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleTableColumnDurationText>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleTableColumnDurationText>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -24,8 +23,7 @@ public class NimbleTableColumnDurationTextTests
     {
         var table = RenderWithPropertySet(x => x.FieldName!, "MyDuration");
 
-        var expectedMarkup = @"field-name=""MyDuration""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("field-name", "MyDuration");
     }
 
     [Fact]
@@ -33,15 +31,12 @@ public class NimbleTableColumnDurationTextTests
     {
         var table = RenderWithPropertySet(x => x.Placeholder, "Custom placeholder");
 
-        var expectedMarkup = @"placeholder=""Custom placeholder""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("placeholder", "Custom placeholder");
     }
 
     private IRenderedComponent<NimbleTableColumnDurationText> RenderWithPropertySet<TProperty>(Expression<Func<NimbleTableColumnDurationText, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleTableColumnDurationText>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleTableColumnDurationText>(p => p.Add(propertyGetter, propertyValue));
     }
 }
 

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnMappingTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnMappingTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 #nullable enable
@@ -8,14 +9,12 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleTableColumnMapping"/>
 /// </summary>
-public class NimbleTableColumnMappingTests
+public class NimbleTableColumnMappingTests : BunitTestBase
 {
     [Fact]
     public void NimbleTableColumnMapping_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleTableColumnMapping<int>>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleTableColumnMapping<int>>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -24,8 +23,7 @@ public class NimbleTableColumnMappingTests
     {
         var column = RenderTableEnumColumn<int>();
 
-        var expectedMarkup = @"key-type=""number""";
-        Assert.Contains(expectedMarkup, column.Markup);
+        column.AssertAttribute("key-type", "number");
     }
 
     [Fact]
@@ -33,8 +31,7 @@ public class NimbleTableColumnMappingTests
     {
         var column = RenderTableEnumColumn<uint>();
 
-        var expectedMarkup = @"key-type=""number""";
-        Assert.Contains(expectedMarkup, column.Markup);
+        column.AssertAttribute("key-type", "number");
     }
 
     [Fact]
@@ -42,8 +39,7 @@ public class NimbleTableColumnMappingTests
     {
         var column = RenderTableEnumColumn<short>();
 
-        var expectedMarkup = @"key-type=""number""";
-        Assert.Contains(expectedMarkup, column.Markup);
+        column.AssertAttribute("key-type", "number");
     }
 
     [Fact]
@@ -51,8 +47,7 @@ public class NimbleTableColumnMappingTests
     {
         var column = RenderTableEnumColumn<ushort>();
 
-        var expectedMarkup = @"key-type=""number""";
-        Assert.Contains(expectedMarkup, column.Markup);
+        column.AssertAttribute("key-type", "number");
     }
 
     [Fact]
@@ -72,8 +67,7 @@ public class NimbleTableColumnMappingTests
     {
         var column = RenderTableEnumColumn<byte>();
 
-        var expectedMarkup = @"key-type=""number""";
-        Assert.Contains(expectedMarkup, column.Markup);
+        column.AssertAttribute("key-type", "number");
     }
 
     [Fact]
@@ -81,8 +75,7 @@ public class NimbleTableColumnMappingTests
     {
         var column = RenderTableEnumColumn<sbyte>();
 
-        var expectedMarkup = @"key-type=""number""";
-        Assert.Contains(expectedMarkup, column.Markup);
+        column.AssertAttribute("key-type", "number");
     }
 
     [Fact]
@@ -90,8 +83,7 @@ public class NimbleTableColumnMappingTests
     {
         var column = RenderTableEnumColumn<float>();
 
-        var expectedMarkup = @"key-type=""number""";
-        Assert.Contains(expectedMarkup, column.Markup);
+        column.AssertAttribute("key-type", "number");
     }
 
     [Fact]
@@ -99,8 +91,7 @@ public class NimbleTableColumnMappingTests
     {
         var column = RenderTableEnumColumn<double>();
 
-        var expectedMarkup = @"key-type=""number""";
-        Assert.Contains(expectedMarkup, column.Markup);
+        column.AssertAttribute("key-type", "number");
     }
 
     [Fact]
@@ -114,8 +105,7 @@ public class NimbleTableColumnMappingTests
     {
         var column = RenderTableEnumColumn<bool>();
 
-        var expectedMarkup = @"key-type=""boolean""";
-        Assert.Contains(expectedMarkup, column.Markup);
+        column.AssertAttribute("key-type", "boolean");
     }
 
     [Fact]
@@ -123,8 +113,7 @@ public class NimbleTableColumnMappingTests
     {
         var column = RenderTableEnumColumn<string>();
 
-        var expectedMarkup = @"key-type=""string""";
-        Assert.Contains(expectedMarkup, column.Markup);
+        column.AssertAttribute("key-type", "string");
     }
 
     [Fact]
@@ -138,8 +127,7 @@ public class NimbleTableColumnMappingTests
     {
         var column = RenderWithPropertySet<int, string>(x => x.FieldName!, "Status");
 
-        var expectedMarkup = @"field-name=""Status""";
-        Assert.Contains(expectedMarkup, column.Markup);
+        column.AssertAttribute("field-name", "Status");
     }
 
     [Fact]
@@ -147,22 +135,17 @@ public class NimbleTableColumnMappingTests
     {
         var column = RenderWithPropertySet<int, MappingColumnWidthMode?>(x => x.WidthMode, MappingColumnWidthMode.IconSize);
 
-        var expectedMarkup = @"width-mode=""icon-size""";
-        Assert.Contains(expectedMarkup, column.Markup);
+        column.AssertAttribute("width-mode", "icon-size");
     }
 
     private IRenderedComponent<NimbleTableColumnMapping<TKey>> RenderTableEnumColumn<TKey>()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleTableColumnMapping<TKey>>();
+        return Render<NimbleTableColumnMapping<TKey>>();
     }
 
     private IRenderedComponent<NimbleTableColumnMapping<TKey>> RenderWithPropertySet<TKey, TProperty>(Expression<Func<NimbleTableColumnMapping<TKey>, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleTableColumnMapping<TKey>>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleTableColumnMapping<TKey>>(p => p.Add(propertyGetter, propertyValue));
     }
 }
 

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnMappingTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnMappingTests.cs
@@ -3,7 +3,6 @@ using System.Linq.Expressions;
 using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
-#nullable enable
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnMenuButtonTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnMenuButtonTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,14 +9,12 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleTableColumnMenuButton"/>
 /// </summary>
-public class NimbleTableColumnMenuButtonTests
+public class NimbleTableColumnMenuButtonTests : BunitTestBase
 {
     [Fact]
     public void NimbleTableColumnMenuButton_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleTableColumnMenuButton>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleTableColumnMenuButton>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -24,8 +23,7 @@ public class NimbleTableColumnMenuButtonTests
     {
         var table = RenderWithPropertySet(x => x.FieldName!, "MyField");
 
-        var expectedMarkup = @"field-name=""MyField""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("field-name", "MyField");
     }
 
     [Fact]
@@ -33,15 +31,12 @@ public class NimbleTableColumnMenuButtonTests
     {
         var table = RenderWithPropertySet(x => x.MenuSlot!, "MyMenuSlot");
 
-        var expectedMarkup = @"menu-slot=""MyMenuSlot""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("menu-slot", "MyMenuSlot");
     }
 
     private IRenderedComponent<NimbleTableColumnMenuButton> RenderWithPropertySet<TProperty>(Expression<Func<NimbleTableColumnMenuButton, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleTableColumnMenuButton>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleTableColumnMenuButton>(p => p.Add(propertyGetter, propertyValue));
     }
 }
 

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnNumberTextTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnNumberTextTests.cs
@@ -3,7 +3,6 @@ using System.Linq.Expressions;
 using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
-#nullable enable
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnNumberTextTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnNumberTextTests.cs
@@ -1,21 +1,20 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
-
+#nullable enable
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>
 /// Tests for <see cref="NimbleTableColumnNumberText"/>
 /// </summary>
-public class NimbleTableColumnNumberTextTests
+public class NimbleTableColumnNumberTextTests : BunitTestBase
 {
     [Fact]
     public void NimbleTableColumnNumberText_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleTableColumnNumberText>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleTableColumnNumberText>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -24,8 +23,7 @@ public class NimbleTableColumnNumberTextTests
     {
         var table = RenderWithPropertySet(x => x.FieldName!, "FirstName");
 
-        var expectedMarkup = @"field-name=""FirstName""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("field-name", "FirstName");
     }
 
     [Fact]
@@ -33,8 +31,7 @@ public class NimbleTableColumnNumberTextTests
     {
         var table = RenderWithPropertySet(x => x.Placeholder, "Custom placeholder");
 
-        var expectedMarkup = @"placeholder=""Custom placeholder""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("placeholder", "Custom placeholder");
     }
 
     [Fact]
@@ -42,8 +39,7 @@ public class NimbleTableColumnNumberTextTests
     {
         var table = RenderWithPropertySet(x => x.DecimalDigits!, 5);
 
-        var expectedMarkup = @"decimal-digits=""5""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("decimal-digits", "5");
     }
 
     [Fact]
@@ -51,34 +47,31 @@ public class NimbleTableColumnNumberTextTests
     {
         var table = RenderWithPropertySet(x => x.DecimalMaximumDigits!, 5);
 
-        var expectedMarkup = @"decimal-maximum-digits=""5""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("decimal-maximum-digits", "5");
     }
 
     [Theory]
-    [InlineData(NumberTextFormat.Default, "<nimble-table-column-number-text((?!format).)*>")]
-    [InlineData(NumberTextFormat.Decimal, @"format=""decimal""")]
-    public void NimbleTableColumnNumberText_WithFormatAttribute_HasTableMarkup(NumberTextFormat value, string expectedMarkupRegEx)
+    [InlineData(NumberTextFormat.Default, null)]
+    [InlineData(NumberTextFormat.Decimal, "decimal")]
+    public void NimbleTableColumnNumberText_WithFormatAttribute_HasTableMarkup(NumberTextFormat value, string? expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.Format, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("format", expectedAttributeValue);
     }
 
     [Theory]
-    [InlineData(NumberTextAlignment.Default, @"<nimble-table-column-number-text((?!alignment).)*>")]
-    [InlineData(NumberTextAlignment.Left, @"alignment=""left""")]
-    [InlineData(NumberTextAlignment.Right, @"alignment=""right""")]
-    public void NimbleTableColumnNumberText_WithCustomLocaleMatcherAttribute_HasTableMarkup(NumberTextAlignment value, string expectedMarkupRegEx)
+    [InlineData(NumberTextAlignment.Default, null)]
+    [InlineData(NumberTextAlignment.Left, "left")]
+    [InlineData(NumberTextAlignment.Right, "right")]
+    public void NimbleTableColumnNumberText_WithCustomLocaleMatcherAttribute_HasTableMarkup(NumberTextAlignment value, string? expectedAttributeValue)
     {
         var table = RenderWithPropertySet(x => x.Alignment, value);
-        Assert.Matches(expectedMarkupRegEx, table.Markup);
+        table.AssertAttribute("alignment", expectedAttributeValue);
     }
 
     private IRenderedComponent<NimbleTableColumnNumberText> RenderWithPropertySet<TProperty>(Expression<Func<NimbleTableColumnNumberText, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleTableColumnNumberText>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleTableColumnNumberText>(p => p.Add(propertyGetter, propertyValue));
     }
 }
 

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnTextTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnTextTests.cs
@@ -3,7 +3,6 @@ using System.Linq.Expressions;
 using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
-#nullable enable
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnTextTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableColumnTextTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 #nullable enable
@@ -8,14 +9,12 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleTableColumnText"/>
 /// </summary>
-public class NimbleTableColumnTextTests
+public class NimbleTableColumnTextTests : BunitTestBase
 {
     [Fact]
     public void NimbleTableColumnText_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleTableColumnText>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleTableColumnText>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -24,8 +23,7 @@ public class NimbleTableColumnTextTests
     {
         var table = RenderWithPropertySet(x => x.FieldName!, "FirstName");
 
-        var expectedMarkup = @"field-name=""FirstName""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("field-name", "FirstName");
     }
 
     [Fact]
@@ -33,15 +31,12 @@ public class NimbleTableColumnTextTests
     {
         var table = RenderWithPropertySet(x => x.Placeholder, "Custom placeholder");
 
-        var expectedMarkup = @"placeholder=""Custom placeholder""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("placeholder", "Custom placeholder");
     }
 
     private IRenderedComponent<NimbleTableColumnText> RenderWithPropertySet<TProperty>(Expression<Func<NimbleTableColumnText, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleTableColumnText>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleTableColumnText>(p => p.Add(propertyGetter, propertyValue));
     }
 }
 

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Text.Json;
 using System.Threading.Tasks;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 #nullable enable
@@ -11,7 +12,7 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleTable"/>
 /// </summary>
-public class NimbleTableTests
+public class NimbleTableTests : BunitTestBase
 {
     internal sealed class TableRowData
     {
@@ -40,20 +41,15 @@ public class NimbleTableTests
     [Fact]
     public void NimbleTable_Rendered_HasTableMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-table";
-        var table = context.Render<NimbleTable<TableRowData>>();
+        var table = Render<NimbleTable<TableRowData>>();
 
-        Assert.Contains(expectedMarkup, table.Markup);
+        Assert.NotNull(table.Find("nimble-table"));
     }
 
     [Fact]
     public void NimbleTable_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleTable<TableRowData>>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleTable<TableRowData>>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -62,8 +58,7 @@ public class NimbleTableTests
     {
         var table = RenderWithPropertySet<string, TableRowData>(x => x.IdFieldName!, "FirstName");
 
-        var expectedMarkup = @"id-field-name=""FirstName""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("id-field-name", "FirstName");
     }
 
     [Fact]
@@ -71,8 +66,7 @@ public class NimbleTableTests
     {
         var table = RenderWithPropertySet<string, TableRowData>(x => x.ParentIdFieldName!, "FirstName");
 
-        var expectedMarkup = @"parent-id-field-name=""FirstName""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("parent-id-field-name", "FirstName");
     }
 
     [Theory]
@@ -83,15 +77,7 @@ public class NimbleTableTests
     {
         var table = RenderWithPropertySet<TableRowSelectionMode?, TableRowData>(x => x.SelectionMode, value);
 
-        if (expectedAttribute == null)
-        {
-            Assert.DoesNotContain("selection-mode", table.Markup);
-        }
-        else
-        {
-            var expectedMarkup = $"selection-mode=\"{expectedAttribute}\"";
-            Assert.Contains(expectedMarkup, table.Markup);
-        }
+        table.AssertAttribute("selection-mode", expectedAttribute);
     }
 
     [Fact]
@@ -103,8 +89,7 @@ public class NimbleTableTests
         };
         var table = RenderWithPropertySet<IDictionary<string, object>, TableRowData>(x => x.AdditionalAttributes!, classAttribute);
 
-        var expectedMarkup = @"class=""table""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("class", "table");
     }
 
     [Fact]
@@ -113,7 +98,7 @@ public class NimbleTableTests
         var parentRowData = new TableRowData("Bob", "Smith");
         var childRowData = new TableRowData("Sally", "Smith");
         var tableData = new TableRowData[] { parentRowData, childRowData };
-        var table = Render<TableRowData>();
+        var table = RenderTable<TableRowData>();
 
         var exception = await Record.ExceptionAsync(async () => { await table.Instance.SetDataAsync(tableData); });
         Assert.Null(exception);
@@ -125,7 +110,7 @@ public class NimbleTableTests
         var parentRowData = new BadTableRowData("Bob", "Smith");
         var childRowData = new BadTableRowData("Sally", "Smith", parentRowData);
         var tableData = new BadTableRowData[] { parentRowData, childRowData };
-        var table = Render<BadTableRowData>();
+        var table = RenderTable<BadTableRowData>();
 
         var exception = await Record.ExceptionAsync(async () => { await table.Instance.SetDataAsync(tableData); });
 
@@ -134,15 +119,11 @@ public class NimbleTableTests
 
     private IRenderedComponent<NimbleTable<TTable>> RenderWithPropertySet<TProperty, TTable>(Expression<Func<NimbleTable<TTable>, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleTable<TTable>>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleTable<TTable>>(p => p.Add(propertyGetter, propertyValue));
     }
 
-    private IRenderedComponent<NimbleTable<TTable>> Render<TTable>()
+    private IRenderedComponent<NimbleTable<TTable>> RenderTable<TTable>()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleTable<TTable>>();
+        return Render<NimbleTable<TTable>>();
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTableTests.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
-#nullable enable
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTabsTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTabsTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using AngleSharp.Dom;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -9,25 +10,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleTabs"/>
 /// </summary>
-public class NimbleTabsTests
+public class NimbleTabsTests : BunitTestBase
 {
     [Fact]
     public void NimbleTabsRendered_HasTabsMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-tabs";
-        var tabs = context.Render<NimbleTabs>();
+        var tabs = Render<NimbleTabs>();
 
-        Assert.Contains(expectedMarkup, tabs.Markup);
+        Assert.NotNull(tabs.Find("nimble-tabs"));
     }
 
     [Fact]
     public void NimbleTabs_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleTabs>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleTabs>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -66,9 +62,7 @@ public class NimbleTabsTests
 
     private IRenderedComponent<NimbleTabs> RenderTabsWithContent()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleTabs>(AddChildContentToTabs);
+        return Render<NimbleTabs>(AddChildContentToTabs);
     }
 
     private void AddChildContentToTabs(ComponentParameterCollectionBuilder<NimbleTabs> parameters)
@@ -80,9 +74,7 @@ public class NimbleTabsTests
 
     private IRenderedComponent<NimbleTabs> CreateTwoTabsWithActiveTabIdSet(string activeTabId)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var tabComponent = context.Render<NimbleTabs>(parameters =>
+        var tabComponent = Render<NimbleTabs>(parameters =>
         {
             parameters.Add(x => x.ActiveId, activeTabId);
             parameters.AddChildContent<NimbleTab>();

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTabsTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTabsTests.cs
@@ -90,10 +90,10 @@ public class NimbleTabsTests : BunitTestBase
 
     private async Task TriggerNimbleTabsActiveIdChangeEventAsync(
         IRenderedComponent<NimbleTabs> tabs,
-        TabsChangeEventArgs eventArgs)
+        TabsChangeEventArgs? eventArgs)
     {
         var tabsElement = tabs.Find("nimble-tabs");
 
-        await tabsElement.TriggerEventAsync("onnimbletabsactiveidchange", eventArgs);
+        await tabsElement.TriggerEventAsync("onnimbletabsactiveidchange", eventArgs!);
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTextAreaTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTextAreaTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,26 +9,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleTextArea"/>
 /// </summary>
-public class NimbleTextAreaTests
+public class NimbleTextAreaTests : BunitTestBase
 {
     [Fact]
     public void NimbleTextArea_Rendered_HasTextAreaMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-text-area";
+        var textField = Render<NimbleTextArea>();
 
-        var textField = context.Render<NimbleTextArea>();
-
-        Assert.Contains(expectedMarkup, textField.Markup);
+        Assert.NotNull(textField.Find("nimble-text-area"));
     }
 
     [Fact]
     public void NimbleTextArea_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleTextArea>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleTextArea>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -40,7 +35,7 @@ public class NimbleTextAreaTests
     {
         var textArea = RenderNimbleTextArea(value);
 
-        Assert.Contains(expectedAttribute, textArea.Markup);
+        textArea.AssertAttribute("resize", expectedAttribute);
     }
 
     [Theory]
@@ -50,7 +45,7 @@ public class NimbleTextAreaTests
     {
         var textArea = RenderNimbleTextArea(value);
 
-        Assert.Contains(expectedAttribute, textArea.Markup);
+        textArea.AssertAttribute("appearance", expectedAttribute);
     }
 
     [Fact]
@@ -58,7 +53,7 @@ public class NimbleTextAreaTests
     {
         var textArea = RenderWithPropertySet(x => x.ErrorText, "bad value");
 
-        Assert.Contains("error-text=\"bad value\"", textArea.Markup);
+        textArea.AssertAttribute("error-text", "bad value");
     }
 
     [Fact]
@@ -66,7 +61,7 @@ public class NimbleTextAreaTests
     {
         var textArea = RenderWithPropertySet(x => x.ErrorVisible, true);
 
-        Assert.Contains("error-visible", textArea.Markup);
+        textArea.AssertHasAttribute("error-visible");
     }
 
     [Fact]
@@ -74,7 +69,7 @@ public class NimbleTextAreaTests
     {
         var textArea = RenderWithPropertySet(x => x.RequiredVisible, true);
 
-        Assert.Contains("required-visible", textArea.Markup);
+        textArea.AssertHasAttribute("required-visible");
     }
 
     [Fact]
@@ -82,27 +77,21 @@ public class NimbleTextAreaTests
     {
         var textArea = RenderWithPropertySet(x => x.AppearanceReadOnly, true);
 
-        Assert.Contains("appearance-readonly", textArea.Markup);
+        textArea.AssertHasAttribute("appearance-readonly");
     }
 
     private IRenderedComponent<NimbleTextArea> RenderNimbleTextArea(TextAreaResize textAreaResize)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleTextArea>(p => p.Add(x => x.TextAreaResize, textAreaResize));
+        return Render<NimbleTextArea>(p => p.Add(x => x.TextAreaResize, textAreaResize));
     }
 
     private IRenderedComponent<NimbleTextArea> RenderNimbleTextArea(TextAreaAppearance appearance)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleTextArea>(p => p.Add(x => x.Appearance, appearance));
+        return Render<NimbleTextArea>(p => p.Add(x => x.Appearance, appearance));
     }
 
     private IRenderedComponent<NimbleTextArea> RenderWithPropertySet<TProperty>(Expression<Func<NimbleTextArea, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleTextArea>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleTextArea>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTextFieldTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTextFieldTests.cs
@@ -15,8 +15,6 @@ public class NimbleTextFieldTests : BunitTestBase
     public void NimbleTextField_Rendered_HasTextFieldMarkup()
     {
         var textField = Render<NimbleTextField>();
-
-        // Find() throws if the element is missing, so it doubles as a presence assertion.
         Assert.NotNull(textField.Find("nimble-text-field"));
     }
 

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTextFieldTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTextFieldTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,26 +9,21 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleTextField"/>
 /// </summary>
-public class NimbleTextFieldTests
+public class NimbleTextFieldTests : BunitTestBase
 {
     [Fact]
     public void NimbleTextField_Rendered_HasTextFieldMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-text-field";
+        var textField = Render<NimbleTextField>();
 
-        var textField = context.Render<NimbleTextField>();
-
-        Assert.Contains(expectedMarkup, textField.Markup);
+        // Find() throws if the element is missing, so it doubles as a presence assertion.
+        Assert.NotNull(textField.Find("nimble-text-field"));
     }
 
     [Fact]
     public void NimbleTextField_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleTextField>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleTextField>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -41,7 +37,7 @@ public class NimbleTextFieldTests
     {
         var textField = RenderWithPropertySet(x => x.TextFieldType, value);
 
-        Assert.Contains(expectedAttribute, textField.Markup);
+        textField.AssertAttribute("type", expectedAttribute);
     }
 
     [Theory]
@@ -53,7 +49,7 @@ public class NimbleTextFieldTests
     {
         var textField = RenderWithPropertySet(x => x.Appearance, value);
 
-        Assert.Contains(expectedAttribute, textField.Markup);
+        textField.AssertAttribute("appearance", expectedAttribute);
     }
 
     [Fact]
@@ -61,7 +57,7 @@ public class NimbleTextFieldTests
     {
         var textField = RenderWithPropertySet(x => x.ErrorText, "bad number");
 
-        Assert.Contains("error-text=\"bad number\"", textField.Markup);
+        textField.AssertAttribute("error-text", "bad number");
     }
 
     [Fact]
@@ -69,7 +65,7 @@ public class NimbleTextFieldTests
     {
         var textField = RenderWithPropertySet(x => x.ErrorVisible, true);
 
-        Assert.Contains("error-visible", textField.Markup);
+        textField.AssertHasAttribute("error-visible");
     }
 
     [Fact]
@@ -77,7 +73,7 @@ public class NimbleTextFieldTests
     {
         var textField = RenderWithPropertySet(x => x.FullBleed, true);
 
-        Assert.Contains("full-bleed", textField.Markup);
+        textField.AssertHasAttribute("full-bleed");
     }
 
     [Fact]
@@ -85,7 +81,7 @@ public class NimbleTextFieldTests
     {
         var textField = RenderWithPropertySet(x => x.RequiredVisible, true);
 
-        Assert.Contains("required-visible", textField.Markup);
+        textField.AssertHasAttribute("required-visible");
     }
 
     [Fact]
@@ -93,13 +89,11 @@ public class NimbleTextFieldTests
     {
         var textField = RenderWithPropertySet(x => x.AppearanceReadOnly, true);
 
-        Assert.Contains("appearance-readonly", textField.Markup);
+        textField.AssertHasAttribute("appearance-readonly");
     }
 
     private IRenderedComponent<NimbleTextField> RenderWithPropertySet<TProperty>(Expression<Func<NimbleTextField, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleTextField>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleTextField>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleThemeProviderTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleThemeProviderTests.cs
@@ -1,31 +1,28 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
+
+#nullable enable
 
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>
 /// Tests for <see cref="NimbleThemeProvider"/>.
 /// </summary>
-public class NimbleThemeProviderTests
+public class NimbleThemeProviderTests : BunitTestBase
 {
     [Fact]
     public void NimbleThemeProvider_Render_HasThemeProviderMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-theme-provider";
+        var themeProvider = Render<NimbleThemeProvider>();
 
-        var themeProvider = context.Render<NimbleThemeProvider>();
-
-        Assert.Contains(expectedMarkup, themeProvider.Markup);
+        Assert.NotNull(themeProvider.Find("nimble-theme-provider"));
     }
 
     [Fact]
     public void NimbleThemeProvider_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleThemeProvider>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleThemeProvider>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -37,8 +34,7 @@ public class NimbleThemeProviderTests
     {
         var themeProvider = RenderNimbleThemeProvider(value);
 
-        var expectedMarkup = $"theme=\"{expectedAttribute}\"";
-        Assert.Contains(expectedMarkup, themeProvider.Markup);
+        themeProvider.AssertAttribute("theme", expectedAttribute);
     }
 
     [Theory]
@@ -48,8 +44,7 @@ public class NimbleThemeProviderTests
     {
         var themeProvider = RenderNimbleThemeProvider(value);
 
-        var expectedMarkup = $"direction=\"{expectedAttribute}\"";
-        Assert.Contains(expectedMarkup, themeProvider.Markup);
+        themeProvider.AssertAttribute("direction", expectedAttribute);
     }
 
     [Fact]
@@ -57,8 +52,7 @@ public class NimbleThemeProviderTests
     {
         var themeProvider = RenderNimbleThemeProvider("de-DE");
 
-        var expectedMarkup = $"lang=\"de-DE\"";
-        Assert.Contains(expectedMarkup, themeProvider.Markup);
+        themeProvider.AssertAttribute("lang", "de-DE");
     }
 
     [Fact]
@@ -66,27 +60,21 @@ public class NimbleThemeProviderTests
     {
         var themeProvider = RenderNimbleThemeProvider(null);
 
-        Assert.DoesNotContain("lang", themeProvider.Markup);
+        themeProvider.AssertAttribute("lang", null);
     }
 
     private IRenderedComponent<NimbleThemeProvider> RenderNimbleThemeProvider(Theme theme)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleThemeProvider>(p => p.Add(x => x.Theme, theme));
+        return Render<NimbleThemeProvider>(p => p.Add(x => x.Theme, theme));
     }
 
     private IRenderedComponent<NimbleThemeProvider> RenderNimbleThemeProvider(Direction direction)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleThemeProvider>(p => p.Add(x => x.Direction, direction));
+        return Render<NimbleThemeProvider>(p => p.Add(x => x.Direction, direction));
     }
 
-    private IRenderedComponent<NimbleThemeProvider> RenderNimbleThemeProvider(string lang)
+    private IRenderedComponent<NimbleThemeProvider> RenderNimbleThemeProvider(string? lang)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleThemeProvider>(p => p.Add(x => x.Lang, lang));
+        return Render<NimbleThemeProvider>(p => p.Add(x => x.Lang, lang));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleThemeProviderTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleThemeProviderTests.cs
@@ -2,8 +2,6 @@ using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
-#nullable enable
-
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleToggleButtonTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleToggleButtonTests.cs
@@ -2,8 +2,6 @@ using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
-#nullable enable
-
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleToggleButtonTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleToggleButtonTests.cs
@@ -1,31 +1,28 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
+
+#nullable enable
 
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>
 /// Tests for <see cref="NimbleToggleButton"/>
 /// </summary>
-public class NimbleToggleButtonTests
+public class NimbleToggleButtonTests : BunitTestBase
 {
     [Fact]
     public void NimbleToggleButton_Rendered_HasButtonMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-toggle-button";
+        var button = Render<NimbleToggleButton>();
 
-        var button = context.Render<NimbleToggleButton>();
-
-        Assert.Contains(expectedMarkup, button.Markup);
+        Assert.NotNull(button.Find("nimble-toggle-button"));
     }
 
     [Fact]
     public void NimbleToggleButton_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleToggleButton>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleToggleButton>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -37,31 +34,27 @@ public class NimbleToggleButtonTests
     {
         var button = RenderNimbleToggleButton(value);
 
-        Assert.Contains(expectedAttribute, button.Markup);
+        button.AssertAttribute("appearance", expectedAttribute);
     }
 
     [Theory]
-    [InlineData(ButtonAppearanceVariant.Default, "<nimble-toggle-button((?!appearance-variant).)*>")]
-    [InlineData(ButtonAppearanceVariant.Primary, "appearance-variant=\"primary\"")]
-    [InlineData(ButtonAppearanceVariant.Accent, "appearance-variant=\"accent\"")]
-    public void ButtonAppearanceVariant_AttributeIsSet(ButtonAppearanceVariant value, string expectedAttribute)
+    [InlineData(ButtonAppearanceVariant.Default, null)]
+    [InlineData(ButtonAppearanceVariant.Primary, "primary")]
+    [InlineData(ButtonAppearanceVariant.Accent, "accent")]
+    public void ButtonAppearanceVariant_AttributeIsSet(ButtonAppearanceVariant value, string? expectedValue)
     {
         var button = RenderNimbleToggleButton(value);
 
-        Assert.Matches(expectedAttribute, button.Markup);
+        button.AssertAttribute("appearance-variant", expectedValue);
     }
 
     private IRenderedComponent<NimbleToggleButton> RenderNimbleToggleButton(ButtonAppearance appearance)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleToggleButton>(p => p.Add(x => x.Appearance, appearance));
+        return Render<NimbleToggleButton>(p => p.Add(x => x.Appearance, appearance));
     }
 
     private IRenderedComponent<NimbleToggleButton> RenderNimbleToggleButton(ButtonAppearanceVariant appearanceVariant)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleToggleButton>(p => p.Add(x => x.AppearanceVariant, appearanceVariant));
+        return Render<NimbleToggleButton>(p => p.Add(x => x.AppearanceVariant, appearanceVariant));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleToolbarTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleToolbarTests.cs
@@ -1,3 +1,4 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Xunit;
@@ -7,25 +8,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleToolbar"/>
 /// </summary>
-public class NimbleToolbarTests
+public class NimbleToolbarTests : BunitTestBase
 {
     [Fact]
     public void NimbleToolbarRendered_HasToolbarMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-toolbar";
-        var toolbar = context.Render<NimbleToolbar>();
+        var toolbar = Render<NimbleToolbar>();
 
-        Assert.Contains(expectedMarkup, toolbar.Markup);
+        Assert.NotNull(toolbar.Find("nimble-toolbar"));
     }
 
     [Fact]
     public void NimbleToolbar_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleToolbar>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleToolbar>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -33,16 +29,13 @@ public class NimbleToolbarTests
     public void NimbleToolbarWithChildContent_HasChildMarkup()
     {
         var toolbar = RenderToolbarWithContent<NimbleButton>();
-        var expectedMarkup = "nimble-button";
 
-        Assert.Contains(expectedMarkup, toolbar.Markup);
+        Assert.NotNull(toolbar.Find("nimble-button"));
     }
 
     private IRenderedComponent<NimbleToolbar> RenderToolbarWithContent<TContent>()
         where TContent : IComponent
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleToolbar>(parameters => parameters.AddChildContent<TContent>());
+        return Render<NimbleToolbar>(parameters => parameters.AddChildContent<TContent>());
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTooltipTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTooltipTests.cs
@@ -1,45 +1,42 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
+
+#nullable enable
 
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>
 /// Tests for <see cref="NimbleTooltip"/>.
 /// </summary>
-public class NimbleTooltipTests
+public class NimbleTooltipTests : BunitTestBase
 {
     [Fact]
     public void NimbleTooltip_Render_HasTooltipMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-tooltip";
+        var tooltip = Render<NimbleTooltip>();
 
-        var tooltip = context.Render<NimbleTooltip>();
-
-        Assert.Contains(expectedMarkup, tooltip.Markup);
+        Assert.NotNull(tooltip.Find("nimble-tooltip"));
     }
 
     [Fact]
     public void NimbleTooltip_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleTooltip>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleTooltip>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
     [Theory]
-    [InlineData(TooltipSeverity.Default, "<nimble-tooltip>")]
-    [InlineData(TooltipSeverity.Error, "severity=\"error\"")]
-    [InlineData(TooltipSeverity.Information, "severity=\"information\"")]
-    public void TooltipSeverity_AttributeIsSet(TooltipSeverity value, string expectedAttribute)
+    [InlineData(TooltipSeverity.Default, null)]
+    [InlineData(TooltipSeverity.Error, "error")]
+    [InlineData(TooltipSeverity.Information, "information")]
+    public void TooltipSeverity_AttributeIsSet(TooltipSeverity value, string? expectedValue)
     {
         var tooltip = RenderWithPropertySet(x => x.Severity, value);
 
-        Assert.Contains(expectedAttribute, tooltip.Markup);
+        tooltip.AssertAttribute("severity", expectedValue);
     }
 
     [Fact]
@@ -47,13 +44,11 @@ public class NimbleTooltipTests
     {
         var tooltip = RenderWithPropertySet(x => x.IconVisible, true);
 
-        Assert.Contains("icon-visible", tooltip.Markup);
+        tooltip.AssertHasAttribute("icon-visible");
     }
 
     private IRenderedComponent<NimbleTooltip> RenderWithPropertySet<TProperty>(Expression<Func<NimbleTooltip, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleTooltip>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleTooltip>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTooltipTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTooltipTests.cs
@@ -4,8 +4,6 @@ using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
-#nullable enable
-
 namespace NimbleBlazor.Tests.Unit.Components;
 
 /// <summary>

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTreeViewTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleTreeViewTests.cs
@@ -1,3 +1,4 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -6,26 +7,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleTreeView"/>
 /// </summary>
-public class NimbleTreeViewTests
+public class NimbleTreeViewTests : BunitTestBase
 {
     [Fact]
     public void NimbleTreeView_Rendered_HasNimbleTreeViewMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-tree-view";
+        var treeView = Render<NimbleTreeView>();
 
-        var treeView = context.Render<NimbleTreeView>();
-
-        Assert.Contains(expectedMarkup, treeView.Markup);
+        Assert.NotNull(treeView.Find("nimble-tree-view"));
     }
 
     [Fact]
     public void NimbleTreeView_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleTreeView>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleTreeView>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -37,13 +32,11 @@ public class NimbleTreeViewTests
     {
         var treeView = RenderNimbleTreeView(value);
 
-        Assert.Contains(expectedAttribute, treeView.Markup);
+        treeView.AssertAttribute("selection-mode", expectedAttribute);
     }
 
     private IRenderedComponent<NimbleTreeView> RenderNimbleTreeView(SelectionMode selectionMode)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleTreeView>(p => p.Add(x => x.SelectionMode, selectionMode));
+        return Render<NimbleTreeView>(p => p.Add(x => x.SelectionMode, selectionMode));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleUnitByteTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleUnitByteTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,26 +9,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleUnitByte"/>
 /// </summary>
-public class NimbleUnitByteTests
+public class NimbleUnitByteTests : BunitTestBase
 {
     [Fact]
     public void NimbleUnitByte_Rendered_HasUnitByteMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-unit-byte";
+        var element = Render<NimbleUnitByte>();
 
-        var element = context.Render<NimbleUnitByte>();
-
-        Assert.Contains(expectedMarkup, element.Markup);
+        Assert.NotNull(element.Find("nimble-unit-byte"));
     }
 
     [Fact]
     public void NimbleUnitByte_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleUnitByte>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleUnitByte>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -36,13 +31,11 @@ public class NimbleUnitByteTests
     {
         var element = RenderWithPropertySet(x => x.Binary, true);
 
-        Assert.Contains("binary", element.Markup);
+        element.AssertHasAttribute("binary");
     }
 
     private IRenderedComponent<NimbleUnitByte> RenderWithPropertySet<TProperty>(Expression<Func<NimbleUnitByte, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleUnitByte>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleUnitByte>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleUnitCelsiusTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleUnitCelsiusTests.cs
@@ -1,3 +1,4 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -6,26 +7,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleUnitCelsius"/>
 /// </summary>
-public class NimbleUnitCelsiusTests
+public class NimbleUnitCelsiusTests : BunitTestBase
 {
     [Fact]
     public void NimbleUnitCelsius_Rendered_HasUnitCelsiusMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-unit-celsius";
+        var element = Render<NimbleUnitCelsius>();
 
-        var element = context.Render<NimbleUnitCelsius>();
-
-        Assert.Contains(expectedMarkup, element.Markup);
+        Assert.NotNull(element.Find("nimble-unit-celsius"));
     }
 
     [Fact]
     public void NimbleUnitCelsius_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleUnitCelsius>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleUnitCelsius>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleUnitFahrenheitTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleUnitFahrenheitTests.cs
@@ -1,3 +1,4 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -6,26 +7,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleUnitFahrenheit"/>
 /// </summary>
-public class NimbleUnitFahrenheitTests
+public class NimbleUnitFahrenheitTests : BunitTestBase
 {
     [Fact]
     public void NimbleUnitFahrenheit_Rendered_HasUnitFahrenheitMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-unit-fahrenheit";
+        var element = Render<NimbleUnitFahrenheit>();
 
-        var element = context.Render<NimbleUnitFahrenheit>();
-
-        Assert.Contains(expectedMarkup, element.Markup);
+        Assert.NotNull(element.Find("nimble-unit-fahrenheit"));
     }
 
     [Fact]
     public void NimbleUnitFahrenheit_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleUnitFahrenheit>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleUnitFahrenheit>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleUnitVoltTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleUnitVoltTests.cs
@@ -1,3 +1,4 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -6,26 +7,20 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleUnitVolt"/>
 /// </summary>
-public class NimbleUnitVoltTests
+public class NimbleUnitVoltTests : BunitTestBase
 {
     [Fact]
     public void NimbleUnitVolt_Rendered_HasUnitVoltMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "nimble-unit-volt";
+        var element = Render<NimbleUnitVolt>();
 
-        var element = context.Render<NimbleUnitVolt>();
-
-        Assert.Contains(expectedMarkup, element.Markup);
+        Assert.NotNull(element.Find("nimble-unit-volt"));
     }
 
     [Fact]
     public void NimbleUnitVolt_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<NimbleUnitVolt>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<NimbleUnitVolt>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleWaferMapTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleWaferMapTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,15 +9,14 @@ namespace NimbleBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="NimbleWaferMap"/>.
 /// </summary>
-public class NimbleWaferMapTests
+public class NimbleWaferMapTests : BunitTestBase
 {
     [Fact]
     public void NimbleWaferMap_WithGridMinXAttribute_HasMarkup()
     {
         var waferMap = RenderWithPropertySet(x => x.GridMinX!, 3);
 
-        var expectedMarkup = "grid-min-x=\"3\"";
-        Assert.Contains(expectedMarkup, waferMap.Markup);
+        waferMap.AssertAttribute("grid-min-x", "3");
     }
 
     [Fact]
@@ -24,8 +24,7 @@ public class NimbleWaferMapTests
     {
         var waferMap = RenderWithPropertySet(x => x.GridMaxX!, 3);
 
-        var expectedMarkup = "grid-max-x=\"3\"";
-        Assert.Contains(expectedMarkup, waferMap.Markup);
+        waferMap.AssertAttribute("grid-max-x", "3");
     }
 
     [Fact]
@@ -33,8 +32,7 @@ public class NimbleWaferMapTests
     {
         var waferMap = RenderWithPropertySet(x => x.GridMinY!, 3);
 
-        var expectedMarkup = "grid-min-y=\"3\"";
-        Assert.Contains(expectedMarkup, waferMap.Markup);
+        waferMap.AssertAttribute("grid-min-y", "3");
     }
 
     [Fact]
@@ -42,8 +40,7 @@ public class NimbleWaferMapTests
     {
         var waferMap = RenderWithPropertySet(x => x.GridMaxY!, 3);
 
-        var expectedMarkup = "grid-max-y=\"3\"";
-        Assert.Contains(expectedMarkup, waferMap.Markup);
+        waferMap.AssertAttribute("grid-max-y", "3");
     }
 
     [Fact]
@@ -51,8 +48,7 @@ public class NimbleWaferMapTests
     {
         var waferMap = RenderWithPropertySet(x => x.DieLabelsHidden!, true);
 
-        var expectedMarkup = "die-labels-hidden";
-        Assert.Contains(expectedMarkup, waferMap.Markup);
+        waferMap.AssertHasAttribute("die-labels-hidden");
     }
 
     [Fact]
@@ -60,8 +56,7 @@ public class NimbleWaferMapTests
     {
         var waferMap = RenderWithPropertySet(x => x.DieLabelsSuffix!, "a");
 
-        var expectedMarkup = "die-labels-suffix=\"a\"";
-        Assert.Contains(expectedMarkup, waferMap.Markup);
+        waferMap.AssertAttribute("die-labels-suffix", "a");
     }
 
     [Fact]
@@ -69,8 +64,7 @@ public class NimbleWaferMapTests
     {
         var waferMap = RenderWithPropertySet(x => x.MaxCharacters!, 3);
 
-        var expectedMarkup = "max-characters=\"3\"";
-        Assert.Contains(expectedMarkup, waferMap.Markup);
+        waferMap.AssertAttribute("max-characters", "3");
     }
 
     [Fact]
@@ -78,8 +72,7 @@ public class NimbleWaferMapTests
     {
         var waferMap = RenderWithPropertySet(x => x.ColorScaleMode!, WaferMapColorScaleMode.Ordinal);
 
-        var expectedMarkup = "ordinal";
-        Assert.Contains(expectedMarkup, waferMap.Markup);
+        waferMap.AssertAttribute("color-scale-mode", "ordinal");
     }
 
     [Fact]
@@ -89,7 +82,7 @@ public class NimbleWaferMapTests
         {
             var numberField = RenderWithPropertySet(x => x.GridMinX, 1.5);
 
-            Assert.Contains("grid-min-x=\"1.5\"", numberField.Markup);
+            numberField.AssertAttribute("grid-min-x", "1.5");
         }
     }
 
@@ -100,7 +93,7 @@ public class NimbleWaferMapTests
         {
             var numberField = RenderWithPropertySet(x => x.GridMaxX, 1.5);
 
-            Assert.Contains("grid-max-x=\"1.5\"", numberField.Markup);
+            numberField.AssertAttribute("grid-max-x", "1.5");
         }
     }
 
@@ -111,7 +104,7 @@ public class NimbleWaferMapTests
         {
             var numberField = RenderWithPropertySet(x => x.GridMinY, 1.5);
 
-            Assert.Contains("grid-min-y=\"1.5\"", numberField.Markup);
+            numberField.AssertAttribute("grid-min-y", "1.5");
         }
     }
 
@@ -122,7 +115,7 @@ public class NimbleWaferMapTests
         {
             var numberField = RenderWithPropertySet(x => x.GridMaxY, 1.5);
 
-            Assert.Contains("grid-max-y=\"1.5\"", numberField.Markup);
+            numberField.AssertAttribute("grid-max-y", "1.5");
         }
     }
 
@@ -133,7 +126,7 @@ public class NimbleWaferMapTests
         {
             var numberField = RenderWithPropertySet(x => x.MaxCharacters, 1.5);
 
-            Assert.Contains("max-characters=\"1.5\"", numberField.Markup);
+            numberField.AssertAttribute("max-characters", "1.5");
         }
     }
 
@@ -145,7 +138,7 @@ public class NimbleWaferMapTests
     {
         var waferMap = RenderWithPropertySet(x => x.OriginLocation!, value);
 
-        Assert.Contains(expectedAttribute, waferMap.Markup);
+        waferMap.AssertAttribute("origin-location", expectedAttribute);
     }
 
     [Theory]
@@ -156,13 +149,11 @@ public class NimbleWaferMapTests
     {
         var waferMap = RenderWithPropertySet(x => x.Orientation!, value);
 
-        Assert.Contains(expectedAttribute, waferMap.Markup);
+        waferMap.AssertAttribute("orientation", expectedAttribute);
     }
 
     private IRenderedComponent<NimbleWaferMap> RenderWithPropertySet<TProperty>(Expression<Func<NimbleWaferMap, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<NimbleWaferMap>(p => p.Add(propertyGetter, propertyValue));
+        return Render<NimbleWaferMap>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/CustomSortOrderBaseTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/CustomSortOrderBaseTests.cs
@@ -4,7 +4,6 @@ using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Xunit;
-#nullable enable
 namespace NimbleBlazor.Tests.Unit;
 
 public abstract class CustomSortOrderBaseTests<T> : BunitTestBase where T : ComponentBase, ICustomSortOrderColumn

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/CustomSortOrderBaseTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/CustomSortOrderBaseTests.cs
@@ -1,26 +1,24 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Xunit;
 #nullable enable
 namespace NimbleBlazor.Tests.Unit;
 
-public abstract class CustomSortOrderBaseTests<T> where T : ComponentBase, ICustomSortOrderColumn
+public abstract class CustomSortOrderBaseTests<T> : BunitTestBase where T : ComponentBase, ICustomSortOrderColumn
 {
     [Fact]
     public void NimbleTableColumn_WithSortByFieldNameAttribute_HasTableMarkup()
     {
         var tableColumn = RenderWithPropertySet(x => x.SortByFieldName!, "custom-sort-field-name");
 
-        var expectedMarkup = @"sort-by-field-name=""custom-sort-field-name""";
-        Assert.Contains(expectedMarkup, tableColumn.Markup);
+        tableColumn.AssertAttribute("sort-by-field-name", "custom-sort-field-name");
     }
 
     private IRenderedComponent<T> RenderWithPropertySet<TProperty>(Expression<Func<T, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<T>(p => p.Add(propertyGetter, propertyValue));
+        return Render<T>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/FractionalWidthBaseTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/FractionalWidthBaseTests.cs
@@ -4,7 +4,6 @@ using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Xunit;
-#nullable enable
 namespace NimbleBlazor.Tests.Unit;
 
 public abstract class FractionalWidthBaseTests<T> : BunitTestBase where T : ComponentBase, IFractionalWidthColumn

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/FractionalWidthBaseTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/FractionalWidthBaseTests.cs
@@ -1,20 +1,20 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Xunit;
 #nullable enable
 namespace NimbleBlazor.Tests.Unit;
 
-public abstract class FractionalWidthBaseTests<T> where T : ComponentBase, IFractionalWidthColumn
+public abstract class FractionalWidthBaseTests<T> : BunitTestBase where T : ComponentBase, IFractionalWidthColumn
 {
     [Fact]
     public void NimbleTableColumn_WithFractionalWidthAttribute_HasTableMarkup()
     {
         var table = RenderWithPropertySet(x => x.FractionalWidth!, 2);
 
-        var expectedMarkup = @"fractional-width=""2""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("fractional-width", "2");
     }
 
     [Fact]
@@ -22,8 +22,7 @@ public abstract class FractionalWidthBaseTests<T> where T : ComponentBase, IFrac
     {
         var table = RenderWithPropertySet(x => x.MinPixelWidth!, 40);
 
-        var expectedMarkup = @"min-pixel-width=""40""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("min-pixel-width", "40");
     }
 
     [Fact]
@@ -33,7 +32,7 @@ public abstract class FractionalWidthBaseTests<T> where T : ComponentBase, IFrac
         {
             var numberField = RenderWithPropertySet(x => x.FractionalWidth, 1.5);
 
-            Assert.Contains("fractional-width=\"1.5\"", numberField.Markup);
+            numberField.AssertAttribute("fractional-width", "1.5");
         }
     }
 
@@ -44,14 +43,12 @@ public abstract class FractionalWidthBaseTests<T> where T : ComponentBase, IFrac
         {
             var numberField = RenderWithPropertySet(x => x.MinPixelWidth, 1.5);
 
-            Assert.Contains("min-pixel-width=\"1.5\"", numberField.Markup);
+            numberField.AssertAttribute("min-pixel-width", "1.5");
         }
     }
 
     private IRenderedComponent<T> RenderWithPropertySet<TProperty>(Expression<Func<T, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<T>(p => p.Add(propertyGetter, propertyValue));
+        return Render<T>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/GroupableBaseTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/GroupableBaseTests.cs
@@ -1,20 +1,20 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Xunit;
 #nullable enable
 namespace NimbleBlazor.Tests.Unit;
 
-public abstract class GroupableBaseTests<T> where T : ComponentBase, IGroupableColumn
+public abstract class GroupableBaseTests<T> : BunitTestBase where T : ComponentBase, IGroupableColumn
 {
     [Fact]
     public void NimbleTableColumn_WithGroupIndexAttribute_HasTableMarkup()
     {
         var tableColumn = RenderWithPropertySet(x => x.GroupIndex!, 0);
 
-        var expectedMarkup = @"group-index=""0""";
-        Assert.Contains(expectedMarkup, tableColumn.Markup);
+        tableColumn.AssertAttribute("group-index", "0");
     }
 
     [Fact]
@@ -22,14 +22,11 @@ public abstract class GroupableBaseTests<T> where T : ComponentBase, IGroupableC
     {
         var tableColumn = RenderWithPropertySet(x => x.GroupingDisabled!, true);
 
-        var expectedMarkup = @"grouping-disabled";
-        Assert.Contains(expectedMarkup, tableColumn.Markup);
+        tableColumn.AssertHasAttribute("grouping-disabled");
     }
 
     private IRenderedComponent<T> RenderWithPropertySet<TProperty>(Expression<Func<T, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<T>(p => p.Add(propertyGetter, propertyValue));
+        return Render<T>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/GroupableBaseTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/GroupableBaseTests.cs
@@ -4,7 +4,6 @@ using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Xunit;
-#nullable enable
 namespace NimbleBlazor.Tests.Unit;
 
 public abstract class GroupableBaseTests<T> : BunitTestBase where T : ComponentBase, IGroupableColumn

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/NimbleAnchorBaseTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/NimbleAnchorBaseTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,7 +9,7 @@ namespace NimbleBlazor.Tests.Unit;
 /// <summary>
 /// Tests for <see cref="NimbleAnchorBase"/>.
 /// </summary>
-public abstract class NimbleAnchorBaseTests<T> where T : NimbleAnchorBase
+public abstract class NimbleAnchorBaseTests<T> : BunitTestBase where T : NimbleAnchorBase
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1000:Do not declare static members on generic types", Justification = "Static needed for MemberData of Theory")]
     public static TheoryData<Expression<Func<T, string>>, string> Data => new()
@@ -30,13 +31,11 @@ public abstract class NimbleAnchorBaseTests<T> where T : NimbleAnchorBase
     {
         var anchorMenuItem = RenderWithPropertySet(propertyGetter, "foo");
 
-        Assert.Contains($"{markupName}=\"foo\"", anchorMenuItem.Markup);
+        anchorMenuItem.AssertAttribute(markupName, "foo");
     }
 
     private IRenderedComponent<T> RenderWithPropertySet<TProperty>(Expression<Func<T, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<T>(p => p.Add(propertyGetter, propertyValue));
+        return Render<T>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/NimbleAnchorBaseTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/NimbleAnchorBaseTests.cs
@@ -12,7 +12,7 @@ namespace NimbleBlazor.Tests.Unit;
 public abstract class NimbleAnchorBaseTests<T> : BunitTestBase where T : NimbleAnchorBase
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1000:Do not declare static members on generic types", Justification = "Static needed for MemberData of Theory")]
-    public static TheoryData<Expression<Func<T, string>>, string> Data => new()
+    public static TheoryData<Expression<Func<T, string?>>, string> Data => new()
         {
             { x => x.Href, "href" },
             { x => x.HrefLang, "hreflang" },
@@ -27,7 +27,7 @@ public abstract class NimbleAnchorBaseTests<T> : BunitTestBase where T : NimbleA
 #pragma warning disable xUnit1042 // The member referenced by the MemberData attribute returns untyped data rows
     [MemberData(nameof(Data))]
 #pragma warning restore xUnit1042 // The member referenced by the MemberData attribute returns untyped data rows
-    public void NimbleAnchorBase_AttributeIsSet(Expression<Func<T, string>> propertyGetter, string markupName)
+    public void NimbleAnchorBase_AttributeIsSet(Expression<Func<T, string?>> propertyGetter, string markupName)
     {
         var anchorMenuItem = RenderWithPropertySet(propertyGetter, "foo");
 

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/NimbleTableColumnTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/NimbleTableColumnTests.cs
@@ -1,19 +1,19 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 #nullable enable
 namespace NimbleBlazor.Tests.Unit;
 
-public abstract class NimbleTableColumnTests<T> where T : NimbleTableColumn
+public abstract class NimbleTableColumnTests<T> : BunitTestBase where T : NimbleTableColumn
 {
     [Fact]
     public void NimbleTableColumn_WithColumnIdAttribute_HasTableMarkup()
     {
         var table = RenderWithPropertySet(x => x.ColumnId!, "my-column-id");
 
-        var expectedMarkup = @"column-id=""my-column-id""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("column-id", "my-column-id");
     }
 
     [Fact]
@@ -21,8 +21,7 @@ public abstract class NimbleTableColumnTests<T> where T : NimbleTableColumn
     {
         var table = RenderWithPropertySet(x => x.ActionMenuSlot!, "my-slot");
 
-        var expectedMarkup = @"action-menu-slot=""my-slot""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("action-menu-slot", "my-slot");
     }
 
     [Fact]
@@ -30,8 +29,7 @@ public abstract class NimbleTableColumnTests<T> where T : NimbleTableColumn
     {
         var table = RenderWithPropertySet(x => x.ActionMenuLabel!, "Cell actions");
 
-        var expectedMarkup = @"action-menu-label=""Cell actions""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("action-menu-label", "Cell actions");
     }
 
     [Fact]
@@ -39,14 +37,11 @@ public abstract class NimbleTableColumnTests<T> where T : NimbleTableColumn
     {
         var table = RenderWithPropertySet(x => x.ColumnHidden!, true);
 
-        var expectedMarkup = "column-hidden";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertHasAttribute("column-hidden");
     }
 
     private IRenderedComponent<T> RenderWithPropertySet<TProperty>(Expression<Func<T, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<T>(p => p.Add(propertyGetter, propertyValue));
+        return Render<T>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/NimbleTableColumnTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/NimbleTableColumnTests.cs
@@ -3,7 +3,6 @@ using System.Linq.Expressions;
 using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
-#nullable enable
 namespace NimbleBlazor.Tests.Unit;
 
 public abstract class NimbleTableColumnTests<T> : BunitTestBase where T : NimbleTableColumn

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/SortableBaseTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/SortableBaseTests.cs
@@ -4,7 +4,6 @@ using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Xunit;
-#nullable enable
 namespace NimbleBlazor.Tests.Unit;
 
 public abstract class SortableBaseTests<T> : BunitTestBase where T : ComponentBase, ISortableColumn

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/SortableBaseTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/SortableBaseTests.cs
@@ -1,20 +1,20 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Xunit;
 #nullable enable
 namespace NimbleBlazor.Tests.Unit;
 
-public abstract class SortableBaseTests<T> where T : ComponentBase, ISortableColumn
+public abstract class SortableBaseTests<T> : BunitTestBase where T : ComponentBase, ISortableColumn
 {
     [Fact]
     public void NimbleTableColumn_WithSortIndexAttribute_HasTableMarkup()
     {
         var tableColumn = RenderWithPropertySet(x => x.SortIndex!, 0);
 
-        var expectedMarkup = @"sort-index=""0""";
-        Assert.Contains(expectedMarkup, tableColumn.Markup);
+        tableColumn.AssertAttribute("sort-index", "0");
     }
 
     [Fact]
@@ -22,8 +22,7 @@ public abstract class SortableBaseTests<T> where T : ComponentBase, ISortableCol
     {
         var table = RenderWithPropertySet(x => x.SortDirection!, TableColumnSortDirection.Descending);
 
-        var expectedMarkup = @"sort-direction=""descending""";
-        Assert.Contains(expectedMarkup, table.Markup);
+        table.AssertAttribute("sort-direction", "descending");
     }
 
     [Fact]
@@ -31,14 +30,11 @@ public abstract class SortableBaseTests<T> where T : ComponentBase, ISortableCol
     {
         var tableColumn = RenderWithPropertySet(x => x.SortingDisabled!, true);
 
-        var expectedMarkup = @"sorting-disabled";
-        Assert.Contains(expectedMarkup, tableColumn.Markup);
+        tableColumn.AssertHasAttribute("sorting-disabled");
     }
 
     private IRenderedComponent<T> RenderWithPropertySet<TProperty>(Expression<Func<T, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<T>(p => p.Add(propertyGetter, propertyValue));
+        return Render<T>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/packages.lock.json
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/packages.lock.json
@@ -494,6 +494,14 @@
           "xunit.abstractions": "2.0.3"
         }
       },
+      "blazorworkspace.testing.unit": {
+        "type": "Project",
+        "dependencies": {
+          "NI.CSharp.Analyzers": "[2.0.35, )",
+          "bunit": "[2.7.2, )",
+          "xunit": "[2.9.3, )"
+        }
+      },
       "nimbleblazor": {
         "type": "Project",
         "dependencies": {
@@ -956,6 +964,14 @@
         "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
         "dependencies": {
           "xunit.abstractions": "2.0.3"
+        }
+      },
+      "blazorworkspace.testing.unit": {
+        "type": "Project",
+        "dependencies": {
+          "NI.CSharp.Analyzers": "[2.0.35, )",
+          "bunit": "[2.7.2, )",
+          "xunit": "[2.9.3, )"
         }
       },
       "nimbleblazor": {

--- a/packages/blazor-workspace/Tests/OkBlazor.Tests/OkBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/OkBlazor.Tests/OkBlazor.Tests.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\OkBlazor\OkBlazor.csproj" />
+    <ProjectReference Include="..\BlazorWorkspace.Testing.Unit\BlazorWorkspace.Testing.Unit.csproj" />
   </ItemGroup>
 
 </Project>

--- a/packages/blazor-workspace/Tests/OkBlazor.Tests/OkBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/OkBlazor.Tests/OkBlazor.Tests.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <Nullable>enable</Nullable>
     <RootNamespace>OkBlazor.Tests</RootNamespace>
     <AssemblyName>OkBlazor.Tests</AssemblyName>
   </PropertyGroup>

--- a/packages/blazor-workspace/Tests/OkBlazor.Tests/Unit/Components/Ex/OkExButtonTests.cs
+++ b/packages/blazor-workspace/Tests/OkBlazor.Tests/Unit/Components/Ex/OkExButtonTests.cs
@@ -1,3 +1,4 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -6,26 +7,20 @@ namespace OkBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="OkExButton"/>.
 /// </summary>
-public class OkExButtonTests
+public class OkExButtonTests : BunitTestBase
 {
     [Fact]
     public void OkExButton_Render_HasRectangleMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "ok-ex-button";
+        var component = Render<OkExButton>();
 
-        var component = context.Render<OkExButton>();
-
-        Assert.Contains(expectedMarkup, component.Markup);
+        Assert.NotNull(component.Find("ok-ex-button"));
     }
 
     [Fact]
     public void OkExButton_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<OkExButton>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<OkExButton>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 }

--- a/packages/blazor-workspace/Tests/OkBlazor.Tests/Unit/Components/Fv/OkFvAccordionItemTests.cs
+++ b/packages/blazor-workspace/Tests/OkBlazor.Tests/Unit/Components/Fv/OkFvAccordionItemTests.cs
@@ -1,3 +1,4 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -6,45 +7,35 @@ namespace OkBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="OkFvAccordionItem"/>.
 /// </summary>
-public class OkFvAccordionItemTests
+public class OkFvAccordionItemTests : BunitTestBase
 {
     [Fact]
     public void OkFvAccordionItem_Render_HasAccordionMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        var component = Render<OkFvAccordionItem>();
 
-        var component = context.Render<OkFvAccordionItem>();
-
-        Assert.Contains("ok-fv-accordion-item", component.Markup);
+        Assert.NotNull(component.Find("ok-fv-accordion-item"));
     }
 
     [Fact]
     public void OkFvAccordionItem_Render_MapsParametersToAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-
-        var component = context.Render<OkFvAccordionItem>(parameters => parameters
+        var component = Render<OkFvAccordionItem>(parameters => parameters
             .Add(parameter => parameter.Header, "Accordion heading")
             .Add(parameter => parameter.Appearance, FvAccordionItemAppearance.Block)
             .Add(parameter => parameter.Expanded, true)
             .AddChildContent("Accordion body"));
-        var element = component.Find("ok-fv-accordion-item");
 
-        Assert.Equal("Accordion heading", element.GetAttribute("header"));
-        Assert.Equal("block", element.GetAttribute("appearance"));
-        Assert.True(element.HasAttribute("expanded"));
-        Assert.Contains("Accordion body", component.Markup);
+        component.AssertAttribute("header", "Accordion heading");
+        component.AssertAttribute("appearance", "block");
+        component.AssertHasAttribute("expanded");
+        Assert.Contains("Accordion body", component.RootElement().TextContent);
     }
 
     [Fact]
     public void OkFvAccordionItem_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-
-        var exception = Record.Exception(() => context.Render<OkFvAccordionItem>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<OkFvAccordionItem>(parameters => parameters.AddUnmatched("class", "foo")));
 
         Assert.Null(exception);
     }

--- a/packages/blazor-workspace/Tests/OkBlazor.Tests/Unit/Components/Ts/OkTsIconDynamicTests.cs
+++ b/packages/blazor-workspace/Tests/OkBlazor.Tests/Unit/Components/Ts/OkTsIconDynamicTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
@@ -9,20 +10,18 @@ namespace OkBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="OkTsIconDynamic"/>.
 /// </summary>
-public class OkTsIconDynamicTests
+public class OkTsIconDynamicTests : BunitTestBase
 {
     [Fact]
     public async Task OkTsIconDynamic_RegisterIconDynamicAsync_InvokesRegisterIconDynamicAsync()
     {
-        using var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var javascriptRuntime = context.Services.GetRequiredService<IJSRuntime>();
+        var javascriptRuntime = Services.GetRequiredService<IJSRuntime>();
         const string tagName = "ok-ts-icon-dynamic-awesome";
         const string url = "data:image/png;base64,AAAA";
 
         await OkTsIconDynamic.RegisterIconDynamicAsync(javascriptRuntime, tagName, url);
 
-        var invocation = Assert.Single(context.JSInterop.Invocations);
+        var invocation = Assert.Single(JSInterop.Invocations);
         Assert.Equal("OkBlazor.TsIconDynamic.registerIconDynamic", invocation.Identifier);
         Assert.Equal(tagName, invocation.Arguments[0]);
         Assert.Equal(url, invocation.Arguments[1]);

--- a/packages/blazor-workspace/Tests/OkBlazor.Tests/packages.lock.json
+++ b/packages/blazor-workspace/Tests/OkBlazor.Tests/packages.lock.json
@@ -481,6 +481,14 @@
           "xunit.abstractions": "2.0.3"
         }
       },
+      "blazorworkspace.testing.unit": {
+        "type": "Project",
+        "dependencies": {
+          "NI.CSharp.Analyzers": "[2.0.35, )",
+          "bunit": "[2.7.2, )",
+          "xunit": "[2.9.3, )"
+        }
+      },
       "okblazor": {
         "type": "Project",
         "dependencies": {
@@ -929,6 +937,14 @@
         "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
         "dependencies": {
           "xunit.abstractions": "2.0.3"
+        }
+      },
+      "blazorworkspace.testing.unit": {
+        "type": "Project",
+        "dependencies": {
+          "NI.CSharp.Analyzers": "[2.0.35, )",
+          "bunit": "[2.7.2, )",
+          "xunit": "[2.9.3, )"
         }
       },
       "okblazor": {

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/SprightBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/SprightBlazor.Tests.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <Nullable>enable</Nullable>
     <RootNamespace>SprightBlazor.Tests</RootNamespace>
     <AssemblyName>SprightBlazor.Tests</AssemblyName>
   </PropertyGroup>

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/SprightBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/SprightBlazor.Tests.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\SprightBlazor\SprightBlazor.csproj" />
+    <ProjectReference Include="..\BlazorWorkspace.Testing.Unit\BlazorWorkspace.Testing.Unit.csproj" />
   </ItemGroup>
 
 </Project>

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/Unit/Components/SprightChatConversationTests.cs
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/Unit/Components/SprightChatConversationTests.cs
@@ -1,4 +1,5 @@
-﻿using Bunit;
+﻿using BlazorWorkspace.Testing.Unit;
+using Bunit;
 using Xunit;
 
 namespace SprightBlazor.Tests.Unit.Components;
@@ -6,39 +7,30 @@ namespace SprightBlazor.Tests.Unit.Components;
 /// <summary>
 /// Test for <see cref="SprightChatConversation"/>.
 /// </summary>
-public class SprightChatConversationTests
+public class SprightChatConversationTests : BunitTestBase
 {
     [Fact]
     public void SprightChatConversation_Render_HasChatConversationMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "spright-chat-conversation";
+        var component = Render<SprightChatConversation>();
 
-        var component = context.Render<SprightChatConversation>();
-
-        Assert.Contains(expectedMarkup, component.Markup);
+        Assert.NotNull(component.Find("spright-chat-conversation"));
     }
 
     [Fact]
     public void SprightChatConversation_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<SprightChatConversation>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<SprightChatConversation>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
     [Fact]
     public void SprightChatConversation_WithToolbar_RendersContent()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-
-        var component = context.Render<SprightChatConversation>(parameters => parameters
+        var component = Render<SprightChatConversation>(parameters => parameters
             .AddChildContent("<button slot=\"toolbar\">Toolbar Button</button>"));
 
-        Assert.Contains("slot=\"toolbar\"", component.Markup);
-        Assert.Contains("Toolbar Button", component.Markup);
+        var toolbarButton = component.Find("button[slot=\"toolbar\"]");
+        Assert.Equal("Toolbar Button", toolbarButton.TextContent);
     }
 }

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/Unit/Components/SprightChatInputTests.cs
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/Unit/Components/SprightChatInputTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,26 +9,20 @@ namespace SprightBlazor.Tests.Unit.Components;
 /// <summary>
 /// Test for <see cref="SprightChaInputTests"/>.
 /// </summary>
-public class SprightChatInputTests
+public class SprightChatInputTests : BunitTestBase
 {
     [Fact]
     public void SprightChatInput_Render_HasChatInputMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "spright-chat-input";
+        var component = Render<SprightChatInput>();
 
-        var component = context.Render<SprightChatInput>();
-
-        Assert.Contains(expectedMarkup, component.Markup);
+        Assert.NotNull(component.Find("spright-chat-input"));
     }
 
     [Fact]
     public void SprightChatInput_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<SprightChatInput>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<SprightChatInput>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
@@ -37,7 +32,7 @@ public class SprightChatInputTests
         var value = "Tell me something.";
         var chatInput = RenderWithPropertySet(x => x.Value, value);
 
-        Assert.Contains("value", chatInput.Markup);
+        chatInput.AssertHasAttribute("value");
     }
 
     [Fact]
@@ -46,7 +41,7 @@ public class SprightChatInputTests
         var placeholder = "Type here...";
         var chatInput = RenderWithPropertySet(x => x.Placeholder, placeholder);
 
-        Assert.Contains("placeholder", chatInput.Markup);
+        chatInput.AssertHasAttribute("placeholder");
     }
 
     [Fact]
@@ -54,7 +49,7 @@ public class SprightChatInputTests
     {
         var chatInput = RenderWithPropertySet(x => x.SendButtonLabel, "Send now");
 
-        Assert.Contains("send-button-label", chatInput.Markup);
+        chatInput.AssertHasAttribute("send-button-label");
     }
 
     [Fact]
@@ -62,7 +57,7 @@ public class SprightChatInputTests
     {
         var chatInput = RenderWithPropertySet(x => x.StopButtonLabel, "Cancel");
 
-        Assert.Contains("stop-button-label", chatInput.Markup);
+        chatInput.AssertHasAttribute("stop-button-label");
     }
 
     [Fact]
@@ -70,7 +65,7 @@ public class SprightChatInputTests
     {
         var chatInput = RenderWithPropertySet(x => x.SendDisabled, true);
 
-        Assert.Contains("send-disabled", chatInput.Markup);
+        chatInput.AssertHasAttribute("send-disabled");
     }
 
     [Fact]
@@ -78,7 +73,7 @@ public class SprightChatInputTests
     {
         var chatInput = RenderWithPropertySet(x => x.Processing, true);
 
-        Assert.Contains("processing", chatInput.Markup);
+        chatInput.AssertHasAttribute("processing");
     }
 
     [Fact]
@@ -86,7 +81,7 @@ public class SprightChatInputTests
     {
         var chatInput = RenderWithPropertySet(x => x.MaxLength, 100);
 
-        Assert.Contains("maxlength", chatInput.Markup);
+        chatInput.AssertHasAttribute("maxlength");
     }
 
     [Fact]
@@ -94,7 +89,7 @@ public class SprightChatInputTests
     {
         var chatInput = RenderWithPropertySet(x => x.ErrorText, "Invalid input");
 
-        Assert.Contains("error-text=\"Invalid input\"", chatInput.Markup);
+        chatInput.AssertAttribute("error-text", "Invalid input");
     }
 
     [Fact]
@@ -102,13 +97,11 @@ public class SprightChatInputTests
     {
         var chatInput = RenderWithPropertySet(x => x.ErrorVisible, true);
 
-        Assert.Contains("error-visible", chatInput.Markup);
+        chatInput.AssertHasAttribute("error-visible");
     }
 
     private IRenderedComponent<SprightChatInput> RenderWithPropertySet<TProperty>(Expression<Func<SprightChatInput, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<SprightChatInput>(p => p.Add(propertyGetter, propertyValue));
+        return Render<SprightChatInput>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/Unit/Components/SprightChatMessageInboundTests.cs
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/Unit/Components/SprightChatMessageInboundTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq.Expressions;
+﻿using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,26 +7,20 @@ namespace SprightBlazor.Tests.Unit.Components;
 /// <summary>
 /// Test for <see cref="SprightChatMessageInbound"/>.
 /// </summary>
-public class SprightChatMessageInboundTests
+public class SprightChatMessageInboundTests : BunitTestBase
 {
     [Fact]
     public void SprightChatMessageInbound_Render_HasChatMessageMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "spright-chat-message-inbound";
+        var component = Render<SprightChatMessageInbound>();
 
-        var component = context.Render<SprightChatMessageInbound>();
-
-        Assert.Contains(expectedMarkup, component.Markup);
+        Assert.NotNull(component.Find("spright-chat-message-inbound"));
     }
 
     [Fact]
     public void SprightChatMessageInbound_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<SprightChatMessageInbound>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<SprightChatMessageInbound>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 }

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/Unit/Components/SprightChatMessageOutboundTests.cs
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/Unit/Components/SprightChatMessageOutboundTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq.Expressions;
+﻿using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,26 +7,20 @@ namespace SprightBlazor.Tests.Unit.Components;
 /// <summary>
 /// Test for <see cref="SprightChatMessageOutbound"/>.
 /// </summary>
-public class SprightChatMessageOutboundTests
+public class SprightChatMessageOutboundTests : BunitTestBase
 {
     [Fact]
     public void SprightChatMessageOutbound_Render_HasChatMessageMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "spright-chat-message-outbound";
+        var component = Render<SprightChatMessageOutbound>();
 
-        var component = context.Render<SprightChatMessageOutbound>();
-
-        Assert.Contains(expectedMarkup, component.Markup);
+        Assert.NotNull(component.Find("spright-chat-message-outbound"));
     }
 
     [Fact]
     public void SprightChatMessageOutbound_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<SprightChatMessageOutbound>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<SprightChatMessageOutbound>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 }

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/Unit/Components/SprightChatMessageSystemTests.cs
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/Unit/Components/SprightChatMessageSystemTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq.Expressions;
+﻿using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,26 +7,20 @@ namespace SprightBlazor.Tests.Unit.Components;
 /// <summary>
 /// Test for <see cref="SprightChatMessageSystem"/>.
 /// </summary>
-public class SprightChatMessageSystemTests
+public class SprightChatMessageSystemTests : BunitTestBase
 {
     [Fact]
     public void SprightChatMessageSystem_Render_HasChatMessageMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "spright-chat-message-system";
+        var component = Render<SprightChatMessageSystem>();
 
-        var component = context.Render<SprightChatMessageSystem>();
-
-        Assert.Contains(expectedMarkup, component.Markup);
+        Assert.NotNull(component.Find("spright-chat-message-system"));
     }
 
     [Fact]
     public void SprightChatMessageSystem_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<SprightChatMessageSystem>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<SprightChatMessageSystem>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 }

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/Unit/Components/SprightChatMessageTests.cs
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/Unit/Components/SprightChatMessageTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,44 +9,36 @@ namespace SprightBlazor.Tests.Unit.Components;
 /// <summary>
 /// Test for <see cref="SprightChatMessage"/>.
 /// </summary>
-public class SprightChatMessageTests
+public class SprightChatMessageTests : BunitTestBase
 {
     [Fact]
     public void SprightChatMessage_Render_HasChatMessageMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "spright-chat-message";
+        var component = Render<SprightChatMessage>();
 
-        var component = context.Render<SprightChatMessage>();
-
-        Assert.Contains(expectedMarkup, component.Markup);
+        Assert.NotNull(component.Find("spright-chat-message"));
     }
 
     [Fact]
     public void SprightChatMessage_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<SprightChatMessage>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<SprightChatMessage>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
     [Theory]
-    [InlineData(ChatMessageType.Outbound, "message-type=\"outbound\"")]
-    [InlineData(ChatMessageType.Inbound, "message-type=\"inbound\"")]
-    [InlineData(ChatMessageType.System, "message-type=\"system\"")]
+    [InlineData(ChatMessageType.Outbound, "outbound")]
+    [InlineData(ChatMessageType.Inbound, "inbound")]
+    [InlineData(ChatMessageType.System, "system")]
     public void SprightChatMessageTypeVariant_AttributeIsSet(ChatMessageType value, string expectedAttribute)
     {
         var message = RenderWithPropertySet(x => x.MessageType, value);
 
-        Assert.Contains(expectedAttribute, message.Markup);
+        message.AssertAttribute("message-type", expectedAttribute);
     }
 
     private IRenderedComponent<SprightChatMessage> RenderWithPropertySet<TProperty>(Expression<Func<SprightChatMessage, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<SprightChatMessage>(p => p.Add(propertyGetter, propertyValue));
+        return Render<SprightChatMessage>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/Unit/Components/SprightChatMessageWelcomeTests.cs
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/Unit/Components/SprightChatMessageWelcomeTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -8,45 +9,37 @@ namespace SprightBlazor.Tests.Unit.Components;
 /// <summary>
 /// Test for <see cref="SprightChatMessageWelcome"/>.
 /// </summary>
-public class SprightChatMessageWelcomeTests
+public class SprightChatMessageWelcomeTests : BunitTestBase
 {
     [Fact]
     public void SprightChatMessageWelcome_Render_HasChatMessageMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "spright-chat-message-welcome";
+        var component = Render<SprightChatMessageWelcome>();
 
-        var component = context.Render<SprightChatMessageWelcome>();
-
-        Assert.Contains(expectedMarkup, component.Markup);
+        Assert.NotNull(component.Find("spright-chat-message-welcome"));
     }
 
     [Fact]
     public void SprightChatMessageWelcome_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<SprightChatMessageWelcome>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<SprightChatMessageWelcome>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 
     [Theory]
-    [InlineData("Welcome to Nigel", "welcome-title=\"Welcome to Nigel\"")]
-    [InlineData("Log in to continue", "subtitle=\"Log in to continue\"")]
-    public void SprightChatMessageWelcome_AttributeIsSet(string value, string expectedAttribute)
+    [InlineData("Welcome to Nigel", "welcome-title")]
+    [InlineData("Log in to continue", "subtitle")]
+    public void SprightChatMessageWelcome_AttributeIsSet(string value, string attributeName)
     {
-        var message = expectedAttribute.StartsWith("welcome-title", StringComparison.Ordinal)
+        var message = attributeName == "welcome-title"
             ? RenderWithPropertySet(x => x.WelcomeTitle, value)
             : RenderWithPropertySet(x => x.Subtitle, value);
 
-        Assert.Contains(expectedAttribute, message.Markup);
+        message.AssertAttribute(attributeName, value);
     }
 
     private IRenderedComponent<SprightChatMessageWelcome> RenderWithPropertySet<TProperty>(Expression<Func<SprightChatMessageWelcome, TProperty>> propertyGetter, TProperty propertyValue)
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        return context.Render<SprightChatMessageWelcome>(p => p.Add(propertyGetter, propertyValue));
+        return Render<SprightChatMessageWelcome>(p => p.Add(propertyGetter, propertyValue));
     }
 }

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/Unit/Components/SprightRectangleTests.cs
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/Unit/Components/SprightRectangleTests.cs
@@ -1,3 +1,4 @@
+using BlazorWorkspace.Testing.Unit;
 using Bunit;
 using Xunit;
 
@@ -6,26 +7,20 @@ namespace SprightBlazor.Tests.Unit.Components;
 /// <summary>
 /// Tests for <see cref="SprightRectangle"/>.
 /// </summary>
-public class SprightRectangleTests
+public class SprightRectangleTests : BunitTestBase
 {
     [Fact]
     public void SprightRectangle_Render_HasRectangleMarkup()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var expectedMarkup = "spright-rectangle";
+        var component = Render<SprightRectangle>();
 
-        var component = context.Render<SprightRectangle>();
-
-        Assert.Contains(expectedMarkup, component.Markup);
+        Assert.NotNull(component.Find("spright-rectangle"));
     }
 
     [Fact]
     public void SprightRectangle_SupportsAdditionalAttributes()
     {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        var exception = Record.Exception(() => context.Render<SprightRectangle>(parameters => parameters.AddUnmatched("class", "foo")));
+        var exception = Record.Exception(() => Render<SprightRectangle>(parameters => parameters.AddUnmatched("class", "foo")));
         Assert.Null(exception);
     }
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Switches the primary assertion behavior in bUnit tests from text matching to [DOM Node / `MarkupMatches()`](https://bunit.dev/docs/verification/verify-markup.html).

## 👩‍💻 Implementation

- Added a unit test base assembly with utilities to help attribute assertions
- Enabled Nullable in the unit projects (matches other projects)
- Migrated bUnit tests to either DOM assertions or MarkupMatches

## 🧪 Testing

Rely on CI

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
