### PR TITLE
Add OK Angular wrappers for FV master-detail components

### DIFF
--- a/change/@ni-ok-angular-22849d67-ebd8-464b-9e30-0d6cc9671440.json
+++ b/change/@ni-ok-angular-22849d67-ebd8-464b-9e30-0d6cc9671440.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add OK Angular master-detail wrappers",
+  "packageName": "@ni/ok-angular",
+  "email": "1458528+fredvisser@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/angular-workspace/example-client-app/src/app/customapp/fv/fv-master-detail-list-section.component.ts
+++ b/packages/angular-workspace/example-client-app/src/app/customapp/fv/fv-master-detail-list-section.component.ts
@@ -1,0 +1,38 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'example-fv-master-detail-list-section',
+    template: `
+        <example-sub-container label="Fv Master Detail List (Ok)">
+            <ok-fv-master-detail-list placeholder="Filter devices...">
+                <ok-fv-master-detail-list-item
+                    title-text="NI-DAQ-001"
+                    subtitle="USB-6001 · Lab A"
+                    value="daq-001"
+                    status-color="#169c44"
+                    status-label="Connected"
+                    selected>
+                </ok-fv-master-detail-list-item>
+                <ok-fv-master-detail-list-item
+                    title-text="NI-SCOPE-002"
+                    subtitle="PXIe-5162 · Lab B"
+                    value="scope-002"
+                    status-color="#169c44"
+                    status-label="Connected">
+                </ok-fv-master-detail-list-item>
+                <ok-fv-master-detail-list-item
+                    title-text="NI-SWITCH-005"
+                    subtitle="PXI-2527 · Rack 3"
+                    value="switch-005"
+                    compact>
+                    <span slot="status" aria-label="Pending changes">!</span>
+                </ok-fv-master-detail-list-item>
+            </ok-fv-master-detail-list>
+        </example-sub-container>
+    `,
+    styles: [`
+        ok-fv-master-detail-list { inline-size: 360px; min-block-size: 360px; }
+    `],
+    standalone: false
+})
+export class FvMasterDetailListSectionComponent {}

--- a/packages/angular-workspace/example-client-app/src/app/customapp/fv/fv-section.component.ts
+++ b/packages/angular-workspace/example-client-app/src/app/customapp/fv/fv-section.component.ts
@@ -7,6 +7,7 @@ import { Component } from '@angular/core';
         <example-fv-card-section></example-fv-card-section>
         <example-fv-chip-selector-section></example-fv-chip-selector-section>
         <example-fv-context-help-section></example-fv-context-help-section>
+        <example-fv-master-detail-list-section></example-fv-master-detail-list-section>
         <example-fv-search-input-section></example-fv-search-input-section>
         <example-fv-split-button-section></example-fv-split-button-section>
         <example-fv-split-button-anchor-section></example-fv-split-button-anchor-section>

--- a/packages/angular-workspace/example-client-app/src/app/customapp/fv/fv-section.module.ts
+++ b/packages/angular-workspace/example-client-app/src/app/customapp/fv/fv-section.module.ts
@@ -4,6 +4,8 @@ import { OkFvAccordionItemModule } from '@ni/ok-angular/fv/accordion-item';
 import { OkFvCardModule } from '@ni/ok-angular/fv/card';
 import { OkFvChipSelectorModule } from '@ni/ok-angular/fv/chip-selector';
 import { OkFvContextHelpModule } from '@ni/ok-angular/fv/context-help';
+import { OkFvMasterDetailListItemModule } from '@ni/ok-angular/fv/master-detail-list-item';
+import { OkFvMasterDetailListModule } from '@ni/ok-angular/fv/master-detail-list';
 import { OkFvSearchInputModule } from '@ni/ok-angular/fv/search-input';
 import { OkFvSplitButtonAnchorModule } from '@ni/ok-angular/fv/split-button-anchor';
 import { OkFvSplitButtonModule } from '@ni/ok-angular/fv/split-button';
@@ -13,6 +15,7 @@ import { FvAccordionItemSectionComponent } from './fv-accordion-item-section.com
 import { FvCardSectionComponent } from './fv-card-section.component';
 import { FvChipSelectorSectionComponent } from './fv-chip-selector-section.component';
 import { FvContextHelpSectionComponent } from './fv-context-help-section.component';
+import { FvMasterDetailListSectionComponent } from './fv-master-detail-list-section.component';
 import { FvSearchInputSectionComponent } from './fv-search-input-section.component';
 import { FvSectionComponent } from './fv-section.component';
 import { FvSplitButtonAnchorSectionComponent } from './fv-split-button-anchor-section.component';
@@ -27,6 +30,7 @@ import { SubContainerModule } from '../sub-container/sub-container.module';
         FvCardSectionComponent,
         FvChipSelectorSectionComponent,
         FvContextHelpSectionComponent,
+        FvMasterDetailListSectionComponent,
         FvSearchInputSectionComponent,
         FvSplitButtonSectionComponent,
         FvSplitButtonAnchorSectionComponent,
@@ -39,6 +43,8 @@ import { SubContainerModule } from '../sub-container/sub-container.module';
         OkFvCardModule,
         OkFvChipSelectorModule,
         OkFvContextHelpModule,
+        OkFvMasterDetailListModule,
+        OkFvMasterDetailListItemModule,
         OkFvSearchInputModule,
         OkFvSplitButtonModule,
         OkFvSplitButtonAnchorModule,

--- a/packages/angular-workspace/ok-angular/fv/master-detail-list-item/ng-package.json
+++ b/packages/angular-workspace/ok-angular/fv/master-detail-list-item/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/packages/angular-workspace/ok-angular/fv/master-detail-list-item/ok-fv-master-detail-list-item.directive.ts
+++ b/packages/angular-workspace/ok-angular/fv/master-detail-list-item/ok-fv-master-detail-list-item.directive.ts
@@ -1,0 +1,84 @@
+import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
+import type { FvMasterDetailListItem } from '@ni/ok-components/dist/esm/fv/master-detail-list-item';
+import { fvMasterDetailListItemTag } from '@ni/ok-components/dist/esm/fv/master-detail-list-item';
+import { type BooleanValueOrAttribute, toBooleanProperty } from '@ni/nimble-angular/internal-utilities';
+
+export type { FvMasterDetailListItem };
+export { fvMasterDetailListItemTag };
+
+/**
+ * Directive to provide Angular integration for the master-detail list item.
+ */
+@Directive({
+    selector: 'ok-fv-master-detail-list-item',
+    standalone: false
+})
+export class OkFvMasterDetailListItemDirective {
+    public get titleText(): string {
+        return this.elementRef.nativeElement.titleText;
+    }
+
+    @Input('title-text')
+    public set titleText(value: string) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'titleText', value);
+    }
+
+    public get subtitle(): string {
+        return this.elementRef.nativeElement.subtitle;
+    }
+
+    @Input()
+    public set subtitle(value: string) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'subtitle', value);
+    }
+
+    public get value(): string {
+        return this.elementRef.nativeElement.value;
+    }
+
+    @Input()
+    public set value(value: string) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'value', value);
+    }
+
+    public get compact(): boolean {
+        return this.elementRef.nativeElement.compact;
+    }
+
+    @Input()
+    public set compact(value: BooleanValueOrAttribute) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'compact', toBooleanProperty(value));
+    }
+
+    public get selected(): boolean {
+        return this.elementRef.nativeElement.selected;
+    }
+
+    @Input()
+    public set selected(value: BooleanValueOrAttribute) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'selected', toBooleanProperty(value));
+    }
+
+    public get statusColor(): string {
+        return this.elementRef.nativeElement.statusColor;
+    }
+
+    @Input('status-color')
+    public set statusColor(value: string) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'statusColor', value);
+    }
+
+    public get statusLabel(): string {
+        return this.elementRef.nativeElement.statusLabel;
+    }
+
+    @Input('status-label')
+    public set statusLabel(value: string) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'statusLabel', value);
+    }
+
+    public constructor(
+        private readonly elementRef: ElementRef<FvMasterDetailListItem>,
+        private readonly renderer: Renderer2
+    ) {}
+}

--- a/packages/angular-workspace/ok-angular/fv/master-detail-list-item/ok-fv-master-detail-list-item.module.ts
+++ b/packages/angular-workspace/ok-angular/fv/master-detail-list-item/ok-fv-master-detail-list-item.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { OkFvMasterDetailListItemDirective } from './ok-fv-master-detail-list-item.directive';
+
+import '@ni/ok-components/dist/esm/fv/master-detail-list-item';
+
+@NgModule({
+    declarations: [OkFvMasterDetailListItemDirective],
+    imports: [CommonModule],
+    exports: [OkFvMasterDetailListItemDirective]
+})
+export class OkFvMasterDetailListItemModule { }

--- a/packages/angular-workspace/ok-angular/fv/master-detail-list-item/public-api.ts
+++ b/packages/angular-workspace/ok-angular/fv/master-detail-list-item/public-api.ts
@@ -1,0 +1,2 @@
+export * from './ok-fv-master-detail-list-item.directive';
+export * from './ok-fv-master-detail-list-item.module';

--- a/packages/angular-workspace/ok-angular/fv/master-detail-list-item/tests/ok-fv-master-detail-list-item.directive.spec.ts
+++ b/packages/angular-workspace/ok-angular/fv/master-detail-list-item/tests/ok-fv-master-detail-list-item.directive.spec.ts
@@ -1,0 +1,272 @@
+import { Component, ElementRef, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { type FvMasterDetailListItem, OkFvMasterDetailListItemDirective } from '../ok-fv-master-detail-list-item.directive';
+import { OkFvMasterDetailListItemModule } from '../ok-fv-master-detail-list-item.module';
+
+describe('Ok fv master detail list item', () => {
+    describe('module', () => {
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [OkFvMasterDetailListItemModule]
+            });
+        });
+
+        it('custom element is defined', () => {
+            expect(customElements.get('ok-fv-master-detail-list-item')).not.toBeUndefined();
+        });
+    });
+
+    describe('with no values in template', () => {
+        @Component({
+            template: `
+                <ok-fv-master-detail-list-item #item></ok-fv-master-detail-list-item>
+            `,
+            standalone: false
+        })
+        class TestHostComponent {
+            @ViewChild('item', { read: OkFvMasterDetailListItemDirective }) public directive: OkFvMasterDetailListItemDirective;
+            @ViewChild('item', { read: ElementRef }) public elementRef: ElementRef<FvMasterDetailListItem>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: OkFvMasterDetailListItemDirective;
+        let nativeElement: FvMasterDetailListItem;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [OkFvMasterDetailListItemModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('has expected defaults for titleText', () => {
+            expect(directive.titleText).toBe('');
+            expect(nativeElement.titleText).toBe('');
+        });
+
+        it('has expected defaults for subtitle', () => {
+            expect(directive.subtitle).toBe('');
+            expect(nativeElement.subtitle).toBe('');
+        });
+
+        it('has expected defaults for value', () => {
+            expect(directive.value).toBe('');
+            expect(nativeElement.value).toBe('');
+        });
+
+        it('has expected defaults for compact', () => {
+            expect(directive.compact).toBeFalse();
+            expect(nativeElement.compact).toBeFalse();
+        });
+
+        it('has expected defaults for selected', () => {
+            expect(directive.selected).toBeFalse();
+            expect(nativeElement.selected).toBeFalse();
+        });
+
+        it('has expected defaults for statusColor', () => {
+            expect(directive.statusColor).toBe('');
+            expect(nativeElement.statusColor).toBe('');
+        });
+
+        it('has expected defaults for statusLabel', () => {
+            expect(directive.statusLabel).toBe('');
+            expect(nativeElement.statusLabel).toBe('');
+        });
+    });
+
+    describe('with template string values', () => {
+        @Component({
+            template: `
+                <ok-fv-master-detail-list-item #item
+                    title-text="PXI-1042"
+                    subtitle="Calibration due"
+                    value="pxi-1042"
+                    compact
+                    selected
+                    status-color="var(--ni-semantic-color-warning)"
+                    status-label="Warning">
+                </ok-fv-master-detail-list-item>
+            `,
+            standalone: false
+        })
+        class TestHostComponent {
+            @ViewChild('item', { read: OkFvMasterDetailListItemDirective }) public directive: OkFvMasterDetailListItemDirective;
+            @ViewChild('item', { read: ElementRef }) public elementRef: ElementRef<FvMasterDetailListItem>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: OkFvMasterDetailListItemDirective;
+        let nativeElement: FvMasterDetailListItem;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [OkFvMasterDetailListItemModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('will use template string values for titleText', () => {
+            expect(directive.titleText).toBe('PXI-1042');
+            expect(nativeElement.titleText).toBe('PXI-1042');
+        });
+
+        it('will use template string values for subtitle', () => {
+            expect(directive.subtitle).toBe('Calibration due');
+            expect(nativeElement.subtitle).toBe('Calibration due');
+        });
+
+        it('will use template string values for value', () => {
+            expect(directive.value).toBe('pxi-1042');
+            expect(nativeElement.value).toBe('pxi-1042');
+        });
+
+        it('will use template string values for compact', () => {
+            expect(directive.compact).toBeTrue();
+            expect(nativeElement.compact).toBeTrue();
+        });
+
+        it('will use template string values for selected', () => {
+            expect(directive.selected).toBeTrue();
+            expect(nativeElement.selected).toBeTrue();
+        });
+
+        it('will use template string values for statusColor', () => {
+            expect(directive.statusColor).toBe('var(--ni-semantic-color-warning)');
+            expect(nativeElement.statusColor).toBe('var(--ni-semantic-color-warning)');
+        });
+
+        it('will use template string values for statusLabel', () => {
+            expect(directive.statusLabel).toBe('Warning');
+            expect(nativeElement.statusLabel).toBe('Warning');
+        });
+    });
+
+    describe('with property bound values', () => {
+        @Component({
+            template: `
+                <ok-fv-master-detail-list-item #item
+                    [title-text]="titleText"
+                    [subtitle]="subtitle"
+                    [value]="value"
+                    [compact]="compact"
+                    [selected]="selected"
+                    [status-color]="statusColor"
+                    [status-label]="statusLabel">
+                </ok-fv-master-detail-list-item>
+            `,
+            standalone: false
+        })
+        class TestHostComponent {
+            @ViewChild('item', { read: OkFvMasterDetailListItemDirective }) public directive: OkFvMasterDetailListItemDirective;
+            @ViewChild('item', { read: ElementRef }) public elementRef: ElementRef<FvMasterDetailListItem>;
+            public titleText = 'PXI-1042';
+            public subtitle = 'Calibration due';
+            public value = 'pxi-1042';
+            public compact = false;
+            public selected = false;
+            public statusColor = 'var(--ni-semantic-color-warning)';
+            public statusLabel = 'Warning';
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: OkFvMasterDetailListItemDirective;
+        let nativeElement: FvMasterDetailListItem;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [OkFvMasterDetailListItemModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('can be configured with property binding for titleText', () => {
+            expect(directive.titleText).toBe('PXI-1042');
+            expect(nativeElement.titleText).toBe('PXI-1042');
+
+            fixture.componentInstance.titleText = 'DAQ-1';
+            fixture.detectChanges();
+
+            expect(directive.titleText).toBe('DAQ-1');
+            expect(nativeElement.titleText).toBe('DAQ-1');
+        });
+
+        it('can be configured with property binding for subtitle', () => {
+            expect(directive.subtitle).toBe('Calibration due');
+            expect(nativeElement.subtitle).toBe('Calibration due');
+
+            fixture.componentInstance.subtitle = 'Ready to run';
+            fixture.detectChanges();
+
+            expect(directive.subtitle).toBe('Ready to run');
+            expect(nativeElement.subtitle).toBe('Ready to run');
+        });
+
+        it('can be configured with property binding for value', () => {
+            expect(directive.value).toBe('pxi-1042');
+            expect(nativeElement.value).toBe('pxi-1042');
+
+            fixture.componentInstance.value = 'daq-1';
+            fixture.detectChanges();
+
+            expect(directive.value).toBe('daq-1');
+            expect(nativeElement.value).toBe('daq-1');
+        });
+
+        it('can be configured with property binding for compact', () => {
+            expect(directive.compact).toBeFalse();
+            expect(nativeElement.compact).toBeFalse();
+
+            fixture.componentInstance.compact = true;
+            fixture.detectChanges();
+
+            expect(directive.compact).toBeTrue();
+            expect(nativeElement.compact).toBeTrue();
+        });
+
+        it('can be configured with property binding for selected', () => {
+            expect(directive.selected).toBeFalse();
+            expect(nativeElement.selected).toBeFalse();
+
+            fixture.componentInstance.selected = true;
+            fixture.detectChanges();
+
+            expect(directive.selected).toBeTrue();
+            expect(nativeElement.selected).toBeTrue();
+        });
+
+        it('can be configured with property binding for statusColor', () => {
+            expect(directive.statusColor).toBe('var(--ni-semantic-color-warning)');
+            expect(nativeElement.statusColor).toBe('var(--ni-semantic-color-warning)');
+
+            fixture.componentInstance.statusColor = 'var(--ni-semantic-color-success)';
+            fixture.detectChanges();
+
+            expect(directive.statusColor).toBe('var(--ni-semantic-color-success)');
+            expect(nativeElement.statusColor).toBe('var(--ni-semantic-color-success)');
+        });
+
+        it('can be configured with property binding for statusLabel', () => {
+            expect(directive.statusLabel).toBe('Warning');
+            expect(nativeElement.statusLabel).toBe('Warning');
+
+            fixture.componentInstance.statusLabel = 'Ready';
+            fixture.detectChanges();
+
+            expect(directive.statusLabel).toBe('Ready');
+            expect(nativeElement.statusLabel).toBe('Ready');
+        });
+    });
+});

--- a/packages/angular-workspace/ok-angular/fv/master-detail-list/ng-package.json
+++ b/packages/angular-workspace/ok-angular/fv/master-detail-list/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/packages/angular-workspace/ok-angular/fv/master-detail-list/ok-fv-master-detail-list.directive.ts
+++ b/packages/angular-workspace/ok-angular/fv/master-detail-list/ok-fv-master-detail-list.directive.ts
@@ -1,0 +1,29 @@
+import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
+import type { FvMasterDetailList } from '@ni/ok-components/dist/esm/fv/master-detail-list';
+import { fvMasterDetailListTag } from '@ni/ok-components/dist/esm/fv/master-detail-list';
+
+export type { FvMasterDetailList };
+export { fvMasterDetailListTag };
+
+/**
+ * Directive to provide Angular integration for the master-detail list.
+ */
+@Directive({
+    selector: 'ok-fv-master-detail-list',
+    standalone: false
+})
+export class OkFvMasterDetailListDirective {
+    public get placeholder(): string {
+        return this.elementRef.nativeElement.placeholder;
+    }
+
+    @Input()
+    public set placeholder(value: string) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'placeholder', value);
+    }
+
+    public constructor(
+        private readonly elementRef: ElementRef<FvMasterDetailList>,
+        private readonly renderer: Renderer2
+    ) {}
+}

--- a/packages/angular-workspace/ok-angular/fv/master-detail-list/ok-fv-master-detail-list.module.ts
+++ b/packages/angular-workspace/ok-angular/fv/master-detail-list/ok-fv-master-detail-list.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { OkFvMasterDetailListDirective } from './ok-fv-master-detail-list.directive';
+
+import '@ni/ok-components/dist/esm/fv/master-detail-list';
+
+@NgModule({
+    declarations: [OkFvMasterDetailListDirective],
+    imports: [CommonModule],
+    exports: [OkFvMasterDetailListDirective]
+})
+export class OkFvMasterDetailListModule { }

--- a/packages/angular-workspace/ok-angular/fv/master-detail-list/public-api.ts
+++ b/packages/angular-workspace/ok-angular/fv/master-detail-list/public-api.ts
@@ -1,0 +1,2 @@
+export * from './ok-fv-master-detail-list.directive';
+export * from './ok-fv-master-detail-list.module';

--- a/packages/angular-workspace/ok-angular/fv/master-detail-list/tests/ok-fv-master-detail-list.directive.spec.ts
+++ b/packages/angular-workspace/ok-angular/fv/master-detail-list/tests/ok-fv-master-detail-list.directive.spec.ts
@@ -1,0 +1,131 @@
+import { Component, ElementRef, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { type FvMasterDetailList, OkFvMasterDetailListDirective } from '../ok-fv-master-detail-list.directive';
+import { OkFvMasterDetailListModule } from '../ok-fv-master-detail-list.module';
+import { OkFvMasterDetailListItemModule } from '../../master-detail-list-item/ok-fv-master-detail-list-item.module';
+
+describe('Ok fv master detail list', () => {
+    describe('module', () => {
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [OkFvMasterDetailListModule]
+            });
+        });
+
+        it('custom element is defined', () => {
+            expect(customElements.get('ok-fv-master-detail-list')).not.toBeUndefined();
+        });
+    });
+
+    describe('with no values in template', () => {
+        @Component({
+            template: `
+                <ok-fv-master-detail-list #list>
+                    <ok-fv-master-detail-list-item title-text="DAQ-1"></ok-fv-master-detail-list-item>
+                </ok-fv-master-detail-list>
+            `,
+            standalone: false
+        })
+        class TestHostComponent {
+            @ViewChild('list', { read: OkFvMasterDetailListDirective }) public directive: OkFvMasterDetailListDirective;
+            @ViewChild('list', { read: ElementRef }) public elementRef: ElementRef<FvMasterDetailList>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: OkFvMasterDetailListDirective;
+        let nativeElement: FvMasterDetailList;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [OkFvMasterDetailListModule, OkFvMasterDetailListItemModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('has expected defaults for placeholder', () => {
+            expect(directive.placeholder).toBe('Filter items...');
+            expect(nativeElement.placeholder).toBe('Filter items...');
+        });
+    });
+
+    describe('with template string values', () => {
+        @Component({
+            template: `
+                <ok-fv-master-detail-list #list placeholder="Filter devices">
+                    <ok-fv-master-detail-list-item title-text="DAQ-1"></ok-fv-master-detail-list-item>
+                </ok-fv-master-detail-list>
+            `,
+            standalone: false
+        })
+        class TestHostComponent {
+            @ViewChild('list', { read: OkFvMasterDetailListDirective }) public directive: OkFvMasterDetailListDirective;
+            @ViewChild('list', { read: ElementRef }) public elementRef: ElementRef<FvMasterDetailList>;
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: OkFvMasterDetailListDirective;
+        let nativeElement: FvMasterDetailList;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [OkFvMasterDetailListModule, OkFvMasterDetailListItemModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('will use template string values for placeholder', () => {
+            expect(directive.placeholder).toBe('Filter devices');
+            expect(nativeElement.placeholder).toBe('Filter devices');
+        });
+    });
+
+    describe('with property bound values', () => {
+        @Component({
+            template: `
+                <ok-fv-master-detail-list #list [placeholder]="placeholder">
+                    <ok-fv-master-detail-list-item title-text="DAQ-1"></ok-fv-master-detail-list-item>
+                </ok-fv-master-detail-list>
+            `,
+            standalone: false
+        })
+        class TestHostComponent {
+            @ViewChild('list', { read: OkFvMasterDetailListDirective }) public directive: OkFvMasterDetailListDirective;
+            @ViewChild('list', { read: ElementRef }) public elementRef: ElementRef<FvMasterDetailList>;
+            public placeholder = 'Filter devices';
+        }
+
+        let fixture: ComponentFixture<TestHostComponent>;
+        let directive: OkFvMasterDetailListDirective;
+        let nativeElement: FvMasterDetailList;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                declarations: [TestHostComponent],
+                imports: [OkFvMasterDetailListModule, OkFvMasterDetailListItemModule]
+            });
+            fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            directive = fixture.componentInstance.directive;
+            nativeElement = fixture.componentInstance.elementRef.nativeElement;
+        });
+
+        it('can be configured with property binding for placeholder', () => {
+            expect(directive.placeholder).toBe('Filter devices');
+            expect(nativeElement.placeholder).toBe('Filter devices');
+
+            fixture.componentInstance.placeholder = 'Filter systems';
+            fixture.detectChanges();
+
+            expect(directive.placeholder).toBe('Filter systems');
+            expect(nativeElement.placeholder).toBe('Filter systems');
+        });
+    });
+});

--- a/packages/eslint-config-nimble/ok/fv/ignore-attributes.js
+++ b/packages/eslint-config-nimble/ok/fv/ignore-attributes.js
@@ -9,7 +9,10 @@ const exampleAppOnlyIgnoreAttributes = [
     'header',
     'options',
     'selected-values',
+    'status-label',
+    'status-color',
     'subtitle',
+    'title-text',
     'trigger-label',
 ];
 

--- a/packages/storybook/src/docs/component-data/ok/fv/index.ts
+++ b/packages/storybook/src/docs/component-data/ok/fv/index.ts
@@ -17,7 +17,7 @@ export const componentDataOkFv = [
         componentHref: './?path=/docs/ok-fv-card--docs',
         library: 'ok',
         componentStatus: ComponentFrameworkStatus.ready,
-        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.ready,
         blazorStatus: ComponentFrameworkStatus.doesNotExist,
         reactStatus: ComponentFrameworkStatus.doesNotExist
     },
@@ -26,7 +26,7 @@ export const componentDataOkFv = [
         componentHref: './?path=/docs/ok-fv-chip-selector--docs',
         library: 'ok',
         componentStatus: ComponentFrameworkStatus.ready,
-        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.ready,
         blazorStatus: ComponentFrameworkStatus.doesNotExist,
         reactStatus: ComponentFrameworkStatus.doesNotExist
     },
@@ -35,7 +35,24 @@ export const componentDataOkFv = [
         componentHref: './?path=/docs/ok-fv-context-help--docs',
         library: 'ok',
         componentStatus: ComponentFrameworkStatus.ready,
-        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
+        reactStatus: ComponentFrameworkStatus.doesNotExist
+    },
+    {
+        componentName: 'Fv Master Detail List',
+        componentHref: './?path=/docs/ok-fv-master-detail-list--docs',
+        library: 'ok',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
+        reactStatus: ComponentFrameworkStatus.doesNotExist
+    },
+    {
+        componentName: 'Fv Master Detail List Item',
+        library: 'ok',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.ready,
         blazorStatus: ComponentFrameworkStatus.doesNotExist,
         reactStatus: ComponentFrameworkStatus.doesNotExist
     },
@@ -55,7 +72,7 @@ export const componentDataOkFv = [
         componentHref: './?path=/docs/ok-fv-split-button--docs',
         library: 'ok',
         componentStatus: ComponentFrameworkStatus.ready,
-        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.ready,
         blazorStatus: ComponentFrameworkStatus.doesNotExist,
         reactStatus: ComponentFrameworkStatus.doesNotExist
     },
@@ -64,7 +81,7 @@ export const componentDataOkFv = [
         componentHref: './?path=/docs/ok-fv-split-button-anchor--docs',
         library: 'ok',
         componentStatus: ComponentFrameworkStatus.ready,
-        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.ready,
         blazorStatus: ComponentFrameworkStatus.doesNotExist,
         reactStatus: ComponentFrameworkStatus.doesNotExist
     },
@@ -73,7 +90,7 @@ export const componentDataOkFv = [
         componentHref: './?path=/docs/ok-fv-summary-panel--docs',
         library: 'ok',
         componentStatus: ComponentFrameworkStatus.ready,
-        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.ready,
         blazorStatus: ComponentFrameworkStatus.doesNotExist,
         reactStatus: ComponentFrameworkStatus.doesNotExist
     },
@@ -81,7 +98,7 @@ export const componentDataOkFv = [
         componentName: 'Fv Summary Panel Tile',
         library: 'ok',
         componentStatus: ComponentFrameworkStatus.ready,
-        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        angularStatus: ComponentFrameworkStatus.ready,
         blazorStatus: ComponentFrameworkStatus.doesNotExist,
         reactStatus: ComponentFrameworkStatus.doesNotExist
     }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Adds Angular OK FV master-detail list components.

## 👩‍💻 Implementation

This PR adds the OK Angular secondary entry points for:

- `ok-fv-master-detail-list`
- `ok-fv-master-detail-list-item`

It also updates the supporting Angular and documentation surfaces that need to move with those wrappers:

- adds Angular directive/module/public API/test coverage for both wrappers
- adds example-client-app coverage for the FV master-detail list
- updates the OK FV component status page data so Angular availability matches the actual wrapper surface

The wrappers follow the existing OK Angular pattern by exposing element properties as Angular inputs and relying on native DOM events from the underlying custom elements.

## 🧪 Testing

Validated locally with:

- `npm run build:ok -w @ni-private/angular-workspace`
- `cd packages/angular-workspace && npx ng build example-client-app`
- `npm run test-ok -w @ni-private/angular-workspace -- --watch=false --browsers=ChromeHeadless`

The PR includes directive tests for both new Angular wrappers.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
