### PR TITLE
Fix components not centering

### DIFF
--- a/change/@ni-spright-components-bf5c8bda-15f8-43da-b405-8075d8f85213.json
+++ b/change/@ni-spright-components-bf5c8bda-15f8-43da-b405-8075d8f85213.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix components not centering",
+  "packageName": "@ni/spright-components",
+  "email": "163188334+Alexia-Claudia-Micu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/spright-components/src/chat/conversation/styles.ts
+++ b/packages/spright-components/src/chat/conversation/styles.ts
@@ -89,7 +89,8 @@ export const styles = css`
     }
 
     .messages-anchored {
-        flex: 1;
+        flex: none;
+        min-height: 100%;
     }
 
     :host([appearance='overlay']) .messages {

--- a/packages/spright-components/src/chat/conversation/styles.ts
+++ b/packages/spright-components/src/chat/conversation/styles.ts
@@ -85,7 +85,7 @@ export const styles = css`
         display: none;
     }
 
-    .messages-anchored.anchor-active {
+    .messages-anchored {
         min-height: 100%;
     }
 

--- a/packages/spright-components/src/chat/conversation/styles.ts
+++ b/packages/spright-components/src/chat/conversation/styles.ts
@@ -75,18 +75,21 @@ export const styles = css`
 
     .messages-history,
     .messages-anchored {
-        flex: none;
         display: flex;
         flex-direction: column;
         row-gap: 32px;
+    }
+
+    .messages-history {
+        flex: none;
     }
 
     .messages-history.region-empty {
         display: none;
     }
 
-    .messages-anchored.anchor-active {
-        min-height: 100%;
+    .messages-anchored {
+        flex: 1;
     }
 
     :host([appearance='overlay']) .messages {

--- a/packages/spright-components/src/chat/conversation/styles.ts
+++ b/packages/spright-components/src/chat/conversation/styles.ts
@@ -75,21 +75,17 @@ export const styles = css`
 
     .messages-history,
     .messages-anchored {
+        flex: none;
         display: flex;
         flex-direction: column;
         row-gap: 32px;
-    }
-
-    .messages-history {
-        flex: none;
     }
 
     .messages-history.region-empty {
         display: none;
     }
 
-    .messages-anchored {
-        flex: none;
+    .messages-anchored.anchor-active {
         min-height: 100%;
     }
 

--- a/packages/spright-components/src/chat/message/welcome/styles.ts
+++ b/packages/spright-components/src/chat/message/welcome/styles.ts
@@ -19,10 +19,10 @@ export const styles = css`
         min-width: ${standardPadding};
         min-height: ${standardPadding};
 
+        flex: 1;
         flex-direction: row;
         justify-content: center;
-        flex-shrink: 0;
-        margin: auto 0;
+        align-items: center;
         font: ${bodyFont};
         color: ${bodyFontColor};
     }

--- a/packages/spright-components/src/chat/message/welcome/styles.ts
+++ b/packages/spright-components/src/chat/message/welcome/styles.ts
@@ -22,6 +22,7 @@ export const styles = css`
         flex-direction: row;
         justify-content: center;
         flex-shrink: 0;
+        margin: auto 0;
         font: ${bodyFont};
         color: ${bodyFontColor};
     }

--- a/packages/storybook/src/spright/chat/conversation/chat-conversation-matrix.stories.ts
+++ b/packages/storybook/src/spright/chat/conversation/chat-conversation-matrix.stories.ts
@@ -5,6 +5,7 @@ import { chatMessageTag } from '@ni/spright-components/dist/esm/chat/message';
 import { chatMessageInboundTag } from '@ni/spright-components/dist/esm/chat/message/inbound';
 import { chatMessageOutboundTag } from '@ni/spright-components/dist/esm/chat/message/outbound';
 import { chatMessageSystemTag } from '@ni/spright-components/dist/esm/chat/message/system';
+import { chatMessageWelcomeTag } from '@ni/spright-components/dist/esm/chat/message/welcome';
 import { ChatMessageType } from '@ni/spright-components/dist/esm/chat/message/types';
 import { chatConversationTag } from '@ni/spright-components/dist/esm/chat/conversation';
 import {
@@ -40,12 +41,14 @@ const systemTypeState = messageTypeStates[2];
 const messageComponentStates = [
     ['outbound', chatMessageOutboundTag],
     ['inbound', chatMessageInboundTag],
-    ['system', chatMessageSystemTag]
+    ['system', chatMessageSystemTag],
+    ['welcome', chatMessageWelcomeTag]
 ] as const;
 type MessageComponentStates = (typeof messageComponentStates)[number];
 const outboundComponentState = messageComponentStates[0];
 const inboundComponentState = messageComponentStates[1];
 const systemComponentState = messageComponentStates[2];
+const welcomeComponentState = messageComponentStates[3];
 
 const metadata: Meta = {
     title: 'Tests Spright/Chat Conversation',
@@ -170,7 +173,9 @@ const messageComponentSizing = (
             width: 100%;
             height: 100%;
         ">
-            <${messageComponentType}>
+            <${messageComponentType} style="
+                outline: 1px solid green;
+            ">
                 <div style="
                     width: ${contentWidth};
                     height: ${contentHeight};
@@ -204,6 +209,15 @@ export const inboundMessageSizing: StoryFn = createStory(html`
 export const systemMessageSizing: StoryFn = createStory(html`
     ${createMatrix(messageComponentSizing, [
         [systemComponentState],
+        viewportStates,
+        contentWidthStates,
+        contentHeightStates
+    ])}
+`);
+
+export const welcomeMessageSizing: StoryFn = createStory(html`
+    ${createMatrix(messageComponentSizing, [
+        [welcomeComponentState],
         viewportStates,
         contentWidthStates,
         contentHeightStates

--- a/packages/storybook/src/spright/chat/conversation/chat-conversation.stories.ts
+++ b/packages/storybook/src/spright/chat/conversation/chat-conversation.stories.ts
@@ -253,27 +253,29 @@ interface ChatMessageWelcomeArgs {
 
 export const chatMessageWelcome: StoryObj<ChatMessageWelcomeArgs> = {
     render: createUserSelectedThemeStory(html`
-        <${chatMessageWelcomeTag}
-            welcome-title="${x => x.welcomeTitle}"
-            subtitle="${x => x.subtitle}"
-        >
-            ${when(x => x.brandIcon, html`
-                <${iconMessageBotTag} slot="brand-icon"></${iconMessageBotTag}>
-            `)}
-            ${when(x => x.defaultSlot === ExampleWelcomeSlotContent.loginButton, html`
-                <${anchorButtonTag} appearance="block" appearance-variant="primary" href="javascript:void(0)">
-                    Login
-                </${anchorButtonTag}>
-            `)}
-            ${when(x => x.defaultSlot === ExampleWelcomeSlotContent.suggestions, html`
-                <${buttonTag} appearance="block">
-                    Help me get started
-                </${buttonTag}>
-                <${buttonTag} appearance="block">
-                    What can you do?
-                </${buttonTag}>
-            `)}
-        </${chatMessageWelcomeTag}>
+        <${chatConversationTag}>
+            <${chatMessageWelcomeTag}
+                welcome-title="${x => x.welcomeTitle}"
+                subtitle="${x => x.subtitle}"
+            >
+                ${when(x => x.brandIcon, html`
+                    <${iconMessageBotTag} slot="brand-icon"></${iconMessageBotTag}>
+                `)}
+                ${when(x => x.defaultSlot === ExampleWelcomeSlotContent.loginButton, html`
+                    <${anchorButtonTag} appearance="block" appearance-variant="primary" href="javascript:void(0)">
+                        Login
+                    </${anchorButtonTag}>
+                `)}
+                ${when(x => x.defaultSlot === ExampleWelcomeSlotContent.suggestions, html`
+                    <${buttonTag} appearance="block">
+                        Help me get started
+                    </${buttonTag}>
+                    <${buttonTag} appearance="block">
+                        What can you do?
+                    </${buttonTag}>
+                `)}
+            </${chatMessageWelcomeTag}>
+        </${chatConversationTag}>
     `),
     argTypes: {
         welcomeTitle: {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

[Azdo issue](https://dev.azure.com/ni/DevCentral/_workitems/edit/3946267)

The auto-scroll refactor wrapped the default slot in a `.messages-anchored` div with `[flex: none]`. The previously used min-height: 100% approach does not work on flex items whose parent has no explicit height (only a computed one from flex: 1, which browsers resolve to 0). This caused `.messages-anchored` to collapse to its content height, leaving no free space for the welcome message to center within.

## 👩‍💻 Implementation

- Changed messages-anchored to always be min-height: 100%
- Changed welcome message sizing to fill available space in the flex layout.

## 🧪 Testing

Storybook and example app testing.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
