### PR TITLE
Replace security scanning section with a link to the reference document.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,7 @@ specs @rajsite @jattasNI @mollykreis
 
 # .snyk security scanning configuration file
 /.snyk @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick
+/.wiz @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick
 
 # Change files don't need explicit reviewers
 /change

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,7 +28,7 @@
 # Specs (placed after packages to have higher precedence for spec files contained in packages)
 specs @rajsite @jattasNI @mollykreis
 
-# .snyk security scanning configuration file
+# Security scanning configuration files
 /.snyk @ni/security-scanning-owners
 /.wiz @ni/security-scanning-owners
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,8 +29,8 @@
 specs @rajsite @jattasNI @mollykreis
 
 # .snyk security scanning configuration file
-/.snyk @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick
-/.wiz @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick
+/.snyk @ni/security-scanning-owners
+/.wiz @ni/security-scanning-owners
 
 # Change files don't need explicit reviewers
 /change

--- a/.wiz
+++ b/.wiz
@@ -1,2 +1,9 @@
+# Wiz Code global path exclusions for this repository.
+#
+# NOTE: Both /* and /**/* patterns are required per directory due to a known
+# Wiz glob bug (WZ-81029) where /**/* does not match direct children of a
+# directory. The /* pattern catches direct children while /**/* catches nested
+# files. This duplication can be removed once the bug is fixed.
+
 ignore:
   global_paths: {}

--- a/.wiz
+++ b/.wiz
@@ -1,0 +1,2 @@
+ignore:
+  global_paths: {}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,7 +238,7 @@ npm install @ni/nimble-tokens --workspace=@ni/nimble-components
 
 ### Security scanning
 
-See the [security scanning reference](https://dev.azure.com/ni/DevCentral/_wiki/wikis/Stratus/160265/Security-scanning-reference) for information on security scanning tools, workflows, and best practices.
+**Contributors within NI/Emerson**: See the [security scanning reference](https://dev.azure.com/ni/DevCentral/_wiki/wikis/Stratus/160265/Security-scanning-reference) for information on security scanning tools, workflows, and best practices.
 
 **Contributors outside of NI/Emerson**: If you are having issues resolving a vulnerability identified on your PR, consult with a code owner to understand your options for resolution.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,17 +236,11 @@ Example: Add a monorepo package `nimble-tokens` as a dependency to another monor
 npm install @ni/nimble-tokens --workspace=@ni/nimble-components
 ```
 
-### Security scanning with Snyk
+### Security scanning
 
-This repository uses [Snyk](https://snyk.io/) for security scanning to identify and fix vulnerabilities in code before they reach production. Snyk provides Static Application Security Testing (SAST) that scans your code for security issues as you develop.
+See the [security scanning reference](https://dev.azure.com/ni/DevCentral/_wiki/wikis/Stratus/160265/Security-scanning-reference) for information on security scanning tools, workflows, and best practices.
 
-- **IDE integration**: Install the Snyk extension for [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=snyk-security.snyk-vulnerability-scanner) or [Visual Studio](https://marketplace.visualstudio.com/items?itemName=snyk-security.snyk-vulnerability-scanner-vs-2022) to get real-time security feedback while writing code. To suggest the Snyk extension to contributors, add `.vscode/extensions.json` or `.vsconfig` files to your project root. The VSCode Snyk extension has a richer feature set and is the preferred IDE for working with Snyk.
-- **Pull request scanning**: Snyk automatically scans PRs and posts comments for high/critical vulnerabilities.
-- **Post-merge monitoring**: Automated bugs are created for unresolved issues after code is merged.
-
-**Contributors within NI/Emerson**: For detailed guidance on working with Snyk, including how to address security issues and create ignore records, see the [Snyk reference](https://dev.azure.com/ni/DevCentral/_wiki/wikis/Stratus/146862/Snyk-reference).
-
-**Contributors outside of NI/Emerson**: If you are having issues resolving a vulnerability Snyk identifies on your PR, consult with a code owner to understand your options for resolution.
+**Contributors outside of NI/Emerson**: If you are having issues resolving a vulnerability identified on your PR, consult with a code owner to understand your options for resolution.
 
 ## Updating dependencies
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The security scanning content is duplicated across several repos and we will continue to have updates as we roll out more scanning.

## 👩‍💻 Implementation

Link to the handbook document instead of duplicating content across the repos.

## 🧪 Testing

PR

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
