### PR TITLE
Support CSS `field-sizing` on text-area, text-field, number-field, and combobox

### DIFF
--- a/change/@ni-nimble-components-6d58234e-1827-4414-a92d-2c3b47400e14.json
+++ b/change/@ni-nimble-components-6d58234e-1827-4414-a92d-2c3b47400e14.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Support CSS field-sizing on text-area and text-field",
+  "comment": "Support CSS field-sizing on text-area, text-field, number-field, and combobox. Also minor padding adjustment for number-field",
   "packageName": "@ni/nimble-components",
   "email": "7282195+m-akinc@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@ni-nimble-components-6d58234e-1827-4414-a92d-2c3b47400e14.json
+++ b/change/@ni-nimble-components-6d58234e-1827-4414-a92d-2c3b47400e14.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Support CSS field-sizing on text-area and text-field",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/combobox/styles.ts
+++ b/packages/nimble-components/src/combobox/styles.ts
@@ -50,6 +50,7 @@ export const styles = css`
         border: none;
         color: inherit;
         margin: auto 0;
+        width: 100%;
         font: inherit;
         height: var(--ni-private-height-within-border);
     }

--- a/packages/nimble-components/src/combobox/styles.ts
+++ b/packages/nimble-components/src/combobox/styles.ts
@@ -22,6 +22,7 @@ export const styles = css`
     ${requiredVisibleStyles}
 
     :host {
+        field-sizing: fixed;
         --ni-private-hover-bottom-border-width: 2px;
         --ni-private-bottom-border-width: 1px;
         --ni-private-height-within-border: calc(
@@ -30,6 +31,7 @@ export const styles = css`
     }
 
     .control {
+        field-sizing: inherit;
         bottom-border-width: var(--ni-private-bottom-border-width);
     }
 
@@ -37,13 +39,17 @@ export const styles = css`
         border-bottom-color: ${borderHoverColor};
     }
 
+    slot[name='control'] {
+        field-sizing: inherit;
+    }
+
     .selected-value {
+        field-sizing: inherit;
         -webkit-appearance: none;
         background: transparent;
         border: none;
         color: inherit;
         margin: auto 0;
-        width: 100%;
         font: inherit;
         height: var(--ni-private-height-within-border);
     }

--- a/packages/nimble-components/src/combobox/template.ts
+++ b/packages/nimble-components/src/combobox/template.ts
@@ -49,7 +49,6 @@ ComboboxOptions
                     part="selected-value"
                     placeholder="${x => x.placeholder}"
                     role="combobox"
-                    size="1"
                     type="text"
                     ?disabled="${x => x.disabled}"
                     :value="${x => x.value}"

--- a/packages/nimble-components/src/combobox/template.ts
+++ b/packages/nimble-components/src/combobox/template.ts
@@ -49,6 +49,7 @@ ComboboxOptions
                     part="selected-value"
                     placeholder="${x => x.placeholder}"
                     role="combobox"
+                    size="1"
                     type="text"
                     ?disabled="${x => x.disabled}"
                     :value="${x => x.value}"

--- a/packages/nimble-components/src/number-field/styles.ts
+++ b/packages/nimble-components/src/number-field/styles.ts
@@ -142,7 +142,7 @@ export const styles = css`
     }
     
     :host([hide-step]) .control {
-        padding-right: ${mediumPadding};
+        padding-right: ${smallPadding};
     }
 
     .control:hover,

--- a/packages/nimble-components/src/number-field/styles.ts
+++ b/packages/nimble-components/src/number-field/styles.ts
@@ -140,6 +140,10 @@ export const styles = css`
         padding: 0px;
         padding-left: ${mediumPadding};
     }
+    
+    :host([hide-step]) .control {
+        padding-right: ${mediumPadding};
+    }
 
     .control:hover,
     .control:focus,
@@ -253,6 +257,7 @@ export const styles = css`
 
             :host([full-bleed]) .control {
                 padding-left: 0px;
+                padding-right: 0px;
             }
         `
     )

--- a/packages/nimble-components/src/number-field/styles.ts
+++ b/packages/nimble-components/src/number-field/styles.ts
@@ -32,6 +32,7 @@ export const styles = css`
         outline: none;
         ${userSelectNone}
         color: ${bodyFontColor};
+        field-sizing: fixed;
         --ni-private-hover-indicator-width: calc(${borderWidth} + 1px);
         --ni-private-height-within-border: calc(
             ${controlHeight} - 2 * ${borderWidth}

--- a/packages/nimble-components/src/number-field/styles.ts
+++ b/packages/nimble-components/src/number-field/styles.ts
@@ -64,6 +64,7 @@ export const styles = css`
         position: relative;
         display: flex;
         flex-direction: row;
+        field-sizing: inherit;
         justify-content: center;
         align-items: center;
         border-radius: 0px;
@@ -131,6 +132,7 @@ export const styles = css`
         font: inherit;
         background: transparent;
         color: inherit;
+        field-sizing: inherit;
         height: var(--ni-private-height-within-border);
         width: 100%;
         border: none;

--- a/packages/nimble-components/src/text-area/styles.ts
+++ b/packages/nimble-components/src/text-area/styles.ts
@@ -63,6 +63,7 @@ export const styles = css`
         display: flex;
         justify-content: center;
         position: relative;
+        field-sizing: inherit;
         height: 100%;
         width: 100%;
     }
@@ -107,6 +108,7 @@ export const styles = css`
         border-radius: 0px;
         align-items: flex-end;
         border: ${borderWidth} solid transparent;
+        field-sizing: inherit;
         min-width: 100px;
         min-height: calc(${iconSize} + ${standardPadding});
         padding: 8px;

--- a/packages/nimble-components/src/text-area/styles.ts
+++ b/packages/nimble-components/src/text-area/styles.ts
@@ -33,6 +33,7 @@ export const styles = css`
         ${userSelectNone}
         color: ${bodyFontColor};
         field-sizing: fixed;
+        min-width: 100px;
         flex-direction: column;
         vertical-align: top;
         --ni-private-hover-indicator-width: calc(${borderWidth} + 1px);
@@ -110,7 +111,6 @@ export const styles = css`
         align-items: flex-end;
         border: ${borderWidth} solid transparent;
         field-sizing: inherit;
-        min-width: 100px;
         min-height: calc(${iconSize} + ${standardPadding});
         padding: 8px;
         ${

--- a/packages/nimble-components/src/text-area/styles.ts
+++ b/packages/nimble-components/src/text-area/styles.ts
@@ -32,6 +32,7 @@ export const styles = css`
         outline: none;
         ${userSelectNone}
         color: ${bodyFontColor};
+        field-sizing: fixed;
         flex-direction: column;
         vertical-align: top;
         --ni-private-hover-indicator-width: calc(${borderWidth} + 1px);

--- a/packages/nimble-components/src/text-field/styles.ts
+++ b/packages/nimble-components/src/text-field/styles.ts
@@ -151,13 +151,10 @@ export const styles = css`
         field-sizing: inherit;
         height: var(--ni-private-height-within-border);
         width: 100%;
-        margin: auto ${smallPadding} auto 0px;
+        margin-top: auto;
+        margin-bottom: auto;
         border: none;
         text-overflow: ellipsis;
-    }
-
-    :host([error-visible]) .control {
-        margin-right: 0px;
     }
 
     .control:hover,

--- a/packages/nimble-components/src/text-field/styles.ts
+++ b/packages/nimble-components/src/text-field/styles.ts
@@ -68,6 +68,7 @@ export const styles = css`
         display: flex;
         flex-direction: row;
         border-radius: 0px;
+        field-sizing: inherit;
         font: inherit;
         align-items: center;
         justify-content: center;
@@ -146,6 +147,7 @@ export const styles = css`
         background: transparent;
         color: inherit;
         padding: 0px;
+        field-sizing: inherit;
         height: var(--ni-private-height-within-border);
         width: 100%;
         margin-top: auto;

--- a/packages/nimble-components/src/text-field/styles.ts
+++ b/packages/nimble-components/src/text-field/styles.ts
@@ -151,10 +151,13 @@ export const styles = css`
         field-sizing: inherit;
         height: var(--ni-private-height-within-border);
         width: 100%;
-        margin-top: auto;
-        margin-bottom: auto;
+        margin: auto ${smallPadding} auto 0px;
         border: none;
         text-overflow: ellipsis;
+    }
+
+    :host([error-visible]) .control {
+        margin-right: 0px;
     }
 
     .control:hover,

--- a/packages/nimble-components/src/text-field/styles.ts
+++ b/packages/nimble-components/src/text-field/styles.ts
@@ -34,6 +34,7 @@ export const styles = css`
         outline: none;
         ${userSelectNone}
         color: ${bodyFontColor};
+        field-sizing: fixed;
         --ni-private-hover-indicator-width: calc(${borderWidth} + 1px);
         --ni-private-height-within-border: calc(
             ${controlHeight} - 2 * ${borderWidth}

--- a/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
@@ -1,6 +1,6 @@
 import type { StoryFn, Meta } from '@storybook/html-vite';
 import { html, ViewTemplate } from '@ni/fast-element';
-import { bodyFont, bodyFontColor, mediumPadding, standardPadding } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
+import { bodyFontColor, bodyPlus1EmphasizedFont, standardPadding } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { listOptionTag } from '@ni/nimble-components/dist/esm/list-option';
 import { comboboxTag } from '@ni/nimble-components/dist/esm/combobox';
 import { DropdownAppearance } from '@ni/nimble-components/dist/esm/patterns/dropdown/types';
@@ -247,91 +247,55 @@ export const blankListOption: StoryFn = createStory(
     </${comboboxTag}>`
 );
 
-export const fieldSizing: StoryFn = createStory(
-    html`
-        <style>
-            div {
-                display: flex;
-                flex-direction: column;
-                align-items: flex-start;
-                margin-bottom: var(${mediumPadding.cssCustomProperty});
-            }
-            label {
-                font: var(${bodyFont.cssCustomProperty});
-                color: var(${bodyFontColor.cssCustomProperty});
-            }
-            ${comboboxTag} {
-                border: 1px dashed;
-            }
-            .field-sizing-content ${comboboxTag} {
-                field-sizing: content;
-            }
-            .no-min-width ${comboboxTag} {
-                min-width: 0;
-            }
-            .fixed-width ${comboboxTag} {
-                width: 200px;
-            }
-            ${comboboxTag}[error-text] {
-                margin-bottom: var(${standardPadding.cssCustomProperty});
-            }
-        </style>
-        <div class="field-sizing-content no-min-width">
-            <label>field-sizing: content; min-width: 0;</label>
-            <${comboboxTag} value="tiny">
-                This is a Combobox
-                <${listOptionTag} value="1">Option 1</${listOptionTag}>
-            </${comboboxTag}>
-            <${comboboxTag} value="tiny">
-                <${listOptionTag} value="1">Option 1</${listOptionTag}>
-            </${comboboxTag}>
-            <${comboboxTag} error-text="Error text" error-visible value="tiny">
-                <${listOptionTag} value="1">Option 1</${listOptionTag}>
-            </${comboboxTag}>
-            <${comboboxTag} error-text="Error text, but this time longer" error-visible value="tiny">
-                <${listOptionTag} value="1">Option 1</${listOptionTag}>
-            </${comboboxTag}>
-        </div>
-        <div class="field-sizing-content">
-            <label>field-sizing: content;</label>
-            <${comboboxTag} value="tiny">
-                This is a Combobox
-                <${listOptionTag} value="1">Option 1</${listOptionTag}>
-            </${comboboxTag}>
-            <${comboboxTag} value="tiny">
-                <${listOptionTag} value="1">Option 1</${listOptionTag}>
-            </${comboboxTag}>
-            <${comboboxTag} value="value longer than the standard min-width">
-                <${listOptionTag} value="1">Option 1</${listOptionTag}>
-            </${comboboxTag}>
-            <${comboboxTag} error-text="Error text" error-visible value="tiny">
-                <${listOptionTag} value="1">Option 1</${listOptionTag}>
-            </${comboboxTag}>
-            <${comboboxTag} error-text="Error text, but this time longer" error-visible value="tiny">
-                <${listOptionTag} value="1">Option 1</${listOptionTag}>
-            </${comboboxTag}>
-        </div>
-        <div class="fixed-width">
-            <label>width: 200px;</label>
-            <${comboboxTag} value="tiny">
-                This is a Combobox
-                <${listOptionTag} value="1">Option 1</${listOptionTag}>
-            </${comboboxTag}>
-            <${comboboxTag} value="tiny">
-                <${listOptionTag} value="1">Option 1</${listOptionTag}>
-            </${comboboxTag}>
-            <${comboboxTag} value="value longer than the standard min-width">
-                <${listOptionTag} value="1">Option 1</${listOptionTag}>
-            </${comboboxTag}>
-            <${comboboxTag} error-text="Error text" error-visible value="tiny">
-                <${listOptionTag} value="1">Option 1</${listOptionTag}>
-            </${comboboxTag}>
-            <${comboboxTag} error-text="Error text, but this time longer" error-visible value="tiny">
-                <${listOptionTag} value="1">Option 1</${listOptionTag}>
-            </${comboboxTag}>
-        </div>
-    `
-);
+const fieldSizingTestCase = (
+    fieldSizingStyle: string,
+    [widthStyleLabel, widthStyles]: [string, string],
+    value: string,
+    errorString: string | undefined
+): ViewTemplate => html`
+    <${comboboxTag}
+        style="${fieldSizingStyle} ${widthStyles} ${errorString ? 'margin-bottom: 24px' : 'margin-bottom: 4px'}"
+        value="${value}"
+        ?error-visible="${() => errorString !== undefined}"
+        error-text="${() => errorString}"
+    >
+        ${widthStyleLabel}
+        <${listOptionTag} value="1">Option 1</${listOptionTag}>
+    </${comboboxTag}>
+`;
+
+export const fieldSizing: StoryFn = createStory(html`
+    <style>
+        div {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+        }
+        label {
+            font: var(${bodyPlus1EmphasizedFont.cssCustomProperty});
+            color: var(${bodyFontColor.cssCustomProperty});
+            margin-bottom: 6px;
+        }
+    </style>
+    <label>field-sizing=content (no min-width unless specified)</label>
+    ${createMatrix(fieldSizingTestCase, [
+        ['field-sizing: content;'],
+        [
+            ['', 'min-width: 0;'],
+            ['min-width=176px', ''],
+            ['width=300px', 'width: 300px;'],
+        ],
+        ['tiny', 'Text longer than the default width.'],
+        [undefined, 'Error text is helpful']
+    ])}
+    <label>Default styling (min-width=176px)</label>
+    ${createMatrix(fieldSizingTestCase, [
+        [''],
+        [['', '']],
+        ['tiny', 'Text longer than the default width.'],
+        [undefined, 'Error text is helpful']
+    ])}
+`);
 
 export const heightTest: StoryFn = createStory(
     html`

--- a/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
@@ -1,6 +1,6 @@
 import type { StoryFn, Meta } from '@storybook/html-vite';
 import { html, ViewTemplate } from '@ni/fast-element';
-import { bodyFontColor, bodyPlus1EmphasizedFont, standardPadding } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
+import { bodyFont, bodyFontColor, standardPadding } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { listOptionTag } from '@ni/nimble-components/dist/esm/list-option';
 import { comboboxTag } from '@ni/nimble-components/dist/esm/combobox';
 import { DropdownAppearance } from '@ni/nimble-components/dist/esm/patterns/dropdown/types';
@@ -19,6 +19,14 @@ import {
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { loremIpsum } from '../../utilities/lorem-ipsum';
+import {
+    fieldSizingStates,
+    type FieldSizingState,
+    fieldSizingErrorStates,
+    type FieldSizingErrorState,
+    fieldSizingLabelStates,
+    type FieldSizingLabelState
+} from '../patterns/field-sizing/states';
 
 const appearanceStates = [
     ['Underline', DropdownAppearance.underline],
@@ -247,55 +255,66 @@ export const blankListOption: StoryFn = createStory(
     </${comboboxTag}>`
 );
 
-const fieldSizingTestCase = (
-    fieldSizingStyle: string,
-    [widthStyleLabel, widthStyles]: [string, string],
-    value: string,
-    errorString: string | undefined
+const fieldSizingWidthStates = [
+    ['Default', ''],
+    ['min-width=0', 'min-width: 0;'],
+    ['width=300px', 'width: 300px;']
+] as const;
+type FieldSizingWidthState = (typeof fieldSizingWidthStates)[number];
+
+const fieldSizingValueStates = [
+    ['Blank', '', ''],
+    ['Placeholder Short', '', 'tiny'],
+    ['Placeholder Long', '', 'Placeholder longer than the default width'],
+    ['Short', 'tiny', ''],
+    ['Long', 'Text longer than the default width', '']
+] as const;
+type FieldSizingValueState = (typeof fieldSizingValueStates)[number];
+
+const fieldSizingComponent = (
+    [widthName, widthStyles]: FieldSizingWidthState,
+    [errorName, errorString]: FieldSizingErrorState,
+    [labelName, label]: FieldSizingLabelState,
+    [fieldSizingName, fieldSizingStyle]: FieldSizingState,
+    [valueName, value, placeholder]: FieldSizingValueState
 ): ViewTemplate => html`
-    <${comboboxTag}
-        style="${fieldSizingStyle} ${widthStyles} ${errorString ? 'margin-bottom: 24px' : 'margin-bottom: 4px'}"
-        value="${value}"
-        ?error-visible="${() => errorString !== undefined}"
-        error-text="${() => errorString}"
-    >
-        ${widthStyleLabel}
-        <${listOptionTag} value="1">Option 1</${listOptionTag}>
-    </${comboboxTag}>
+    <div style="display: inline-flex; flex-direction: column; align-items: flex-start; width: min-content;">
+        <div style="width: 400px; box-sizing: border-box;">Width(${widthName}) Error(${errorName}) Label(${labelName}) FieldSizing(${fieldSizingName}) Value(${valueName})</div>
+        <${comboboxTag}
+            style="${fieldSizingStyle} ${widthStyles} ${errorString ? 'margin-bottom: 24px' : 'margin-bottom: 4px'}"
+            value="${() => value}"
+            placeholder="${() => placeholder}"
+            ?error-visible="${() => errorString !== undefined}"
+            error-text="${() => errorString}"
+        >
+            ${() => label}
+            <${listOptionTag} value="1">Option 1</${listOptionTag}>
+        </${comboboxTag}>
+    </div>
 `;
 
-export const fieldSizing: StoryFn = createStory(html`
-    <style>
-        div {
-            display: flex;
-            flex-direction: column;
-            align-items: flex-start;
-        }
-        label {
-            font: var(${bodyPlus1EmphasizedFont.cssCustomProperty});
-            color: var(${bodyFontColor.cssCustomProperty});
-            margin-bottom: 6px;
-        }
-    </style>
-    <label>field-sizing=content (no min-width unless specified)</label>
-    ${createMatrix(fieldSizingTestCase, [
-        ['field-sizing: content;'],
-        [
-            ['', 'min-width: 0;'],
-            ['min-width=176px', ''],
-            ['width=300px', 'width: 300px;'],
-        ],
-        ['tiny', 'Text longer than the default width.'],
-        [undefined, 'Error text is helpful']
-    ])}
-    <label>Default styling (min-width=176px)</label>
-    ${createMatrix(fieldSizingTestCase, [
-        [''],
-        [['', '']],
-        ['tiny', 'Text longer than the default width.'],
-        [undefined, 'Error text is helpful']
-    ])}
-`);
+const fieldSizingMatrixTemplate = (template: ViewTemplate): ViewTemplate => html`
+    <div style="
+        display: grid;
+        grid-template-columns: ${'1fr '.repeat(fieldSizingValueStates.length)};
+        font: var(${bodyFont.cssCustomProperty});
+        color: var(${bodyFontColor.cssCustomProperty});
+        width: 1800px;
+    ">
+    ${template}
+    </div>
+`;
+
+export const fieldSizing: StoryFn = createFixedThemeStory(
+    fieldSizingMatrixTemplate(createMatrix(fieldSizingComponent, [
+        fieldSizingWidthStates,
+        fieldSizingErrorStates,
+        fieldSizingLabelStates,
+        fieldSizingStates,
+        fieldSizingValueStates
+    ])),
+    lightThemeWhiteBackground
+);
 
 export const heightTest: StoryFn = createStory(
     html`

--- a/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
@@ -1,6 +1,6 @@
 import type { StoryFn, Meta } from '@storybook/html-vite';
 import { html, ViewTemplate } from '@ni/fast-element';
-import { standardPadding } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
+import { controlLabelFont, controlLabelFontColor, standardPadding } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { listOptionTag } from '@ni/nimble-components/dist/esm/list-option';
 import { comboboxTag } from '@ni/nimble-components/dist/esm/combobox';
 import { DropdownAppearance } from '@ni/nimble-components/dist/esm/patterns/dropdown/types';
@@ -245,6 +245,55 @@ export const blankListOption: StoryFn = createStory(
         <${listOptionTag} value="1">Option 1</${listOptionTag}>
         <${listOptionTag}></${listOptionTag}>
     </${comboboxTag}>`
+);
+
+export const fieldSizing: StoryFn = createStory(
+    html`
+        <style>
+            label {
+                font: var(${controlLabelFont.cssCustomProperty});
+                color: var(${controlLabelFontColor.cssCustomProperty})
+            }
+        </style>
+        <div style="display: flex; flex-direction: column">
+            <label>Setting field-sizing=content & min-width=0</label>
+            <div>
+                <${comboboxTag} style="border: 1px dashed; field-sizing: content; min-width: 0;" value="tiny">
+                    field-sizing:content
+                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
+                </${comboboxTag}>
+                <${comboboxTag} style="border: 1px dashed; field-sizing: content; min-width: 0;" value="tiny">
+                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
+                </${comboboxTag}>
+            </div>
+            <label>Setting field-sizing=content with default min-width (menu-min-width)</label>
+            <div>
+                <${comboboxTag} style="border: 1px dashed; field-sizing: content;" value="tiny">
+                    field-sizing:content
+                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
+                </${comboboxTag}>
+                <${comboboxTag} style="border: 1px dashed; field-sizing: content;" value="tiny">
+                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
+                </${comboboxTag}>
+                <${comboboxTag} style="border: 1px dashed; field-sizing: content;" value="value longer than the standard min-width">
+                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
+                </${comboboxTag}>
+            </div>
+            <label>Default field-sizing (fixed)</label>
+            <div>
+                <${comboboxTag} style="border: 1px dashed;" value="tiny">
+                    Default field-sizing
+                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
+                </${comboboxTag}>
+                <${comboboxTag} style="border: 1px dashed;" value="tiny">
+                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
+                </${comboboxTag}>
+                <${comboboxTag} style="border: 1px dashed;" value="value longer than the standard min-width">
+                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
+                </${comboboxTag}>
+            </div>
+        </div>
+    `
 );
 
 export const heightTest: StoryFn = createStory(

--- a/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
+++ b/packages/storybook/src/nimble/combobox/combobox-matrix.stories.ts
@@ -1,6 +1,6 @@
 import type { StoryFn, Meta } from '@storybook/html-vite';
 import { html, ViewTemplate } from '@ni/fast-element';
-import { controlLabelFont, controlLabelFontColor, standardPadding } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
+import { bodyFont, bodyFontColor, mediumPadding, standardPadding } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { listOptionTag } from '@ni/nimble-components/dist/esm/list-option';
 import { comboboxTag } from '@ni/nimble-components/dist/esm/combobox';
 import { DropdownAppearance } from '@ni/nimble-components/dist/esm/patterns/dropdown/types';
@@ -250,48 +250,85 @@ export const blankListOption: StoryFn = createStory(
 export const fieldSizing: StoryFn = createStory(
     html`
         <style>
+            div {
+                display: flex;
+                flex-direction: column;
+                align-items: flex-start;
+                margin-bottom: var(${mediumPadding.cssCustomProperty});
+            }
             label {
-                font: var(${controlLabelFont.cssCustomProperty});
-                color: var(${controlLabelFontColor.cssCustomProperty})
+                font: var(${bodyFont.cssCustomProperty});
+                color: var(${bodyFontColor.cssCustomProperty});
+            }
+            ${comboboxTag} {
+                border: 1px dashed;
+            }
+            .field-sizing-content ${comboboxTag} {
+                field-sizing: content;
+            }
+            .no-min-width ${comboboxTag} {
+                min-width: 0;
+            }
+            .fixed-width ${comboboxTag} {
+                width: 200px;
+            }
+            ${comboboxTag}[error-text] {
+                margin-bottom: var(${standardPadding.cssCustomProperty});
             }
         </style>
-        <div style="display: flex; flex-direction: column">
-            <label>Setting field-sizing=content & min-width=0</label>
-            <div>
-                <${comboboxTag} style="border: 1px dashed; field-sizing: content; min-width: 0;" value="tiny">
-                    field-sizing:content
-                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
-                </${comboboxTag}>
-                <${comboboxTag} style="border: 1px dashed; field-sizing: content; min-width: 0;" value="tiny">
-                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
-                </${comboboxTag}>
-            </div>
-            <label>Setting field-sizing=content with default min-width (menu-min-width)</label>
-            <div>
-                <${comboboxTag} style="border: 1px dashed; field-sizing: content;" value="tiny">
-                    field-sizing:content
-                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
-                </${comboboxTag}>
-                <${comboboxTag} style="border: 1px dashed; field-sizing: content;" value="tiny">
-                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
-                </${comboboxTag}>
-                <${comboboxTag} style="border: 1px dashed; field-sizing: content;" value="value longer than the standard min-width">
-                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
-                </${comboboxTag}>
-            </div>
-            <label>Default field-sizing (fixed)</label>
-            <div>
-                <${comboboxTag} style="border: 1px dashed;" value="tiny">
-                    Default field-sizing
-                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
-                </${comboboxTag}>
-                <${comboboxTag} style="border: 1px dashed;" value="tiny">
-                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
-                </${comboboxTag}>
-                <${comboboxTag} style="border: 1px dashed;" value="value longer than the standard min-width">
-                    <${listOptionTag} value="1">Option 1</${listOptionTag}>
-                </${comboboxTag}>
-            </div>
+        <div class="field-sizing-content no-min-width">
+            <label>field-sizing: content; min-width: 0;</label>
+            <${comboboxTag} value="tiny">
+                This is a Combobox
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${comboboxTag}>
+            <${comboboxTag} value="tiny">
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${comboboxTag}>
+            <${comboboxTag} error-text="Error text" error-visible value="tiny">
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${comboboxTag}>
+            <${comboboxTag} error-text="Error text, but this time longer" error-visible value="tiny">
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${comboboxTag}>
+        </div>
+        <div class="field-sizing-content">
+            <label>field-sizing: content;</label>
+            <${comboboxTag} value="tiny">
+                This is a Combobox
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${comboboxTag}>
+            <${comboboxTag} value="tiny">
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${comboboxTag}>
+            <${comboboxTag} value="value longer than the standard min-width">
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${comboboxTag}>
+            <${comboboxTag} error-text="Error text" error-visible value="tiny">
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${comboboxTag}>
+            <${comboboxTag} error-text="Error text, but this time longer" error-visible value="tiny">
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${comboboxTag}>
+        </div>
+        <div class="fixed-width">
+            <label>width: 200px;</label>
+            <${comboboxTag} value="tiny">
+                This is a Combobox
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${comboboxTag}>
+            <${comboboxTag} value="tiny">
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${comboboxTag}>
+            <${comboboxTag} value="value longer than the standard min-width">
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${comboboxTag}>
+            <${comboboxTag} error-text="Error text" error-visible value="tiny">
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${comboboxTag}>
+            <${comboboxTag} error-text="Error text, but this time longer" error-visible value="tiny">
+                <${listOptionTag} value="1">Option 1</${listOptionTag}>
+            </${comboboxTag}>
         </div>
     `
 );

--- a/packages/storybook/src/nimble/combobox/combobox.mdx
+++ b/packages/storybook/src/nimble/combobox/combobox.mdx
@@ -11,6 +11,7 @@ import { comboboxTag } from '@ni/nimble-components/dist/esm/combobox/';
 import { listOptionTag } from '@ni/nimble-components/dist/esm/list-option/';
 import { selectTag } from '@ni/nimble-components/dist/esm/select/';
 import { Tag } from '../../utilities/story-layout';
+import FieldSizingDocs from '../patterns/field-sizing.mdx';
 
 <Meta of={comboboxStories} />
 <Title of={comboboxStories} />
@@ -31,19 +32,21 @@ to those in the list. .
 <Controls of={comboboxStories.combobox} />
 <ComponentApisLink />
 
-{/* ## Styling */}
+## Styling
+
+<FieldSizingDocs hasMinWidth={true} />
 
 {/* ## Usage */}
 
 {/* ## Examples */}
 
-### Native element and Blazor
+## Native element and Blazor
 
 The value of the combobox comes from the text content of the selected
 autocomplete <Tag name={listOptionTag} />, or, if no matching autocomplete is
 found, the value is the user-entered text.
 
-### Angular
+## Angular
 
 In Angular, an autocomplete <Tag name={listOptionTag} /> can be created with an
 `ngValue`. In that case the `ngModel` of the combobox will be the `ngValue` of

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -2,6 +2,7 @@ import type { StoryFn, Meta } from '@storybook/html-vite';
 import { html, ViewTemplate } from '@ni/fast-element';
 import { numberFieldTag } from '@ni/nimble-components/dist/esm/number-field';
 import { NumberFieldAppearance } from '@ni/nimble-components/dist/esm/number-field/types';
+import { bodyFont, bodyFontColor, mediumPadding, standardPadding } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { createFixedThemeStory, createStory } from '../../utilities/storybook';
 import {
     createMatrixThemeStory,
@@ -259,21 +260,65 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
 
 export const fieldSizing: StoryFn = createStory(
     html`
-        <div style="display: flex; flex-direction: column">
-            <div>
-                <${numberFieldTag} style="border: 1px dashed; field-sizing: content;" value="1.234">
-                    field-sizing:content
-                </${numberFieldTag}>
-                <${numberFieldTag} style="border: 1px dashed; field-sizing: content;" value="1.234">
-                </${numberFieldTag}>
-            </div>
-            <div>
-                <${numberFieldTag} style="border: 1px dashed;" value="1.234">
-                    Default field-sizing
-                </${numberFieldTag}>
-                <${numberFieldTag} style="border: 1px dashed;" value="1.234">
-                </${numberFieldTag}>
-            </div>
+        <style>
+            div {
+                display: flex;
+                flex-direction: column;
+                align-items: flex-start;
+                margin-bottom: var(${mediumPadding.cssCustomProperty});
+            }
+            label {
+                font: var(${bodyFont.cssCustomProperty});
+                color: var(${bodyFontColor.cssCustomProperty});
+            }
+            ${numberFieldTag} {
+                border: 1px dashed;
+            }
+            .field-sizing-content ${numberFieldTag} {
+                field-sizing: content;
+            }
+            .fixed-width ${numberFieldTag} {
+                width: 200px;
+            }
+            ${numberFieldTag}[error-text] {
+                margin-bottom: var(${standardPadding.cssCustomProperty});
+            }
+        </style>
+        <div class="field-sizing-content">
+            <label>field-sizing: content;</label>
+            <${numberFieldTag} value="1.234">
+                This is a Number Field
+            </${numberFieldTag}>
+            <${numberFieldTag} value="1.234">
+            </${numberFieldTag}>
+            <${numberFieldTag} value="1.234" hide-step>
+            </${numberFieldTag}>
+            <${numberFieldTag} value="12345678901234">
+            </${numberFieldTag}>
+            <${numberFieldTag} placeholder="Enter a number">
+            </${numberFieldTag}>
+            <${numberFieldTag} error-text="Error text" error-visible value="1.234">
+            </${numberFieldTag}>
+            <${numberFieldTag} error-text="Error text, but this time longer" error-visible value="1.234">
+            </${numberFieldTag}>
+        </div>
+        <div class="fixed-width">
+            <label>width: 200px;</label>
+            <${numberFieldTag} value="1.234">
+                This is a Number Field
+            </${numberFieldTag}>
+            <${numberFieldTag} value="1.234">
+            </${numberFieldTag}>
+            <${numberFieldTag} value="1.234" hide-step>
+            </${numberFieldTag}>
+            <${numberFieldTag} value="12345678901234">
+            </${numberFieldTag}>
+            <${numberFieldTag} placeholder="Enter a number">
+            </${numberFieldTag}>
+            <${numberFieldTag} error-text="Error text" error-visible value="1.234">
+            </${numberFieldTag}>
+            <${numberFieldTag} error-text="Error text, but this time longer" error-visible value="1.234">
+            </${numberFieldTag}>
         </div>
     `
 );

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -2,7 +2,7 @@ import type { StoryFn, Meta } from '@storybook/html-vite';
 import { html, ViewTemplate } from '@ni/fast-element';
 import { numberFieldTag } from '@ni/nimble-components/dist/esm/number-field';
 import { NumberFieldAppearance } from '@ni/nimble-components/dist/esm/number-field/types';
-import { bodyFont, bodyFontColor, mediumPadding, standardPadding } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
+import { bodyFontColor, bodyPlus1EmphasizedFont } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { createFixedThemeStory, createStory } from '../../utilities/storybook';
 import {
     createMatrixThemeStory,
@@ -258,70 +258,63 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
     )
 );
 
-export const fieldSizing: StoryFn = createStory(
-    html`
-        <style>
-            div {
-                display: flex;
-                flex-direction: column;
-                align-items: flex-start;
-                margin-bottom: var(${mediumPadding.cssCustomProperty});
-            }
-            label {
-                font: var(${bodyFont.cssCustomProperty});
-                color: var(${bodyFontColor.cssCustomProperty});
-            }
-            ${numberFieldTag} {
-                border: 1px dashed;
-            }
-            .field-sizing-content ${numberFieldTag} {
-                field-sizing: content;
-            }
-            .fixed-width ${numberFieldTag} {
-                width: 200px;
-            }
-            ${numberFieldTag}[error-text] {
-                margin-bottom: var(${standardPadding.cssCustomProperty});
-            }
-        </style>
-        <div class="field-sizing-content">
-            <label>field-sizing: content;</label>
-            <${numberFieldTag} value="1.234">
-                This is a Number Field
-            </${numberFieldTag}>
-            <${numberFieldTag} value="1.234">
-            </${numberFieldTag}>
-            <${numberFieldTag} value="1.234" hide-step>
-            </${numberFieldTag}>
-            <${numberFieldTag} value="12345678901234">
-            </${numberFieldTag}>
-            <${numberFieldTag} placeholder="Enter a number">
-            </${numberFieldTag}>
-            <${numberFieldTag} error-text="Error text" error-visible value="1.234">
-            </${numberFieldTag}>
-            <${numberFieldTag} error-text="Error text, but this time longer" error-visible value="1.234">
-            </${numberFieldTag}>
-        </div>
-        <div class="fixed-width">
-            <label>width: 200px;</label>
-            <${numberFieldTag} value="1.234">
-                This is a Number Field
-            </${numberFieldTag}>
-            <${numberFieldTag} value="1.234">
-            </${numberFieldTag}>
-            <${numberFieldTag} value="1.234" hide-step>
-            </${numberFieldTag}>
-            <${numberFieldTag} value="12345678901234">
-            </${numberFieldTag}>
-            <${numberFieldTag} placeholder="Enter a number">
-            </${numberFieldTag}>
-            <${numberFieldTag} error-text="Error text" error-visible value="1.234">
-            </${numberFieldTag}>
-            <${numberFieldTag} error-text="Error text, but this time longer" error-visible value="1.234">
-            </${numberFieldTag}>
-        </div>
-    `
-);
+const fieldSizingTestCase = (
+    fieldSizingStyle: string,
+    [widthLabel, widthStyles]: [string, string],
+    value: string,
+    hideStep: boolean,
+    errorString: string | undefined,
+): ViewTemplate => html`
+    <${numberFieldTag}
+        appearance="${() => NumberFieldAppearance.outline}"
+        style="${fieldSizingStyle} ${widthStyles} ${errorString ? 'margin-bottom: 24px' : 'margin-bottom: 4px'}"
+        value="${value}"
+        ?error-visible="${() => errorString !== undefined}"
+        error-text="${() => errorString}"
+        ?hide-step="${() => hideStep}"
+    >
+        ${widthLabel}
+    </${numberFieldTag}>
+`;
+
+export const fieldSizing: StoryFn = createStory(html`
+    <style>
+        div {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+        }
+        label {
+            font: var(${bodyPlus1EmphasizedFont.cssCustomProperty});
+            color: var(${bodyFontColor.cssCustomProperty});
+            margin-bottom: 6px;
+        }
+    </style>
+    <label>field-sizing=content</label>
+    ${createMatrix(fieldSizingTestCase, [
+        ['field-sizing: content;'],
+        [['', ''], ['width=120px', 'width: 120px;']],
+        ['1.234', '12345678901234'],
+        [false, true],
+        [undefined, 'Error text is helpful'],
+    ])}
+    <label>fixed width</label>
+    ${createMatrix(fieldSizingTestCase, [
+        [''],
+        [['width=120px', 'width: 120px;']],
+        ['1.234', '12345678901234'],
+        [false, true],
+        [undefined, 'Error text is helpful'],
+    ])}
+    <label>Default styling</label>
+    ${createMatrix(fieldSizingTestCase, [
+        [''],
+        [['', '']],
+        ['1.234', '12345678901234'],
+        [false, true],
+        [undefined, 'Error text is helpful'],
+    ])}
+`);
 
 export const heightTest: StoryFn = createStory(
     html`

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -2,7 +2,7 @@ import type { StoryFn, Meta } from '@storybook/html-vite';
 import { html, ViewTemplate } from '@ni/fast-element';
 import { numberFieldTag } from '@ni/nimble-components/dist/esm/number-field';
 import { NumberFieldAppearance } from '@ni/nimble-components/dist/esm/number-field/types';
-import { bodyFontColor, bodyPlus1EmphasizedFont } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
+import { bodyFont, bodyFontColor } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { createFixedThemeStory, createStory } from '../../utilities/storybook';
 import {
     createMatrixThemeStory,
@@ -27,6 +27,14 @@ import {
 } from '../../utilities/states';
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
+import {
+    fieldSizingStates,
+    type FieldSizingState,
+    fieldSizingErrorStates,
+    type FieldSizingErrorState,
+    fieldSizingLabelStates,
+    type FieldSizingLabelState
+} from '../patterns/field-sizing/states';
 
 const appearanceStates = [
     ['Underline', NumberFieldAppearance.underline],
@@ -258,63 +266,70 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
     )
 );
 
-const fieldSizingTestCase = (
-    fieldSizingStyle: string,
-    [widthLabel, widthStyles]: [string, string],
-    value: string,
-    hideStep: boolean,
-    errorString: string | undefined,
+const fieldSizingWidthStates = [
+    ['Default', ''],
+    ['120px', 'width: 120px;']
+] as const;
+type FieldSizingWidthState = (typeof fieldSizingWidthStates)[number];
+
+const fieldSizingValueStates = [
+    ['Short', '1.234'],
+    ['Long', '12345678901234']
+] as const;
+type FieldSizingValueState = (typeof fieldSizingValueStates)[number];
+
+const fieldSizingHideStepStates = [
+    ['Shown', false],
+    ['Hidden', true]
+] as const;
+type FieldSizingHideStepState = (typeof fieldSizingHideStepStates)[number];
+
+const fieldSizingComponent = (
+    [widthName, widthStyles]: FieldSizingWidthState,
+    [hideStepName, hideStep]: FieldSizingHideStepState,
+    [errorName, errorString]: FieldSizingErrorState,
+    [labelName, label]: FieldSizingLabelState,
+    [fieldSizingName, fieldSizingStyle]: FieldSizingState,
+    [valueName, value]: FieldSizingValueState
 ): ViewTemplate => html`
-    <${numberFieldTag}
-        appearance="${() => NumberFieldAppearance.outline}"
-        style="${fieldSizingStyle} ${widthStyles} ${errorString ? 'margin-bottom: 24px' : 'margin-bottom: 4px'}"
-        value="${value}"
-        ?error-visible="${() => errorString !== undefined}"
-        error-text="${() => errorString}"
-        ?hide-step="${() => hideStep}"
-    >
-        ${widthLabel}
-    </${numberFieldTag}>
+    <div style="display: inline-flex; flex-direction: column; align-items: flex-start; width: min-content;">
+        <div style="width: 480px; box-sizing: border-box;">Width(${widthName}) HideStep(${hideStepName}) Error(${errorName}) Label(${labelName}) FieldSizing(${fieldSizingName}) Value(${valueName})</div>
+        <${numberFieldTag}
+            appearance="${() => NumberFieldAppearance.outline}"
+            style="${fieldSizingStyle} ${widthStyles} ${errorString ? 'margin-bottom: 24px' : 'margin-bottom: 4px'}"
+            value="${() => value}"
+            ?error-visible="${() => errorString !== undefined}"
+            error-text="${() => errorString}"
+            ?hide-step="${() => hideStep}"
+        >
+            ${() => label}
+        </${numberFieldTag}>
+    </div>
 `;
 
-export const fieldSizing: StoryFn = createStory(html`
-    <style>
-        div {
-            display: flex;
-            flex-direction: column;
-            align-items: flex-start;
-        }
-        label {
-            font: var(${bodyPlus1EmphasizedFont.cssCustomProperty});
-            color: var(${bodyFontColor.cssCustomProperty});
-            margin-bottom: 6px;
-        }
-    </style>
-    <label>field-sizing=content</label>
-    ${createMatrix(fieldSizingTestCase, [
-        ['field-sizing: content;'],
-        [['', ''], ['width=120px', 'width: 120px;']],
-        ['1.234', '12345678901234'],
-        [false, true],
-        [undefined, 'Error text is helpful'],
-    ])}
-    <label>fixed width</label>
-    ${createMatrix(fieldSizingTestCase, [
-        [''],
-        [['width=120px', 'width: 120px;']],
-        ['1.234', '12345678901234'],
-        [false, true],
-        [undefined, 'Error text is helpful'],
-    ])}
-    <label>Default styling</label>
-    ${createMatrix(fieldSizingTestCase, [
-        [''],
-        [['', '']],
-        ['1.234', '12345678901234'],
-        [false, true],
-        [undefined, 'Error text is helpful'],
-    ])}
-`);
+const fieldSizingMatrixTemplate = (template: ViewTemplate): ViewTemplate => html`
+    <div style="
+        display: grid;
+        grid-template-columns: ${'1fr '.repeat(fieldSizingValueStates.length)};
+        font: var(${bodyFont.cssCustomProperty});
+        color: var(${bodyFontColor.cssCustomProperty});
+        width: 1100px;
+    ">
+    ${template}
+    </div>
+`;
+
+export const fieldSizing: StoryFn = createFixedThemeStory(
+    fieldSizingMatrixTemplate(createMatrix(fieldSizingComponent, [
+        fieldSizingWidthStates,
+        fieldSizingHideStepStates,
+        fieldSizingErrorStates,
+        fieldSizingLabelStates,
+        fieldSizingStates,
+        fieldSizingValueStates
+    ])),
+    lightThemeWhiteBackground
+);
 
 export const heightTest: StoryFn = createStory(
     html`

--- a/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/number-field/number-field-matrix.stories.ts
@@ -257,6 +257,27 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
     )
 );
 
+export const fieldSizing: StoryFn = createStory(
+    html`
+        <div style="display: flex; flex-direction: column">
+            <div>
+                <${numberFieldTag} style="border: 1px dashed; field-sizing: content;" value="1.234">
+                    field-sizing:content
+                </${numberFieldTag}>
+                <${numberFieldTag} style="border: 1px dashed; field-sizing: content;" value="1.234">
+                </${numberFieldTag}>
+            </div>
+            <div>
+                <${numberFieldTag} style="border: 1px dashed;" value="1.234">
+                    Default field-sizing
+                </${numberFieldTag}>
+                <${numberFieldTag} style="border: 1px dashed;" value="1.234">
+                </${numberFieldTag}>
+            </div>
+        </div>
+    `
+);
+
 export const heightTest: StoryFn = createStory(
     html`
         <div style="display: flex; flex-direction: column">

--- a/packages/storybook/src/nimble/number-field/number-field.mdx
+++ b/packages/storybook/src/nimble/number-field/number-field.mdx
@@ -21,7 +21,7 @@ of the `lang` token, which can be set via the
 
 ## Styling
 
-<FieldSizingDocs hasMinWidth={true} />
+<FieldSizingDocs />
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/number-field/number-field.mdx
+++ b/packages/storybook/src/nimble/number-field/number-field.mdx
@@ -1,6 +1,7 @@
 import { Canvas, Meta, Controls, Title } from '@storybook/addon-docs/blocks';
 import * as numberFieldStories from './number-field.stories';
 import ComponentApisLink from '../../docs/component-apis-link.mdx';
+import FieldSizingDocs from '../patterns/field-sizing.mdx';
 
 <Meta of={numberFieldStories} />
 <Title of={numberFieldStories} />
@@ -18,7 +19,9 @@ of the `lang` token, which can be set via the
 <Controls of={numberFieldStories.numberField} />
 <ComponentApisLink />
 
-{/* ## Styling */}
+## Styling
+
+<FieldSizingDocs hasMinWidth={true} />
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/patterns/field-sizing.mdx
+++ b/packages/storybook/src/nimble/patterns/field-sizing.mdx
@@ -1,0 +1,4 @@
+### Auto-sizing
+
+Apply the CSS property `field-sizing: content` to the element to allow it to grow and shrink automatically
+based on the size of its content. {props.multiLine && 'For input text to wrap to a new line and grow the element vertically, the width must be constrained.'} {props.hasMinWidth && <>{"Note that the element's width will not shrink smaller than the value of the "}<code>min-width</code>{" CSS property or the width of the label."}</>}

--- a/packages/storybook/src/nimble/patterns/field-sizing/states.ts
+++ b/packages/storybook/src/nimble/patterns/field-sizing/states.ts
@@ -1,0 +1,22 @@
+// States shared across the `field-sizing` matrix stories of the various
+// text-input-like components (text-field, text-area, number-field, combobox).
+// Only states that are naturally identical across those components live here;
+// component-specific dimensions (width, value, etc.) stay in each story file.
+
+export const fieldSizingStates = [
+    ['Default', ''],
+    ['Content', 'field-sizing: content;']
+] as const;
+export type FieldSizingState = (typeof fieldSizingStates)[number];
+
+export const fieldSizingErrorStates = [
+    ['None', undefined],
+    ['Visible', 'Error text is helpful']
+] as const;
+export type FieldSizingErrorState = (typeof fieldSizingErrorStates)[number];
+
+export const fieldSizingLabelStates = [
+    ['Short', 'Label'],
+    ['Long', 'A longer label that is much longer than the default width']
+] as const;
+export type FieldSizingLabelState = (typeof fieldSizingLabelStates)[number];

--- a/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
@@ -2,7 +2,7 @@ import type { StoryFn, Meta } from '@storybook/html-vite';
 import { html, ViewTemplate } from '@ni/fast-element';
 import { textAreaTag } from '@ni/nimble-components/dist/esm/text-area';
 import { TextAreaAppearance } from '@ni/nimble-components/dist/esm/text-area/types';
-import { bodyFontColor, bodyPlus1EmphasizedFont } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
+import { bodyFont, bodyFontColor } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { createFixedThemeStory, createStory } from '../../utilities/storybook';
 import {
     createMatrixThemeStory,
@@ -21,6 +21,14 @@ import {
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
 import { loremIpsum } from '../../utilities/lorem-ipsum';
+import {
+    fieldSizingStates,
+    type FieldSizingState,
+    fieldSizingErrorStates,
+    type FieldSizingErrorState,
+    fieldSizingLabelStates,
+    type FieldSizingLabelState
+} from '../patterns/field-sizing/states';
 
 const appearanceStates = [
     ['Outline', TextAreaAppearance.outline],
@@ -191,54 +199,62 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
     )
 );
 
-const fieldSizingTestCase = (
-    fieldSizingStyle: string,
-    [widthStyleLabel, widthStyles]: [string, string],
-    value: string,
-    errorString: string | undefined
+const fieldSizingWidthStates = [
+    ['Default', ''],
+    ['min-width=0', 'min-width: 0;'],
+    ['width=200px', 'width: 200px;']
+] as const;
+type FieldSizingWidthState = (typeof fieldSizingWidthStates)[number];
+
+const fieldSizingValueStates = [
+    ['Short', 'tiny'],
+    ['Long', 'Text longer than the default width'],
+    ['Multiline', 'line 1\nline 2\nline 3']
+] as const;
+type FieldSizingValueState = (typeof fieldSizingValueStates)[number];
+
+const fieldSizingComponent = (
+    [widthName, widthStyles]: FieldSizingWidthState,
+    [errorName, errorString]: FieldSizingErrorState,
+    [labelName, label]: FieldSizingLabelState,
+    [fieldSizingName, fieldSizingStyle]: FieldSizingState,
+    [valueName, value]: FieldSizingValueState
 ): ViewTemplate => html`
-    <${textAreaTag}
-        style="${fieldSizingStyle} ${widthStyles} ${errorString ? 'margin-bottom: 24px' : 'margin-bottom: 4px'}"
-        value="${value}"
-        ?error-visible="${() => errorString !== undefined}"
-        error-text="${() => errorString}"
-    >
-        ${widthStyleLabel}
-    </${textAreaTag}>
+    <div style="display: inline-flex; flex-direction: column; align-items: flex-start; width: min-content;">
+        <div style="width: 480px; box-sizing: border-box;">Width(${widthName}) Error(${errorName}) Label(${labelName}) FieldSizing(${fieldSizingName}) Value(${valueName})</div>
+        <${textAreaTag}
+            style="${fieldSizingStyle} ${widthStyles} ${errorString ? 'margin-bottom: 24px' : 'margin-bottom: 4px'}"
+            value="${() => value}"
+            ?error-visible="${() => errorString !== undefined}"
+            error-text="${() => errorString}"
+        >
+            ${() => label}
+        </${textAreaTag}>
+    </div>
 `;
 
-export const fieldSizing: StoryFn = createStory(html`
-    <style>
-        div {
-            display: flex;
-            flex-direction: column;
-            align-items: flex-start;
-        }
-        label {
-            font: var(${bodyPlus1EmphasizedFont.cssCustomProperty});
-            color: var(${bodyFontColor.cssCustomProperty});
-            margin-bottom: 6px;
-        }
-    </style>
-    <label>field-sizing=content (no min-width unless specified)</label>
-    ${createMatrix(fieldSizingTestCase, [
-        ['field-sizing: content;'],
-        [
-            ['', 'min-width: 0;'],
-            ['min-width=100px', ''],
-            ['width=200px', 'width: 200px;'],
-        ],
-        ['tiny', 'Text longer than the default width.', 'line 1\nline 2\nline 3'],
-        [undefined, 'Error text is helpful']
-    ])}
-    <label>Default styling (size=20, and rows=2)</label>
-    ${createMatrix(fieldSizingTestCase, [
-        [''],
-        [['', '']],
-        ['tiny', 'Text longer than the default width.', 'line 1\nline 2\nline 3'],
-        [undefined, 'Error text is helpful']
-    ])}
-`);
+const fieldSizingMatrixTemplate = (template: ViewTemplate): ViewTemplate => html`
+    <div style="
+        display: grid;
+        grid-template-columns: ${'1fr '.repeat(fieldSizingValueStates.length)};
+        font: var(${bodyFont.cssCustomProperty});
+        color: var(${bodyFontColor.cssCustomProperty});
+        width: 1500px;
+    ">
+    ${template}
+    </div>
+`;
+
+export const fieldSizing: StoryFn = createFixedThemeStory(
+    fieldSizingMatrixTemplate(createMatrix(fieldSizingComponent, [
+        fieldSizingWidthStates,
+        fieldSizingErrorStates,
+        fieldSizingLabelStates,
+        fieldSizingStates,
+        fieldSizingValueStates
+    ])),
+    lightThemeWhiteBackground
+);
 
 export const heightTest: StoryFn = createStory(
     html`

--- a/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
@@ -20,6 +20,7 @@ import {
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
 import { loremIpsum } from '../../utilities/lorem-ipsum';
+import { mediumPadding, bodyFont, bodyFontColor, standardPadding } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 
 const appearanceStates = [
     ['Outline', TextAreaAppearance.outline],
@@ -192,21 +193,101 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
 
 export const fieldSizing: StoryFn = createStory(
     html`
-        <div style="display: flex; flex-direction: column">
-            <div>
-                <${textAreaTag} style="border: 1px dashed; field-sizing: content;" value="short\n  and\n    sweet">
-                    field-sizing:content
-                </${textAreaTag}>
-                <${textAreaTag} style="border: 1px dashed; field-sizing: content;" value="¯\\_(ツ)_/¯">
-                </${textAreaTag}>
-            </div>
-            <div>
-                <${textAreaTag} style="border: 1px dashed;" value="short\n  and\n    sweet">
-                    Default field-sizing
-                </${textAreaTag}>
-                <${textAreaTag} style="border: 1px dashed;" value="¯\\_(ツ)_/¯">
-                </${textAreaTag}>
-            </div>
+        <style>
+            div {
+                display: flex;
+                flex-direction: column;
+                align-items: flex-start;
+                margin-bottom: var(${mediumPadding.cssCustomProperty});
+            }
+            label {
+                font: var(${bodyFont.cssCustomProperty});
+                color: var(${bodyFontColor.cssCustomProperty});
+            }
+            ${textAreaTag} {
+                border: 1px dashed;
+            }
+            .field-sizing-content ${textAreaTag} {
+                field-sizing: content;
+            }
+            .no-min-width ${textAreaTag} {
+                min-width: 0;
+            }
+            .fixed-width ${textAreaTag} {
+                width: 200px;
+            }
+            ${textAreaTag}[error-text] {
+                margin-bottom: var(${standardPadding.cssCustomProperty});
+            }
+        </style>
+        <div class="field-sizing-content no-min-width">
+            <label>field-sizing: content; min-width: 0;</label>
+            <${textAreaTag} value="tiny">
+                This is a Text Area
+            </${textAreaTag}>
+            <${textAreaTag} value="tiny" error-text="Error text is helpful" error-visible>
+                This is a Text Area
+            </${textAreaTag}>
+            <${textAreaTag} value="This is longer than the label text.">
+                This is a Text Area
+            </${textAreaTag}>
+            <${textAreaTag} value="This is longer than the label text." error-text="Error text is helpful" error-visible>
+                This is a Text Area
+            </${textAreaTag}>
+            <${textAreaTag} value="line 1\nline 2\nline 3">
+            </${textAreaTag}>
+            <${textAreaTag} value="line 1\nline 2\nline 3" error-text="Error text is helpful" error-visible>
+            </${textAreaTag}>
+            <${textAreaTag} value="tiny">
+            </${textAreaTag}>
+            <${textAreaTag} value="tiny" error-text="Error text is helpful" error-visible>
+            </${textAreaTag}>
+        </div>
+        <div class="field-sizing-content">
+            <label>field-sizing: content;</label>
+            <${textAreaTag} value="tiny">
+                This is a Text Area
+            </${textAreaTag}>
+            <${textAreaTag} value="tiny" error-text="Error text is helpful" error-visible>
+                This is a Text Area
+            </${textAreaTag}>
+            <${textAreaTag} value="This is longer than the label text.">
+                This is a Text Area
+            </${textAreaTag}>
+            <${textAreaTag} value="This is longer than the label text." error-text="Error text is helpful" error-visible>
+                This is a Text Area
+            </${textAreaTag}>
+            <${textAreaTag} value="line 1\nline 2\nline 3">
+            </${textAreaTag}>
+            <${textAreaTag} value="line 1\nline 2\nline 3" error-text="Error text is helpful" error-visible>
+            </${textAreaTag}>
+            <${textAreaTag} value="tiny">
+            </${textAreaTag}>
+            <${textAreaTag} value="tiny" error-text="Error text is helpful" error-visible>
+            </${textAreaTag}>
+        </div>
+        <div>
+            <label>(Default)</label>
+            <${textAreaTag} value="tiny">
+                This is a Text Area
+            </${textAreaTag}>
+            <${textAreaTag} value="tiny" error-text="Error text is helpful" error-visible>
+                This is a Text Area
+            </${textAreaTag}>
+            <${textAreaTag} value="This is longer than the label text.">
+                This is a Text Area
+            </${textAreaTag}>
+            <${textAreaTag} value="This is longer than the label text." error-text="Error text is helpful" error-visible>
+                This is a Text Area
+            </${textAreaTag}>
+            <${textAreaTag} value="line 1\nline 2\nline 3">
+            </${textAreaTag}>
+            <${textAreaTag} value="line 1\nline 2\nline 3" error-text="Error text is helpful" error-visible>
+            </${textAreaTag}>
+            <${textAreaTag} value="tiny">
+            </${textAreaTag}>
+            <${textAreaTag} value="tiny" error-text="Error text is helpful" error-visible>
+            </${textAreaTag}>
         </div>
     `
 );

--- a/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
@@ -2,7 +2,7 @@ import type { StoryFn, Meta } from '@storybook/html-vite';
 import { html, ViewTemplate } from '@ni/fast-element';
 import { textAreaTag } from '@ni/nimble-components/dist/esm/text-area';
 import { TextAreaAppearance } from '@ni/nimble-components/dist/esm/text-area/types';
-import { mediumPadding, bodyFont, bodyFontColor, standardPadding } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
+import { bodyFontColor, bodyPlus1EmphasizedFont } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { createFixedThemeStory, createStory } from '../../utilities/storybook';
 import {
     createMatrixThemeStory,
@@ -191,129 +191,54 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
     )
 );
 
-export const fieldSizing: StoryFn = createStory(
-    html`
-        <style>
-            div {
-                display: flex;
-                flex-direction: column;
-                align-items: flex-start;
-                margin-bottom: var(${mediumPadding.cssCustomProperty});
-            }
-            label {
-                font: var(${bodyFont.cssCustomProperty});
-                color: var(${bodyFontColor.cssCustomProperty});
-            }
-            ${textAreaTag} {
-                border: 1px dashed;
-            }
-            .field-sizing-content ${textAreaTag} {
-                field-sizing: content;
-            }
-            .no-min-width ${textAreaTag} {
-                min-width: 0;
-            }
-            .fixed-width ${textAreaTag} {
-                width: 200px;
-            }
-            ${textAreaTag}[error-text] {
-                margin-bottom: var(${standardPadding.cssCustomProperty});
-            }
-        </style>
-        <div class="field-sizing-content no-min-width">
-            <label>field-sizing: content; min-width: 0;</label>
-            <${textAreaTag} value="tiny">
-                This is a Text Area
-            </${textAreaTag}>
-            <${textAreaTag} value="tiny" error-text="Error text is helpful" error-visible>
-                This is a Text Area
-            </${textAreaTag}>
-            <${textAreaTag} value="This is longer than the label text.">
-                This is a Text Area
-            </${textAreaTag}>
-            <${textAreaTag} value="This is longer than the label text." error-text="Error text is helpful" error-visible>
-                This is a Text Area
-            </${textAreaTag}>
-            <${textAreaTag} value="line 1\nline 2\nline 3">
-            </${textAreaTag}>
-            <${textAreaTag} value="line 1\nline 2\nline 3" error-text="Error text is helpful" error-visible>
-            </${textAreaTag}>
-            <${textAreaTag} value="tiny">
-            </${textAreaTag}>
-            <${textAreaTag} value="tiny" error-text="Error text is helpful" error-visible>
-            </${textAreaTag}>
-        </div>
-        <div class="field-sizing-content">
-            <label>field-sizing: content;</label>
-            <${textAreaTag} value="tiny">
-                This is a Text Area
-            </${textAreaTag}>
-            <${textAreaTag} value="tiny" error-text="Error text is helpful" error-visible>
-                This is a Text Area
-            </${textAreaTag}>
-            <${textAreaTag} value="This is longer than the label text.">
-                This is a Text Area
-            </${textAreaTag}>
-            <${textAreaTag} value="This is longer than the label text." error-text="Error text is helpful" error-visible>
-                This is a Text Area
-            </${textAreaTag}>
-            <${textAreaTag} value="line 1\nline 2\nline 3">
-            </${textAreaTag}>
-            <${textAreaTag} value="line 1\nline 2\nline 3" error-text="Error text is helpful" error-visible>
-            </${textAreaTag}>
-            <${textAreaTag} value="tiny">
-            </${textAreaTag}>
-            <${textAreaTag} value="tiny" error-text="Error text is helpful" error-visible>
-            </${textAreaTag}>
-        </div>
-        <div class="field-sizing-content fixed-width">
-            <label>field-sizing: content; width: 200px;</label>
-            <${textAreaTag} value="tiny">
-                This is a Text Area
-            </${textAreaTag}>
-            <${textAreaTag} value="tiny" error-text="Error text is helpful" error-visible>
-                This is a Text Area
-            </${textAreaTag}>
-            <${textAreaTag} value="This is longer than the label text.">
-                This is a Text Area
-            </${textAreaTag}>
-            <${textAreaTag} value="This is longer than the label text." error-text="Error text is helpful" error-visible>
-                This is a Text Area
-            </${textAreaTag}>
-            <${textAreaTag} value="line 1\nline 2\nline 3">
-            </${textAreaTag}>
-            <${textAreaTag} value="line 1\nline 2\nline 3" error-text="Error text is helpful" error-visible>
-            </${textAreaTag}>
-            <${textAreaTag} value="tiny">
-            </${textAreaTag}>
-            <${textAreaTag} value="tiny" error-text="Error text is helpful" error-visible>
-            </${textAreaTag}>
-        </div>
-        <div>
-            <label>(Default)</label>
-            <${textAreaTag} value="tiny">
-                This is a Text Area
-            </${textAreaTag}>
-            <${textAreaTag} value="tiny" error-text="Error text is helpful" error-visible>
-                This is a Text Area
-            </${textAreaTag}>
-            <${textAreaTag} value="This is longer than the label text.">
-                This is a Text Area
-            </${textAreaTag}>
-            <${textAreaTag} value="This is longer than the label text." error-text="Error text is helpful" error-visible>
-                This is a Text Area
-            </${textAreaTag}>
-            <${textAreaTag} value="line 1\nline 2\nline 3">
-            </${textAreaTag}>
-            <${textAreaTag} value="line 1\nline 2\nline 3" error-text="Error text is helpful" error-visible>
-            </${textAreaTag}>
-            <${textAreaTag} value="tiny">
-            </${textAreaTag}>
-            <${textAreaTag} value="tiny" error-text="Error text is helpful" error-visible>
-            </${textAreaTag}>
-        </div>
-    `
-);
+const fieldSizingTestCase = (
+    fieldSizingStyle: string,
+    [widthStyleLabel, widthStyles]: [string, string],
+    value: string,
+    errorString: string | undefined
+): ViewTemplate => html`
+    <${textAreaTag}
+        style="${fieldSizingStyle} ${widthStyles} ${errorString ? 'margin-bottom: 24px' : 'margin-bottom: 4px'}"
+        value="${value}"
+        ?error-visible="${() => errorString !== undefined}"
+        error-text="${() => errorString}"
+    >
+        ${widthStyleLabel}
+    </${textAreaTag}>
+`;
+
+export const fieldSizing: StoryFn = createStory(html`
+    <style>
+        div {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+        }
+        label {
+            font: var(${bodyPlus1EmphasizedFont.cssCustomProperty});
+            color: var(${bodyFontColor.cssCustomProperty});
+            margin-bottom: 6px;
+        }
+    </style>
+    <label>field-sizing=content (no min-width unless specified)</label>
+    ${createMatrix(fieldSizingTestCase, [
+        ['field-sizing: content;'],
+        [
+            ['', 'min-width: 0;'],
+            ['min-width=100px', ''],
+            ['width=200px', 'width: 200px;'],
+        ],
+        ['tiny', 'Text longer than the default width.', 'line 1\nline 2\nline 3'],
+        [undefined, 'Error text is helpful']
+    ])}
+    <label>Default styling (size=20, and rows=2)</label>
+    ${createMatrix(fieldSizingTestCase, [
+        [''],
+        [['', '']],
+        ['tiny', 'Text longer than the default width.', 'line 1\nline 2\nline 3'],
+        [undefined, 'Error text is helpful']
+    ])}
+`);
 
 export const heightTest: StoryFn = createStory(
     html`

--- a/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
@@ -190,6 +190,27 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
     )
 );
 
+export const fieldSizing: StoryFn = createStory(
+    html`
+        <div style="display: flex; flex-direction: column">
+            <div>
+                <${textAreaTag} style="border: 1px dashed; field-sizing: content;" value="short\n  and\n    sweet">
+                    field-sizing:content
+                </${textAreaTag}>
+                <${textAreaTag} style="border: 1px dashed; field-sizing: content;" value="¯\\_(ツ)_/¯">
+                </${textAreaTag}>
+            </div>
+            <div>
+                <${textAreaTag} style="border: 1px dashed;" value="short\n  and\n    sweet">
+                    Default field-sizing
+                </${textAreaTag}>
+                <${textAreaTag} style="border: 1px dashed;" value="¯\\_(ツ)_/¯">
+                </${textAreaTag}>
+            </div>
+        </div>
+    `
+);
+
 export const heightTest: StoryFn = createStory(
     html`
         <div style="display: flex; flex-direction: column">

--- a/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-area/text-area-matrix.stories.ts
@@ -2,6 +2,7 @@ import type { StoryFn, Meta } from '@storybook/html-vite';
 import { html, ViewTemplate } from '@ni/fast-element';
 import { textAreaTag } from '@ni/nimble-components/dist/esm/text-area';
 import { TextAreaAppearance } from '@ni/nimble-components/dist/esm/text-area/types';
+import { mediumPadding, bodyFont, bodyFontColor, standardPadding } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { createFixedThemeStory, createStory } from '../../utilities/storybook';
 import {
     createMatrixThemeStory,
@@ -20,7 +21,6 @@ import {
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
 import { loremIpsum } from '../../utilities/lorem-ipsum';
-import { mediumPadding, bodyFont, bodyFontColor, standardPadding } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 
 const appearanceStates = [
     ['Outline', TextAreaAppearance.outline],
@@ -245,6 +245,29 @@ export const fieldSizing: StoryFn = createStory(
         </div>
         <div class="field-sizing-content">
             <label>field-sizing: content;</label>
+            <${textAreaTag} value="tiny">
+                This is a Text Area
+            </${textAreaTag}>
+            <${textAreaTag} value="tiny" error-text="Error text is helpful" error-visible>
+                This is a Text Area
+            </${textAreaTag}>
+            <${textAreaTag} value="This is longer than the label text.">
+                This is a Text Area
+            </${textAreaTag}>
+            <${textAreaTag} value="This is longer than the label text." error-text="Error text is helpful" error-visible>
+                This is a Text Area
+            </${textAreaTag}>
+            <${textAreaTag} value="line 1\nline 2\nline 3">
+            </${textAreaTag}>
+            <${textAreaTag} value="line 1\nline 2\nline 3" error-text="Error text is helpful" error-visible>
+            </${textAreaTag}>
+            <${textAreaTag} value="tiny">
+            </${textAreaTag}>
+            <${textAreaTag} value="tiny" error-text="Error text is helpful" error-visible>
+            </${textAreaTag}>
+        </div>
+        <div class="field-sizing-content fixed-width">
+            <label>field-sizing: content; width: 200px;</label>
             <${textAreaTag} value="tiny">
                 This is a Text Area
             </${textAreaTag}>

--- a/packages/storybook/src/nimble/text-area/text-area.mdx
+++ b/packages/storybook/src/nimble/text-area/text-area.mdx
@@ -8,11 +8,15 @@ import ComponentApisLink from '../../docs/component-apis-link.mdx';
 A multi-line text input control. The text area is often used in a form to
 collect user inputs like comments or reviews.
 
-If you configure your text area to be resizable (with the `resize` attribute) in
-a certain dimension, do not set an explicit size for that dimension (via
-`height` and/or `width` `style` properties), or you may experience unexpected
+If you configure your text area to be user-resizable (with the `resize`
+attribute) in a certain dimension, do not set an explicit size for that dimension
+(via `height` and/or `width` `style` properties), or you may experience unexpected
 resize behavior. If you want to set the initial size of a resizable text area,
 use the `rows` and/or `cols` attribute(s).
+
+To make the text area grow automatically to fit its content, style the element
+with `field-sizing: content`. This will allow it to grow both horizontally and
+vertically. Set a fixed `width` if you only want it to grow vertically.
 
 <Canvas of={textAreaStories.textArea} />
 

--- a/packages/storybook/src/nimble/text-area/text-area.mdx
+++ b/packages/storybook/src/nimble/text-area/text-area.mdx
@@ -1,22 +1,13 @@
 import { Canvas, Meta, Controls, Title } from '@storybook/addon-docs/blocks';
 import * as textAreaStories from './text-area.stories';
 import ComponentApisLink from '../../docs/component-apis-link.mdx';
+import FieldSizingDocs from '../patterns/field-sizing.mdx';
 
 <Meta of={textAreaStories} />
 <Title of={textAreaStories} />
 
 A multi-line text input control. The text area is often used in a form to
 collect user inputs like comments or reviews.
-
-If you configure your text area to be user-resizable (with the `resize`
-attribute) in a certain dimension, do not set an explicit size for that dimension
-(via `height` and/or `width` `style` properties), or you may experience unexpected
-resize behavior. If you want to set the initial size of a resizable text area,
-use the `rows` and/or `cols` attribute(s).
-
-To make the text area grow automatically to fit its content, style the element
-with `field-sizing: content`. This will allow it to grow both horizontally and
-vertically. Set a fixed `width` if you only want it to grow vertically.
 
 <Canvas of={textAreaStories.textArea} />
 
@@ -25,7 +16,15 @@ vertically. Set a fixed `width` if you only want it to grow vertically.
 <Controls of={textAreaStories.textArea} />
 <ComponentApisLink />
 
-{/* ## Styling */}
+## Styling
+
+If you configure your text area to be user-resizable (with the `resize`
+attribute) in a certain dimension, do not set an explicit size for that dimension
+(via `height` and/or `width` `style` properties), or you may experience unexpected
+resize behavior. If you want to set the initial size of a resizable text area,
+use the `rows` and/or `cols` attribute(s).
+
+<FieldSizingDocs multiLine={true} hasMinWidth={true} />
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
@@ -9,7 +9,7 @@ import {
     TextFieldAppearance,
     TextFieldType
 } from '@ni/nimble-components/dist/esm/text-field/types';
-import { bodyFontColor, bodyPlus1EmphasizedFont } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
+import { bodyFont, bodyFontColor } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { createStory, createFixedThemeStory } from '../../utilities/storybook';
 import {
     createMatrixThemeStory,
@@ -34,6 +34,14 @@ import {
 import { hiddenWrapper } from '../../utilities/hidden';
 import { textCustomizationWrapper } from '../../utilities/text-customization';
 import { loremIpsum } from '../../utilities/lorem-ipsum';
+import {
+    fieldSizingStates,
+    type FieldSizingState,
+    fieldSizingErrorStates,
+    type FieldSizingErrorState,
+    fieldSizingLabelStates,
+    type FieldSizingLabelState
+} from '../patterns/field-sizing/states';
 
 const [
     lightThemeWhiteBackground,
@@ -854,69 +862,82 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
     )
 );
 
-const fieldSizingTestCase = (
-    fieldSizingStyle: string,
-    [widthStyleLabel, widthStyles]: [string, string],
-    value: string,
-    fillSlots: boolean,
-    errorString: string | undefined
+const fieldSizingWidthStates = [
+    ['Default', ''],
+    ['200px', 'width: 200px;']
+] as const;
+type FieldSizingWidthState = (typeof fieldSizingWidthStates)[number];
+
+const fieldSizingValueStates = [
+    ['Empty', ''],
+    ['Short', 'tiny'],
+    ['Long', 'Longer value than the default width']
+] as const;
+type FieldSizingValueState = (typeof fieldSizingValueStates)[number];
+
+const fieldSizingSlotStates = [
+    ['None', false],
+    ['Filled', true]
+] as const;
+type FieldSizingSlotState = (typeof fieldSizingSlotStates)[number];
+
+const fieldSizingComponent = (
+    [widthName, widthStyles]: FieldSizingWidthState,
+    [slotName, fillSlots]: FieldSizingSlotState,
+    [errorName, errorString]: FieldSizingErrorState,
+    [labelName, label]: FieldSizingLabelState,
+    [fieldSizingName, fieldSizingStyle]: FieldSizingState,
+    [valueName, value]: FieldSizingValueState
 ): ViewTemplate => html`
-    <${textFieldTag}
-        appearance="outline"
-        style="${fieldSizingStyle} ${widthStyles} ${errorString ? 'margin-bottom: 24px' : 'margin-bottom: 4px'}"
-        value="${value}"
-        placeholder="Enter a value"
-        ?error-visible="${() => errorString !== undefined}"
-        error-text="${() => errorString}"
-    >
-        ${widthStyleLabel}
-        ${fillSlots ? html`
-            <${iconTagTag} slot="start"></${iconTagTag}>
-            <${buttonTag} slot="actions" appearance="outline" content-hidden>
-                <${iconPencilTag} slot="start"></${iconPencilTag}>
-                Edit
-            </${buttonTag}>
-            <${buttonTag} slot="actions" appearance="outline" content-hidden>
-                <${iconXmarkTag} slot="start"></${iconXmarkTag}>
-                Clear
-            </${buttonTag}>
-        ` : ''}
-    </${textFieldTag}>
+    <div style="display: inline-flex; flex-direction: column; align-items: flex-start; width: min-content;">
+        <div style="width: 480px; padding-right: 16px; box-sizing: border-box;">Width(${widthName}) Slots(${slotName}) Error(${errorName}) Label(${labelName}) FieldSizing(${fieldSizingName}) Value(${valueName})</div>
+        <${textFieldTag}
+            appearance="outline"
+            style="${fieldSizingStyle} ${widthStyles} ${errorString ? 'margin-bottom: 24px' : 'margin-bottom: 4px'}"
+            value="${() => value}"
+            placeholder="Enter a value"
+            ?error-visible="${() => errorString !== undefined}"
+            error-text="${() => errorString}"
+        >
+            ${() => label}
+            ${when(() => fillSlots, html`
+                <${iconTagTag} slot="start"></${iconTagTag}>
+                <${buttonTag} slot="actions" appearance="outline" content-hidden>
+                    <${iconPencilTag} slot="start"></${iconPencilTag}>
+                    Edit
+                </${buttonTag}>
+                <${buttonTag} slot="actions" appearance="outline" content-hidden>
+                    <${iconXmarkTag} slot="start"></${iconXmarkTag}>
+                    Clear
+                </${buttonTag}>
+            `)}
+        </${textFieldTag}>
+    </div>
 `;
 
-export const fieldSizing: StoryFn = createStory(html`
-    <style>
-        div {
-            display: flex;
-            flex-direction: column;
-            align-items: flex-start;
-        }
-        label {
-            font: var(${bodyPlus1EmphasizedFont.cssCustomProperty});
-            color: var(${bodyFontColor.cssCustomProperty});
-            margin-bottom: 6px;
-        }
-    </style>
-    <label>field-sizing=content</label>
-    ${createMatrix(fieldSizingTestCase, [
-        ['field-sizing: content;'],
-        [
-            ['', ''],
-            ['width=200px', 'width: 200px;'],
-        ],
-        ['tiny', '', 'Longer value than the default width.'],
-        [false, true],
-        [undefined, 'Error text is helpful']
-    ])}
-    <label>Default styling</label>
-    ${createMatrix(fieldSizingTestCase, [
-        [''],
-        [['', '']],
-        ['tiny', '', 'Longer value than the default width.'],
-        [false, true],
-        [undefined, 'Error text is helpful']
-    ])}
-`);
+const fieldSizingMatrixTemplate = (template: ViewTemplate): ViewTemplate => html`
+    <div style="
+        display: grid;
+        grid-template-columns: ${'1fr '.repeat(fieldSizingValueStates.length)};
+        font: var(${bodyFont.cssCustomProperty});
+        color: var(${bodyFontColor.cssCustomProperty});
+        width: 1500px;
+    ">
+    ${template}
+    </div>
+`;
+
+export const fieldSizing: StoryFn = createFixedThemeStory(
+    fieldSizingMatrixTemplate(createMatrix(fieldSizingComponent, [
+        fieldSizingWidthStates,
+        fieldSizingSlotStates,
+        fieldSizingErrorStates,
+        fieldSizingLabelStates,
+        fieldSizingStates,
+        fieldSizingValueStates
+    ])),
+    lightThemeWhiteBackground
+);
 
 export const heightTest: StoryFn = createStory(
     html`

--- a/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
@@ -9,7 +9,7 @@ import {
     TextFieldAppearance,
     TextFieldType
 } from '@ni/nimble-components/dist/esm/text-field/types';
-import { bodyFont, bodyFontColor, mediumPadding, standardPadding } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
+import { bodyFontColor, bodyPlus1EmphasizedFont } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { createStory, createFixedThemeStory } from '../../utilities/storybook';
 import {
     createMatrixThemeStory,
@@ -854,106 +854,69 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
     )
 );
 
-export const fieldSizing: StoryFn = createStory(
-    html`
-        <style>
-            div {
-                display: flex;
-                flex-direction: column;
-                align-items: flex-start;
-                margin-bottom: var(${mediumPadding.cssCustomProperty});
-            }
-            label {
-                font: var(${bodyFont.cssCustomProperty});
-                color: var(${bodyFontColor.cssCustomProperty});
-            }
-            ${textFieldTag} {
-                border: 1px dashed;
-            }
-            .field-sizing-content ${textFieldTag} {
-                field-sizing: content;
-            }
-            .fixed-width ${textFieldTag} {
-                width: 200px;
-            }
-            ${textFieldTag}[error-text] {
-                margin-bottom: var(${standardPadding.cssCustomProperty});
-            }
-        </style>
-        <div class="field-sizing-content">
-            <label>field-sizing: content;</label>
-            <${textFieldTag} value="tiny">
-                This is a Text Field
-            </${textFieldTag}>
-            <${textFieldTag} value="tiny">
-            </${textFieldTag}>
-            <${textFieldTag} placeholder="Enter a value">
-            </${textFieldTag}>
-            <${textFieldTag} error-text="Error text" error-visible value="tiny">
-            </${textFieldTag}>
-            <${textFieldTag} error-text="Error text, but this time longer" error-visible value="tiny">
-            </${textFieldTag}>
-            <${textFieldTag} value="tiny">
-                <${iconTagTag} slot="start"></${iconTagTag}>
-                <${buttonTag} slot="actions" appearance="outline" content-hidden>
-                    <${iconPencilTag} slot="start"></${iconPencilTag}>
-                    Edit
-                </${buttonTag}>
-                <${buttonTag} slot="actions" appearance="outline" content-hidden>
-                    <${iconXmarkTag} slot="start"></${iconXmarkTag}>
-                    Clear
-                </${buttonTag}>
-            </${textFieldTag}>
-            <${textFieldTag} error-text="Error text" error-visible value="tiny">
-                <${iconTagTag} slot="start"></${iconTagTag}>
-                <${buttonTag} slot="actions" appearance="outline" content-hidden>
-                    <${iconPencilTag} slot="start"></${iconPencilTag}>
-                    Edit
-                </${buttonTag}>
-                <${buttonTag} slot="actions" appearance="outline" content-hidden>
-                    <${iconXmarkTag} slot="start"></${iconXmarkTag}>
-                    Clear
-                </${buttonTag}>
-            </${textFieldTag}>
-        </div>
-        <div>
-            <label>(Default)</label>
-            <${textFieldTag} value="tiny">
-                This is a Text Field
-            </${textFieldTag}>
-            <${textFieldTag} value="tiny">
-            </${textFieldTag}>
-            <${textFieldTag} placeholder="Enter a value">
-            </${textFieldTag}>
-            <${textFieldTag} error-text="Error text" error-visible value="tiny">
-            </${textFieldTag}>
-            <${textFieldTag} error-text="Error text, but this time longer" error-visible value="tiny">
-            </${textFieldTag}>
-            <${textFieldTag} value="tiny">
-                <${iconTagTag} slot="start"></${iconTagTag}>
-                <${buttonTag} slot="actions" appearance="outline" content-hidden>
-                    <${iconPencilTag} slot="start"></${iconPencilTag}>
-                    Edit
-                </${buttonTag}>
-                <${buttonTag} slot="actions" appearance="outline" content-hidden>
-                    <${iconXmarkTag} slot="start"></${iconXmarkTag}>
-                    Clear
-                </${buttonTag}>
-            </${textFieldTag}>
-            <${textFieldTag} error-text="Error text" error-visible value="tiny">
-                <${iconTagTag} slot="start"></${iconTagTag}>
-                <${buttonTag} slot="actions" appearance="outline" content-hidden>
-                    <${iconPencilTag} slot="start"></${iconPencilTag}>
-                    Edit
-                </${buttonTag}>
-                <${buttonTag} slot="actions" appearance="outline" content-hidden>
-                    <${iconXmarkTag} slot="start"></${iconXmarkTag}>
-                    Clear
-                </${buttonTag}>
-            </${textFieldTag}>
-        </div>
-    `
-);
+const fieldSizingTestCase = (
+    fieldSizingStyle: string,
+    [widthStyleLabel, widthStyles]: [string, string],
+    value: string,
+    fillSlots: boolean,
+    errorString: string | undefined
+): ViewTemplate => html`
+    <${textFieldTag}
+        appearance="outline"
+        style="${fieldSizingStyle} ${widthStyles} ${errorString ? 'margin-bottom: 24px' : 'margin-bottom: 4px'}"
+        value="${value}"
+        placeholder="Enter a value"
+        ?error-visible="${() => errorString !== undefined}"
+        error-text="${() => errorString}"
+    >
+        ${widthStyleLabel}
+        ${fillSlots ? html`
+            <${iconTagTag} slot="start"></${iconTagTag}>
+            <${buttonTag} slot="actions" appearance="outline" content-hidden>
+                <${iconPencilTag} slot="start"></${iconPencilTag}>
+                Edit
+            </${buttonTag}>
+            <${buttonTag} slot="actions" appearance="outline" content-hidden>
+                <${iconXmarkTag} slot="start"></${iconXmarkTag}>
+                Clear
+            </${buttonTag}>
+        ` : ''}
+    </${textFieldTag}>
+`;
+
+export const fieldSizing: StoryFn = createStory(html`
+    <style>
+        div {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+        }
+        label {
+            font: var(${bodyPlus1EmphasizedFont.cssCustomProperty});
+            color: var(${bodyFontColor.cssCustomProperty});
+            margin-bottom: 6px;
+        }
+    </style>
+    <label>field-sizing=content</label>
+    ${createMatrix(fieldSizingTestCase, [
+        ['field-sizing: content;'],
+        [
+            ['', ''],
+            ['width=200px', 'width: 200px;'],
+        ],
+        ['tiny', '', 'Longer value than the default width.'],
+        [false, true],
+        [undefined, 'Error text is helpful']
+    ])}
+    <label>Default styling</label>
+    ${createMatrix(fieldSizingTestCase, [
+        [''],
+        [['', '']],
+        ['tiny', '', 'Longer value than the default width.'],
+        [false, true],
+        [undefined, 'Error text is helpful']
+    ])}
+`);
 
 export const heightTest: StoryFn = createStory(
     html`

--- a/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
@@ -853,6 +853,27 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
     )
 );
 
+export const fieldSizing: StoryFn = createStory(
+    html`
+        <div style="display: flex; flex-direction: column">
+            <div>
+                <${textFieldTag} style="border: 1px dashed; field-sizing: content;" value="short and sweet">
+                    field-sizing:content
+                </${textFieldTag}>
+                <${textFieldTag} style="border: 1px dashed; field-sizing: content;" value="¯\\_(ツ)_/¯">
+                </${textFieldTag}>
+            </div>
+            <div>
+                <${textFieldTag} style="border: 1px dashed;" value="short and sweet">
+                    Default field-sizing
+                </${textFieldTag}>
+                <${textFieldTag} style="border: 1px dashed;" value="¯\\_(ツ)_/¯">
+                </${textFieldTag}>
+            </div>
+        </div>
+    `
+);
+
 export const heightTest: StoryFn = createStory(
     html`
         <div style="display: flex; flex-direction: column">

--- a/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
+++ b/packages/storybook/src/nimble/text-field/text-field-matrix.stories.ts
@@ -9,6 +9,7 @@ import {
     TextFieldAppearance,
     TextFieldType
 } from '@ni/nimble-components/dist/esm/text-field/types';
+import { bodyFont, bodyFontColor, mediumPadding, standardPadding } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { createStory, createFixedThemeStory } from '../../utilities/storybook';
 import {
     createMatrixThemeStory,
@@ -855,21 +856,101 @@ export const textCustomized: StoryFn = createMatrixThemeStory(
 
 export const fieldSizing: StoryFn = createStory(
     html`
-        <div style="display: flex; flex-direction: column">
-            <div>
-                <${textFieldTag} style="border: 1px dashed; field-sizing: content;" value="short and sweet">
-                    field-sizing:content
-                </${textFieldTag}>
-                <${textFieldTag} style="border: 1px dashed; field-sizing: content;" value="¯\\_(ツ)_/¯">
-                </${textFieldTag}>
-            </div>
-            <div>
-                <${textFieldTag} style="border: 1px dashed;" value="short and sweet">
-                    Default field-sizing
-                </${textFieldTag}>
-                <${textFieldTag} style="border: 1px dashed;" value="¯\\_(ツ)_/¯">
-                </${textFieldTag}>
-            </div>
+        <style>
+            div {
+                display: flex;
+                flex-direction: column;
+                align-items: flex-start;
+                margin-bottom: var(${mediumPadding.cssCustomProperty});
+            }
+            label {
+                font: var(${bodyFont.cssCustomProperty});
+                color: var(${bodyFontColor.cssCustomProperty});
+            }
+            ${textFieldTag} {
+                border: 1px dashed;
+            }
+            .field-sizing-content ${textFieldTag} {
+                field-sizing: content;
+            }
+            .fixed-width ${textFieldTag} {
+                width: 200px;
+            }
+            ${textFieldTag}[error-text] {
+                margin-bottom: var(${standardPadding.cssCustomProperty});
+            }
+        </style>
+        <div class="field-sizing-content">
+            <label>field-sizing: content;</label>
+            <${textFieldTag} value="tiny">
+                This is a Text Field
+            </${textFieldTag}>
+            <${textFieldTag} value="tiny">
+            </${textFieldTag}>
+            <${textFieldTag} placeholder="Enter a value">
+            </${textFieldTag}>
+            <${textFieldTag} error-text="Error text" error-visible value="tiny">
+            </${textFieldTag}>
+            <${textFieldTag} error-text="Error text, but this time longer" error-visible value="tiny">
+            </${textFieldTag}>
+            <${textFieldTag} value="tiny">
+                <${iconTagTag} slot="start"></${iconTagTag}>
+                <${buttonTag} slot="actions" appearance="outline" content-hidden>
+                    <${iconPencilTag} slot="start"></${iconPencilTag}>
+                    Edit
+                </${buttonTag}>
+                <${buttonTag} slot="actions" appearance="outline" content-hidden>
+                    <${iconXmarkTag} slot="start"></${iconXmarkTag}>
+                    Clear
+                </${buttonTag}>
+            </${textFieldTag}>
+            <${textFieldTag} error-text="Error text" error-visible value="tiny">
+                <${iconTagTag} slot="start"></${iconTagTag}>
+                <${buttonTag} slot="actions" appearance="outline" content-hidden>
+                    <${iconPencilTag} slot="start"></${iconPencilTag}>
+                    Edit
+                </${buttonTag}>
+                <${buttonTag} slot="actions" appearance="outline" content-hidden>
+                    <${iconXmarkTag} slot="start"></${iconXmarkTag}>
+                    Clear
+                </${buttonTag}>
+            </${textFieldTag}>
+        </div>
+        <div>
+            <label>(Default)</label>
+            <${textFieldTag} value="tiny">
+                This is a Text Field
+            </${textFieldTag}>
+            <${textFieldTag} value="tiny">
+            </${textFieldTag}>
+            <${textFieldTag} placeholder="Enter a value">
+            </${textFieldTag}>
+            <${textFieldTag} error-text="Error text" error-visible value="tiny">
+            </${textFieldTag}>
+            <${textFieldTag} error-text="Error text, but this time longer" error-visible value="tiny">
+            </${textFieldTag}>
+            <${textFieldTag} value="tiny">
+                <${iconTagTag} slot="start"></${iconTagTag}>
+                <${buttonTag} slot="actions" appearance="outline" content-hidden>
+                    <${iconPencilTag} slot="start"></${iconPencilTag}>
+                    Edit
+                </${buttonTag}>
+                <${buttonTag} slot="actions" appearance="outline" content-hidden>
+                    <${iconXmarkTag} slot="start"></${iconXmarkTag}>
+                    Clear
+                </${buttonTag}>
+            </${textFieldTag}>
+            <${textFieldTag} error-text="Error text" error-visible value="tiny">
+                <${iconTagTag} slot="start"></${iconTagTag}>
+                <${buttonTag} slot="actions" appearance="outline" content-hidden>
+                    <${iconPencilTag} slot="start"></${iconPencilTag}>
+                    Edit
+                </${buttonTag}>
+                <${buttonTag} slot="actions" appearance="outline" content-hidden>
+                    <${iconXmarkTag} slot="start"></${iconXmarkTag}>
+                    Clear
+                </${buttonTag}>
+            </${textFieldTag}>
         </div>
     `
 );

--- a/packages/storybook/src/nimble/text-field/text-field.mdx
+++ b/packages/storybook/src/nimble/text-field/text-field.mdx
@@ -1,6 +1,7 @@
 import { Canvas, Meta, Controls, Title } from '@storybook/addon-docs/blocks';
 import * as textFieldStories from './text-field.stories';
 import ComponentApisLink from '../../docs/component-apis-link.mdx';
+import FieldSizingDocs from '../patterns/field-sizing.mdx';
 
 <Meta of={textFieldStories} />
 <Title of={textFieldStories} />
@@ -14,7 +15,9 @@ A single-line text field.
 <Controls of={textFieldStories.textField} />
 <ComponentApisLink />
 
-{/* ## Styling */}
+## Styling
+
+<FieldSizingDocs hasMinWidth={true} />
 
 {/* ## Usage */}
 

--- a/packages/storybook/src/nimble/text-field/text-field.mdx
+++ b/packages/storybook/src/nimble/text-field/text-field.mdx
@@ -17,7 +17,7 @@ A single-line text field.
 
 ## Styling
 
-<FieldSizingDocs hasMinWidth={true} />
+<FieldSizingDocs />
 
 {/* ## Usage */}
 


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

I wanted to size a `nimble-text-field` to the width of its content. This isn't straightforward unless you use the [`field-sizing` CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/field-sizing). The property has been supported in Chrome/Edge for a couple years, but only in Safari (12/2025) and Firefox (6/2026) fairly recently. It would be very useful if you could apply the style to our custom elements and see the effect on the the native elements in the shadow DOM.

Also, apparently resolves #1228

Found one edge case (field-sizing: content, and a fixed width) captured in matrix tests that does not block this PR. Created an issue: https://github.com/ni/nimble/issues/2999

## 👩‍💻 Implementation

`field-sizing` is only supported on `input` and `textarea` elements, so it only really applies to `nimble-text-field`, `nimble-number-field`, `nimble-text-area`, and `nimble-combo-box`.

Updated stylesheets to appy `field-sizing: inherit` to the native `input` and `textarea` elements, as well as their containing `div`s and/or `slot`s. This allows a user to style the host element and have that style "cascade".

In the case of `nimble-combobox` and `nimble-text-area`, there is a `min-width` by default, so if you want it to size smaller than that, you need to explicitly change that property, too.

Additionally, added a 4-px padding to the right side of the `nimble-number-field` when the stepper buttons are hidden to better match the design.

## 🧪 Testing

Added visual test cases for `nimble-text-field`, `nimble-number-field`, `nimble-text-area`, and `nimble-combobox`.

## ✅ Checklist
- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
