### PR TITLE
Update to fast-foundation 10.2.5 and re-enable test

### DIFF
--- a/change/@ni-nimble-components-254c0fcf-de4c-436f-b125-e64207a38f42.json
+++ b/change/@ni-nimble-components-254c0fcf-de4c-436f-b125-e64207a38f42.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update to fast-foundation 10.2.5",
+  "packageName": "@ni/nimble-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-ok-components-c9c322fe-b556-42e4-b529-d813bcb8bcc1.json
+++ b/change/@ni-ok-components-c9c322fe-b556-42e4-b529-d813bcb8bcc1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update to fast-foundation 10.2.5",
+  "packageName": "@ni/ok-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-spright-components-7298d7ac-ae36-4b46-9fbd-d687a589f1b4.json
+++ b/change/@ni-spright-components-7298d7ac-ae36-4b46-9fbd-d687a589f1b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update to fast-foundation 10.2.5",
+  "packageName": "@ni/spright-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6485,9 +6485,9 @@
       "license": "MIT"
     },
     "node_modules/@ni/fast-foundation": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/@ni/fast-foundation/-/fast-foundation-10.2.4.tgz",
-      "integrity": "sha512-fl3h5gzS3oRO6OHQV0+DGjxNd4dt1D6cJkmwyI51qY6b6YTHCpJUwWKxRWy/Z3UjctsNVsqpEFEnAd6TfBHFHQ==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/@ni/fast-foundation/-/fast-foundation-10.2.5.tgz",
+      "integrity": "sha512-y0vYzqj0V2lFDFktUvmXzYesP3Md8xCBLCeMC4vZycYCky4SzPon2RjAEZcW2WUtgZiBVWIarsC3OP5CNio3fg==",
       "license": "MIT",
       "dependencies": {
         "@ni/fast-element": "^10.1.2",
@@ -33472,7 +33472,7 @@
       "dependencies": {
         "@ni/fast-colors": "^10.0.0",
         "@ni/fast-element": "^10.1.2",
-        "@ni/fast-foundation": "^10.2.4",
+        "@ni/fast-foundation": "^10.2.5",
         "@ni/fast-web-utilities": "^10.0.0",
         "@ni/nimble-tokens": "^8.18.1",
         "@ni/unit-format": "^1.0.5",
@@ -33556,7 +33556,7 @@
       "license": "MIT",
       "dependencies": {
         "@ni/fast-element": "^10.1.2",
-        "@ni/fast-foundation": "^10.2.4",
+        "@ni/fast-foundation": "^10.2.5",
         "@ni/fast-web-utilities": "^10.0.0",
         "@ni/nimble-components": "^35.12.6",
         "@ni/spright-components": "^6.21.8",
@@ -33694,7 +33694,7 @@
       "license": "MIT",
       "dependencies": {
         "@ni/fast-element": "^10.1.2",
-        "@ni/fast-foundation": "^10.2.4",
+        "@ni/fast-foundation": "^10.2.5",
         "@ni/fast-web-utilities": "^10.0.0",
         "@ni/nimble-components": "^35.12.6",
         "@ni/nimble-tokens": "^8.18.1",
@@ -33735,7 +33735,7 @@
         "@chromatic-com/storybook": "^5.1.2",
         "@ni-private/eslint-config-nimble": "*",
         "@ni/fast-element": "^10.1.2",
-        "@ni/fast-foundation": "^10.2.4",
+        "@ni/fast-foundation": "^10.2.5",
         "@ni/fast-web-utilities": "^10.0.0",
         "@ni/nimble-components": "*",
         "@ni/nimble-react": "*",

--- a/packages/angular-workspace/nimble-angular/src/directives/tooltip/tests/nimble-tooltip.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/tooltip/tests/nimble-tooltip.directive.spec.ts
@@ -256,8 +256,7 @@ describe('Nimble tooltip', () => {
             expect(nativeElement.anchor).toBe('anchor2');
         });
 
-        // Test is disabled because of [FAST bug](https://github.com/microsoft/fast/issues/6257)
-        xit('can be configured with attribute binding for delay', () => {
+        it('can be configured with attribute binding for delay', () => {
             expect(directive.delay).toBe(300);
             expect(nativeElement.delay).toBe(300);
 

--- a/packages/nimble-components/package.json
+++ b/packages/nimble-components/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@ni/fast-colors": "^10.0.0",
     "@ni/fast-element": "^10.1.2",
-    "@ni/fast-foundation": "^10.2.4",
+    "@ni/fast-foundation": "^10.2.5",
     "@ni/fast-web-utilities": "^10.0.0",
     "@ni/nimble-tokens": "^8.18.1",
     "@ni/unit-format": "^1.0.5",

--- a/packages/ok-components/package.json
+++ b/packages/ok-components/package.json
@@ -41,7 +41,7 @@
   "customElements": "dist/custom-elements.json",
   "dependencies": {
     "@ni/fast-element": "^10.1.2",
-    "@ni/fast-foundation": "^10.2.4",
+    "@ni/fast-foundation": "^10.2.5",
     "@ni/fast-web-utilities": "^10.0.0",
     "@ni/nimble-components": "^35.12.6",
     "@ni/spright-components": "^6.21.8",

--- a/packages/spright-components/package.json
+++ b/packages/spright-components/package.json
@@ -41,7 +41,7 @@
   "customElements": "dist/custom-elements.json",
   "dependencies": {
     "@ni/fast-element": "^10.1.2",
-    "@ni/fast-foundation": "^10.2.4",
+    "@ni/fast-foundation": "^10.2.5",
     "@ni/fast-web-utilities": "^10.0.0",
     "@ni/nimble-components": "^35.12.6",
     "@ni/nimble-tokens": "^8.18.1",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -25,7 +25,7 @@
     "@chromatic-com/storybook": "^5.1.2",
     "@ni-private/eslint-config-nimble": "*",
     "@ni/fast-element": "^10.1.2",
-    "@ni/fast-foundation": "^10.2.4",
+    "@ni/fast-foundation": "^10.2.5",
     "@ni/fast-web-utilities": "^10.0.0",
     "@ni/nimble-components": "*",
     "@ni/nimble-react": "*",


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

I fixed a minor issue with the tooltip's attribute binding in `@ni/fast-foundation` 10.2.5. By uptaking this fixed version, we can re-enable a test, as well.