### PR TITLE
Fix WebKit test failure for the Rich text mention

### DIFF
--- a/change/@ni-nimble-components-9d9a3ea4-0474-49a6-a345-6900ca379e08.json
+++ b/change/@ni-nimble-components-9d9a3ea4-0474-49a6-a345-6900ca379e08.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Fix webkit test failure that occurred due to the underlying prosemirror issue is now resolved",
+  "comment": "Fix the WebKit test failure caused by an underlying ProseMirror issue that has now been resolved",
   "packageName": "@ni/nimble-components",
   "email": "123377523+vivinkrishna-ni@users.noreply.github.com",
   "dependentChangeType": "none"

--- a/change/@ni-nimble-components-9d9a3ea4-0474-49a6-a345-6900ca379e08.json
+++ b/change/@ni-nimble-components-9d9a3ea4-0474-49a6-a345-6900ca379e08.json
@@ -1,5 +1,5 @@
 {
-  "type": "none",
+  "type": "patch",
   "comment": "Fix the WebKit test failure caused by an underlying ProseMirror issue that has now been resolved",
   "packageName": "@ni/nimble-components",
   "email": "123377523+vivinkrishna-ni@users.noreply.github.com",

--- a/change/@ni-nimble-components-9d9a3ea4-0474-49a6-a345-6900ca379e08.json
+++ b/change/@ni-nimble-components-9d9a3ea4-0474-49a6-a345-6900ca379e08.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix webkit test failure that occurred due to the underlying prosemirror issue is now resolved",
+  "packageName": "@ni/nimble-components",
+  "email": "123377523+vivinkrishna-ni@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/nimble-components/src/rich-text/editor/testing/rich-text-editor.pageobject.ts
+++ b/packages/nimble-components/src/rich-text/editor/testing/rich-text-editor.pageobject.ts
@@ -182,7 +182,7 @@ export class RichTextEditorPageObject {
 
     public getMentionButtonLabel(buttonIndex: number): string {
         const buttons: Button[] = this.getMentionButtons()!;
-        return buttons[buttonIndex]?.innerText ?? '';
+        return (buttons[buttonIndex]?.innerText ?? '').trim();
     }
 
     public getButtonCheckedState(button: ToolbarButton): boolean {

--- a/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
+++ b/packages/nimble-components/src/rich-text/editor/tests/rich-text-editor-mention.spec.ts
@@ -352,8 +352,7 @@ describe('RichTextEditorMention', () => {
                 expect(pageObject.getMentionButtonLabel(0)).toBe('');
             });
 
-            // WebKit skipped, see https://github.com/ni/nimble/issues/1938
-            it('should have button title and text when `button-label` updated #SkipWebkit', async () => {
+            it('should have button title and text when `button-label` updated', async () => {
                 const { userMentionElement } = await appendUserMentionConfiguration(element);
                 userMentionElement.buttonLabel = 'at mention';
                 await waitForUpdatesAsync();


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

<!---
Provide some background and a description of your work.
What problem does this change solve?

Include links to issues, work items, or other discussions.
-->

Fixes #1938 

## 👩‍💻 Implementation

<!---
Describe how the change addresses the problem. Consider factors such as complexity, alternative solutions, performance impact, etc. 

Consider listing files with important changes or comment on them directly in the pull request.
-->

1. The underlying issue was fixed in the `Prosemirror-view` package, where it previously caused a console error and made the cursor disappear. As mentioned in the [comment](https://github.com/ProseMirror/prosemirror/issues/1454#issuecomment-2722857281), the console log error has been fixed, which in turn fixes the test failure in WebKit. 
    1. Although it was mentioned that the cursor disappearing issue is not yet fixed, when I tried locally in WebKit, the issue appears to be fixed.
        <img width="553" height="347" alt="hard-enter-issue-webkit" src="https://github.com/user-attachments/assets/b0d03964-d010-428e-ba24-76519e037467" />
2. Another reason the test was failing is that it uses the `innerText`, where WebKit preserves whitespace/newlines that exist in the DOM. Therefore, the actual label name returned by the `innerText` matches `at mention\n  `, while the expected value does not include the whitespace and newline characters. To fix that, added a `.trim()` to the button label page object.
     1. Also, the `innerText.trim()` is used in [several places](https://github.com/search?q=repo%3Ani%2Fnimble%20innerText.trim()&type=code) in the nimble.


## 🧪 Testing

<!---
Detail the testing done to ensure this submission meets requirements. 

Include automated/manual test additions or modifications, testing done on a local build, private CI run results, and additional testing not covered by automatic pull request validation. If any functionality is not covered by automated testing, provide justification.
-->
Test passes

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
