### PR TITLE
Forward autocomplete in nimble-text-field

### DIFF
--- a/change/@ni-nimble-components-a1b2c3d4-e5f6-4789-8abc-def012345678.json
+++ b/change/@ni-nimble-components-a1b2c3d4-e5f6-4789-8abc-def012345678.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Forward autocomplete attribute to nimble-text-field internal input for password manager / autofill support",
+  "packageName": "@ni/nimble-components",
+  "email": "kevin.tan@emerson.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nimble-components/src/text-field/index.ts
+++ b/packages/nimble-components/src/text-field/index.ts
@@ -34,6 +34,17 @@ export class TextField extends mixinErrorPattern(
     @attr
     public appearance: TextFieldAppearance = TextFieldAppearance.underline;
 
+    /**
+     * The autofill hint forwarded to the internal input (e.g. "username",
+     * "current-password", "off") for browser password managers and autofill.
+     *
+     * @public
+     * @remarks
+     * HTML Attribute: autocomplete
+     */
+    @attr
+    public autocomplete?: string;
+
     @attr({ attribute: 'full-bleed', mode: 'boolean' })
     public fullBleed = false;
 

--- a/packages/nimble-components/src/text-field/template.ts
+++ b/packages/nimble-components/src/text-field/template.ts
@@ -60,6 +60,7 @@ TextFieldOptions
                 ?spellcheck="${x => x.spellcheck}"
                 :value="${x => x.value}"
                 type="${x => x.type}"
+                autocomplete="${x => x.autocomplete}"
                 aria-atomic="${x => x.ariaAtomic}"
                 aria-busy="${x => x.ariaBusy}"
                 aria-controls="${x => x.ariaControls}"

--- a/packages/nimble-components/src/text-field/tests/text-field.spec.ts
+++ b/packages/nimble-components/src/text-field/tests/text-field.spec.ts
@@ -36,4 +36,15 @@ describe('TextField', () => {
         processUpdates();
         expect(element.control.getAttribute('aria-required')).toBe('false');
     });
+
+    it('reflects "autocomplete" to the internal control', () => {
+        element.autocomplete = 'username';
+        processUpdates();
+        expect(element.control.getAttribute('autocomplete')).toBe('username');
+    });
+
+    it('does not set "autocomplete" on the internal control when unset', () => {
+        processUpdates();
+        expect(element.control.hasAttribute('autocomplete')).toBeFalse();
+    });
 });

--- a/packages/storybook/src/nimble/text-field/text-field.stories.ts
+++ b/packages/storybook/src/nimble/text-field/text-field.stories.ts
@@ -28,6 +28,7 @@ interface TextFieldArgs {
     label: string;
     placeholder: string;
     type: TextFieldType;
+    autocomplete: string;
     appearance: string;
     fullBleed: boolean;
     value: string;
@@ -66,6 +67,7 @@ const metadata: Meta<TextFieldArgs> = {
             placeholder="${x => x.placeholder}"
             :value="${x => x.value}"
             type="${x => x.type}"
+            autocomplete="${x => x.autocomplete}"
             appearance="${x => x.appearance}"
             ?readonly="${x => x.readonly}"
             ?disabled="${x => x.disabled}"
@@ -104,6 +106,11 @@ const metadata: Meta<TextFieldArgs> = {
             control: { type: 'radio' },
             description:
                 'They type of input to accept and render in the text field. This corresponds to [the `type` attribute of the native `input` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#type) though only a subset of values are supported.',
+            table: { category: apiCategory.attributes }
+        },
+        autocomplete: {
+            description:
+                'The autofill hint forwarded to the internal input so browser password managers and native autofill can classify the field. This corresponds to [the `autocomplete` attribute of the native `input` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) (e.g. `username`, `current-password`, `new-password`, `email`, `off`).',
             table: { category: apiCategory.attributes }
         },
         appearance: {
@@ -185,6 +192,7 @@ const metadata: Meta<TextFieldArgs> = {
         label: 'default label',
         placeholder: 'Enter text...',
         type: TextFieldType.text,
+        autocomplete: '',
         appearance: 'underline',
         fullBleed: false,
         value: '',


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

`nimble-text-field`'s real <input> lives in shadow DOM. Browsers read that input's `autocomplete` attribute to autofill login fields, but `nimble-text-field` was not forwarding this attribute so username/password fields weren't being recognized.

## 👩‍💻 Implementation

- Add a public `autocomplete` attribute and forward it to the internal `input`

## 🧪 Testing

- Added unit tests to verifying autocomplete is forwarded to the internal input when set and absent when unset

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [X] I have updated the project documentation to reflect my changes or determined no changes are needed.
