### PR TITLE
Update Ok Breakpoint Column to fix menu stacking

### DIFF
--- a/change/@ni-ok-components-cb7387a7-8eee-4791-bcd6-4d483fcfc381.json
+++ b/change/@ni-ok-components-cb7387a7-8eee-4791-bcd6-4d483fcfc381.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix for clipped Ok Breakpoint Column menu in Pinned column",
+  "packageName": "@ni/ok-components",
+  "email": "5265744+hellovolcano@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/ok-components/src/ts/table-column/breakpoint/cell-view/index.ts
+++ b/packages/ok-components/src/ts/table-column/breakpoint/cell-view/index.ts
@@ -51,6 +51,8 @@ export class TsTableColumnBreakpointCellView extends TableCellView<
 
     private focusLastItemWhenOpened = false;
 
+    private restoreRowMenuOpenOnClose = false;
+
     /** @internal */
     @observable
     private readonly breakpointEnabledString = 'Breakpoint enabled';
@@ -206,6 +208,24 @@ export class TsTableColumnBreakpointCellView extends TableCellView<
         }
     }
 
+    public openChanged(_prev: boolean, next: boolean): void {
+        const row = this.getOwningRow();
+        if (!row) {
+            return;
+        }
+
+        if (next) {
+            this.restoreRowMenuOpenOnClose = !row.hasAttribute('menu-open');
+            row.menuOpen = true;
+            return;
+        }
+
+        if (this.restoreRowMenuOpenOnClose) {
+            row.menuOpen = false;
+            this.restoreRowMenuOpenOnClose = false;
+        }
+    }
+
     public focusoutHandler(e: FocusEvent): boolean {
         if (!this.open) {
             return true;
@@ -331,6 +351,30 @@ export class TsTableColumnBreakpointCellView extends TableCellView<
         this.open = false;
         this.button?.focus();
     };
+
+    private getOwningRow(): (HTMLElement & { menuOpen: boolean }) | undefined {
+        const rootNode = this.getRootNode();
+        if (!(rootNode instanceof ShadowRoot)) {
+            return undefined;
+        }
+
+        const tableCell = rootNode.host;
+        if (!(tableCell instanceof HTMLElement)) {
+            return undefined;
+        }
+
+        const rowRootNode = tableCell.getRootNode();
+        if (!(rowRootNode instanceof ShadowRoot)) {
+            return undefined;
+        }
+
+        const tableRow = rowRootNode.host;
+        if (!(tableRow instanceof HTMLElement) || tableRow.localName !== 'nimble-table-row') {
+            return undefined;
+        }
+
+        return tableRow as HTMLElement & { menuOpen: boolean };
+    }
 
     private getRequestedStateFromEvent(event: Event): BreakpointState | undefined {
         const target = event.target;

--- a/packages/ok-components/src/ts/table-column/breakpoint/testing/ts-table-column-breakpoint.pageobject.ts
+++ b/packages/ok-components/src/ts/table-column/breakpoint/testing/ts-table-column-breakpoint.pageobject.ts
@@ -64,6 +64,10 @@ export class TsTableColumnBreakpointPageObject<T extends TableRecord> {
         return this.getContextMenuRegion(rowIndex, columnIndex) !== null;
     }
 
+    public isRowMenuOpen(rowIndex: number): boolean {
+        return this.tablePageObject.getRow(rowIndex).hasAttribute('menu-open');
+    }
+
     public pressContextMenuKey(
         rowIndex: number,
         columnIndex: number,

--- a/packages/ok-components/src/ts/table-column/breakpoint/tests/ts-table-column-breakpoint.spec.ts
+++ b/packages/ok-components/src/ts/table-column/breakpoint/tests/ts-table-column-breakpoint.spec.ts
@@ -302,6 +302,27 @@ describe('TsTableColumnBreakpoint', () => {
             expect(breakpointPageObject.isContextMenuOpen(0, 0)).toBeFalse();
         });
 
+        it('sets row menu-open while the context menu is open', async () => {
+            await table.setData([
+                { id: '1', breakpointState: BreakpointState.off }
+            ]);
+            await waitForUpdatesAsync();
+
+            expect(breakpointPageObject.isRowMenuOpen(0)).toBeFalse();
+
+            breakpointPageObject.rightClickBreakpointButton(0, 0);
+            await waitForUpdatesAsync();
+
+            expect(breakpointPageObject.isContextMenuOpen(0, 0)).toBeTrue();
+            expect(breakpointPageObject.isRowMenuOpen(0)).toBeTrue();
+
+            breakpointPageObject.pressContextMenuKey(0, 0, { key: 'Escape' });
+            await waitForUpdatesAsync();
+
+            expect(breakpointPageObject.isContextMenuOpen(0, 0)).toBeFalse();
+            expect(breakpointPageObject.isRowMenuOpen(0)).toBeFalse();
+        });
+
         it('emits breakpoint-column-state-change-requested when selecting a menu item after right-click', async () => {
             await table.setData([
                 { id: '1', breakpointState: BreakpointState.off }

--- a/packages/storybook/src/ok/ts/table-column-breakpoint/ts-table-column-breakpoint-matrix.stories.ts
+++ b/packages/storybook/src/ok/ts/table-column-breakpoint/ts-table-column-breakpoint-matrix.stories.ts
@@ -3,6 +3,7 @@ import { html, ViewTemplate } from '@ni/fast-element';
 import { tableTag } from '@ni/nimble-components/dist/esm/table';
 import { tsTableColumnBreakpointTag } from '@ni/ok-components/dist/esm/ts/table-column/breakpoint';
 import { BreakpointState } from '@ni/ok-components/dist/esm/ts/table-column/breakpoint/types';
+import { TableColumnPinLocation } from '@ni/nimble-components/dist/esm/table/types';
 import {
     createMatrixThemeStory,
     createMatrix,
@@ -44,6 +45,12 @@ const data = [
     }
 ] as const;
 
+const pinnedStates = [
+    ['not pinned', undefined],
+    ['pinned', TableColumnPinLocation.left]
+] as const;
+type PinnedState = (typeof pinnedStates)[number];
+
 const metadata: Meta = {
     title: 'Tests Ok/Ts Table Column: Breakpoint',
     parameters: {
@@ -53,18 +60,19 @@ const metadata: Meta = {
 
 export default metadata;
 
-const component = (): ViewTemplate => html`
+const component = ([pinnedLabel, pinnedValue]: PinnedState): ViewTemplate => html`
     <${tableTag} id-field-name="id" style="height: 320px">
         <${tsTableColumnBreakpointTag}
             field-name="breakpointState"
+            pin-location="${() => pinnedValue}"
         >
-            BP
+            BP ${() => `(${pinnedLabel})`}
         </${tsTableColumnBreakpointTag}>
     </${tableTag}>
 `;
 
 export const themeMatrix: StoryFn = createMatrixThemeStory(
-    createMatrix(component)
+    createMatrix(component, [pinnedStates])
 );
 
 themeMatrix.play = async (): Promise<void> => {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

<!---
Provide some background and a description of your work.
What problem does this change solve?

Include links to issues, work items, or other discussions.
-->

Pinning the breakpoint column was causing the menu to be clipped behind the sibling pinned cells.

## 👩‍💻 Implementation

- Set the `menu-open` attribute on menu open and remove on close so the current menu can be displayed above the other pinned cells

note: this is likely a temporary fix that should be addressed later via a refactor to how we toggle the breakpoint's menu

## 🧪 Testing

Verified in storybook
Added some matrix tests

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [X] I have updated the project documentation to reflect my changes or determined no changes are needed.
