### PR TITLE
Fix chat send button not re-enabling

### DIFF
--- a/change/@ni-spright-components-1812c098-b28e-45a8-9766-edeb9c7555cc.json
+++ b/change/@ni-spright-components-1812c098-b28e-45a8-9766-edeb9c7555cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix send button not being re-enabled",
+  "packageName": "@ni/spright-components",
+  "email": "163188334+Alexia-Claudia-Micu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/spright-components/src/chat/input/index.ts
+++ b/packages/spright-components/src/chat/input/index.ts
@@ -117,7 +117,7 @@ export class ChatInput extends mixinErrorPattern(FoundationElement) {
      */
     public textAreaInputHandler(): void {
         this.value = this.textArea!.value;
-        this.isInputEmpty = this.shouldDisableSendButton();
+        this.isInputEmpty = this.textArea!.value.length === 0;
         this.adjustTextAreaHeight();
         this.queueUpdateScrollbarWidth();
     }
@@ -142,7 +142,7 @@ export class ChatInput extends mixinErrorPattern(FoundationElement) {
     public valueChanged(): void {
         if (this.textArea) {
             this.textArea.value = this.value;
-            this.isInputEmpty = this.shouldDisableSendButton();
+            this.isInputEmpty = this.textArea.value.length === 0;
             this.adjustTextAreaHeight();
             this.queueUpdateScrollbarWidth();
         }
@@ -154,7 +154,7 @@ export class ChatInput extends mixinErrorPattern(FoundationElement) {
     public override connectedCallback(): void {
         super.connectedCallback();
         this.textArea!.value = this.value;
-        this.isInputEmpty = this.shouldDisableSendButton();
+        this.isInputEmpty = this.textArea!.value.length === 0;
         this.adjustTextAreaHeight();
         this.resizeObserver = new ResizeObserver(() => this.onResize());
         this.resizeObserver.observe(this);

--- a/packages/spright-components/src/chat/input/tests/chat-input.spec.ts
+++ b/packages/spright-components/src/chat/input/tests/chat-input.spec.ts
@@ -155,6 +155,18 @@ describe('ChatInput', () => {
 
             expect(page.isButtonEnabled()).toBeTrue();
         });
+
+        it('enables send button when changed to false after user types while true', () => {
+            element.sendDisabled = true;
+            processUpdates();
+
+            page.setText('new value');
+
+            element.sendDisabled = false;
+            processUpdates();
+
+            expect(page.isButtonEnabled()).toBeTrue();
+        });
     });
 
     describe('user input', () => {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The send button is disabled when either `sendDisabled` is true (consumer side) or the text box is empty. The bug was that `shouldDisableSendButton` combined both conditions and its result was held in `isInputEmpty` (which only refreshed on text events).

Since `sendDisabled` is an attribute, its state change never caused `IsInputEmpty` to refresh.

## 👩‍💻 Implementation

`IsInputEmpty` now only tracks `this.textArea!.value.length === 0`  leaving the button state to be calculated in the template:  `            ?disabled=${x => (x.processing ? false : (x.sendDisabled || x.isInputEmpty))}` 

## 🧪 Testing

Added unit test.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
