### PR TITLE
Add React wrappers for OK FV components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33892,6 +33892,17 @@
       "devDependencies": {
         "@ni-private/eslint-config-nimble": "*",
         "@ni/ok-components": "^1.6.5",
+        "@types/jasmine": "^5.1.4",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "jasmine-core": "^5.1.2",
+        "karma": "^6.3.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-jasmine": "^5.1.0",
+        "karma-vite": "^1.0.5",
+        "playwright": "1.60.0",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
         "typescript": "~5.8.3"
       },
       "peerDependencies": {

--- a/packages/react-workspace/ok-react/karma.conf.cjs
+++ b/packages/react-workspace/ok-react/karma.conf.cjs
@@ -1,0 +1,36 @@
+const playwright = require('playwright');
+const path = require('path');
+const karmaChromeLauncher = require('karma-chrome-launcher');
+const karmaJasmine = require('karma-jasmine');
+const karmaVite = require('karma-vite');
+
+process.env.CHROME_BIN = playwright.chromium.executablePath();
+
+module.exports = config => {
+    config.set({
+        basePath: path.resolve(__dirname),
+        frameworks: ['vite', 'jasmine'],
+        plugins: [karmaVite, karmaJasmine, karmaChromeLauncher],
+        files: [
+            {
+                pattern: 'src/**/*.spec.ts',
+                type: 'module',
+                watched: false,
+                served: false,
+            },
+        ],
+        browsers: ['ChromeHeadless'],
+        logLevel: config.LOG_ERROR,
+        vite: {
+            autoInit: true,
+            config: {
+                clearScreen: false,
+                resolve: {
+                    alias: {
+                        '/base': '',
+                    }
+                }
+            }
+        }
+    });
+};

--- a/packages/react-workspace/ok-react/package.json
+++ b/packages/react-workspace/ok-react/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint .",
     "format": "eslint . --fix",
     "pack": "npm pack",
+    "test": "karma start karma.conf.cjs --single-run",
     "invoke-publish": "npm publish"
   },
   "type": "module",
@@ -51,6 +52,17 @@
   "devDependencies": {
     "@ni/ok-components": "^1.6.5",
     "@ni-private/eslint-config-nimble": "*",
+    "@types/jasmine": "^5.1.4",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "jasmine-core": "^5.1.2",
+    "karma": "^6.3.0",
+    "karma-chrome-launcher": "^3.1.0",
+    "karma-jasmine": "^5.1.0",
+    "karma-vite": "^1.0.5",
+    "playwright": "1.60.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "typescript": "~5.8.3"
   }
 }

--- a/packages/react-workspace/ok-react/src/fv/card/index.ts
+++ b/packages/react-workspace/ok-react/src/fv/card/index.ts
@@ -1,0 +1,12 @@
+'use client';
+
+import { FvCard, fvCardTag } from '@ni/ok-components/dist/esm/fv/card';
+import {
+    FvCardAppearance,
+    FvCardInteractionMode
+} from '@ni/ok-components/dist/esm/fv/card/types';
+import { wrap } from '../../utilities/react-wrapper';
+
+export { fvCardTag };
+export { type FvCard, FvCardAppearance, FvCardInteractionMode };
+export const OkFvCard = wrap(FvCard);

--- a/packages/react-workspace/ok-react/src/fv/chip-selector/index.ts
+++ b/packages/react-workspace/ok-react/src/fv/chip-selector/index.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { FvChipSelector, fvChipSelectorTag } from '@ni/ok-components/dist/esm/fv/chip-selector';
+import { wrap, type EventName } from '../../utilities/react-wrapper';
+
+export { fvChipSelectorTag };
+export { type FvChipSelector };
+export const OkFvChipSelector = wrap(FvChipSelector, {
+    events: {
+        onChange: 'change' as EventName<FvChipSelectorChangeEvent>,
+    }
+});
+export interface FvChipSelectorChangeEvent extends CustomEvent<{ selectedValues: string[] }> {
+    target: FvChipSelector;
+}

--- a/packages/react-workspace/ok-react/src/fv/context-help/index.ts
+++ b/packages/react-workspace/ok-react/src/fv/context-help/index.ts
@@ -1,0 +1,9 @@
+'use client';
+
+import { FvContextHelp, fvContextHelpTag } from '@ni/ok-components/dist/esm/fv/context-help';
+import type { FvContextHelpSeverity } from '@ni/ok-components/dist/esm/fv/context-help/types';
+import { wrap } from '../../utilities/react-wrapper';
+
+export { fvContextHelpTag };
+export { type FvContextHelp, type FvContextHelpSeverity };
+export const OkFvContextHelp = wrap(FvContextHelp);

--- a/packages/react-workspace/ok-react/src/fv/master-detail-list-item/index.ts
+++ b/packages/react-workspace/ok-react/src/fv/master-detail-list-item/index.ts
@@ -1,0 +1,11 @@
+'use client';
+
+import {
+    FvMasterDetailListItem,
+    fvMasterDetailListItemTag
+} from '@ni/ok-components/dist/esm/fv/master-detail-list-item';
+import { wrap } from '../../utilities/react-wrapper';
+
+export { fvMasterDetailListItemTag };
+export { type FvMasterDetailListItem };
+export const OkFvMasterDetailListItem = wrap(FvMasterDetailListItem);

--- a/packages/react-workspace/ok-react/src/fv/master-detail-list/index.ts
+++ b/packages/react-workspace/ok-react/src/fv/master-detail-list/index.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import {
+    FvMasterDetailList,
+    fvMasterDetailListTag,
+    type FvMasterDetailListChangeDetail
+} from '@ni/ok-components/dist/esm/fv/master-detail-list';
+import { wrap, type EventName } from '../../utilities/react-wrapper';
+
+export { fvMasterDetailListTag };
+export { type FvMasterDetailList, type FvMasterDetailListChangeDetail };
+export const OkFvMasterDetailList = wrap(FvMasterDetailList, {
+    events: {
+        onChange: 'change' as EventName<FvMasterDetailListChangeEvent>,
+    }
+});
+export interface FvMasterDetailListChangeEvent extends CustomEvent<FvMasterDetailListChangeDetail> {
+    target: FvMasterDetailList;
+}

--- a/packages/react-workspace/ok-react/src/fv/split-button-anchor/index.ts
+++ b/packages/react-workspace/ok-react/src/fv/split-button-anchor/index.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import {
+    FvSplitButtonAnchor,
+    fvSplitButtonAnchorTag
+} from '@ni/ok-components/dist/esm/fv/split-button-anchor';
+import {
+    FvSplitButtonAnchorAppearance,
+    FvSplitButtonAnchorAppearanceVariant
+} from '@ni/ok-components/dist/esm/fv/split-button-anchor/types';
+import { wrap, type EventName } from '../../utilities/react-wrapper';
+
+export { fvSplitButtonAnchorTag };
+export {
+    type FvSplitButtonAnchor,
+    FvSplitButtonAnchorAppearance,
+    FvSplitButtonAnchorAppearanceVariant
+};
+export const OkFvSplitButtonAnchor = wrap(FvSplitButtonAnchor, {
+    events: {
+        onTrigger: 'trigger' as EventName<FvSplitButtonAnchorTriggerEvent>,
+        onToggle: 'toggle' as EventName<FvSplitButtonAnchorToggleEvent>,
+    }
+});
+export interface FvSplitButtonAnchorTriggerEvent extends CustomEvent {
+    target: FvSplitButtonAnchor;
+}
+export interface FvSplitButtonAnchorToggleEvent extends CustomEvent<{ open: boolean }> {
+    target: FvSplitButtonAnchor;
+}

--- a/packages/react-workspace/ok-react/src/fv/split-button/index.ts
+++ b/packages/react-workspace/ok-react/src/fv/split-button/index.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { FvSplitButton, fvSplitButtonTag } from '@ni/ok-components/dist/esm/fv/split-button';
+import {
+    FvSplitButtonAppearance,
+    FvSplitButtonAppearanceVariant
+} from '@ni/ok-components/dist/esm/fv/split-button/types';
+import { wrap, type EventName } from '../../utilities/react-wrapper';
+
+export { fvSplitButtonTag };
+export {
+    type FvSplitButton,
+    FvSplitButtonAppearance,
+    FvSplitButtonAppearanceVariant
+};
+export const OkFvSplitButton = wrap(FvSplitButton, {
+    events: {
+        onTrigger: 'trigger' as EventName<FvSplitButtonTriggerEvent>,
+        onToggle: 'toggle' as EventName<FvSplitButtonToggleEvent>,
+    }
+});
+export interface FvSplitButtonTriggerEvent extends CustomEvent {
+    target: FvSplitButton;
+}
+export interface FvSplitButtonToggleEvent extends CustomEvent<{ open: boolean }> {
+    target: FvSplitButton;
+}

--- a/packages/react-workspace/ok-react/src/fv/summary-panel-tile/index.ts
+++ b/packages/react-workspace/ok-react/src/fv/summary-panel-tile/index.ts
@@ -1,0 +1,12 @@
+'use client';
+
+import {
+    FvSummaryPanelTile,
+    fvSummaryPanelTileTag
+} from '@ni/ok-components/dist/esm/fv/summary-panel-tile';
+import { FvSummaryPanelTileTextPosition } from '@ni/ok-components/dist/esm/fv/summary-panel-tile/types';
+import { wrap } from '../../utilities/react-wrapper';
+
+export { fvSummaryPanelTileTag };
+export { type FvSummaryPanelTile, FvSummaryPanelTileTextPosition };
+export const OkFvSummaryPanelTile = wrap(FvSummaryPanelTile);

--- a/packages/react-workspace/ok-react/src/fv/summary-panel/index.ts
+++ b/packages/react-workspace/ok-react/src/fv/summary-panel/index.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { FvSummaryPanel, fvSummaryPanelTag } from '@ni/ok-components/dist/esm/fv/summary-panel';
+import { wrap, type EventName } from '../../utilities/react-wrapper';
+
+export { fvSummaryPanelTag };
+export { type FvSummaryPanel };
+export const OkFvSummaryPanel = wrap(FvSummaryPanel, {
+    events: {
+        onEditItems: 'edit-items' as EventName<FvSummaryPanelEditItemsEvent>,
+    }
+});
+export interface FvSummaryPanelEditItemsEvent extends CustomEvent {
+    target: FvSummaryPanel;
+}

--- a/packages/react-workspace/ok-react/src/fv/tests/events.spec.ts
+++ b/packages/react-workspace/ok-react/src/fv/tests/events.spec.ts
@@ -1,0 +1,135 @@
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+    fvChipSelectorTag,
+    OkFvChipSelector
+} from '../chip-selector';
+import type { FvChipSelectorChangeEvent } from '../chip-selector';
+import {
+    fvMasterDetailListTag,
+    OkFvMasterDetailList
+} from '../master-detail-list';
+import type { FvMasterDetailListChangeEvent } from '../master-detail-list';
+import {
+    fvSplitButtonAnchorTag,
+    OkFvSplitButtonAnchor
+} from '../split-button-anchor';
+import type {
+    FvSplitButtonAnchorToggleEvent,
+    FvSplitButtonAnchorTriggerEvent
+} from '../split-button-anchor';
+import {
+    fvSplitButtonTag,
+    OkFvSplitButton
+} from '../split-button';
+import type {
+    FvSplitButtonToggleEvent,
+    FvSplitButtonTriggerEvent
+} from '../split-button';
+import {
+    fvSummaryPanelTag,
+    OkFvSummaryPanel
+} from '../summary-panel';
+import type { FvSummaryPanelEditItemsEvent } from '../summary-panel';
+
+Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', { value: true });
+
+function getRequiredElement<T extends Element>(container: HTMLElement, selector: string): T {
+    const element = container.querySelector<T>(selector);
+    if (!element) {
+        throw new Error(`Expected ${selector} to render`);
+    }
+
+    return element;
+}
+
+describe('OK React wrapper events', () => {
+    let container: HTMLDivElement;
+    let root: Root;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.append(container);
+        root = createRoot(container);
+    });
+
+    afterEach(() => {
+        act(() => {
+            root.unmount();
+        });
+        container.remove();
+    });
+
+    function render(component: ReturnType<typeof createElement>): void {
+        act(() => {
+            root.render(component);
+        });
+    }
+
+    it('passes chip selector changes to onChange', () => {
+        const onChange = jasmine.createSpy<(event: FvChipSelectorChangeEvent) => void>('onChange');
+        render(createElement(OkFvChipSelector, { onChange }));
+
+        const element = getRequiredElement(container, fvChipSelectorTag);
+        const event = new CustomEvent('change', { detail: { selectedValues: ['active'] } }) as unknown as FvChipSelectorChangeEvent;
+        void act(() => element.dispatchEvent(event));
+
+        expect(onChange).toHaveBeenCalledOnceWith(event);
+    });
+
+    it('passes master-detail list changes to onChange', () => {
+        const onChange = jasmine.createSpy<(event: FvMasterDetailListChangeEvent) => void>('onChange');
+        render(createElement(OkFvMasterDetailList, { onChange }));
+
+        const element = getRequiredElement(container, fvMasterDetailListTag);
+        const event = new CustomEvent('change', { detail: { item: null, value: null } }) as unknown as FvMasterDetailListChangeEvent;
+        void act(() => element.dispatchEvent(event));
+
+        expect(onChange).toHaveBeenCalledOnceWith(event);
+    });
+
+    it('passes split button trigger and toggle events to React handlers', () => {
+        const onTrigger = jasmine.createSpy<(event: FvSplitButtonTriggerEvent) => void>('onTrigger');
+        const onToggle = jasmine.createSpy<(event: FvSplitButtonToggleEvent) => void>('onToggle');
+        render(createElement(OkFvSplitButton, { onTrigger, onToggle }));
+
+        const element = getRequiredElement(container, fvSplitButtonTag);
+        const triggerEvent = new CustomEvent('trigger') as unknown as FvSplitButtonTriggerEvent;
+        const toggleEvent = new CustomEvent('toggle', { detail: { open: true } }) as unknown as FvSplitButtonToggleEvent;
+        act(() => {
+            element.dispatchEvent(triggerEvent);
+            element.dispatchEvent(toggleEvent);
+        });
+
+        expect(onTrigger).toHaveBeenCalledOnceWith(triggerEvent);
+        expect(onToggle).toHaveBeenCalledOnceWith(toggleEvent);
+    });
+
+    it('passes split button anchor trigger and toggle events to React handlers', () => {
+        const onTrigger = jasmine.createSpy<(event: FvSplitButtonAnchorTriggerEvent) => void>('onTrigger');
+        const onToggle = jasmine.createSpy<(event: FvSplitButtonAnchorToggleEvent) => void>('onToggle');
+        render(createElement(OkFvSplitButtonAnchor, { onTrigger, onToggle }));
+
+        const element = getRequiredElement(container, fvSplitButtonAnchorTag);
+        const triggerEvent = new CustomEvent('trigger') as unknown as FvSplitButtonAnchorTriggerEvent;
+        const toggleEvent = new CustomEvent('toggle', { detail: { open: true } }) as unknown as FvSplitButtonAnchorToggleEvent;
+        act(() => {
+            element.dispatchEvent(triggerEvent);
+            element.dispatchEvent(toggleEvent);
+        });
+
+        expect(onTrigger).toHaveBeenCalledOnceWith(triggerEvent);
+        expect(onToggle).toHaveBeenCalledOnceWith(toggleEvent);
+    });
+
+    it('passes summary panel edit events to onEditItems', () => {
+        const onEditItems = jasmine.createSpy<(event: FvSummaryPanelEditItemsEvent) => void>('onEditItems');
+        render(createElement(OkFvSummaryPanel, { onEditItems }));
+
+        const element = getRequiredElement(container, fvSummaryPanelTag);
+        const event = new CustomEvent('edit-items') as unknown as FvSummaryPanelEditItemsEvent;
+        void act(() => element.dispatchEvent(event));
+
+        expect(onEditItems).toHaveBeenCalledOnceWith(event);
+    });
+});


### PR DESCRIPTION
Adds `@lit/react` wrappers for the OK FV card, chip selector, context help, master-detail list and list item, split button and anchor, and summary panel/tile components.

The wrappers expose the relevant component classes, tags, appearance types, and custom events with typed callback payloads.

Validation:
- `npm run lint -w @ni/ok-react`
- `npm run build -w @ni/ok-react`
- `npm run test -w @ni/ok-react` (five Chromium event-mapping specs)
- `npm pack --dry-run -w @ni/ok-react`