### PR TITLE
Export `TableColumnDateTextPageObject` from nimble-angular

### DIFF
--- a/change/@ni-nimble-angular-f3fa4334-0c27-46bf-b40e-5d2717a848a3.json
+++ b/change/@ni-nimble-angular-f3fa4334-0c27-46bf-b40e-5d2717a848a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Export TableColumnDateTextPageObject from nimble-angular",
+  "packageName": "@ni/nimble-angular",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/angular-workspace/nimble-angular/table-column/date-text/testing/ng-package.json
+++ b/packages/angular-workspace/nimble-angular/table-column/date-text/testing/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+      "entryFile": "public-api.ts"
+    }
+}

--- a/packages/angular-workspace/nimble-angular/table-column/date-text/testing/public-api.ts
+++ b/packages/angular-workspace/nimble-angular/table-column/date-text/testing/public-api.ts
@@ -1,0 +1,1 @@
+export * from '@ni/nimble-components/dist/esm/table-column/date-text/testing/table-column-date-text.pageobject';

--- a/packages/angular-workspace/nimble-angular/table-column/date-text/testing/public-api.ts
+++ b/packages/angular-workspace/nimble-angular/table-column/date-text/testing/public-api.ts
@@ -1,1 +1,1 @@
-export * from '@ni/nimble-components/dist/esm/table-column/date-text/testing/table-column-date-text.pageobject';
+export * from './table-column-date-text.pageobject';

--- a/packages/angular-workspace/nimble-angular/table-column/date-text/testing/table-column-date-text.pageobject.ts
+++ b/packages/angular-workspace/nimble-angular/table-column/date-text/testing/table-column-date-text.pageobject.ts
@@ -1,0 +1,3 @@
+import { TableColumnDateTextPageObject } from '@ni/nimble-components/dist/esm/table-column/date-text/testing/table-column-date-text.pageobject';
+
+export { TableColumnDateTextPageObject };

--- a/packages/angular-workspace/nimble-angular/table-column/duration-text/testing/ng-package.json
+++ b/packages/angular-workspace/nimble-angular/table-column/duration-text/testing/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+      "entryFile": "public-api.ts"
+    }
+}

--- a/packages/angular-workspace/nimble-angular/table-column/duration-text/testing/public-api.ts
+++ b/packages/angular-workspace/nimble-angular/table-column/duration-text/testing/public-api.ts
@@ -1,0 +1,1 @@
+export * from './table-column-duration-text.pageobject';

--- a/packages/angular-workspace/nimble-angular/table-column/duration-text/testing/table-column-duration-text.pageobject.ts
+++ b/packages/angular-workspace/nimble-angular/table-column/duration-text/testing/table-column-duration-text.pageobject.ts
@@ -1,0 +1,3 @@
+import { TableColumnDurationTextPageObject } from '@ni/nimble-components/dist/esm/table-column/duration-text/testing/table-column-duration-text.pageobject';
+
+export { TableColumnDurationTextPageObject };


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Angular client tests are running into date formatting issues under Angular 21 (specifically, the space before AM/PM is a narrow, non-breaking space rather than a regular space). There is a date-text column page object in `nimble-components` that normalizes spaces to handle this, but it isn't exported by `nimble-angular`.

## 👩‍💻 Implementation

Create a new entry point, `@ni/nimble-angular/table-column/date-text/testing`, that exports `TableColumnDateTextPageObject`.

## 🧪 Testing

Created tgz and verified that an SLE app can import and instantiate the page object.