### PR TITLE
Enter doesn't send chat message when send is disabled

### DIFF
--- a/change/@ni-spright-components-3910b083-e07b-4576-af44-ced284d7d937.json
+++ b/change/@ni-spright-components-3910b083-e07b-4576-af44-ced284d7d937.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Enter doesn't send chat message when send is disabled.",
+  "packageName": "@ni/spright-components",
+  "email": "163188334+Alexia-Claudia-Micu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/spright-components/src/chat/input/index.ts
+++ b/packages/spright-components/src/chat/input/index.ts
@@ -194,7 +194,7 @@ export class ChatInput extends mixinErrorPattern(FoundationElement) {
     }
 
     private shouldDisableSendButton(): boolean {
-        return this.textArea!.value.length === 0;
+        return this.sendDisabled || this.textArea!.value.length === 0;
     }
 
     private resetInput(): void {

--- a/packages/spright-components/src/chat/input/tests/chat-input.spec.ts
+++ b/packages/spright-components/src/chat/input/tests/chat-input.spec.ts
@@ -330,6 +330,18 @@ describe('ChatInput', () => {
             expect(spy).not.toHaveBeenCalled();
         });
 
+        it('via Enter with sendDisabled set triggers no send event', async () => {
+            const spy = jasmine.createSpy();
+            element.addEventListener('send', spy);
+            element.value = 'new value';
+            element.sendDisabled = true;
+            processUpdates();
+            await page.pressEnterKey();
+
+            expect(spy).not.toHaveBeenCalled();
+            expect(element.value).toBe('new value');
+        });
+
         it('Shift-Enter triggers no send event', async () => {
             const spy = jasmine.createSpy();
             element.addEventListener('send', spy);


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The case in which the user sends a message through enter key was omitted.

## 👩‍💻 Implementation

Added condition to check if the submit button is disabled in `shouldDisableSendButton()`.

## 🧪 Testing

Added test and manual testing in storybook.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
