### PR TITLE
Angular 21: Manually enable provideZoneChangeDetection and directive type binding updates

### DIFF
--- a/change/@ni-nimble-angular-9dd4d2e9-7e45-4dd1-8eef-d575581f335b.json
+++ b/change/@ni-nimble-angular-9dd4d2e9-7e45-4dd1-8eef-d575581f335b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix type errors in VCA host bindings, and pre-emptively add provideZoneChangeDetection() to tests",
+  "packageName": "@ni/nimble-angular",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/angular-workspace/example-client-app/src/app/app.component.spec.ts
+++ b/packages/angular-workspace/example-client-app/src/app/app.component.spec.ts
@@ -1,17 +1,13 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { NimbleNumberFieldModule, NimbleTextFieldModule } from '@ni/nimble-angular';
+import { AppModule } from './app.module';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
-            declarations: [
-                AppComponent
-            ],
             imports: [
-                NimbleTextFieldModule,
-                NimbleNumberFieldModule
+                AppModule
             ],
             providers: [provideZoneChangeDetection()]
         });

--- a/packages/angular-workspace/example-client-app/src/app/app.component.spec.ts
+++ b/packages/angular-workspace/example-client-app/src/app/app.component.spec.ts
@@ -1,4 +1,4 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, provideZoneChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { NimbleNumberFieldModule, NimbleTextFieldModule } from '@ni/nimble-angular';
 import { AppComponent } from './app.component';
@@ -13,6 +13,7 @@ describe('AppComponent', () => {
                 NimbleTextFieldModule,
                 NimbleNumberFieldModule
             ],
+            providers: [provideZoneChangeDetection()],
             schemas: [CUSTOM_ELEMENTS_SCHEMA]
         });
     });

--- a/packages/angular-workspace/example-client-app/src/app/app.component.spec.ts
+++ b/packages/angular-workspace/example-client-app/src/app/app.component.spec.ts
@@ -1,4 +1,4 @@
-import { CUSTOM_ELEMENTS_SCHEMA, provideZoneChangeDetection } from '@angular/core';
+import { provideZoneChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { NimbleNumberFieldModule, NimbleTextFieldModule } from '@ni/nimble-angular';
 import { AppComponent } from './app.component';
@@ -13,8 +13,7 @@ describe('AppComponent', () => {
                 NimbleTextFieldModule,
                 NimbleNumberFieldModule
             ],
-            providers: [provideZoneChangeDetection()],
-            schemas: [CUSTOM_ELEMENTS_SCHEMA]
+            providers: [provideZoneChangeDetection()]
         });
     });
 

--- a/packages/angular-workspace/nimble-angular/anchor-step/tests/nimble-anchor-step.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/anchor-step/tests/nimble-anchor-step.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild, provideZoneChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { AnchorStepSeverity, type AnchorStep, NimbleAnchorStepDirective } from '../nimble-anchor-step.directive';
@@ -53,7 +53,8 @@ describe('Nimble anchor step', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorStepModule]
+                imports: [NimbleAnchorStepModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -155,7 +156,8 @@ describe('Nimble anchor step', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorStepModule]
+                imports: [NimbleAnchorStepModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -269,7 +271,8 @@ describe('Nimble anchor step', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorStepModule]
+                imports: [NimbleAnchorStepModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -455,7 +458,8 @@ describe('Nimble anchor step', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorStepModule]
+                imports: [NimbleAnchorStepModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/chip/tests/nimble-chip.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/chip/tests/nimble-chip.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { type Chip, ChipAppearance, NimbleChipDirective } from '../nimble-chip.directive';
@@ -36,7 +36,8 @@ describe('Nimble chip', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleChipModule]
+                imports: [NimbleChipModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -82,7 +83,8 @@ describe('Nimble chip', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleChipModule]
+                imports: [NimbleChipModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -132,7 +134,8 @@ describe('Nimble chip', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleChipModule]
+                imports: [NimbleChipModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -200,7 +203,8 @@ describe('Nimble chip', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleChipModule]
+                imports: [NimbleChipModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/label-provider/core/tests/nimble-label-provider-core-with-defaults.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/label-provider/core/tests/nimble-label-provider-core-with-defaults.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import { computeMsgId } from '@angular/compiler';
@@ -23,7 +23,8 @@ describe('Nimble LabelProviderCore withDefaults directive', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [TestHostComponent],
-            imports: [NimbleLabelProviderCoreModule, CommonModule]
+            imports: [NimbleLabelProviderCoreModule, CommonModule],
+            providers: [provideZoneChangeDetection()],
         });
     });
 

--- a/packages/angular-workspace/nimble-angular/label-provider/core/tests/nimble-label-provider-core.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/label-provider/core/tests/nimble-label-provider-core.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type LabelProviderCore, NimbleLabelProviderCoreDirective } from '../nimble-label-provider-core.directive';
 import { NimbleLabelProviderCoreModule } from '../nimble-label-provider-core.module';
@@ -48,7 +48,8 @@ describe('Nimble Label Provider Core', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleLabelProviderCoreModule]
+                imports: [NimbleLabelProviderCoreModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -162,7 +163,8 @@ describe('Nimble Label Provider Core', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleLabelProviderCoreModule]
+                imports: [NimbleLabelProviderCoreModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -290,7 +292,8 @@ describe('Nimble Label Provider Core', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleLabelProviderCoreModule]
+                imports: [NimbleLabelProviderCoreModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -502,7 +505,8 @@ describe('Nimble Label Provider Core', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleLabelProviderCoreModule]
+                imports: [NimbleLabelProviderCoreModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/label-provider/rich-text/tests/nimble-label-provider-rich-text-with-defaults.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/label-provider/rich-text/tests/nimble-label-provider-rich-text-with-defaults.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import { computeMsgId } from '@angular/compiler';
@@ -23,7 +23,8 @@ describe('Nimble LabelProviderRichText withDefaults directive', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [TestHostComponent],
-            imports: [NimbleLabelProviderRichTextModule, CommonModule]
+            imports: [NimbleLabelProviderRichTextModule, CommonModule],
+            providers: [provideZoneChangeDetection()],
         });
         loadTranslations({
             [computeMsgId('Bold', 'Nimble rich text - toggle bold')]: 'Translated Bold',

--- a/packages/angular-workspace/nimble-angular/label-provider/rich-text/tests/nimble-label-provider-rich-text.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/label-provider/rich-text/tests/nimble-label-provider-rich-text.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type LabelProviderRichText, NimbleLabelProviderRichTextDirective } from '../nimble-label-provider-rich-text.directive';
 import { NimbleLabelProviderRichTextModule } from '../nimble-label-provider-rich-text.module';
@@ -11,7 +11,8 @@ describe('Nimble Label Provider Rich text', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [NimbleLabelProviderRichTextModule]
+            imports: [NimbleLabelProviderRichTextModule],
+            providers: [provideZoneChangeDetection()],
         });
     });
 
@@ -38,7 +39,8 @@ describe('Nimble Label Provider Rich text', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleLabelProviderRichTextModule]
+                imports: [NimbleLabelProviderRichTextModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -92,7 +94,8 @@ describe('Nimble Label Provider Rich text', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleLabelProviderRichTextModule]
+                imports: [NimbleLabelProviderRichTextModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -150,7 +153,8 @@ describe('Nimble Label Provider Rich text', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleLabelProviderRichTextModule]
+                imports: [NimbleLabelProviderRichTextModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -232,7 +236,8 @@ describe('Nimble Label Provider Rich text', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleLabelProviderRichTextModule]
+                imports: [NimbleLabelProviderRichTextModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/label-provider/table/tests/nimble-label-provider-table-with-defaults.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/label-provider/table/tests/nimble-label-provider-table-with-defaults.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import { computeMsgId } from '@angular/compiler';
@@ -23,7 +23,8 @@ describe('Nimble LabelProviderTable withDefaults directive', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [TestHostComponent],
-            imports: [NimbleLabelProviderTableModule, CommonModule]
+            imports: [NimbleLabelProviderTableModule, CommonModule],
+            providers: [provideZoneChangeDetection()],
         });
     });
 

--- a/packages/angular-workspace/nimble-angular/label-provider/table/tests/nimble-label-provider-table.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/label-provider/table/tests/nimble-label-provider-table.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type LabelProviderTable, NimbleLabelProviderTableDirective } from '../nimble-label-provider-table.directive';
 import { NimbleLabelProviderTableModule } from '../nimble-label-provider-table.module';
@@ -23,7 +23,8 @@ describe('Nimble Label Provider Table', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [NimbleLabelProviderTableModule]
+            imports: [NimbleLabelProviderTableModule],
+            providers: [provideZoneChangeDetection()],
         });
     });
 
@@ -50,7 +51,8 @@ describe('Nimble Label Provider Table', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleLabelProviderTableModule]
+                imports: [NimbleLabelProviderTableModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -176,7 +178,8 @@ describe('Nimble Label Provider Table', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleLabelProviderTableModule]
+                imports: [NimbleLabelProviderTableModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -318,7 +321,8 @@ describe('Nimble Label Provider Table', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleLabelProviderTableModule]
+                imports: [NimbleLabelProviderTableModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -556,7 +560,8 @@ describe('Nimble Label Provider Table', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleLabelProviderTableModule]
+                imports: [NimbleLabelProviderTableModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/mapping/empty/tests/nimble-mapping-empty.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/mapping/empty/tests/nimble-mapping-empty.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NimbleTableModule } from '../../../table/nimble-table.module';
 import { NimbleTableColumnMappingModule } from '../../../table-column/mapping/nimble-table-column-mapping.module';
@@ -45,7 +45,8 @@ describe('NimbleMappingEmpty', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMappingEmptyModule, NimbleTableColumnMappingModule, NimbleTableModule]
+                imports: [NimbleMappingEmptyModule, NimbleTableColumnMappingModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()]
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -94,7 +95,8 @@ describe('NimbleMappingEmpty', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMappingEmptyModule, NimbleTableColumnMappingModule, NimbleTableModule]
+                imports: [NimbleMappingEmptyModule, NimbleTableColumnMappingModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -155,7 +157,8 @@ describe('NimbleMappingEmpty', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMappingEmptyModule, NimbleTableColumnMappingModule, NimbleTableModule]
+                imports: [NimbleMappingEmptyModule, NimbleTableColumnMappingModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);

--- a/packages/angular-workspace/nimble-angular/mapping/icon/tests/nimble-mapping-icon.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/mapping/icon/tests/nimble-mapping-icon.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { IconSeverity } from '@ni/nimble-angular';
 import { NimbleTableModule } from '../../../table/nimble-table.module';
@@ -49,7 +49,8 @@ describe('NimbleMappingIcon', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMappingIconModule, NimbleTableColumnMappingModule, NimbleTableModule]
+                imports: [NimbleMappingIconModule, NimbleTableColumnMappingModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -119,7 +120,8 @@ describe('NimbleMappingIcon', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMappingIconModule, NimbleTableColumnMappingModule, NimbleTableModule]
+                imports: [NimbleMappingIconModule, NimbleTableColumnMappingModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -219,7 +221,8 @@ describe('NimbleMappingIcon', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMappingIconModule, NimbleTableColumnMappingModule, NimbleTableModule]
+                imports: [NimbleMappingIconModule, NimbleTableColumnMappingModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);

--- a/packages/angular-workspace/nimble-angular/mapping/spinner/tests/nimble-mapping-spinner.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/mapping/spinner/tests/nimble-mapping-spinner.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NimbleTableModule } from '../../../table/nimble-table.module';
 import { NimbleTableColumnMappingModule } from '../../../table-column/mapping/nimble-table-column-mapping.module';
@@ -46,7 +46,8 @@ describe('NimbleMappingSpinner', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMappingSpinnerModule, NimbleTableColumnMappingModule, NimbleTableModule]
+                imports: [NimbleMappingSpinnerModule, NimbleTableColumnMappingModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -102,7 +103,8 @@ describe('NimbleMappingSpinner', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMappingSpinnerModule, NimbleTableColumnMappingModule, NimbleTableModule]
+                imports: [NimbleMappingSpinnerModule, NimbleTableColumnMappingModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -176,7 +178,8 @@ describe('NimbleMappingSpinner', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMappingSpinnerModule, NimbleTableColumnMappingModule, NimbleTableModule]
+                imports: [NimbleMappingSpinnerModule, NimbleTableColumnMappingModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);

--- a/packages/angular-workspace/nimble-angular/mapping/text/tests/nimble-mapping-text.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/mapping/text/tests/nimble-mapping-text.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NimbleTableModule } from '../../../table/nimble-table.module';
 import { NimbleTableColumnMappingModule } from '../../../table-column/mapping/nimble-table-column-mapping.module';
@@ -45,7 +45,8 @@ describe('NimbleMappingText', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMappingTextModule, NimbleTableColumnMappingModule, NimbleTableModule]
+                imports: [NimbleMappingTextModule, NimbleTableColumnMappingModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -94,7 +95,8 @@ describe('NimbleMappingText', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMappingTextModule, NimbleTableColumnMappingModule, NimbleTableModule]
+                imports: [NimbleMappingTextModule, NimbleTableColumnMappingModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -155,7 +157,8 @@ describe('NimbleMappingText', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMappingTextModule, NimbleTableColumnMappingModule, NimbleTableModule]
+                imports: [NimbleMappingTextModule, NimbleTableColumnMappingModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);

--- a/packages/angular-workspace/nimble-angular/mapping/user/tests/nimble-mapping-user.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/mapping/user/tests/nimble-mapping-user.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NimbleRichTextMentionUsersModule } from '../../../rich-text-mention/users/nimble-rich-text-mention-users.module';
 import { NimbleRichTextEditorModule } from '../../../rich-text/editor/nimble-rich-text-editor.module';
@@ -40,7 +40,8 @@ describe('NimbleMappingUser', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMappingUserModule, NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule]
+                imports: [NimbleMappingUserModule, NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -87,7 +88,8 @@ describe('NimbleMappingUser', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMappingUserModule, NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule]
+                imports: [NimbleMappingUserModule, NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -136,7 +138,8 @@ describe('NimbleMappingUser', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMappingUserModule, NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule]
+                imports: [NimbleMappingUserModule, NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -197,7 +200,8 @@ describe('NimbleMappingUser', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMappingUserModule, NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule]
+                imports: [NimbleMappingUserModule, NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);

--- a/packages/angular-workspace/nimble-angular/pipes/tests/number-text.pipe.spec.ts
+++ b/packages/angular-workspace/nimble-angular/pipes/tests/number-text.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { type ComponentFixture, TestBed } from '@angular/core/testing';
 import { parameterizeSpec } from '@ni/jasmine-parameterized';
 import { NumberTextPipe } from '../number-text.pipe';
@@ -132,7 +132,8 @@ describe('NumberTextPipe', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NumberTextPipe]
+                imports: [NumberTextPipe],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);

--- a/packages/angular-workspace/nimble-angular/pipes/tests/test-custom-pipe.spec.ts
+++ b/packages/angular-workspace/nimble-angular/pipes/tests/test-custom-pipe.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Pipe, type PipeTransform, ViewChild } from '@angular/core';
+import { Component, ElementRef, Pipe, type PipeTransform, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { TestBed, type ComponentFixture } from '@angular/core/testing';
 
 describe('Custom pipe instantiation', () => {
@@ -38,7 +38,8 @@ describe('Custom pipe instantiation', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [TestHostComponent],
-            imports: [InstanceIdPipe]
+            imports: [InstanceIdPipe],
+            providers: [provideZoneChangeDetection()],
         });
 
         fixture = TestBed.createComponent(TestHostComponent);

--- a/packages/angular-workspace/nimble-angular/rich-text-mention/users/tests/nimble-rich-text-mention-users.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/rich-text-mention/users/tests/nimble-rich-text-mention-users.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NimbleRichTextMentionUsersModule } from '../nimble-rich-text-mention-users.module';
 import { NimbleRichTextEditorModule } from '../../../rich-text/editor/nimble-rich-text-editor.module';
@@ -37,7 +37,8 @@ describe('NimbleRichTextMentionUsers', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule]
+                imports: [NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -77,7 +78,8 @@ describe('NimbleRichTextMentionUsers', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule]
+                imports: [NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -124,7 +126,8 @@ describe('NimbleRichTextMentionUsers', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule]
+                imports: [NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -178,7 +181,8 @@ describe('NimbleRichTextMentionUsers', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule]
+                imports: [NimbleRichTextMentionUsersModule, NimbleRichTextEditorModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);

--- a/packages/angular-workspace/nimble-angular/rich-text/editor/tests/nimble-rich-text-editor.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/rich-text/editor/tests/nimble-rich-text-editor.directive.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { NimbleRichTextEditorModule } from '../nimble-rich-text-editor.module';
 import { NimbleRichTextEditorDirective, type RichTextEditor } from '../nimble-rich-text-editor.directive';
@@ -36,7 +36,8 @@ describe('Nimble Rich Text Editor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRichTextEditorModule]
+                imports: [NimbleRichTextEditorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -120,7 +121,8 @@ describe('Nimble Rich Text Editor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRichTextEditorModule]
+                imports: [NimbleRichTextEditorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -184,7 +186,8 @@ describe('Nimble Rich Text Editor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRichTextEditorModule]
+                imports: [NimbleRichTextEditorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -302,7 +305,8 @@ describe('Nimble Rich Text Editor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRichTextEditorModule]
+                imports: [NimbleRichTextEditorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/rich-text/viewer/tests/nimble-rich-text-viewer.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/rich-text/viewer/tests/nimble-rich-text-viewer.directive.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { NimbleRichTextViewerModule } from '../nimble-rich-text-viewer.module';
 import { NimbleRichTextViewerDirective, type RichTextViewer } from '../nimble-rich-text-viewer.directive';
 
@@ -35,7 +35,8 @@ describe('Nimble Rich Text Viewer', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRichTextViewerModule]
+                imports: [NimbleRichTextViewerModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -85,7 +86,8 @@ describe('Nimble Rich Text Viewer', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRichTextViewerModule]
+                imports: [NimbleRichTextViewerModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -121,7 +123,8 @@ describe('Nimble Rich Text Viewer', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRichTextViewerModule]
+                imports: [NimbleRichTextViewerModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/anchor-button/tests/nimble-anchor-button.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/anchor-button/tests/nimble-anchor-button.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { ButtonAppearance, ButtonAppearanceVariant } from '../../../public-api';
@@ -52,7 +52,8 @@ describe('Nimble anchor button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorButtonModule]
+                imports: [NimbleAnchorButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -148,7 +149,8 @@ describe('Nimble anchor button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorButtonModule]
+                imports: [NimbleAnchorButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -255,7 +257,8 @@ describe('Nimble anchor button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorButtonModule]
+                imports: [NimbleAnchorButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -429,7 +432,8 @@ describe('Nimble anchor button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorButtonModule]
+                imports: [NimbleAnchorButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/anchor-menu-item/tests/nimble-anchor-menu-item.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/anchor-menu-item/tests/nimble-anchor-menu-item.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, ElementRef } from '@angular/core';
+import { Component, ViewChild, ElementRef, provideZoneChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NimbleAnchorMenuItemDirective, type AnchorMenuItem } from '../nimble-anchor-menu-item.directive';
 import { NimbleAnchorMenuItemModule } from '../nimble-anchor-menu-item.module';
@@ -48,7 +48,8 @@ describe('Nimble anchor menu item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorMenuItemModule]
+                imports: [NimbleAnchorMenuItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -126,7 +127,8 @@ describe('Nimble anchor menu item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorMenuItemModule]
+                imports: [NimbleAnchorMenuItemModule],
+                                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -212,7 +214,8 @@ describe('Nimble anchor menu item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorMenuItemModule]
+                imports: [NimbleAnchorMenuItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -346,7 +349,8 @@ describe('Nimble anchor menu item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorMenuItemModule]
+                imports: [NimbleAnchorMenuItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/anchor-menu-item/tests/nimble-anchor-menu-item.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/anchor-menu-item/tests/nimble-anchor-menu-item.directive.spec.ts
@@ -128,7 +128,7 @@ describe('Nimble anchor menu item', () => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
                 imports: [NimbleAnchorMenuItemModule],
-                                providers: [provideZoneChangeDetection()],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/anchor-tab/tests/nimble-anchor-tab.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/anchor-tab/tests/nimble-anchor-tab.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type AnchorTab, NimbleAnchorTabDirective } from '../nimble-anchor-tab.directive';
 import { NimbleAnchorTabModule } from '../nimble-anchor-tab.module';
@@ -48,7 +48,8 @@ describe('Nimble anchor tab', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorTabModule]
+                imports: [NimbleAnchorTabModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -120,7 +121,8 @@ describe('Nimble anchor tab', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorTabModule]
+                imports: [NimbleAnchorTabModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -199,7 +201,8 @@ describe('Nimble anchor tab', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorTabModule]
+                imports: [NimbleAnchorTabModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -320,7 +323,8 @@ describe('Nimble anchor tab', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorTabModule]
+                imports: [NimbleAnchorTabModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/anchor-tabs/tests/nimble-anchor-tabs.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/anchor-tabs/tests/nimble-anchor-tabs.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, ElementRef, ViewChildren, QueryList } from '@angular/core';
+import { Component, ViewChild, ElementRef, ViewChildren, QueryList, provideZoneChangeDetection } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { NimbleAnchorTabsModule } from '../nimble-anchor-tabs.module';
 import { processUpdates, waitForUpdatesAsync } from '../../../testing/async-helpers';
@@ -31,7 +31,8 @@ describe('Nimble anchor tabs', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [TestHostComponent],
-            imports: [NimbleAnchorTabsModule]
+            imports: [NimbleAnchorTabsModule],
+            providers: [provideZoneChangeDetection()],
         });
     });
 

--- a/packages/angular-workspace/nimble-angular/src/directives/anchor-tree-item/tests/nimble-anchor-tree-item.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/anchor-tree-item/tests/nimble-anchor-tree-item.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { type AnchorTreeItem, NimbleAnchorTreeItemDirective } from '../nimble-anchor-tree-item.directive';
@@ -49,7 +49,8 @@ describe('Nimble anchor tree item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorTreeItemModule]
+                imports: [NimbleAnchorTreeItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -133,7 +134,8 @@ describe('Nimble anchor tree item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorTreeItemModule]
+                imports: [NimbleAnchorTreeItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -226,7 +228,8 @@ describe('Nimble anchor tree item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorTreeItemModule]
+                imports: [NimbleAnchorTreeItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -375,7 +378,8 @@ describe('Nimble anchor tree item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorTreeItemModule]
+                imports: [NimbleAnchorTreeItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/anchor/tests/nimble-anchor.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/anchor/tests/nimble-anchor.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type Anchor, AnchorAppearance, NimbleAnchorDirective } from '../nimble-anchor.directive';
 import { NimbleAnchorModule } from '../nimble-anchor.module';
@@ -50,7 +50,8 @@ describe('Nimble anchor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorModule]
+                imports: [NimbleAnchorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -140,7 +141,8 @@ describe('Nimble anchor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorModule]
+                imports: [NimbleAnchorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -240,7 +242,8 @@ describe('Nimble anchor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorModule]
+                imports: [NimbleAnchorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -400,7 +403,8 @@ describe('Nimble anchor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleAnchorModule]
+                imports: [NimbleAnchorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/banner/tests/nimble-banner.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/banner/tests/nimble-banner.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type Banner, BannerSeverity, NimbleBannerDirective } from '../nimble-banner.directive';
 import { NimbleBannerModule } from '../nimble-banner.module';
@@ -35,7 +35,8 @@ describe('Nimble banner', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleBannerModule]
+                imports: [NimbleBannerModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -87,7 +88,8 @@ describe('Nimble banner', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleBannerModule]
+                imports: [NimbleBannerModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -143,7 +145,8 @@ describe('Nimble banner', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleBannerModule]
+                imports: [NimbleBannerModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -223,7 +226,8 @@ describe('Nimble banner', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleBannerModule]
+                imports: [NimbleBannerModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/breadcrumb-item/tests/nimble-breadcrumb-item.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/breadcrumb-item/tests/nimble-breadcrumb-item.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type BreadcrumbItem, NimbleBreadcrumbItemDirective } from '../nimble-breadcrumb-item.directive';
 import { NimbleBreadcrumbItemModule } from '../nimble-breadcrumb-item.module';
@@ -48,7 +48,8 @@ describe('Nimble breadcrumb item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleBreadcrumbItemModule]
+                imports: [NimbleBreadcrumbItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -119,7 +120,8 @@ describe('Nimble breadcrumb item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleBreadcrumbItemModule]
+                imports: [NimbleBreadcrumbItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -198,7 +200,8 @@ describe('Nimble breadcrumb item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleBreadcrumbItemModule]
+                imports: [NimbleBreadcrumbItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -319,7 +322,8 @@ describe('Nimble breadcrumb item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleBreadcrumbItemModule]
+                imports: [NimbleBreadcrumbItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/breadcrumb/tests/nimble-breadcrumb.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/breadcrumb/tests/nimble-breadcrumb.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type Breadcrumb, BreadcrumbAppearance, NimbleBreadcrumbDirective } from '../nimble-breadcrumb.directive';
 import { NimbleBreadcrumbModule } from '../nimble-breadcrumb.module';
@@ -33,7 +33,8 @@ describe('Nimble breadcrumb', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleBreadcrumbModule]
+                imports: [NimbleBreadcrumbModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -68,7 +69,8 @@ describe('Nimble breadcrumb', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleBreadcrumbModule]
+                imports: [NimbleBreadcrumbModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -105,7 +107,8 @@ describe('Nimble breadcrumb', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleBreadcrumbModule]
+                imports: [NimbleBreadcrumbModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -148,7 +151,8 @@ describe('Nimble breadcrumb', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleBreadcrumbModule]
+                imports: [NimbleBreadcrumbModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/button/tests/nimble-button.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/button/tests/nimble-button.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { ButtonAppearance, ButtonAppearanceVariant } from '../../../public-api';
@@ -37,7 +37,8 @@ describe('Nimble button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleButtonModule]
+                imports: [NimbleButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -89,7 +90,8 @@ describe('Nimble button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleButtonModule]
+                imports: [NimbleButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -146,7 +148,8 @@ describe('Nimble button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleButtonModule]
+                imports: [NimbleButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -227,7 +230,8 @@ describe('Nimble button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleButtonModule]
+                imports: [NimbleButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/card-button/tests/nimble-card-button.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/card-button/tests/nimble-card-button.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { NimbleCardButtonDirective, type CardButton } from '../nimble-card-button.directive';
@@ -34,7 +34,8 @@ describe('Nimble card button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleCardButtonModule]
+                imports: [NimbleCardButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -74,7 +75,8 @@ describe('Nimble card button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleCardButtonModule]
+                imports: [NimbleCardButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -116,7 +118,8 @@ describe('Nimble card button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleCardButtonModule]
+                imports: [NimbleCardButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -170,7 +173,8 @@ describe('Nimble card button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleCardButtonModule]
+                imports: [NimbleCardButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/checkbox/tests/nimble-checkbox-control-value-accessor.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/checkbox/tests/nimble-checkbox-control-value-accessor.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { parameterizeSuite } from '@ni/jasmine-parameterized';
@@ -34,7 +34,8 @@ describe('Nimble checkbox control value accessor', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [TestHostComponent],
-            imports: [NimbleCheckboxModule, FormsModule]
+            imports: [NimbleCheckboxModule, FormsModule],
+            providers: [provideZoneChangeDetection()],
         });
     });
 
@@ -121,7 +122,8 @@ parameterizeSuite(testCases, (suite, name, value) => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleCheckboxModule, FormsModule, ReactiveFormsModule]
+                imports: [NimbleCheckboxModule, FormsModule, ReactiveFormsModule],
+                providers: [provideZoneChangeDetection()],
             });
         });
 

--- a/packages/angular-workspace/nimble-angular/src/directives/checkbox/tests/nimble-checkbox.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/checkbox/tests/nimble-checkbox.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { type Checkbox, NimbleCheckboxDirective } from '../nimble-checkbox.directive';
@@ -36,7 +36,8 @@ describe('Nimble checkbox', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleCheckboxModule]
+                imports: [NimbleCheckboxModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -100,7 +101,8 @@ describe('Nimble checkbox', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleCheckboxModule]
+                imports: [NimbleCheckboxModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -171,7 +173,8 @@ describe('Nimble checkbox', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleCheckboxModule]
+                imports: [NimbleCheckboxModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -276,7 +279,8 @@ describe('Nimble checkbox', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleCheckboxModule]
+                imports: [NimbleCheckboxModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/combobox/tests/nimble-combobox-control-value-accessor.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/combobox/tests/nimble-combobox-control-value-accessor.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NimbleComboboxModule } from '../nimble-combobox.module';
@@ -84,7 +84,8 @@ describe('Nimble combobox control value accessor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleComboboxModule, NimbleListOptionModule, FormsModule]
+                imports: [NimbleComboboxModule, NimbleListOptionModule, FormsModule],
+                providers: [provideZoneChangeDetection()],
             });
         });
 
@@ -382,7 +383,8 @@ describe('Nimble combobox control value accessor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleComboboxModule, NimbleListOptionModule, ReactiveFormsModule]
+                imports: [NimbleComboboxModule, NimbleListOptionModule, ReactiveFormsModule],
+                providers: [provideZoneChangeDetection()],
             });
         });
 

--- a/packages/angular-workspace/nimble-angular/src/directives/combobox/tests/nimble-combobox.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/combobox/tests/nimble-combobox.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { FormsModule } from '@angular/forms';
@@ -37,7 +37,8 @@ describe('Nimble combobox', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleComboboxModule]
+                imports: [NimbleComboboxModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -156,7 +157,8 @@ describe('Nimble combobox', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleComboboxModule]
+                imports: [NimbleComboboxModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -256,7 +258,8 @@ describe('Nimble combobox', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleComboboxModule]
+                imports: [NimbleComboboxModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -417,7 +420,8 @@ describe('Nimble combobox', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleComboboxModule]
+                imports: [NimbleComboboxModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -582,7 +586,8 @@ describe('Nimble combobox', () => {
         beforeEach(async () => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleComboboxModule, NimbleListOptionModule, FormsModule]
+                imports: [NimbleComboboxModule, NimbleListOptionModule, FormsModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/dialog/tests/nimble-dialog.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/dialog/tests/nimble-dialog.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type Dialog, NimbleDialogDirective } from '../nimble-dialog.directive';
 import { NimbleDialogModule } from '../nimble-dialog.module';
@@ -35,7 +35,8 @@ describe('Nimble dialog', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleDialogModule]
+                imports: [NimbleDialogModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -86,7 +87,8 @@ describe('Nimble dialog', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleDialogModule]
+                imports: [NimbleDialogModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -135,7 +137,8 @@ describe('Nimble dialog', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleDialogModule]
+                imports: [NimbleDialogModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -202,7 +205,8 @@ describe('Nimble dialog', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleDialogModule]
+                imports: [NimbleDialogModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/drawer/tests/nimble-drawer.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/drawer/tests/nimble-drawer.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type Drawer, DrawerLocation, NimbleDrawerDirective } from '../nimble-drawer.directive';
 import { NimbleDrawerModule } from '../nimble-drawer.module';
@@ -35,7 +35,8 @@ describe('Nimble drawer', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleDrawerModule]
+                imports: [NimbleDrawerModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -86,7 +87,8 @@ describe('Nimble drawer', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleDrawerModule]
+                imports: [NimbleDrawerModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -135,7 +137,8 @@ describe('Nimble drawer', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleDrawerModule]
+                imports: [NimbleDrawerModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -202,7 +205,8 @@ describe('Nimble drawer', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleDrawerModule]
+                imports: [NimbleDrawerModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/icon-base/tests/nimble-icon-base.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/icon-base/tests/nimble-icon-base.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { IconSeverity } from '../../../public-api';
 import { type IconCheck, NimbleIconCheckDirective } from '../../icons/check/nimble-icon-check.directive';
@@ -36,7 +36,8 @@ describe('Nimble icon check', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleIconCheckModule]
+                imports: [NimbleIconCheckModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -71,7 +72,8 @@ describe('Nimble icon check', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleIconCheckModule]
+                imports: [NimbleIconCheckModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -108,7 +110,8 @@ describe('Nimble icon check', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleIconCheckModule]
+                imports: [NimbleIconCheckModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -151,7 +154,8 @@ describe('Nimble icon check', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleIconCheckModule]
+                imports: [NimbleIconCheckModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/list-option-group/tests/nimble-list-option-group.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/list-option-group/tests/nimble-list-option-group.directive.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { NimbleListOptionGroupModule } from '../nimble-list-option-group.module';
 import type { ListOptionGroup } from '../../../public-api';
@@ -37,7 +37,8 @@ describe('Nimble listbox option group', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleListOptionGroupModule]
+                imports: [NimbleListOptionGroupModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -78,7 +79,8 @@ describe('Nimble listbox option group', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleListOptionGroupModule]
+                imports: [NimbleListOptionGroupModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -122,7 +124,8 @@ describe('Nimble listbox option group', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleListOptionGroupModule]
+                imports: [NimbleListOptionGroupModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -178,7 +181,8 @@ describe('Nimble listbox option group', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleListOptionGroupModule]
+                imports: [NimbleListOptionGroupModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/list-option/tests/nimble-list-option.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/list-option/tests/nimble-list-option.directive.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { NimbleListOptionModule } from '../nimble-list-option.module';
 import type { ListOption } from '../../../public-api';
@@ -37,7 +37,8 @@ describe('Nimble listbox option', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleListOptionModule]
+                imports: [NimbleListOptionModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -84,7 +85,8 @@ describe('Nimble listbox option', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleListOptionModule]
+                imports: [NimbleListOptionModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -135,7 +137,8 @@ describe('Nimble listbox option', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleListOptionModule]
+                imports: [NimbleListOptionModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -204,7 +207,8 @@ describe('Nimble listbox option', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleListOptionModule]
+                imports: [NimbleListOptionModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/menu-button/tests/nimble-menu-button.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/menu-button/tests/nimble-menu-button.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { ButtonAppearance, ButtonAppearanceVariant } from '../../../public-api';
@@ -37,7 +37,8 @@ describe('Nimble menu button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMenuButtonModule]
+                imports: [NimbleMenuButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -95,7 +96,8 @@ describe('Nimble menu button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMenuButtonModule]
+                imports: [NimbleMenuButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -159,7 +161,8 @@ describe('Nimble menu button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMenuButtonModule]
+                imports: [NimbleMenuButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -253,7 +256,8 @@ describe('Nimble menu button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMenuButtonModule]
+                imports: [NimbleMenuButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/menu-item/tests/nimble-menu-item.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/menu-item/tests/nimble-menu-item.directive.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { NimbleMenuItemModule } from '../nimble-menu-item.module';
 import { type MenuItem, NimbleMenuItemDirective } from '../nimble-menu-item.directive';
@@ -36,7 +36,8 @@ describe('Nimble menu item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMenuItemModule]
+                imports: [NimbleMenuItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -71,7 +72,8 @@ describe('Nimble menu item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMenuItemModule]
+                imports: [NimbleMenuItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -108,7 +110,8 @@ describe('Nimble menu item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMenuItemModule]
+                imports: [NimbleMenuItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -151,7 +154,8 @@ describe('Nimble menu item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleMenuItemModule]
+                imports: [NimbleMenuItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/number-field/nimble-number-field-control-value-accessor.directive.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/number-field/nimble-number-field-control-value-accessor.directive.ts
@@ -11,7 +11,7 @@ import { NumberValueAccessor } from '../../thirdparty/directives/number_value_ac
     selector: 'nimble-number-field[formControlName],nimble-number-field[formControl],nimble-number-field[ngModel]',
     // The following host metadata is duplicated from NumberValueAccessor
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    host: { '(input)': 'onChange($event.target.value)', '(blur)': 'onTouched()' },
+    host: { '(input)': 'onChange($any($event.target).value)', '(blur)': 'onTouched()' },
     providers: [{
         provide: NG_VALUE_ACCESSOR,
         useExisting: forwardRef(() => NimbleNumberFieldControlValueAccessorDirective),

--- a/packages/angular-workspace/nimble-angular/src/directives/number-field/tests/nimble-number-field-control-value-accessor.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/number-field/tests/nimble-number-field-control-value-accessor.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { processUpdates } from '../../../testing/async-helpers';
@@ -29,7 +29,8 @@ describe('Nimble number field control value accessor', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [TestHostComponent],
-            imports: [NimbleNumberFieldModule, FormsModule]
+            imports: [NimbleNumberFieldModule, FormsModule],
+            providers: [provideZoneChangeDetection()],
         });
     });
 

--- a/packages/angular-workspace/nimble-angular/src/directives/number-field/tests/nimble-number-field.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/number-field/tests/nimble-number-field.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute, NumberValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { NimbleNumberFieldDirective, type NumberField, NumberFieldAppearance } from '../nimble-number-field.directive';
@@ -34,7 +34,8 @@ describe('Nimble number field', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleNumberFieldModule]
+                imports: [NimbleNumberFieldModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -210,7 +211,8 @@ describe('Nimble number field', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleNumberFieldModule]
+                imports: [NimbleNumberFieldModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -330,7 +332,8 @@ describe('Nimble number field', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleNumberFieldModule]
+                imports: [NimbleNumberFieldModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -528,7 +531,8 @@ describe('Nimble number field', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleNumberFieldModule]
+                imports: [NimbleNumberFieldModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/radio-group/tests/nimble-radio-group.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/radio-group/tests/nimble-radio-group.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { NimbleRadioGroupDirective, type RadioGroup, Orientation } from '../nimble-radio-group.directive';
@@ -34,7 +34,8 @@ describe('Nimble radio group', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRadioGroupModule]
+                imports: [NimbleRadioGroupModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -119,7 +120,8 @@ describe('Nimble radio group', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRadioGroupModule]
+                imports: [NimbleRadioGroupModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -189,7 +191,8 @@ describe('Nimble radio group', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRadioGroupModule]
+                imports: [NimbleRadioGroupModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -295,7 +298,8 @@ describe('Nimble radio group', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRadioGroupModule]
+                imports: [NimbleRadioGroupModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/radio/nimble-radio-control-value-accessor.directive.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/radio/nimble-radio-control-value-accessor.directive.ts
@@ -11,7 +11,7 @@ import { RadioControlValueAccessor, RadioControlRegistry } from '../../thirdpart
     selector: 'nimble-radio[formControlName],nimble-radio[formControl],nimble-radio[ngModel]',
     // The following host metadata is duplicated from RadioControlValueAccessor
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    host: { '(change)': 'nimbleOnChange($event.target.checked)', '(blur)': 'onTouched()' },
+    host: { '(change)': 'nimbleOnChange($any($event.target).checked)', '(blur)': 'onTouched()' },
     providers: [{
         provide: NG_VALUE_ACCESSOR,
         useExisting: forwardRef(() => NimbleRadioControlValueAccessorDirective),

--- a/packages/angular-workspace/nimble-angular/src/directives/radio/tests/nimble-radio-control-value-accessor.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/radio/tests/nimble-radio-control-value-accessor.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NimbleRadioModule } from '../nimble-radio.module';
@@ -46,7 +46,8 @@ describe('Nimble radio control value accessor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRadioGroupModule, NimbleRadioModule, FormsModule, ReactiveFormsModule]
+                imports: [NimbleRadioGroupModule, NimbleRadioModule, FormsModule, ReactiveFormsModule],
+                providers: [provideZoneChangeDetection()],
             });
         });
 
@@ -147,7 +148,8 @@ describe('Nimble radio control value accessor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRadioGroupModule, NimbleRadioModule, ReactiveFormsModule]
+                imports: [NimbleRadioGroupModule, NimbleRadioModule, ReactiveFormsModule],
+                providers: [provideZoneChangeDetection()],
             });
         });
 

--- a/packages/angular-workspace/nimble-angular/src/directives/radio/tests/nimble-radio.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/radio/tests/nimble-radio.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { NimbleRadioDirective, type Radio } from '../nimble-radio.directive';
@@ -34,7 +34,8 @@ describe('Nimble radio', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRadioModule]
+                imports: [NimbleRadioModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -70,7 +71,8 @@ describe('Nimble radio', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRadioModule]
+                imports: [NimbleRadioModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -102,7 +104,8 @@ describe('Nimble radio', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRadioModule]
+                imports: [NimbleRadioModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -140,7 +143,8 @@ describe('Nimble radio', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleRadioModule]
+                imports: [NimbleRadioModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/select/nimble-select-control-value-accessor.directive.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/select/nimble-select-control-value-accessor.directive.ts
@@ -13,7 +13,7 @@ import { SelectControlValueAccessor } from '../../thirdparty/directives/select_c
     selector: 'nimble-select:not([multiple])[formControlName],nimble-select:not([multiple])[formControl],nimble-select:not([multiple])[ngModel]',
     // The following host metadata is duplicated from SelectControlValueAccessor
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    host: { '(change)': 'onChange($event.target.value)', '(blur)': 'onTouched()' },
+    host: { '(change)': 'onChange($any($event.target).value)', '(blur)': 'onTouched()' },
     providers: [{
         provide: NG_VALUE_ACCESSOR,
         useExisting: forwardRef(() => NimbleSelectControlValueAccessorDirective),

--- a/packages/angular-workspace/nimble-angular/src/directives/select/tests/nimble-select-control-value-accessor.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/select/tests/nimble-select-control-value-accessor.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, type OnChanges, type OnInit, SimpleChange, type SimpleChanges, ViewChild } from '@angular/core';
+import { Component, ElementRef, Input, type OnChanges, type OnInit, provideZoneChangeDetection, SimpleChange, type SimpleChanges, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { AbstractControl, FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { SelectPageObject } from '@ni/nimble-angular/select/testing';
@@ -50,7 +50,8 @@ describe('Nimble select control value accessor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSelectModule, NimbleListOptionModule, FormsModule]
+                imports: [NimbleSelectModule, NimbleListOptionModule, FormsModule],
+                providers: [provideZoneChangeDetection()],
             });
         });
 
@@ -152,7 +153,8 @@ describe('Nimble select control value accessor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSelectModule, NimbleListOptionModule, FormsModule]
+                imports: [NimbleSelectModule, NimbleListOptionModule, FormsModule],
+                providers: [provideZoneChangeDetection()],
             });
         });
 
@@ -241,7 +243,8 @@ describe('Nimble select control value accessor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSelectModule, NimbleListOptionModule, FormsModule, ReactiveFormsModule]
+                imports: [NimbleSelectModule, NimbleListOptionModule, FormsModule, ReactiveFormsModule],
+                providers: [provideZoneChangeDetection()],
             });
         });
 
@@ -316,7 +319,8 @@ describe('Nimble select control value accessor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSelectModule, NimbleListOptionModule, FormsModule, ReactiveFormsModule]
+                imports: [NimbleSelectModule, NimbleListOptionModule, FormsModule, ReactiveFormsModule],
+                providers: [provideZoneChangeDetection()],
             });
         });
 
@@ -397,7 +401,8 @@ describe('Nimble select control value accessor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSelectModule, NimbleListOptionModule, NimbleListOptionGroupModule, FormsModule, ReactiveFormsModule]
+                imports: [NimbleSelectModule, NimbleListOptionModule, NimbleListOptionGroupModule, FormsModule, ReactiveFormsModule],
+                providers: [provideZoneChangeDetection()],
             });
         });
 
@@ -474,7 +479,8 @@ describe('Nimble select control value accessor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSelectModule, NimbleListOptionModule, NimbleListOptionGroupModule, FormsModule, ReactiveFormsModule]
+                imports: [NimbleSelectModule, NimbleListOptionModule, NimbleListOptionGroupModule, FormsModule, ReactiveFormsModule],
+                providers: [provideZoneChangeDetection()],
             });
         });
 

--- a/packages/angular-workspace/nimble-angular/src/directives/select/tests/nimble-select.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/select/tests/nimble-select.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { DropdownAppearance } from '../../../public-api';
@@ -35,7 +35,8 @@ describe('Nimble select', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSelectModule]
+                imports: [NimbleSelectModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -154,7 +155,8 @@ describe('Nimble select', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSelectModule]
+                imports: [NimbleSelectModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -254,7 +256,8 @@ describe('Nimble select', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSelectModule]
+                imports: [NimbleSelectModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -414,7 +417,8 @@ describe('Nimble select', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSelectModule]
+                imports: [NimbleSelectModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/spinner/tests/nimble-spinner.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/spinner/tests/nimble-spinner.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SpinnerAppearance } from '../../../public-api';
 import { type Spinner, NimbleSpinnerDirective } from '../nimble-spinner.directive';
@@ -36,7 +36,8 @@ describe('Nimble Spinner', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSpinnerModule]
+                imports: [NimbleSpinnerModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -71,7 +72,8 @@ describe('Nimble Spinner', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSpinnerModule]
+                imports: [NimbleSpinnerModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -107,7 +109,8 @@ describe('Nimble Spinner', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSpinnerModule]
+                imports: [NimbleSpinnerModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -149,7 +152,8 @@ describe('Nimble Spinner', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSpinnerModule]
+                imports: [NimbleSpinnerModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/switch/nimble-switch-control-value-accessor.directive.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/switch/nimble-switch-control-value-accessor.directive.ts
@@ -11,7 +11,7 @@ import { CheckboxControlValueAccessor } from '../../thirdparty/directives/checkb
     selector: 'nimble-switch[formControlName],nimble-switch[formControl],nimble-switch[ngModel]',
     // The following host metadata is duplicated from CheckboxControlValueAccessor
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    host: { '(change)': 'onChange($event.target.checked)', '(blur)': 'onTouched()' },
+    host: { '(change)': 'onChange($any($event.target).checked)', '(blur)': 'onTouched()' },
     providers: [{
         provide: NG_VALUE_ACCESSOR,
         useExisting: forwardRef(() => NimbleSwitchControlValueAccessorDirective),

--- a/packages/angular-workspace/nimble-angular/src/directives/switch/tests/nimble-switch-control-value-accessor.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/switch/tests/nimble-switch-control-value-accessor.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { processUpdates } from '../../../testing/async-helpers';
@@ -33,7 +33,8 @@ describe('Nimble switch control value accessor', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [TestHostComponent],
-            imports: [NimbleSwitchModule, FormsModule]
+            imports: [NimbleSwitchModule, FormsModule],
+            providers: [provideZoneChangeDetection()],
         });
     });
 

--- a/packages/angular-workspace/nimble-angular/src/directives/switch/tests/nimble-switch.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/switch/tests/nimble-switch.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { NimbleSwitchDirective } from '../nimble-switch.directive';
@@ -37,7 +37,8 @@ describe('Nimble switch', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSwitchModule]
+                imports: [NimbleSwitchModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -77,7 +78,8 @@ describe('Nimble switch', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSwitchModule]
+                imports: [NimbleSwitchModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -120,7 +122,8 @@ describe('Nimble switch', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSwitchModule]
+                imports: [NimbleSwitchModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -175,7 +178,8 @@ describe('Nimble switch', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleSwitchModule]
+                imports: [NimbleSwitchModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/tab/tests/nimble-tab.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/tab/tests/nimble-tab.directive.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { NimbleTabModule } from '../nimble-tab.module';
 import { NimbleTabDirective, type Tab } from '../nimble-tab.directive';
@@ -36,7 +36,8 @@ describe('Nimble tab', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTabModule]
+                imports: [NimbleTabModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -71,7 +72,8 @@ describe('Nimble tab', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTabModule]
+                imports: [NimbleTabModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -108,7 +110,8 @@ describe('Nimble tab', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTabModule]
+                imports: [NimbleTabModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -151,7 +154,8 @@ describe('Nimble tab', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTabModule]
+                imports: [NimbleTabModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/tabs/tests/nimble-tabs.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/tabs/tests/nimble-tabs.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, ElementRef, ViewChildren, QueryList } from '@angular/core';
+import { Component, ViewChild, ElementRef, ViewChildren, QueryList, provideZoneChangeDetection } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { NimbleTabsModule } from '../nimble-tabs.module';
 import { processUpdates, waitForUpdatesAsync } from '../../../testing/async-helpers';
@@ -34,7 +34,8 @@ describe('Nimble tabs', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [TestHostComponent],
-            imports: [NimbleTabsModule]
+            imports: [NimbleTabsModule],
+            providers: [provideZoneChangeDetection()],
         });
     });
 

--- a/packages/angular-workspace/nimble-angular/src/directives/text-area/nimble-text-area-control-value-accessor.directive.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/text-area/nimble-text-area-control-value-accessor.directive.ts
@@ -13,10 +13,10 @@ import { DefaultValueAccessor } from '../../thirdparty/directives/default_value_
     // The following host metadata is duplicated from DefaultValueAccessor
     host: {
         /* eslint-disable @typescript-eslint/naming-convention */
-        '(input)': '$any(this)._handleInput($event.target.value)',
+        '(input)': '$any(this)._handleInput($any($event.target).value)',
         '(blur)': 'onTouched()',
         '(compositionstart)': '$any(this)._compositionStart()',
-        '(compositionend)': '$any(this)._compositionEnd($event.target.value)'
+        '(compositionend)': '$any(this)._compositionEnd($any($event.target).value)'
         /* eslint-enable @typescript-eslint/naming-convention */
     },
     providers: [{

--- a/packages/angular-workspace/nimble-angular/src/directives/text-area/tests/nimble-text-area-control-value-accessor.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/text-area/tests/nimble-text-area-control-value-accessor.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { processUpdates } from '../../../testing/async-helpers';
@@ -35,7 +35,8 @@ describe('Nimble text area control value accessor', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [TestHostComponent],
-            imports: [NimbleTextAreaModule, FormsModule]
+            imports: [NimbleTextAreaModule, FormsModule],
+            providers: [provideZoneChangeDetection()],
         });
     });
 

--- a/packages/angular-workspace/nimble-angular/src/directives/text-area/tests/nimble-text-area.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/text-area/tests/nimble-text-area.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute, NumberValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { NimbleTextAreaDirective, type TextArea, TextAreaAppearance, TextAreaResize } from '../nimble-text-area.directive';
@@ -36,7 +36,8 @@ describe('Nimble text area', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTextAreaModule]
+                imports: [NimbleTextAreaModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -179,7 +180,8 @@ describe('Nimble text area', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTextAreaModule]
+                imports: [NimbleTextAreaModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -327,7 +329,8 @@ describe('Nimble text area', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTextAreaModule]
+                imports: [NimbleTextAreaModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -577,7 +580,8 @@ describe('Nimble text area', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTextAreaModule]
+                imports: [NimbleTextAreaModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/text-field/nimble-text-field-control-value-accessor.directive.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/text-field/nimble-text-field-control-value-accessor.directive.ts
@@ -12,10 +12,10 @@ import { DefaultValueAccessor } from '../../thirdparty/directives/default_value_
     // The following host metadata is duplicated from DefaultValueAccessor
     host: {
         /* eslint-disable @typescript-eslint/naming-convention */
-        '(input)': '$any(this)._handleInput($event.target.value)',
+        '(input)': '$any(this)._handleInput($any($event.target).value)',
         '(blur)': 'onTouched()',
         '(compositionstart)': '$any(this)._compositionStart()',
-        '(compositionend)': '$any(this)._compositionEnd($event.target.value)'
+        '(compositionend)': '$any(this)._compositionEnd($any($event.target).value)'
         /* eslint-enable @typescript-eslint/naming-convention */
     },
     providers: [{

--- a/packages/angular-workspace/nimble-angular/src/directives/text-field/tests/nimble-text-field-control-value-accessor.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/text-field/tests/nimble-text-field-control-value-accessor.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { processUpdates } from '../../../testing/async-helpers';
@@ -35,7 +35,8 @@ describe('Nimble text field control value accessor', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [TestHostComponent],
-            imports: [NimbleTextFieldModule, FormsModule]
+            imports: [NimbleTextFieldModule, FormsModule],
+            providers: [provideZoneChangeDetection()],
         });
     });
 

--- a/packages/angular-workspace/nimble-angular/src/directives/text-field/tests/nimble-text-field.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/text-field/tests/nimble-text-field.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute, NumberValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { NimbleTextFieldModule } from '../nimble-text-field.module';
@@ -36,7 +36,8 @@ describe('Nimble text field', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTextFieldModule]
+                imports: [NimbleTextFieldModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -255,7 +256,8 @@ describe('Nimble text field', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTextFieldModule]
+                imports: [NimbleTextFieldModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -403,7 +405,8 @@ describe('Nimble text field', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTextFieldModule]
+                imports: [NimbleTextFieldModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -653,7 +656,8 @@ describe('Nimble text field', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTextFieldModule]
+                imports: [NimbleTextFieldModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/theme-provider/tests/nimble-theme-provider.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/theme-provider/tests/nimble-theme-provider.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NimbleThemeProviderModule } from '../nimble-theme-provider.module';
 import { NimbleThemeProviderDirective, Theme, type ThemeProvider } from '../nimble-theme-provider.directive';
@@ -33,7 +33,8 @@ describe('Nimble theme provider', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleThemeProviderModule]
+                imports: [NimbleThemeProviderModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -87,7 +88,8 @@ describe('Nimble theme provider', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleThemeProviderModule]
+                imports: [NimbleThemeProviderModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -130,7 +132,8 @@ describe('Nimble theme provider', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleThemeProviderModule]
+                imports: [NimbleThemeProviderModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -185,7 +188,8 @@ describe('Nimble theme provider', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleThemeProviderModule]
+                imports: [NimbleThemeProviderModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/toggle-button/nimble-toggle-button-control-value-accessor.directive.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/toggle-button/nimble-toggle-button-control-value-accessor.directive.ts
@@ -12,7 +12,7 @@ import { CheckboxControlValueAccessor } from '../../thirdparty/directives/checkb
         'nimble-toggle-button[formControlName],nimble-toggle-button[formControl],nimble-toggle-button[ngModel]',
     // The following host metadata is duplicated from CheckboxControlValueAccessor
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    host: { '(change)': 'onChange($event.target.checked)', '(blur)': 'onTouched()' },
+    host: { '(change)': 'onChange($any($event.target).checked)', '(blur)': 'onTouched()' },
     providers: [{
         provide: NG_VALUE_ACCESSOR,
         useExisting: forwardRef(() => NimbleToggleButtonControlValueAccessorDirective),

--- a/packages/angular-workspace/nimble-angular/src/directives/toggle-button/tests/nimble-toggle-button-control-value-accessor.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/toggle-button/tests/nimble-toggle-button-control-value-accessor.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { processUpdates } from '../../../testing/async-helpers';
@@ -33,7 +33,8 @@ describe('Nimble toggle button control value accessor', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [TestHostComponent],
-            imports: [NimbleToggleButtonModule, FormsModule]
+            imports: [NimbleToggleButtonModule, FormsModule],
+            providers: [provideZoneChangeDetection()],
         });
     });
 

--- a/packages/angular-workspace/nimble-angular/src/directives/toggle-button/tests/nimble-toggle-button.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/toggle-button/tests/nimble-toggle-button.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { ButtonAppearance, ButtonAppearanceVariant } from '../../../public-api';
@@ -37,7 +37,8 @@ describe('Nimble toggle button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleToggleButtonModule]
+                imports: [NimbleToggleButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -95,7 +96,8 @@ describe('Nimble toggle button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleToggleButtonModule]
+                imports: [NimbleToggleButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -159,7 +161,8 @@ describe('Nimble toggle button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleToggleButtonModule]
+                imports: [NimbleToggleButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -253,7 +256,8 @@ describe('Nimble toggle button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleToggleButtonModule]
+                imports: [NimbleToggleButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/tooltip/tests/nimble-tooltip.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/tooltip/tests/nimble-tooltip.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute, NumberValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { type Tooltip, NimbleTooltipDirective, TooltipSeverity } from '../nimble-tooltip.directive';
@@ -44,7 +44,8 @@ describe('Nimble tooltip', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTooltipModule]
+                imports: [NimbleTooltipModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -97,7 +98,8 @@ describe('Nimble tooltip', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTooltipModule]
+                imports: [NimbleTooltipModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -155,7 +157,8 @@ describe('Nimble tooltip', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTooltipModule]
+                imports: [NimbleTooltipModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -237,7 +240,8 @@ describe('Nimble tooltip', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTooltipModule]
+                imports: [NimbleTooltipModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/src/directives/tree-item/tests/nimble-tree-item.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/tree-item/tests/nimble-tree-item.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NimbleTreeItemModule } from '../nimble-tree-item.module';
 import type { TreeItem } from '../nimble-tree-item.directive';
@@ -44,7 +44,8 @@ describe('Nimble tree item directive (using 2-way binding)', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [TestHostComponent],
-            imports: [NimbleTreeViewModule, NimbleTreeItemModule]
+            imports: [NimbleTreeViewModule, NimbleTreeItemModule],
+            providers: [provideZoneChangeDetection()],
         });
     });
 

--- a/packages/angular-workspace/nimble-angular/src/directives/tree-view/tests/nimble-tree-view.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/src/directives/tree-view/tests/nimble-tree-view.directive.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { NimbleTreeViewModule } from '../nimble-tree-view.module';
 import { NimbleTreeViewDirective, type TreeView, TreeViewSelectionMode } from '../nimble-tree-view.directive';
 
@@ -35,7 +35,8 @@ describe('Nimble tree view', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTreeViewModule]
+                imports: [NimbleTreeViewModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -70,7 +71,8 @@ describe('Nimble tree view', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTreeViewModule]
+                imports: [NimbleTreeViewModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -107,7 +109,8 @@ describe('Nimble tree view', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTreeViewModule]
+                imports: [NimbleTreeViewModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -150,7 +153,8 @@ describe('Nimble tree view', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTreeViewModule]
+                imports: [NimbleTreeViewModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/step/tests/nimble-step.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/step/tests/nimble-step.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { NimbleStepModule } from '../nimble-step.module';
@@ -41,7 +41,8 @@ describe('Nimble step', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleStepModule]
+                imports: [NimbleStepModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -100,7 +101,8 @@ describe('Nimble step', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleStepModule]
+                imports: [NimbleStepModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -164,7 +166,8 @@ describe('Nimble step', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleStepModule]
+                imports: [NimbleStepModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -258,7 +261,8 @@ describe('Nimble step', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleStepModule]
+                imports: [NimbleStepModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/stepper/tests/nimble-stepper.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/stepper/tests/nimble-stepper.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NimbleStepperModule } from '../nimble-stepper.module';
 import { NimbleStepperDirective, type Stepper, StepperOrientation } from '../nimble-stepper.directive';
@@ -38,7 +38,8 @@ describe('Nimble stepper', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleStepperModule]
+                imports: [NimbleStepperModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -73,7 +74,8 @@ describe('Nimble stepper', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleStepperModule]
+                imports: [NimbleStepperModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -109,7 +111,8 @@ describe('Nimble stepper', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleStepperModule]
+                imports: [NimbleStepperModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -151,7 +154,8 @@ describe('Nimble stepper', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleStepperModule]
+                imports: [NimbleStepperModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/table-column/anchor/nimble-table-column-anchor-navigation-guard.directive.ts
+++ b/packages/angular-workspace/nimble-angular/table-column/anchor/nimble-table-column-anchor-navigation-guard.directive.ts
@@ -18,8 +18,8 @@ export class NimbleTableColumnAnchorNavigationGuardDirective {
     @Input()
     public navigationGuard?: NavigationGuard;
 
-    @HostListener('delegated-event', ['$event.detail.originalEvent', '$event.detail.recordId'])
-    private onDelegatedEvent(delegatedEvent: Event, recordId: string | undefined): void {
+    @HostListener('delegated-event', ['$any($event).detail.originalEvent', '$any($event).detail.recordId'])
+    public onDelegatedEvent(delegatedEvent: Event, recordId: string | undefined): void {
         if (delegatedEvent.type !== 'click') {
             return;
         }

--- a/packages/angular-workspace/nimble-angular/table-column/anchor/tests/nimble-table-column-anchor-navigation-guard.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/table-column/anchor/tests/nimble-table-column-anchor-navigation-guard.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import { type Anchor, processUpdates, waitForUpdatesAsync } from '@ni/nimble-angular';
@@ -54,7 +54,8 @@ describe('Nimble anchor table column navigation guard', () => {
             imports: [NimbleTableColumnAnchorModule,
                 NimbleTableModule,
                 CommonModule
-            ]
+            ],
+            providers: [provideZoneChangeDetection()],
         });
     });
 

--- a/packages/angular-workspace/nimble-angular/table-column/anchor/tests/nimble-table-column-anchor.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/table-column/anchor/tests/nimble-table-column-anchor.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TableColumnSortDirection } from '@ni/nimble-angular/table-column';
 import { NimbleTableColumnAnchorDirective, type TableColumnAnchor } from '../nimble-table-column-anchor.directive';
@@ -49,7 +49,8 @@ describe('Nimble anchor table column', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnAnchorModule]
+                imports: [NimbleTableColumnAnchorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -223,7 +224,8 @@ describe('Nimble anchor table column', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnAnchorModule]
+                imports: [NimbleTableColumnAnchorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -421,7 +423,8 @@ describe('Nimble anchor table column', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnAnchorModule]
+                imports: [NimbleTableColumnAnchorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -807,7 +810,8 @@ describe('Nimble anchor table column', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnAnchorModule]
+                imports: [NimbleTableColumnAnchorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/table-column/date-text/tests/nimble-table-column-date-text.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/table-column/date-text/tests/nimble-table-column-date-text.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NimbleTableModule } from '../../../table/nimble-table.module';
 import { NimbleTableColumnDateTextModule } from '../nimble-table-column-date-text.module';
@@ -57,7 +57,8 @@ describe('NimbleTableColumnDateText', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnDateTextModule, NimbleTableModule]
+                imports: [NimbleTableColumnDateTextModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -134,7 +135,8 @@ describe('NimbleTableColumnDateText', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnDateTextModule, NimbleTableModule]
+                imports: [NimbleTableColumnDateTextModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -397,7 +399,8 @@ describe('NimbleTableColumnDateText', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnDateTextModule, NimbleTableModule]
+                imports: [NimbleTableColumnDateTextModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -1111,7 +1114,8 @@ describe('NimbleTableColumnDateText', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnDateTextModule, NimbleTableModule]
+                imports: [NimbleTableColumnDateTextModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);

--- a/packages/angular-workspace/nimble-angular/table-column/duration-text/tests/nimble-table-column-duration-text.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/table-column/duration-text/tests/nimble-table-column-duration-text.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NimbleTableModule } from '../../../table/nimble-table.module';
 import { NimbleTableColumnDurationTextModule } from '../nimble-table-column-duration-text.module';
@@ -53,7 +53,8 @@ describe('NimbleTableColumnDurationText', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnDurationTextModule, NimbleTableModule]
+                imports: [NimbleTableColumnDurationTextModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -176,7 +177,8 @@ describe('NimbleTableColumnDurationText', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnDurationTextModule, NimbleTableModule]
+                imports: [NimbleTableColumnDurationTextModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -421,7 +423,8 @@ describe('NimbleTableColumnDurationText', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnDurationTextModule, NimbleTableModule]
+                imports: [NimbleTableColumnDurationTextModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);

--- a/packages/angular-workspace/nimble-angular/table-column/mapping/tests/nimble-table-column-mapping.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/table-column/mapping/tests/nimble-table-column-mapping.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NimbleTableModule } from '../../../table/nimble-table.module';
 import { NimbleTableColumnMappingModule } from '../nimble-table-column-mapping.module';
@@ -9,7 +9,8 @@ describe('NimbleTableColumnMapping', () => {
     describe('module', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
-                imports: [NimbleTableColumnMappingModule]
+                imports: [NimbleTableColumnMappingModule],
+                providers: [provideZoneChangeDetection()],
             });
         });
 
@@ -55,7 +56,8 @@ describe('NimbleTableColumnMapping', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnMappingModule, NimbleTableModule]
+                imports: [NimbleTableColumnMappingModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -192,7 +194,8 @@ describe('NimbleTableColumnMapping', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnMappingModule, NimbleTableModule]
+                imports: [NimbleTableColumnMappingModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -463,7 +466,8 @@ describe('NimbleTableColumnMapping', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnMappingModule, NimbleTableModule]
+                imports: [NimbleTableColumnMappingModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);

--- a/packages/angular-workspace/nimble-angular/table-column/menu-button/tests/nimble-table-column-menu-button.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/table-column/menu-button/tests/nimble-table-column-menu-button.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NimbleTableModule } from '../../../table/nimble-table.module';
 import { NimbleTableColumnMenuButtonModule } from '../nimble-table-column-menu-button.module';
@@ -37,7 +37,8 @@ describe('NimbleTableColumnMenuButtonDirective', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnMenuButtonModule, NimbleTableModule]
+                imports: [NimbleTableColumnMenuButtonModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -80,7 +81,8 @@ describe('NimbleTableColumnMenuButtonDirective', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnMenuButtonModule, NimbleTableModule]
+                imports: [NimbleTableColumnMenuButtonModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -168,7 +170,8 @@ describe('NimbleTableColumnMenuButtonDirective', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnMenuButtonModule, NimbleTableModule]
+                imports: [NimbleTableColumnMenuButtonModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -326,7 +329,8 @@ describe('NimbleTableColumnMenuButtonDirective', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnMenuButtonModule, NimbleTableModule]
+                imports: [NimbleTableColumnMenuButtonModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);

--- a/packages/angular-workspace/nimble-angular/table-column/number-text/tests/nimble-table-column-number-text.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/table-column/number-text/tests/nimble-table-column-number-text.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NimbleTableModule } from '../../../table/nimble-table.module';
 import { TableColumnSortDirection } from '../../nimble-table-column-base.directive';
@@ -38,7 +38,8 @@ describe('NimbleTableColumnNumberText', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnNumberTextModule, NimbleTableModule]
+                imports: [NimbleTableColumnNumberTextModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -98,7 +99,8 @@ describe('NimbleTableColumnNumberText', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnNumberTextModule, NimbleTableModule]
+                imports: [NimbleTableColumnNumberTextModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -249,7 +251,8 @@ describe('NimbleTableColumnNumberText', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnNumberTextModule, NimbleTableModule]
+                imports: [NimbleTableColumnNumberTextModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -568,7 +571,8 @@ describe('NimbleTableColumnNumberText', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnNumberTextModule, NimbleTableModule]
+                imports: [NimbleTableColumnNumberTextModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);

--- a/packages/angular-workspace/nimble-angular/table-column/text/tests/nimble-table-column-text.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/table-column/text/tests/nimble-table-column-text.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NimbleTableModule } from '../../../table/nimble-table.module';
 import { NimbleTableColumnTextModule } from '../nimble-table-column-text.module';
@@ -54,7 +54,8 @@ describe('NimbleTableColumnText', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnTextModule, NimbleTableModule]
+                imports: [NimbleTableColumnTextModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -184,7 +185,8 @@ describe('NimbleTableColumnText', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnTextModule, NimbleTableModule]
+                imports: [NimbleTableColumnTextModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -442,7 +444,8 @@ describe('NimbleTableColumnText', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableColumnTextModule, NimbleTableModule]
+                imports: [NimbleTableColumnTextModule, NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);

--- a/packages/angular-workspace/nimble-angular/table/testing/tests/table.pageobject.spec.ts
+++ b/packages/angular-workspace/nimble-angular/table/testing/tests/table.pageobject.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 import { waitForUpdatesAsync } from '@ni/nimble-angular';
@@ -44,7 +44,8 @@ describe('Table page object', () => {
                 imports: [
                     NimbleTableModule,
                     NimbleTableColumnTextModule
-                ]
+                ],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/table/tests/nimble-table.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/table/tests/nimble-table.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { processUpdates } from '@ni/nimble-angular';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
@@ -46,7 +46,8 @@ describe('Nimble table', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableModule]
+                imports: [NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -123,7 +124,8 @@ describe('Nimble table', () => {
         beforeEach(async () => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableModule]
+                imports: [NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -266,7 +268,8 @@ describe('Nimble table', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableModule]
+                imports: [NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -369,7 +372,8 @@ describe('Nimble table', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleTableModule]
+                imports: [NimbleTableModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/nimble-angular/unit/byte/tests/nimble-unit-byte.directive.spec.ts
+++ b/packages/angular-workspace/nimble-angular/unit/byte/tests/nimble-unit-byte.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NimbleUnitByteModule } from '../nimble-unit-byte.module';
 import { NimbleUnitByteDirective, type UnitByte } from '../nimble-unit-byte.directive';
@@ -34,7 +34,8 @@ describe('Nimble byte unit', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleUnitByteModule]
+                imports: [NimbleUnitByteModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -67,7 +68,8 @@ describe('Nimble byte unit', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleUnitByteModule]
+                imports: [NimbleUnitByteModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -101,7 +103,8 @@ describe('Nimble byte unit', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleUnitByteModule]
+                imports: [NimbleUnitByteModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);
@@ -141,7 +144,8 @@ describe('Nimble byte unit', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [NimbleUnitByteModule]
+                imports: [NimbleUnitByteModule],
+                providers: [provideZoneChangeDetection()],
             });
 
             fixture = TestBed.createComponent(TestHostComponent);

--- a/packages/angular-workspace/ok-angular/fv/accordion-item/tests/ok-fv-accordion-item.directive.spec.ts
+++ b/packages/angular-workspace/ok-angular/fv/accordion-item/tests/ok-fv-accordion-item.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type FvAccordionItem, FvAccordionItemAppearance, OkFvAccordionItemDirective } from '../ok-fv-accordion-item.directive';
 import { OkFvAccordionItemModule } from '../ok-fv-accordion-item.module';
@@ -35,7 +35,8 @@ describe('Ok fv accordion item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvAccordionItemModule]
+                imports: [OkFvAccordionItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -81,7 +82,8 @@ describe('Ok fv accordion item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvAccordionItemModule]
+                imports: [OkFvAccordionItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -130,7 +132,8 @@ describe('Ok fv accordion item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvAccordionItemModule]
+                imports: [OkFvAccordionItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/ok-angular/fv/card/tests/ok-fv-card.directive.spec.ts
+++ b/packages/angular-workspace/ok-angular/fv/card/tests/ok-fv-card.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type FvCard, FvCardAppearance, FvCardInteractionMode, OkFvCardDirective } from '../ok-fv-card.directive';
 import { OkFvCardModule } from '../ok-fv-card.module';
@@ -35,7 +35,8 @@ describe('Ok fv card', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvCardModule]
+                imports: [OkFvCardModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -106,7 +107,8 @@ describe('Ok fv card', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvCardModule]
+                imports: [OkFvCardModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -184,7 +186,8 @@ describe('Ok fv card', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvCardModule]
+                imports: [OkFvCardModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/ok-angular/fv/chip-selector/tests/ok-fv-chip-selector.directive.spec.ts
+++ b/packages/angular-workspace/ok-angular/fv/chip-selector/tests/ok-fv-chip-selector.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type FvChipSelector, OkFvChipSelectorDirective } from '../ok-fv-chip-selector.directive';
 import { OkFvChipSelectorModule } from '../ok-fv-chip-selector.module';
@@ -35,7 +35,8 @@ describe('Ok fv chip selector', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvChipSelectorModule]
+                imports: [OkFvChipSelectorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -105,7 +106,8 @@ describe('Ok fv chip selector', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvChipSelectorModule]
+                imports: [OkFvChipSelectorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -178,7 +180,8 @@ describe('Ok fv chip selector', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvChipSelectorModule]
+                imports: [OkFvChipSelectorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/ok-angular/fv/context-help/tests/ok-fv-context-help.directive.spec.ts
+++ b/packages/angular-workspace/ok-angular/fv/context-help/tests/ok-fv-context-help.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type FvContextHelp, OkFvContextHelpDirective } from '../ok-fv-context-help.directive';
 import { OkFvContextHelpModule } from '../ok-fv-context-help.module';
@@ -35,7 +35,8 @@ describe('Ok fv context help', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvContextHelpModule]
+                imports: [OkFvContextHelpModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -88,7 +89,8 @@ describe('Ok fv context help', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvContextHelpModule]
+                imports: [OkFvContextHelpModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -145,7 +147,8 @@ describe('Ok fv context help', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvContextHelpModule]
+                imports: [OkFvContextHelpModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/ok-angular/fv/master-detail-list-item/tests/ok-fv-master-detail-list-item.directive.spec.ts
+++ b/packages/angular-workspace/ok-angular/fv/master-detail-list-item/tests/ok-fv-master-detail-list-item.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type FvMasterDetailListItem, OkFvMasterDetailListItemDirective } from '../ok-fv-master-detail-list-item.directive';
 import { OkFvMasterDetailListItemModule } from '../ok-fv-master-detail-list-item.module';
@@ -35,7 +35,8 @@ describe('Ok fv master detail list item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvMasterDetailListItemModule]
+                imports: [OkFvMasterDetailListItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -106,7 +107,8 @@ describe('Ok fv master detail list item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvMasterDetailListItemModule]
+                imports: [OkFvMasterDetailListItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -184,7 +186,8 @@ describe('Ok fv master detail list item', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvMasterDetailListItemModule]
+                imports: [OkFvMasterDetailListItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/ok-angular/fv/master-detail-list/tests/ok-fv-master-detail-list.directive.spec.ts
+++ b/packages/angular-workspace/ok-angular/fv/master-detail-list/tests/ok-fv-master-detail-list.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type FvMasterDetailList, OkFvMasterDetailListDirective } from '../ok-fv-master-detail-list.directive';
 import { OkFvMasterDetailListModule } from '../ok-fv-master-detail-list.module';
@@ -38,7 +38,8 @@ describe('Ok fv master detail list', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvMasterDetailListModule, OkFvMasterDetailListItemModule]
+                imports: [OkFvMasterDetailListModule, OkFvMasterDetailListItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -73,7 +74,8 @@ describe('Ok fv master detail list', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvMasterDetailListModule, OkFvMasterDetailListItemModule]
+                imports: [OkFvMasterDetailListModule, OkFvMasterDetailListItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -109,7 +111,8 @@ describe('Ok fv master detail list', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvMasterDetailListModule, OkFvMasterDetailListItemModule]
+                imports: [OkFvMasterDetailListModule, OkFvMasterDetailListItemModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/ok-angular/fv/search-input/tests/ok-fv-search-input.directive.spec.ts
+++ b/packages/angular-workspace/ok-angular/fv/search-input/tests/ok-fv-search-input.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type FvSearchInput, FvSearchInputAppearance, OkFvSearchInputDirective } from '../ok-fv-search-input.directive';
 import { OkFvSearchInputModule } from '../ok-fv-search-input.module';
@@ -35,7 +35,8 @@ describe('Ok Fv Search Input', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvSearchInputModule]
+                imports: [OkFvSearchInputModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -82,7 +83,8 @@ describe('Ok Fv Search Input', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvSearchInputModule]
+                imports: [OkFvSearchInputModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -132,7 +134,8 @@ describe('Ok Fv Search Input', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvSearchInputModule]
+                imports: [OkFvSearchInputModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/ok-angular/fv/split-button-anchor/tests/ok-fv-split-button-anchor.directive.spec.ts
+++ b/packages/angular-workspace/ok-angular/fv/split-button-anchor/tests/ok-fv-split-button-anchor.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type FvSplitButtonAnchor, FvSplitButtonAnchorAppearance, FvSplitButtonAnchorAppearanceVariant, OkFvSplitButtonAnchorDirective } from '../ok-fv-split-button-anchor.directive';
 import { OkFvSplitButtonAnchorModule } from '../ok-fv-split-button-anchor.module';
@@ -35,7 +35,8 @@ describe('Ok fv split button anchor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvSplitButtonAnchorModule]
+                imports: [OkFvSplitButtonAnchorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -117,7 +118,8 @@ describe('Ok fv split button anchor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvSplitButtonAnchorModule]
+                imports: [OkFvSplitButtonAnchorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -204,7 +206,8 @@ describe('Ok fv split button anchor', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvSplitButtonAnchorModule]
+                imports: [OkFvSplitButtonAnchorModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/ok-angular/fv/split-button/tests/ok-fv-split-button.directive.spec.ts
+++ b/packages/angular-workspace/ok-angular/fv/split-button/tests/ok-fv-split-button.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type FvSplitButton, FvSplitButtonAppearance, FvSplitButtonAppearanceVariant, OkFvSplitButtonDirective } from '../ok-fv-split-button.directive';
 import { OkFvSplitButtonModule } from '../ok-fv-split-button.module';
@@ -35,7 +35,8 @@ describe('Ok fv split button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvSplitButtonModule]
+                imports: [OkFvSplitButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -94,7 +95,8 @@ describe('Ok fv split button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvSplitButtonModule]
+                imports: [OkFvSplitButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -153,7 +155,8 @@ describe('Ok fv split button', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvSplitButtonModule]
+                imports: [OkFvSplitButtonModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/ok-angular/fv/summary-panel-tile/tests/ok-fv-summary-panel-tile.directive.spec.ts
+++ b/packages/angular-workspace/ok-angular/fv/summary-panel-tile/tests/ok-fv-summary-panel-tile.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type FvSummaryPanelTile, FvSummaryPanelTileTextPosition, OkFvSummaryPanelTileDirective } from '../ok-fv-summary-panel-tile.directive';
 import { OkFvSummaryPanelTileModule } from '../ok-fv-summary-panel-tile.module';
@@ -35,7 +35,8 @@ describe('Ok fv summary panel tile', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvSummaryPanelTileModule]
+                imports: [OkFvSummaryPanelTileModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -94,7 +95,8 @@ describe('Ok fv summary panel tile', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvSummaryPanelTileModule]
+                imports: [OkFvSummaryPanelTileModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -158,7 +160,8 @@ describe('Ok fv summary panel tile', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvSummaryPanelTileModule]
+                imports: [OkFvSummaryPanelTileModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/ok-angular/fv/summary-panel/tests/ok-fv-summary-panel.directive.spec.ts
+++ b/packages/angular-workspace/ok-angular/fv/summary-panel/tests/ok-fv-summary-panel.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type FvSummaryPanel, OkFvSummaryPanelDirective } from '../ok-fv-summary-panel.directive';
 import { OkFvSummaryPanelModule } from '../ok-fv-summary-panel.module';
@@ -35,7 +35,8 @@ describe('Ok fv summary panel', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvSummaryPanelModule]
+                imports: [OkFvSummaryPanelModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -82,7 +83,8 @@ describe('Ok fv summary panel', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvSummaryPanelModule]
+                imports: [OkFvSummaryPanelModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -132,7 +134,8 @@ describe('Ok fv summary panel', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [OkFvSummaryPanelModule]
+                imports: [OkFvSummaryPanelModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/package.json
+++ b/packages/angular-workspace/package.json
@@ -30,7 +30,8 @@
     "test": "ng test --watch=false",
     "test-nimble": "ng test @ni/nimble-angular --watch=false",
     "test-spright": "ng test @ni/spright-angular --watch=false",
-    "test-ok": "ng test @ni/ok-angular --watch=false"
+    "test-ok": "ng test @ni/ok-angular --watch=false",
+    "test-application": "ng test example-client-app --watch=false"
   },
   "type": "module",
   "dependencies": {

--- a/packages/angular-workspace/spright-angular/chat/input/tests/spright-chat-input.directive.spec.ts
+++ b/packages/angular-workspace/spright-angular/chat/input/tests/spright-chat-input.directive.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import type { BooleanValueOrAttribute } from '@ni/nimble-angular/internal-utilities';
 import { SprightChatInputDirective, type ChatInput } from '../spright-chat-input.directive';
 import { SprightChatInputModule } from '../spright-chat-input.module';
@@ -36,7 +36,8 @@ describe('Spright chat input', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [SprightChatInputModule]
+                imports: [SprightChatInputModule],
+                                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -119,7 +120,8 @@ describe('Spright chat input', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [SprightChatInputModule]
+                imports: [SprightChatInputModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -211,7 +213,8 @@ describe('Spright chat input', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [SprightChatInputModule]
+                imports: [SprightChatInputModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -358,7 +361,8 @@ describe('Spright chat input', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [SprightChatInputModule]
+                imports: [SprightChatInputModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/spright-angular/chat/input/tests/spright-chat-input.directive.spec.ts
+++ b/packages/angular-workspace/spright-angular/chat/input/tests/spright-chat-input.directive.spec.ts
@@ -37,7 +37,7 @@ describe('Spright chat input', () => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
                 imports: [SprightChatInputModule],
-                                providers: [provideZoneChangeDetection()],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/spright-angular/chat/message/tests/spright-chat-message.directive.spec.ts
+++ b/packages/angular-workspace/spright-angular/chat/message/tests/spright-chat-message.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SprightChatMessageModule } from '../spright-chat-message.module';
 import { ChatMessageType, SprightChatMessageDirective, type ChatMessage } from '../spright-chat-message.directive';
@@ -35,7 +35,8 @@ describe('Spright chat message', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [SprightChatMessageModule]
+                imports: [SprightChatMessageModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -70,7 +71,8 @@ describe('Spright chat message', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [SprightChatMessageModule]
+                imports: [SprightChatMessageModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -106,7 +108,8 @@ describe('Spright chat message', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [SprightChatMessageModule]
+                imports: [SprightChatMessageModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -148,7 +151,8 @@ describe('Spright chat message', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [SprightChatMessageModule]
+                imports: [SprightChatMessageModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/spright-angular/chat/message/welcome/tests/spright-chat-message-welcome.directive.spec.ts
+++ b/packages/angular-workspace/spright-angular/chat/message/welcome/tests/spright-chat-message-welcome.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SprightChatMessageWelcomeDirective, type ChatMessageWelcome } from '../spright-chat-message-welcome.directive';
 import { SprightChatMessageWelcomeModule } from '../spright-chat-message-welcome.module';
@@ -35,7 +35,8 @@ describe('Spright chat message welcome', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [SprightChatMessageWelcomeModule]
+                imports: [SprightChatMessageWelcomeModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -74,7 +75,8 @@ describe('Spright chat message welcome', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [SprightChatMessageWelcomeModule]
+                imports: [SprightChatMessageWelcomeModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -115,7 +117,8 @@ describe('Spright chat message welcome', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [SprightChatMessageWelcomeModule]
+                imports: [SprightChatMessageWelcomeModule],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();

--- a/packages/angular-workspace/spright-angular/icon-base/tests/spright-icon-base.directive.spec.ts
+++ b/packages/angular-workspace/spright-angular/icon-base/tests/spright-icon-base.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { type IconWorkItemCalendarWeek, SprightIconWorkItemCalendarWeekDirective, iconWorkItemCalendarWeekTag } from '@ni/spright-angular/icons/work-item-calendar-week';
 import { IconSeverity } from '../spright-icon-base.directive';
@@ -35,7 +35,8 @@ describe('Spright icon calendar week', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [SprightIconWorkItemCalendarWeekDirective]
+                imports: [SprightIconWorkItemCalendarWeekDirective],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -70,7 +71,8 @@ describe('Spright icon calendar week', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [SprightIconWorkItemCalendarWeekDirective]
+                imports: [SprightIconWorkItemCalendarWeekDirective],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -107,7 +109,8 @@ describe('Spright icon calendar week', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [SprightIconWorkItemCalendarWeekDirective]
+                imports: [SprightIconWorkItemCalendarWeekDirective],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
@@ -150,7 +153,8 @@ describe('Spright icon calendar week', () => {
         beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [TestHostComponent],
-                imports: [SprightIconWorkItemCalendarWeekDirective]
+                imports: [SprightIconWorkItemCalendarWeekDirective],
+                providers: [provideZoneChangeDetection()],
             });
             fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

The Angular 21 update will:
- make zoneless change detection the default (we need to re-enable zone based change detection)
- default to type-checking host bindings

We can pre-emptively make the changes that will be necessary, so the actual upgrade change is smaller and quicker to review.

## 👩‍💻 Implementation

- Added `provideZoneChangeDetection()` to the TestBed configuration providers lists (where necessary)
- Added `$any()` in bindings to effectively suppress false-positive type errors where the declared types are not specific enough

## 🧪 Testing

Tests pass

