### PR TITLE
Fix Blazor build by bumping AngleSharp dependency

### DIFF
--- a/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/BlazorWorkspace.Testing.Unit.csproj
+++ b/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/BlazorWorkspace.Testing.Unit.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="1.4.0" />
+    <PackageReference Include="AngleSharp" Version="1.5.2" />
     <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.157" />
     <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
     <PackageReference Include="bunit" Version="2.7.2" />

--- a/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/BlazorWorkspace.Testing.Unit.csproj
+++ b/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/BlazorWorkspace.Testing.Unit.csproj
@@ -10,8 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.5.2" />
-    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.224" />
-    <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
     <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="NI.CSharp.Analyzers" Version="2.0.35" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/BlazorWorkspace.Testing.Unit.csproj
+++ b/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/BlazorWorkspace.Testing.Unit.csproj
@@ -9,6 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="1.4.0" />
+    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.157" />
+    <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
     <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="NI.CSharp.Analyzers" Version="2.0.35" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/BlazorWorkspace.Testing.Unit.csproj
+++ b/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/BlazorWorkspace.Testing.Unit.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.5.2" />
-    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.157" />
+    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.224" />
     <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
     <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="NI.CSharp.Analyzers" Version="2.0.35" />

--- a/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/packages.lock.json
+++ b/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/packages.lock.json
@@ -10,11 +10,11 @@
       },
       "AngleSharp.Css": {
         "type": "Direct",
-        "requested": "[1.0.0-beta.157, )",
-        "resolved": "1.0.0-beta.157",
-        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "requested": "[1.0.0-beta.224, )",
+        "resolved": "1.0.0-beta.224",
+        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
         "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)"
+          "AngleSharp": "[1.5.0, 2.0.0)"
         }
       },
       "AngleSharp.Diffing": {
@@ -447,11 +447,11 @@
       },
       "AngleSharp.Css": {
         "type": "Direct",
-        "requested": "[1.0.0-beta.157, )",
-        "resolved": "1.0.0-beta.157",
-        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "requested": "[1.0.0-beta.224, )",
+        "resolved": "1.0.0-beta.224",
+        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
         "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)"
+          "AngleSharp": "[1.5.0, 2.0.0)"
         }
       },
       "AngleSharp.Diffing": {

--- a/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/packages.lock.json
+++ b/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/packages.lock.json
@@ -8,25 +8,6 @@
         "resolved": "1.5.2",
         "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
       },
-      "AngleSharp.Css": {
-        "type": "Direct",
-        "requested": "[1.0.0-beta.224, )",
-        "resolved": "1.0.0-beta.224",
-        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
-        "dependencies": {
-          "AngleSharp": "[1.5.0, 2.0.0)"
-        }
-      },
-      "AngleSharp.Diffing": {
-        "type": "Direct",
-        "requested": "[1.1.1, )",
-        "resolved": "1.1.1",
-        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
-        "dependencies": {
-          "AngleSharp": "1.1.2",
-          "AngleSharp.Css": "1.0.0-beta.144"
-        }
-      },
       "bunit": {
         "type": "Direct",
         "requested": "[2.7.2, )",
@@ -70,6 +51,23 @@
           "xunit.analyzers": "1.18.0",
           "xunit.assert": "2.9.3",
           "xunit.core": "[2.9.3]"
+        }
+      },
+      "AngleSharp.Css": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.157",
+        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "dependencies": {
+          "AngleSharp": "[1.0.0, 2.0.0)"
+        }
+      },
+      "AngleSharp.Diffing": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
+        "dependencies": {
+          "AngleSharp": "1.1.2",
+          "AngleSharp.Css": "1.0.0-beta.144"
         }
       },
       "Microsoft.AspNetCore.Authorization": {
@@ -445,25 +443,6 @@
         "resolved": "1.5.2",
         "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
       },
-      "AngleSharp.Css": {
-        "type": "Direct",
-        "requested": "[1.0.0-beta.224, )",
-        "resolved": "1.0.0-beta.224",
-        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
-        "dependencies": {
-          "AngleSharp": "[1.5.0, 2.0.0)"
-        }
-      },
-      "AngleSharp.Diffing": {
-        "type": "Direct",
-        "requested": "[1.1.1, )",
-        "resolved": "1.1.1",
-        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
-        "dependencies": {
-          "AngleSharp": "1.1.2",
-          "AngleSharp.Css": "1.0.0-beta.144"
-        }
-      },
       "bunit": {
         "type": "Direct",
         "requested": "[2.7.2, )",
@@ -507,6 +486,23 @@
           "xunit.analyzers": "1.18.0",
           "xunit.assert": "2.9.3",
           "xunit.core": "[2.9.3]"
+        }
+      },
+      "AngleSharp.Css": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.157",
+        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "dependencies": {
+          "AngleSharp": "[1.0.0, 2.0.0)"
+        }
+      },
+      "AngleSharp.Diffing": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
+        "dependencies": {
+          "AngleSharp": "1.1.2",
+          "AngleSharp.Css": "1.0.0-beta.144"
         }
       },
       "Microsoft.AspNetCore.Authorization": {

--- a/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/packages.lock.json
+++ b/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "AngleSharp": {
         "type": "Direct",
-        "requested": "[1.4.0, )",
-        "resolved": "1.4.0",
-        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+        "requested": "[1.5.2, )",
+        "resolved": "1.5.2",
+        "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
       },
       "AngleSharp.Css": {
         "type": "Direct",
@@ -441,9 +441,9 @@
     "net8.0": {
       "AngleSharp": {
         "type": "Direct",
-        "requested": "[1.4.0, )",
-        "resolved": "1.4.0",
-        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+        "requested": "[1.5.2, )",
+        "resolved": "1.5.2",
+        "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
       },
       "AngleSharp.Css": {
         "type": "Direct",

--- a/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/packages.lock.json
+++ b/packages/blazor-workspace/Tests/BlazorWorkspace.Testing.Unit/packages.lock.json
@@ -2,6 +2,31 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
+      "AngleSharp": {
+        "type": "Direct",
+        "requested": "[1.4.0, )",
+        "resolved": "1.4.0",
+        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+      },
+      "AngleSharp.Css": {
+        "type": "Direct",
+        "requested": "[1.0.0-beta.157, )",
+        "resolved": "1.0.0-beta.157",
+        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "dependencies": {
+          "AngleSharp": "[1.0.0, 2.0.0)"
+        }
+      },
+      "AngleSharp.Diffing": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
+        "dependencies": {
+          "AngleSharp": "1.1.2",
+          "AngleSharp.Css": "1.0.0-beta.144"
+        }
+      },
       "bunit": {
         "type": "Direct",
         "requested": "[2.7.2, )",
@@ -45,28 +70,6 @@
           "xunit.analyzers": "1.18.0",
           "xunit.assert": "2.9.3",
           "xunit.core": "[2.9.3]"
-        }
-      },
-      "AngleSharp": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
-      },
-      "AngleSharp.Css": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta.157",
-        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
-        "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)"
-        }
-      },
-      "AngleSharp.Diffing": {
-        "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
-        "dependencies": {
-          "AngleSharp": "1.1.2",
-          "AngleSharp.Css": "1.0.0-beta.144"
         }
       },
       "Microsoft.AspNetCore.Authorization": {
@@ -436,6 +439,31 @@
       }
     },
     "net8.0": {
+      "AngleSharp": {
+        "type": "Direct",
+        "requested": "[1.4.0, )",
+        "resolved": "1.4.0",
+        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+      },
+      "AngleSharp.Css": {
+        "type": "Direct",
+        "requested": "[1.0.0-beta.157, )",
+        "resolved": "1.0.0-beta.157",
+        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "dependencies": {
+          "AngleSharp": "[1.0.0, 2.0.0)"
+        }
+      },
+      "AngleSharp.Diffing": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
+        "dependencies": {
+          "AngleSharp": "1.1.2",
+          "AngleSharp.Css": "1.0.0-beta.144"
+        }
+      },
       "bunit": {
         "type": "Direct",
         "requested": "[2.7.2, )",
@@ -479,28 +507,6 @@
           "xunit.analyzers": "1.18.0",
           "xunit.assert": "2.9.3",
           "xunit.core": "[2.9.3]"
-        }
-      },
-      "AngleSharp": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
-      },
-      "AngleSharp.Css": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta.157",
-        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
-        "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)"
-        }
-      },
-      "AngleSharp.Diffing": {
-        "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
-        "dependencies": {
-          "AngleSharp": "1.1.2",
-          "AngleSharp.Css": "1.0.0-beta.144"
         }
       },
       "Microsoft.AspNetCore.Authorization": {

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/NimbleBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/NimbleBlazor.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="1.4.0" />
+    <PackageReference Include="AngleSharp" Version="1.5.2" />
     <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.157" />
     <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
     <PackageReference Include="bunit" Version="2.7.2" />

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/NimbleBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/NimbleBlazor.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.5.2" />
-    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.157" />
+    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.224" />
     <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
     <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="coverlet.collector" Version="10.0.1" />

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/NimbleBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/NimbleBlazor.Tests.csproj
@@ -10,8 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.5.2" />
-    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.224" />
-    <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
     <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/NimbleBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/NimbleBlazor.Tests.csproj
@@ -9,6 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="1.4.0" />
+    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.157" />
+    <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
     <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/packages.lock.json
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/packages.lock.json
@@ -10,11 +10,11 @@
       },
       "AngleSharp.Css": {
         "type": "Direct",
-        "requested": "[1.0.0-beta.157, )",
-        "resolved": "1.0.0-beta.157",
-        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "requested": "[1.0.0-beta.224, )",
+        "resolved": "1.0.0-beta.224",
+        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
         "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)"
+          "AngleSharp": "[1.5.0, 2.0.0)"
         }
       },
       "AngleSharp.Diffing": {
@@ -500,8 +500,8 @@
       "blazorworkspace.testing.unit": {
         "type": "Project",
         "dependencies": {
-          "AngleSharp": "[1.4.0, )",
-          "AngleSharp.Css": "[1.0.0-beta.157, )",
+          "AngleSharp": "[1.5.2, )",
+          "AngleSharp.Css": "[1.0.0-beta.224, )",
           "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
           "bunit": "[2.7.2, )",
@@ -525,11 +525,11 @@
       },
       "AngleSharp.Css": {
         "type": "Direct",
-        "requested": "[1.0.0-beta.157, )",
-        "resolved": "1.0.0-beta.157",
-        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "requested": "[1.0.0-beta.224, )",
+        "resolved": "1.0.0-beta.224",
+        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
         "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)"
+          "AngleSharp": "[1.5.0, 2.0.0)"
         }
       },
       "AngleSharp.Diffing": {
@@ -978,8 +978,8 @@
       "blazorworkspace.testing.unit": {
         "type": "Project",
         "dependencies": {
-          "AngleSharp": "[1.4.0, )",
-          "AngleSharp.Css": "[1.0.0-beta.157, )",
+          "AngleSharp": "[1.5.2, )",
+          "AngleSharp.Css": "[1.0.0-beta.224, )",
           "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
           "bunit": "[2.7.2, )",

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/packages.lock.json
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "AngleSharp": {
         "type": "Direct",
-        "requested": "[1.4.0, )",
-        "resolved": "1.4.0",
-        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+        "requested": "[1.5.2, )",
+        "resolved": "1.5.2",
+        "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
       },
       "AngleSharp.Css": {
         "type": "Direct",
@@ -500,6 +500,9 @@
       "blazorworkspace.testing.unit": {
         "type": "Project",
         "dependencies": {
+          "AngleSharp": "[1.4.0, )",
+          "AngleSharp.Css": "[1.0.0-beta.157, )",
+          "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
           "bunit": "[2.7.2, )",
           "xunit": "[2.9.3, )"
@@ -516,9 +519,9 @@
     "net8.0": {
       "AngleSharp": {
         "type": "Direct",
-        "requested": "[1.4.0, )",
-        "resolved": "1.4.0",
-        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+        "requested": "[1.5.2, )",
+        "resolved": "1.5.2",
+        "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
       },
       "AngleSharp.Css": {
         "type": "Direct",
@@ -975,6 +978,9 @@
       "blazorworkspace.testing.unit": {
         "type": "Project",
         "dependencies": {
+          "AngleSharp": "[1.4.0, )",
+          "AngleSharp.Css": "[1.0.0-beta.157, )",
+          "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
           "bunit": "[2.7.2, )",
           "xunit": "[2.9.3, )"

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/packages.lock.json
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/packages.lock.json
@@ -2,6 +2,31 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
+      "AngleSharp": {
+        "type": "Direct",
+        "requested": "[1.4.0, )",
+        "resolved": "1.4.0",
+        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+      },
+      "AngleSharp.Css": {
+        "type": "Direct",
+        "requested": "[1.0.0-beta.157, )",
+        "resolved": "1.0.0-beta.157",
+        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "dependencies": {
+          "AngleSharp": "[1.0.0, 2.0.0)"
+        }
+      },
+      "AngleSharp.Diffing": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
+        "dependencies": {
+          "AngleSharp": "1.1.2",
+          "AngleSharp.Css": "1.0.0-beta.144"
+        }
+      },
       "bunit": {
         "type": "Direct",
         "requested": "[2.7.2, )",
@@ -77,28 +102,6 @@
         "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
-      },
-      "AngleSharp": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
-      },
-      "AngleSharp.Css": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta.157",
-        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
-        "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)"
-        }
-      },
-      "AngleSharp.Diffing": {
-        "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
-        "dependencies": {
-          "AngleSharp": "1.1.2",
-          "AngleSharp.Css": "1.0.0-beta.144"
-        }
       },
       "Apache.Arrow": {
         "type": "Transitive",
@@ -511,6 +514,31 @@
       }
     },
     "net8.0": {
+      "AngleSharp": {
+        "type": "Direct",
+        "requested": "[1.4.0, )",
+        "resolved": "1.4.0",
+        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+      },
+      "AngleSharp.Css": {
+        "type": "Direct",
+        "requested": "[1.0.0-beta.157, )",
+        "resolved": "1.0.0-beta.157",
+        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "dependencies": {
+          "AngleSharp": "[1.0.0, 2.0.0)"
+        }
+      },
+      "AngleSharp.Diffing": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
+        "dependencies": {
+          "AngleSharp": "1.1.2",
+          "AngleSharp.Css": "1.0.0-beta.144"
+        }
+      },
       "bunit": {
         "type": "Direct",
         "requested": "[2.7.2, )",
@@ -586,28 +614,6 @@
         "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
-      },
-      "AngleSharp": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
-      },
-      "AngleSharp.Css": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta.157",
-        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
-        "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)"
-        }
-      },
-      "AngleSharp.Diffing": {
-        "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
-        "dependencies": {
-          "AngleSharp": "1.1.2",
-          "AngleSharp.Css": "1.0.0-beta.144"
-        }
       },
       "Apache.Arrow": {
         "type": "Transitive",

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/packages.lock.json
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/packages.lock.json
@@ -8,25 +8,6 @@
         "resolved": "1.5.2",
         "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
       },
-      "AngleSharp.Css": {
-        "type": "Direct",
-        "requested": "[1.0.0-beta.224, )",
-        "resolved": "1.0.0-beta.224",
-        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
-        "dependencies": {
-          "AngleSharp": "[1.5.0, 2.0.0)"
-        }
-      },
-      "AngleSharp.Diffing": {
-        "type": "Direct",
-        "requested": "[1.1.1, )",
-        "resolved": "1.1.1",
-        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
-        "dependencies": {
-          "AngleSharp": "1.1.2",
-          "AngleSharp.Css": "1.0.0-beta.144"
-        }
-      },
       "bunit": {
         "type": "Direct",
         "requested": "[2.7.2, )",
@@ -102,6 +83,23 @@
         "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "AngleSharp.Css": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.224",
+        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
+        "dependencies": {
+          "AngleSharp": "[1.5.0, 2.0.0)"
+        }
+      },
+      "AngleSharp.Diffing": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
+        "dependencies": {
+          "AngleSharp": "1.1.2",
+          "AngleSharp.Css": "1.0.0-beta.144"
+        }
       },
       "Apache.Arrow": {
         "type": "Transitive",
@@ -523,25 +521,6 @@
         "resolved": "1.5.2",
         "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
       },
-      "AngleSharp.Css": {
-        "type": "Direct",
-        "requested": "[1.0.0-beta.224, )",
-        "resolved": "1.0.0-beta.224",
-        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
-        "dependencies": {
-          "AngleSharp": "[1.5.0, 2.0.0)"
-        }
-      },
-      "AngleSharp.Diffing": {
-        "type": "Direct",
-        "requested": "[1.1.1, )",
-        "resolved": "1.1.1",
-        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
-        "dependencies": {
-          "AngleSharp": "1.1.2",
-          "AngleSharp.Css": "1.0.0-beta.144"
-        }
-      },
       "bunit": {
         "type": "Direct",
         "requested": "[2.7.2, )",
@@ -617,6 +596,23 @@
         "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "AngleSharp.Css": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.224",
+        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
+        "dependencies": {
+          "AngleSharp": "[1.5.0, 2.0.0)"
+        }
+      },
+      "AngleSharp.Diffing": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
+        "dependencies": {
+          "AngleSharp": "1.1.2",
+          "AngleSharp.Css": "1.0.0-beta.144"
+        }
       },
       "Apache.Arrow": {
         "type": "Transitive",

--- a/packages/blazor-workspace/Tests/OkBlazor.Tests/OkBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/OkBlazor.Tests/OkBlazor.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.5.2" />
-    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.157" />
+    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.224" />
     <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
     <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="coverlet.collector" Version="10.0.1" />

--- a/packages/blazor-workspace/Tests/OkBlazor.Tests/OkBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/OkBlazor.Tests/OkBlazor.Tests.csproj
@@ -9,8 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.5.2" />
-    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.224" />
-    <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
     <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />

--- a/packages/blazor-workspace/Tests/OkBlazor.Tests/OkBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/OkBlazor.Tests/OkBlazor.Tests.csproj
@@ -8,6 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="1.4.0" />
+    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.157" />
+    <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
     <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />

--- a/packages/blazor-workspace/Tests/OkBlazor.Tests/OkBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/OkBlazor.Tests/OkBlazor.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="1.4.0" />
+    <PackageReference Include="AngleSharp" Version="1.5.2" />
     <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.157" />
     <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
     <PackageReference Include="bunit" Version="2.7.2" />

--- a/packages/blazor-workspace/Tests/OkBlazor.Tests/packages.lock.json
+++ b/packages/blazor-workspace/Tests/OkBlazor.Tests/packages.lock.json
@@ -10,11 +10,11 @@
       },
       "AngleSharp.Css": {
         "type": "Direct",
-        "requested": "[1.0.0-beta.157, )",
-        "resolved": "1.0.0-beta.157",
-        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "requested": "[1.0.0-beta.224, )",
+        "resolved": "1.0.0-beta.224",
+        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
         "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)"
+          "AngleSharp": "[1.5.0, 2.0.0)"
         }
       },
       "AngleSharp.Diffing": {
@@ -488,7 +488,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.5.2, )",
-          "AngleSharp.Css": "[1.0.0-beta.157, )",
+          "AngleSharp.Css": "[1.0.0-beta.224, )",
           "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
           "bunit": "[2.7.2, )",
@@ -511,11 +511,11 @@
       },
       "AngleSharp.Css": {
         "type": "Direct",
-        "requested": "[1.0.0-beta.157, )",
-        "resolved": "1.0.0-beta.157",
-        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "requested": "[1.0.0-beta.224, )",
+        "resolved": "1.0.0-beta.224",
+        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
         "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)"
+          "AngleSharp": "[1.5.0, 2.0.0)"
         }
       },
       "AngleSharp.Diffing": {
@@ -952,7 +952,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.5.2, )",
-          "AngleSharp.Css": "[1.0.0-beta.157, )",
+          "AngleSharp.Css": "[1.0.0-beta.224, )",
           "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
           "bunit": "[2.7.2, )",

--- a/packages/blazor-workspace/Tests/OkBlazor.Tests/packages.lock.json
+++ b/packages/blazor-workspace/Tests/OkBlazor.Tests/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "AngleSharp": {
         "type": "Direct",
-        "requested": "[1.4.0, )",
-        "resolved": "1.4.0",
-        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+        "requested": "[1.5.2, )",
+        "resolved": "1.5.2",
+        "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
       },
       "AngleSharp.Css": {
         "type": "Direct",
@@ -487,7 +487,7 @@
       "blazorworkspace.testing.unit": {
         "type": "Project",
         "dependencies": {
-          "AngleSharp": "[1.4.0, )",
+          "AngleSharp": "[1.5.2, )",
           "AngleSharp.Css": "[1.0.0-beta.157, )",
           "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
@@ -505,9 +505,9 @@
     "net8.0": {
       "AngleSharp": {
         "type": "Direct",
-        "requested": "[1.4.0, )",
-        "resolved": "1.4.0",
-        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+        "requested": "[1.5.2, )",
+        "resolved": "1.5.2",
+        "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
       },
       "AngleSharp.Css": {
         "type": "Direct",
@@ -951,7 +951,7 @@
       "blazorworkspace.testing.unit": {
         "type": "Project",
         "dependencies": {
-          "AngleSharp": "[1.4.0, )",
+          "AngleSharp": "[1.5.2, )",
           "AngleSharp.Css": "[1.0.0-beta.157, )",
           "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",

--- a/packages/blazor-workspace/Tests/OkBlazor.Tests/packages.lock.json
+++ b/packages/blazor-workspace/Tests/OkBlazor.Tests/packages.lock.json
@@ -8,25 +8,6 @@
         "resolved": "1.5.2",
         "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
       },
-      "AngleSharp.Css": {
-        "type": "Direct",
-        "requested": "[1.0.0-beta.224, )",
-        "resolved": "1.0.0-beta.224",
-        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
-        "dependencies": {
-          "AngleSharp": "[1.5.0, 2.0.0)"
-        }
-      },
-      "AngleSharp.Diffing": {
-        "type": "Direct",
-        "requested": "[1.1.1, )",
-        "resolved": "1.1.1",
-        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
-        "dependencies": {
-          "AngleSharp": "1.1.2",
-          "AngleSharp.Css": "1.0.0-beta.144"
-        }
-      },
       "bunit": {
         "type": "Direct",
         "requested": "[2.7.2, )",
@@ -102,6 +83,23 @@
         "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "AngleSharp.Css": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.157",
+        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "dependencies": {
+          "AngleSharp": "[1.0.0, 2.0.0)"
+        }
+      },
+      "AngleSharp.Diffing": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
+        "dependencies": {
+          "AngleSharp": "1.1.2",
+          "AngleSharp.Css": "1.0.0-beta.144"
+        }
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -488,8 +486,6 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.5.2, )",
-          "AngleSharp.Css": "[1.0.0-beta.224, )",
-          "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
           "bunit": "[2.7.2, )",
           "xunit": "[2.9.3, )"
@@ -508,25 +504,6 @@
         "requested": "[1.5.2, )",
         "resolved": "1.5.2",
         "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
-      },
-      "AngleSharp.Css": {
-        "type": "Direct",
-        "requested": "[1.0.0-beta.224, )",
-        "resolved": "1.0.0-beta.224",
-        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
-        "dependencies": {
-          "AngleSharp": "[1.5.0, 2.0.0)"
-        }
-      },
-      "AngleSharp.Diffing": {
-        "type": "Direct",
-        "requested": "[1.1.1, )",
-        "resolved": "1.1.1",
-        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
-        "dependencies": {
-          "AngleSharp": "1.1.2",
-          "AngleSharp.Css": "1.0.0-beta.144"
-        }
       },
       "bunit": {
         "type": "Direct",
@@ -603,6 +580,23 @@
         "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "AngleSharp.Css": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.157",
+        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "dependencies": {
+          "AngleSharp": "[1.0.0, 2.0.0)"
+        }
+      },
+      "AngleSharp.Diffing": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
+        "dependencies": {
+          "AngleSharp": "1.1.2",
+          "AngleSharp.Css": "1.0.0-beta.144"
+        }
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -952,8 +946,6 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.5.2, )",
-          "AngleSharp.Css": "[1.0.0-beta.224, )",
-          "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
           "bunit": "[2.7.2, )",
           "xunit": "[2.9.3, )"

--- a/packages/blazor-workspace/Tests/OkBlazor.Tests/packages.lock.json
+++ b/packages/blazor-workspace/Tests/OkBlazor.Tests/packages.lock.json
@@ -2,6 +2,31 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
+      "AngleSharp": {
+        "type": "Direct",
+        "requested": "[1.4.0, )",
+        "resolved": "1.4.0",
+        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+      },
+      "AngleSharp.Css": {
+        "type": "Direct",
+        "requested": "[1.0.0-beta.157, )",
+        "resolved": "1.0.0-beta.157",
+        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "dependencies": {
+          "AngleSharp": "[1.0.0, 2.0.0)"
+        }
+      },
+      "AngleSharp.Diffing": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
+        "dependencies": {
+          "AngleSharp": "1.1.2",
+          "AngleSharp.Css": "1.0.0-beta.144"
+        }
+      },
       "bunit": {
         "type": "Direct",
         "requested": "[2.7.2, )",
@@ -77,28 +102,6 @@
         "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
-      },
-      "AngleSharp": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
-      },
-      "AngleSharp.Css": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta.157",
-        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
-        "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)"
-        }
-      },
-      "AngleSharp.Diffing": {
-        "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
-        "dependencies": {
-          "AngleSharp": "1.1.2",
-          "AngleSharp.Css": "1.0.0-beta.144"
-        }
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -484,6 +487,9 @@
       "blazorworkspace.testing.unit": {
         "type": "Project",
         "dependencies": {
+          "AngleSharp": "[1.4.0, )",
+          "AngleSharp.Css": "[1.0.0-beta.157, )",
+          "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
           "bunit": "[2.7.2, )",
           "xunit": "[2.9.3, )"
@@ -497,6 +503,31 @@
       }
     },
     "net8.0": {
+      "AngleSharp": {
+        "type": "Direct",
+        "requested": "[1.4.0, )",
+        "resolved": "1.4.0",
+        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+      },
+      "AngleSharp.Css": {
+        "type": "Direct",
+        "requested": "[1.0.0-beta.157, )",
+        "resolved": "1.0.0-beta.157",
+        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "dependencies": {
+          "AngleSharp": "[1.0.0, 2.0.0)"
+        }
+      },
+      "AngleSharp.Diffing": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
+        "dependencies": {
+          "AngleSharp": "1.1.2",
+          "AngleSharp.Css": "1.0.0-beta.144"
+        }
+      },
       "bunit": {
         "type": "Direct",
         "requested": "[2.7.2, )",
@@ -572,28 +603,6 @@
         "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
-      },
-      "AngleSharp": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
-      },
-      "AngleSharp.Css": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta.157",
-        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
-        "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)"
-        }
-      },
-      "AngleSharp.Diffing": {
-        "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
-        "dependencies": {
-          "AngleSharp": "1.1.2",
-          "AngleSharp.Css": "1.0.0-beta.144"
-        }
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -942,6 +951,9 @@
       "blazorworkspace.testing.unit": {
         "type": "Project",
         "dependencies": {
+          "AngleSharp": "[1.4.0, )",
+          "AngleSharp.Css": "[1.0.0-beta.157, )",
+          "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
           "bunit": "[2.7.2, )",
           "xunit": "[2.9.3, )"

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/SprightBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/SprightBlazor.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.5.2" />
-    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.157" />
+    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.224" />
     <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
     <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="coverlet.collector" Version="10.0.1" />

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/SprightBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/SprightBlazor.Tests.csproj
@@ -9,8 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.5.2" />
-    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.224" />
-    <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
     <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/SprightBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/SprightBlazor.Tests.csproj
@@ -8,6 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="1.4.0" />
+    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.157" />
+    <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
     <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/SprightBlazor.Tests.csproj
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/SprightBlazor.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="1.4.0" />
+    <PackageReference Include="AngleSharp" Version="1.5.2" />
     <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.157" />
     <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
     <PackageReference Include="bunit" Version="2.7.2" />

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/packages.lock.json
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/packages.lock.json
@@ -10,11 +10,11 @@
       },
       "AngleSharp.Css": {
         "type": "Direct",
-        "requested": "[1.0.0-beta.157, )",
-        "resolved": "1.0.0-beta.157",
-        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "requested": "[1.0.0-beta.224, )",
+        "resolved": "1.0.0-beta.224",
+        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
         "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)"
+          "AngleSharp": "[1.5.0, 2.0.0)"
         }
       },
       "AngleSharp.Diffing": {
@@ -488,7 +488,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.5.2, )",
-          "AngleSharp.Css": "[1.0.0-beta.157, )",
+          "AngleSharp.Css": "[1.0.0-beta.224, )",
           "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
           "bunit": "[2.7.2, )",
@@ -511,11 +511,11 @@
       },
       "AngleSharp.Css": {
         "type": "Direct",
-        "requested": "[1.0.0-beta.157, )",
-        "resolved": "1.0.0-beta.157",
-        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "requested": "[1.0.0-beta.224, )",
+        "resolved": "1.0.0-beta.224",
+        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
         "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)"
+          "AngleSharp": "[1.5.0, 2.0.0)"
         }
       },
       "AngleSharp.Diffing": {
@@ -952,7 +952,7 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.5.2, )",
-          "AngleSharp.Css": "[1.0.0-beta.157, )",
+          "AngleSharp.Css": "[1.0.0-beta.224, )",
           "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
           "bunit": "[2.7.2, )",

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/packages.lock.json
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "AngleSharp": {
         "type": "Direct",
-        "requested": "[1.4.0, )",
-        "resolved": "1.4.0",
-        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+        "requested": "[1.5.2, )",
+        "resolved": "1.5.2",
+        "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
       },
       "AngleSharp.Css": {
         "type": "Direct",
@@ -487,7 +487,7 @@
       "blazorworkspace.testing.unit": {
         "type": "Project",
         "dependencies": {
-          "AngleSharp": "[1.4.0, )",
+          "AngleSharp": "[1.5.2, )",
           "AngleSharp.Css": "[1.0.0-beta.157, )",
           "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
@@ -505,9 +505,9 @@
     "net8.0": {
       "AngleSharp": {
         "type": "Direct",
-        "requested": "[1.4.0, )",
-        "resolved": "1.4.0",
-        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+        "requested": "[1.5.2, )",
+        "resolved": "1.5.2",
+        "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
       },
       "AngleSharp.Css": {
         "type": "Direct",
@@ -951,7 +951,7 @@
       "blazorworkspace.testing.unit": {
         "type": "Project",
         "dependencies": {
-          "AngleSharp": "[1.4.0, )",
+          "AngleSharp": "[1.5.2, )",
           "AngleSharp.Css": "[1.0.0-beta.157, )",
           "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/packages.lock.json
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/packages.lock.json
@@ -8,25 +8,6 @@
         "resolved": "1.5.2",
         "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
       },
-      "AngleSharp.Css": {
-        "type": "Direct",
-        "requested": "[1.0.0-beta.224, )",
-        "resolved": "1.0.0-beta.224",
-        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
-        "dependencies": {
-          "AngleSharp": "[1.5.0, 2.0.0)"
-        }
-      },
-      "AngleSharp.Diffing": {
-        "type": "Direct",
-        "requested": "[1.1.1, )",
-        "resolved": "1.1.1",
-        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
-        "dependencies": {
-          "AngleSharp": "1.1.2",
-          "AngleSharp.Css": "1.0.0-beta.144"
-        }
-      },
       "bunit": {
         "type": "Direct",
         "requested": "[2.7.2, )",
@@ -102,6 +83,23 @@
         "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "AngleSharp.Css": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.157",
+        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "dependencies": {
+          "AngleSharp": "[1.0.0, 2.0.0)"
+        }
+      },
+      "AngleSharp.Diffing": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
+        "dependencies": {
+          "AngleSharp": "1.1.2",
+          "AngleSharp.Css": "1.0.0-beta.144"
+        }
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -488,8 +486,6 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.5.2, )",
-          "AngleSharp.Css": "[1.0.0-beta.224, )",
-          "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
           "bunit": "[2.7.2, )",
           "xunit": "[2.9.3, )"
@@ -508,25 +504,6 @@
         "requested": "[1.5.2, )",
         "resolved": "1.5.2",
         "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
-      },
-      "AngleSharp.Css": {
-        "type": "Direct",
-        "requested": "[1.0.0-beta.224, )",
-        "resolved": "1.0.0-beta.224",
-        "contentHash": "BF/hPs8sRjhR+rYkBom7WaMLN0w36Qvnu+WvoHK/gL67MrQOONkkivBTGilvta4sNix5Y8T9XVlZsRI8IU2/vA==",
-        "dependencies": {
-          "AngleSharp": "[1.5.0, 2.0.0)"
-        }
-      },
-      "AngleSharp.Diffing": {
-        "type": "Direct",
-        "requested": "[1.1.1, )",
-        "resolved": "1.1.1",
-        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
-        "dependencies": {
-          "AngleSharp": "1.1.2",
-          "AngleSharp.Css": "1.0.0-beta.144"
-        }
       },
       "bunit": {
         "type": "Direct",
@@ -603,6 +580,23 @@
         "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "AngleSharp.Css": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.157",
+        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "dependencies": {
+          "AngleSharp": "[1.0.0, 2.0.0)"
+        }
+      },
+      "AngleSharp.Diffing": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
+        "dependencies": {
+          "AngleSharp": "1.1.2",
+          "AngleSharp.Css": "1.0.0-beta.144"
+        }
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -952,8 +946,6 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[1.5.2, )",
-          "AngleSharp.Css": "[1.0.0-beta.224, )",
-          "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
           "bunit": "[2.7.2, )",
           "xunit": "[2.9.3, )"

--- a/packages/blazor-workspace/Tests/SprightBlazor.Tests/packages.lock.json
+++ b/packages/blazor-workspace/Tests/SprightBlazor.Tests/packages.lock.json
@@ -2,6 +2,31 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
+      "AngleSharp": {
+        "type": "Direct",
+        "requested": "[1.4.0, )",
+        "resolved": "1.4.0",
+        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+      },
+      "AngleSharp.Css": {
+        "type": "Direct",
+        "requested": "[1.0.0-beta.157, )",
+        "resolved": "1.0.0-beta.157",
+        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "dependencies": {
+          "AngleSharp": "[1.0.0, 2.0.0)"
+        }
+      },
+      "AngleSharp.Diffing": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
+        "dependencies": {
+          "AngleSharp": "1.1.2",
+          "AngleSharp.Css": "1.0.0-beta.144"
+        }
+      },
       "bunit": {
         "type": "Direct",
         "requested": "[2.7.2, )",
@@ -77,28 +102,6 @@
         "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
-      },
-      "AngleSharp": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
-      },
-      "AngleSharp.Css": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta.157",
-        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
-        "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)"
-        }
-      },
-      "AngleSharp.Diffing": {
-        "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
-        "dependencies": {
-          "AngleSharp": "1.1.2",
-          "AngleSharp.Css": "1.0.0-beta.144"
-        }
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -484,6 +487,9 @@
       "blazorworkspace.testing.unit": {
         "type": "Project",
         "dependencies": {
+          "AngleSharp": "[1.4.0, )",
+          "AngleSharp.Css": "[1.0.0-beta.157, )",
+          "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
           "bunit": "[2.7.2, )",
           "xunit": "[2.9.3, )"
@@ -497,6 +503,31 @@
       }
     },
     "net8.0": {
+      "AngleSharp": {
+        "type": "Direct",
+        "requested": "[1.4.0, )",
+        "resolved": "1.4.0",
+        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
+      },
+      "AngleSharp.Css": {
+        "type": "Direct",
+        "requested": "[1.0.0-beta.157, )",
+        "resolved": "1.0.0-beta.157",
+        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
+        "dependencies": {
+          "AngleSharp": "[1.0.0, 2.0.0)"
+        }
+      },
+      "AngleSharp.Diffing": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
+        "dependencies": {
+          "AngleSharp": "1.1.2",
+          "AngleSharp.Css": "1.0.0-beta.144"
+        }
+      },
       "bunit": {
         "type": "Direct",
         "requested": "[2.7.2, )",
@@ -572,28 +603,6 @@
         "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
-      },
-      "AngleSharp": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
-      },
-      "AngleSharp.Css": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta.157",
-        "contentHash": "yptHmuGt2tzNGCeD7Orh6HRs4j7MH3IUhI+FM640OlmSwWRMd1yjKnicVcNG147IdF/tjOvgqtvpTU0pH6wVpA==",
-        "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)"
-        }
-      },
-      "AngleSharp.Diffing": {
-        "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
-        "dependencies": {
-          "AngleSharp": "1.1.2",
-          "AngleSharp.Css": "1.0.0-beta.144"
-        }
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
@@ -942,6 +951,9 @@
       "blazorworkspace.testing.unit": {
         "type": "Project",
         "dependencies": {
+          "AngleSharp": "[1.4.0, )",
+          "AngleSharp.Css": "[1.0.0-beta.157, )",
+          "AngleSharp.Diffing": "[1.1.1, )",
           "NI.CSharp.Analyzers": "[2.0.35, )",
           "bunit": "[2.7.2, )",
           "xunit": "[2.9.3, )"


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

PR builds ([example](https://github.com/ni/nimble/actions/runs/29724580939/job/88296624628?pr=2995)) and local builds of main are failing with these errors:

```
@ni-private/blazor-workspace:build: /home/runner/work/nimble/nimble/packages/blazor-workspace/Tests/OkBlazor.Tests/OkBlazor.Tests.csproj : error NU1902: Warning As Error: Package 'AngleSharp' 1.4.0 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-pgww-w46g-26qg [/home/runner/work/nimble/nimble/packages/blazor-workspace/BlazorWorkspace.slnx]
@ni-private/blazor-workspace:build: /home/runner/work/nimble/nimble/packages/blazor-workspace/Tests/SprightBlazor.Tests/SprightBlazor.Tests.csproj : error NU1902: Warning As Error: Package 'AngleSharp' 1.4.0 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-pgww-w46g-26qg [/home/runner/work/nimble/nimble/packages/blazor-workspace/BlazorWorkspace.slnx]
@ni-private/blazor-workspace:build: /home/runner/work/nimble/nimble/packages/blazor-workspace/Tests/NimbleBlazor.Tests/NimbleBlazor.Tests.csproj : error NU1902: Warning As Error: Package 'AngleSharp' 1.4.0 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-pgww-w46g-26qg [/home/runner/work/nimble/nimble/packages/blazor-workspace/BlazorWorkspace.slnx]
```

The cause is [this vulnerability](https://github.com/advisories/GHSA-pgww-w46g-26qg) in AngleSharp, which is pulled in by our dependency on bunit. This seems correct anyway since some test code uses it but relies on the transitive dependency to cause it to be present.

## 👩‍💻 Implementation

We are on [the latest bunit](https://www.nuget.org/packages/bunit/#versions-body-tab) so the only way I'm aware to fix this is to explicitly depend on AngleSharp in order to request the latest version.

## 🧪 Testing

Local and PR builds pass.

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
