### PR TITLE
Add padding between switch and its label

### DIFF
--- a/change/@ni-nimble-components-46a29ba0-9f17-47f3-8087-e11186e45247.json
+++ b/change/@ni-nimble-components-46a29ba0-9f17-47f3-8087-e11186e45247.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add padding between switch and its label",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/switch/styles.ts
+++ b/packages/nimble-components/src/switch/styles.ts
@@ -62,7 +62,7 @@ export const styles = css`
         display: flex;
         align-items: center;
         ${'' /*
-            Reserve space around the control to fill a 32px height until we have a switch 32 design.
+            Reserve space around the 24px control to fill a 32px height until we have a switch 32 design.
             See: https://github.com/ni/nimble/issues/3013
         */}
         padding-top: 2px;

--- a/packages/nimble-components/src/switch/styles.ts
+++ b/packages/nimble-components/src/switch/styles.ts
@@ -51,6 +51,7 @@ export const styles = css`
     .label {
         color: ${controlLabelFontColor};
         font: ${controlLabelFont};
+        padding-bottom: 2px;
     }
 
     :host([disabled]) .label {

--- a/packages/nimble-components/src/switch/styles.ts
+++ b/packages/nimble-components/src/switch/styles.ts
@@ -66,7 +66,47 @@ export const styles = css`
     .switch-container {
         display: flex;
         align-items: center;
-    }
+   :host {
+       outline: none;
+       font: ${bodyFont};
+       color: ${buttonLabelFontColor};
+       flex-direction: column;
+       cursor: pointer;
+       --ni-private-switch-height: 24px;
+       --ni-private-switch-indicator-size: 24px;
+       --ni-private-switch-indicator-inner-size: 18px;
+       --ni-private-switch-indicator-margin: -2px;
+   }
+
+   :host([disabled]) {
+       cursor: default;
+       color: ${buttonLabelDisabledFontColor};
+   }
+
+   .label {
+       color: ${controlLabelFontColor};
+       font: ${controlLabelFont};
+   }
+
+   :host([disabled]) .label {
+       color: ${controlLabelDisabledFontColor};
+   }
+
+   .label__hidden {
+       display: none;
+       visibility: hidden;
+   }
+
+   .switch-container {
+       display: flex;
+       align-items: center;
+       ${'' /*
+           Reserve space around the control to fill a 32px height until we have a switch 32 design.
+           See: https://github.com/ni/nimble/issues/3013
+       */}
+       padding-top: 2px;
+       padding-bottom: 6px;
+   }
 
     slot[name='unchecked-message']::slotted(*) {
         margin-inline-end: 8px;

--- a/packages/nimble-components/src/switch/styles.ts
+++ b/packages/nimble-components/src/switch/styles.ts
@@ -27,7 +27,7 @@ import { themeBehavior } from '../utilities/style/theme';
 export const styles = css`
     ${display('inline-flex')}
 
-   :host {
+    :host {
         outline: none;
         font: ${bodyFont};
         color: ${buttonLabelFontColor};
@@ -37,28 +37,28 @@ export const styles = css`
         --ni-private-switch-indicator-size: 24px;
         --ni-private-switch-indicator-inner-size: 18px;
         --ni-private-switch-indicator-margin: -2px;
-   }
+    }
 
-   :host([disabled]) {
+    :host([disabled]) {
         cursor: default;
         color: ${buttonLabelDisabledFontColor};
-   }
+    }
 
-   .label {
+    .label {
         color: ${controlLabelFontColor};
         font: ${controlLabelFont};
-   }
+    }
 
-   :host([disabled]) .label {
+    :host([disabled]) .label {
         color: ${controlLabelDisabledFontColor};
-   }
+    }
 
-   .label__hidden {
+    .label__hidden {
         display: none;
         visibility: hidden;
-   }
+    }
 
-   .switch-container {
+    .switch-container {
         display: flex;
         align-items: center;
         ${'' /*
@@ -67,7 +67,7 @@ export const styles = css`
         */}
         padding-top: 2px;
         padding-bottom: 6px;
-   }
+    }
 
     slot[name='unchecked-message']::slotted(*) {
         margin-inline-end: 8px;

--- a/packages/nimble-components/src/switch/styles.ts
+++ b/packages/nimble-components/src/switch/styles.ts
@@ -14,7 +14,6 @@ import {
     borderWidth,
     buttonLabelDisabledFontColor,
     buttonLabelFontColor,
-    controlHeight,
     controlLabelDisabledFontColor,
     controlLabelFont,
     controlLabelFontColor,
@@ -28,44 +27,6 @@ import { themeBehavior } from '../utilities/style/theme';
 export const styles = css`
     ${display('inline-flex')}
 
-    :host {
-        outline: none;
-        font: ${bodyFont};
-        color: ${buttonLabelFontColor};
-        flex-direction: column;
-        cursor: pointer;
-        --ni-private-switch-height: 24px;
-        --ni-private-switch-indicator-size: 24px;
-        --ni-private-switch-indicator-inner-size: 18px;
-        --ni-private-switch-indicator-margin: -2px;
-        padding-bottom: calc(
-            ${controlHeight} - var(--ni-private-switch-height)
-        );
-    }
-
-    :host([disabled]) {
-        cursor: default;
-        color: ${buttonLabelDisabledFontColor};
-    }
-
-    .label {
-        color: ${controlLabelFontColor};
-        font: ${controlLabelFont};
-        padding-bottom: 2px;
-    }
-
-    :host([disabled]) .label {
-        color: ${controlLabelDisabledFontColor};
-    }
-
-    .label__hidden {
-        display: none;
-        visibility: hidden;
-    }
-
-    .switch-container {
-        display: flex;
-        align-items: center;
    :host {
        outline: none;
        font: ${bodyFont};

--- a/packages/nimble-components/src/switch/styles.ts
+++ b/packages/nimble-components/src/switch/styles.ts
@@ -28,45 +28,45 @@ export const styles = css`
     ${display('inline-flex')}
 
    :host {
-       outline: none;
-       font: ${bodyFont};
-       color: ${buttonLabelFontColor};
-       flex-direction: column;
-       cursor: pointer;
-       --ni-private-switch-height: 24px;
-       --ni-private-switch-indicator-size: 24px;
-       --ni-private-switch-indicator-inner-size: 18px;
-       --ni-private-switch-indicator-margin: -2px;
+        outline: none;
+        font: ${bodyFont};
+        color: ${buttonLabelFontColor};
+        flex-direction: column;
+        cursor: pointer;
+        --ni-private-switch-height: 24px;
+        --ni-private-switch-indicator-size: 24px;
+        --ni-private-switch-indicator-inner-size: 18px;
+        --ni-private-switch-indicator-margin: -2px;
    }
 
    :host([disabled]) {
-       cursor: default;
-       color: ${buttonLabelDisabledFontColor};
+        cursor: default;
+        color: ${buttonLabelDisabledFontColor};
    }
 
    .label {
-       color: ${controlLabelFontColor};
-       font: ${controlLabelFont};
+        color: ${controlLabelFontColor};
+        font: ${controlLabelFont};
    }
 
    :host([disabled]) .label {
-       color: ${controlLabelDisabledFontColor};
+        color: ${controlLabelDisabledFontColor};
    }
 
    .label__hidden {
-       display: none;
-       visibility: hidden;
+        display: none;
+        visibility: hidden;
    }
 
    .switch-container {
-       display: flex;
-       align-items: center;
-       ${'' /*
-           Reserve space around the control to fill a 32px height until we have a switch 32 design.
-           See: https://github.com/ni/nimble/issues/3013
-       */}
-       padding-top: 2px;
-       padding-bottom: 6px;
+        display: flex;
+        align-items: center;
+        ${'' /*
+            Reserve space around the control to fill a 32px height until we have a switch 32 design.
+            See: https://github.com/ni/nimble/issues/3013
+        */}
+        padding-top: 2px;
+        padding-bottom: 6px;
    }
 
     slot[name='unchecked-message']::slotted(*) {


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The `nimble-switch` design dictates that there should be a two-pixel gap/padding between the label and control:
<img width="616" height="168" alt="image" src="https://github.com/user-attachments/assets/cbac068b-e593-4f29-93cd-0016d92d9d6b" />

Needed for AzDO bug: https://dev.azure.com/ni/DevCentral/_workitems/edit/3957974

## 👩‍💻 Implementation

There is not an existing 2-pixel padding/spacing token, and I'm not sure we need one. I just added a hard-coded 2px bottom padding to the label element.

## 🧪 Testing

Verified in Storybook.
