### PR TITLE
Add Blur event to interactive elements in NimbleBlazor

### DIFF
--- a/change/@ni-nimble-blazor-3ce256ca-8291-4971-8718-818b348b7788.json
+++ b/change/@ni-nimble-blazor-3ce256ca-8291-4971-8718-818b348b7788.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Blur event to interactive elements",
+  "packageName": "@ni/nimble-blazor",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/blazor-workspace/NimbleBlazor/CONTRIBUTING.md
+++ b/packages/blazor-workspace/NimbleBlazor/CONTRIBUTING.md
@@ -57,6 +57,7 @@ public partial class NimbleButton : ComponentBase
 [Parameter(CaptureUnmatchedValues = true)]
 public IDictionary<string, object>? AdditionalAttributes { get; set; }
 ```
+- Interactive components should expose a `Blur` `EventCallback` so that clients can optionally listen to the event
 - Code style conventions are enforced by the [NI C# Style Guide](https://github.com/ni/csharp-styleguide)
 
 ### 2-way Binding Support, Handling DOM Events

--- a/packages/blazor-workspace/NimbleBlazor/Source/Anchor/NimbleAnchor.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Anchor/NimbleAnchor.razor
@@ -1,6 +1,7 @@
 @namespace NimbleBlazor
 @inherits NimbleAnchorBase
 <nimble-anchor
+    @onblur="HandleBlur"
     href="@Href"
     hreflang="@HrefLang"
     ping="@Ping"

--- a/packages/blazor-workspace/NimbleBlazor/Source/Anchor/NimbleAnchor.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Anchor/NimbleAnchor.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -33,4 +34,12 @@ public partial class NimbleAnchor : NimbleAnchorBase
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/AnchorButton/NimbleAnchorButton.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/AnchorButton/NimbleAnchorButton.razor
@@ -1,6 +1,7 @@
 @namespace NimbleBlazor
 @inherits NimbleAnchorBase
 <nimble-anchor-button
+    @onblur="HandleBlur"
     href="@Href"
     hreflang="@HrefLang"
     ping="@Ping"

--- a/packages/blazor-workspace/NimbleBlazor/Source/AnchorButton/NimbleAnchorButton.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/AnchorButton/NimbleAnchorButton.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -39,4 +40,12 @@ public partial class NimbleAnchorButton : NimbleAnchorBase
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/AnchorMenuItem/NimbleAnchorMenuItem.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/AnchorMenuItem/NimbleAnchorMenuItem.razor
@@ -1,6 +1,7 @@
 @namespace NimbleBlazor
 @inherits NimbleAnchorBase
 <nimble-anchor-menu-item
+    @onblur="HandleBlur"
     href="@Href"
     hreflang="@HrefLang"
     ping="@Ping"

--- a/packages/blazor-workspace/NimbleBlazor/Source/AnchorMenuItem/NimbleAnchorMenuItem.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/AnchorMenuItem/NimbleAnchorMenuItem.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -21,4 +22,12 @@ public partial class NimbleAnchorMenuItem : NimbleAnchorBase
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/AnchorStep/NimbleAnchorStep.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/AnchorStep/NimbleAnchorStep.razor
@@ -1,6 +1,7 @@
 @namespace NimbleBlazor
 @inherits NimbleAnchorBase
 <nimble-anchor-step
+    @onblur="HandleBlur"
     href="@Href"
     hreflang="@HrefLang"
     ping="@Ping"

--- a/packages/blazor-workspace/NimbleBlazor/Source/AnchorStep/NimbleAnchorStep.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/AnchorStep/NimbleAnchorStep.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -39,4 +40,12 @@ public partial class NimbleAnchorStep : NimbleAnchorBase
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/AnchorTab/NimbleAnchorTab.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/AnchorTab/NimbleAnchorTab.razor
@@ -1,6 +1,7 @@
 @namespace NimbleBlazor
 @inherits NimbleAnchorBase
 <nimble-anchor-tab
+    @onblur="HandleBlur"
     href="@Href"
     hreflang="@HrefLang"
     ping="@Ping"

--- a/packages/blazor-workspace/NimbleBlazor/Source/AnchorTab/NimbleAnchorTab.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/AnchorTab/NimbleAnchorTab.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -24,4 +25,12 @@ public partial class NimbleAnchorTab : NimbleAnchorBase
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/AnchorTabs/NimbleAnchorTabs.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/AnchorTabs/NimbleAnchorTabs.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-anchor-tabs
+    @onblur="HandleBlur"
     activeid="@BindConverter.FormatValue(ActiveId)"
     @attributes="AdditionalAttributes">
     @ChildContent

--- a/packages/blazor-workspace/NimbleBlazor/Source/AnchorTabs/NimbleAnchorTabs.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/AnchorTabs/NimbleAnchorTabs.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -24,4 +25,12 @@ public partial class NimbleAnchorTabs : ComponentBase
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/AnchorTreeItem/NimbleAnchorTreeItem.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/AnchorTreeItem/NimbleAnchorTreeItem.razor
@@ -1,6 +1,7 @@
 @namespace NimbleBlazor
 @inherits NimbleAnchorBase
 <nimble-anchor-tree-item
+    @onblur="HandleBlur"
     href="@Href"
     hreflang="@HrefLang"
     ping="@Ping"

--- a/packages/blazor-workspace/NimbleBlazor/Source/AnchorTreeItem/NimbleAnchorTreeItem.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/AnchorTreeItem/NimbleAnchorTreeItem.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -27,4 +28,12 @@ public partial class NimbleAnchorTreeItem : NimbleAnchorBase
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Banner/NimbleBanner.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Banner/NimbleBanner.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-banner
+    @onblur="HandleBlur"
     open="@BindConverter.FormatValue(Open)"
     @onnimblebannertoggle="(__value) => UpdateOpen(__value.NewState)"
     severity="@Severity.ToAttributeValue()"

--- a/packages/blazor-workspace/NimbleBlazor/Source/Banner/NimbleBanner.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Banner/NimbleBanner.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -58,4 +59,12 @@ public partial class NimbleBanner : ComponentBase
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Breadcrumb/NimbleBreadcrumb.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Breadcrumb/NimbleBreadcrumb.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-breadcrumb
+    @onblur="HandleBlur"
     appearance="@Appearance.ToAttributeValue()"
     @attributes="AdditionalAttributes">
     @ChildContent

--- a/packages/blazor-workspace/NimbleBlazor/Source/Breadcrumb/NimbleBreadcrumb.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Breadcrumb/NimbleBreadcrumb.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -12,4 +13,12 @@ public partial class NimbleBreadcrumb : ComponentBase
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/BreadcrumbItem/NimbleBreadcrumbItem.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/BreadcrumbItem/NimbleBreadcrumbItem.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-breadcrumb-item
+    @onblur="HandleBlur"
     href="@Href"
     hreflang="@HrefLang"
     ping="@Ping"

--- a/packages/blazor-workspace/NimbleBlazor/Source/BreadcrumbItem/NimbleBreadcrumbItem.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/BreadcrumbItem/NimbleBreadcrumbItem.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -6,6 +7,9 @@ public partial class NimbleBreadcrumbItem : ComponentBase
 {
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
@@ -30,4 +34,9 @@ public partial class NimbleBreadcrumbItem : ComponentBase
 
     [Parameter]
     public string? Type { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Button/NimbleButton.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Button/NimbleButton.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-button
+    @onblur="HandleBlur"
     appearance="@Appearance.ToAttributeValue()"
     appearance-variant="@AppearanceVariant.ToAttributeValue()"
     content-hidden="@ContentHidden"

--- a/packages/blazor-workspace/NimbleBlazor/Source/Button/NimbleButton.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Button/NimbleButton.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -24,4 +25,12 @@ public partial class NimbleButton : ComponentBase
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Card/NimbleCard.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Card/NimbleCard.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-card
+    @onblur="HandleBlur"
     @attributes="AdditionalAttributes">
     @ChildContent
 </nimble-card>

--- a/packages/blazor-workspace/NimbleBlazor/Source/Card/NimbleCard.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Card/NimbleCard.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -9,4 +10,12 @@ public partial class NimbleCard : ComponentBase
 
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/CardButton/NimbleCardButton.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/CardButton/NimbleCardButton.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-card-button
+    @onblur="HandleBlur"
     disabled="@Disabled"
     selected="@Selected"
     @attributes="AdditionalAttributes">

--- a/packages/blazor-workspace/NimbleBlazor/Source/CardButton/NimbleCardButton.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/CardButton/NimbleCardButton.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -15,4 +16,12 @@ public partial class NimbleCardButton : ComponentBase
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Checkbox/NimbleCheckbox.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Checkbox/NimbleCheckbox.razor
@@ -1,6 +1,7 @@
 @namespace NimbleBlazor
 @inherits NimbleInputBase<bool>
 <nimble-checkbox disabled="@Disabled"
+    @onblur="HandleBlur"
     current-checked="@BindConverter.FormatValue(CurrentValue)"
     @onnimblecheckedchange="(__value) => CurrentValue = __value.Checked"
     appearance-indeterminate="@AppearanceIndeterminate"

--- a/packages/blazor-workspace/NimbleBlazor/Source/Checkbox/NimbleCheckbox.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Checkbox/NimbleCheckbox.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -25,5 +26,13 @@ public partial class NimbleCheckbox : NimbleInputBase<bool>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
     protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out bool result, [NotNullWhen(false)] out string? validationErrorMessage) => throw new NotSupportedException($"This component does not parse string inputs. Bind to the '{nameof(CurrentValue)}' property, not '{nameof(CurrentValueAsString)}'.");
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Chip/NimbleChip.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Chip/NimbleChip.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-chip
+    @onblur="HandleBlur"
     removable="@Removable"
     disabled="@Disabled"
     @onnimblechipremove="HandleRemove"

--- a/packages/blazor-workspace/NimbleBlazor/Source/Chip/NimbleChip.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Chip/NimbleChip.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -32,4 +33,12 @@ public partial class NimbleChip : ComponentBase
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Combobox/NimbleCombobox.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Combobox/NimbleCombobox.razor
@@ -2,6 +2,7 @@
 @inherits NimbleInputBase<string?>
 <CascadingValue TValue=NimbleOptionContext IsFixed=true Value=_context @key=_context>
     <nimble-combobox
+        @onblur="HandleBlur"
         current-value="@CurrentValueAsString"
         @onchange="@(EventCallback.Factory.CreateBinder<string?>(this, __value => CurrentValueAsString = __value, CurrentValueAsString))"
         disabled="@Disabled"

--- a/packages/blazor-workspace/NimbleBlazor/Source/Combobox/NimbleCombobox.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Combobox/NimbleCombobox.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -82,6 +83,9 @@ public partial class NimbleCombobox : NimbleInputBase<string?>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
     [CascadingParameter]
     private NimbleOptionContext? CascadedContext { get; set; }
 
@@ -99,5 +103,10 @@ public partial class NimbleCombobox : NimbleInputBase<string?>
         result = value;
         validationErrorMessage = null;
         return true;
+    }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
     }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Dialog/NimbleDialog.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Dialog/NimbleDialog.razor
@@ -1,6 +1,7 @@
 @typeparam TCloseReason
 @namespace NimbleBlazor
 <nimble-dialog
+    @onblur="HandleBlur"
     @ref="_dialogElement"
     prevent-dismiss="@PreventDismiss"
     header-hidden="@HeaderHidden"

--- a/packages/blazor-workspace/NimbleBlazor/Source/Dialog/NimbleDialog.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Dialog/NimbleDialog.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 
 namespace NimbleBlazor;
@@ -46,6 +47,9 @@ public partial class NimbleDialog<TCloseReason> : ComponentBase
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
 
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
     [Inject]
     private IJSRuntime? JSRuntime { get; set; }
 
@@ -71,5 +75,10 @@ public partial class NimbleDialog<TCloseReason> : ComponentBase
     {
         _closeValue = reason;
         await JSRuntime!.InvokeVoidAsync(CloseDialogMethodName, _dialogElement);
+    }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
     }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Drawer/NimbleDrawer.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Drawer/NimbleDrawer.razor
@@ -1,6 +1,7 @@
 @typeparam TCloseReason
 @namespace NimbleBlazor
 <nimble-drawer
+    @onblur="HandleBlur"
     @ref="_drawerElement"
     location="@Location.ToAttributeValue()"
     prevent-dismiss="@PreventDismiss"

--- a/packages/blazor-workspace/NimbleBlazor/Source/Drawer/NimbleDrawer.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Drawer/NimbleDrawer.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 
 namespace NimbleBlazor;
@@ -22,6 +23,9 @@ public partial class NimbleDrawer<TCloseReason> : ComponentBase
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
 
     [Inject]
     private IJSRuntime? JSRuntime { get; set; }
@@ -48,5 +52,10 @@ public partial class NimbleDrawer<TCloseReason> : ComponentBase
     {
         _closeValue = reason;
         await JSRuntime!.InvokeVoidAsync(CloseDrawerMethodName, _drawerElement);
+    }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
     }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/ListOption/NimbleListOption.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/ListOption/NimbleListOption.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-list-option
+    @onblur="HandleBlur"
     disabled="@Disabled"
     value="@BindConverter.FormatValue(Value?.ToString())"
     selected="@Context?.CurrentValue?.Equals(Value)"

--- a/packages/blazor-workspace/NimbleBlazor/Source/ListOption/NimbleListOption.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/ListOption/NimbleListOption.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -29,6 +30,9 @@ public partial class NimbleListOption : ComponentBase
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
     [CascadingParameter] private NimbleOptionContext? CascadedContext { get; set; }
 
     /// <inheritdoc />
@@ -37,5 +41,10 @@ public partial class NimbleListOption : ComponentBase
         Context = (string.IsNullOrEmpty(Name) ? CascadedContext : CascadedContext?.FindContextInAncestors(Name))
             ?? throw new InvalidOperationException($"{GetType()} must have an ancestor {typeof(NimbleSelect)} " +
                 $"with a matching 'Name' property, if specified.");
+    }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
     }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Menu/NimbleMenu.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Menu/NimbleMenu.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-menu
+    @onblur="HandleBlur"
     @attributes="AdditionalAttributes">
     @ChildContent
 </nimble-menu>

--- a/packages/blazor-workspace/NimbleBlazor/Source/Menu/NimbleMenu.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Menu/NimbleMenu.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -9,4 +10,12 @@ public partial class NimbleMenu : ComponentBase
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/MenuButton/NimbleMenuButton.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/MenuButton/NimbleMenuButton.razor
@@ -1,6 +1,7 @@
 @namespace NimbleBlazor
 @inherits ComponentBase
 <nimble-menu-button
+    @onblur="HandleBlur"
     open="@BindConverter.FormatValue(Open)"
     @onnimblemenubuttontoggle="(__value) => HandleToggle(__value)"
     @onnimblemenubuttonbeforetoggle="(__value) => HandleBeforeToggle(__value)"

--- a/packages/blazor-workspace/NimbleBlazor/Source/MenuButton/NimbleMenuButton.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/MenuButton/NimbleMenuButton.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -64,6 +65,9 @@ public partial class NimbleMenuButton : ComponentBase
     [Parameter]
     public EventCallback<MenuButtonToggleEventArgs> BeforeToggle { get; set; }
 
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
     /// <summary>
     /// Called when 'open' changes on the web component.
     /// </summary>
@@ -81,6 +85,11 @@ public partial class NimbleMenuButton : ComponentBase
     protected async void HandleBeforeToggle(MenuButtonToggleEventArgs eventArgs)
     {
         await BeforeToggle.InvokeAsync(eventArgs);
+    }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
     }
 
     /// <summary>

--- a/packages/blazor-workspace/NimbleBlazor/Source/MenuItem/NimbleMenuItem.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/MenuItem/NimbleMenuItem.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-menu-item
+    @onblur="HandleBlur"
     disabled="@Disabled"
     checked="@Checked"
     @attributes="AdditionalAttributes">

--- a/packages/blazor-workspace/NimbleBlazor/Source/MenuItem/NimbleMenuItem.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/MenuItem/NimbleMenuItem.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -15,4 +16,12 @@ public partial class NimbleMenuItem : ComponentBase
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/NumberField/NimbleNumberField.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/NumberField/NimbleNumberField.razor
@@ -1,6 +1,7 @@
 ﻿@namespace NimbleBlazor
 @inherits NimbleInputBase<double?>
 <nimble-number-field
+    @onblur="HandleBlur"
     appearance="@Appearance.ToAttributeValue()"
     current-value="@CurrentValueAsString"
     @onchange="@(EventCallback.Factory.CreateBinder<string?>(this, __value => CurrentValueAsString = __value, CurrentValueAsString))"

--- a/packages/blazor-workspace/NimbleBlazor/Source/NumberField/NimbleNumberField.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/NumberField/NimbleNumberField.razor.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -97,6 +98,9 @@ public partial class NimbleNumberField : NimbleInputBase<double?>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
     /// <inheritdoc />
     protected override string? FormatValueAsString(double? value)
     {
@@ -129,5 +133,10 @@ public partial class NimbleNumberField : NimbleInputBase<double?>
         }
         value = converted;
         return true;
+    }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
     }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Radio/NimbleRadio.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Radio/NimbleRadio.razor
@@ -1,6 +1,7 @@
 @namespace NimbleBlazor
 @inherits ComponentBase
 <nimble-radio current-value="@CurrentValue"
+              @onblur="HandleBlur"
               disabled="@Disabled"
               name="@Name"
               @attributes="AdditionalAttributes">

--- a/packages/blazor-workspace/NimbleBlazor/Source/Radio/NimbleRadio.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Radio/NimbleRadio.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -33,4 +34,12 @@ public partial class NimbleRadio : ComponentBase
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/RadioGroup/NimbleRadioGroup.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/RadioGroup/NimbleRadioGroup.razor
@@ -1,6 +1,7 @@
 @namespace NimbleBlazor
 @inherits NimbleInputBase<string>
 <nimble-radio-group disabled=@Disabled
+                    @onblur="HandleBlur"
                     name="@Name"
                     orientation="@Orientation.ToAttributeValue()"
                     error-visible="@ErrorVisible"

--- a/packages/blazor-workspace/NimbleBlazor/Source/RadioGroup/NimbleRadioGroup.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/RadioGroup/NimbleRadioGroup.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -46,10 +47,18 @@ public partial class NimbleRadioGroup : NimbleInputBase<string>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
     protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out string result, [NotNullWhen(false)] out string? validationErrorMessage)
     {
         result = value ?? string.Empty;
         validationErrorMessage = null;
         return true;
+    }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
     }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/RichText/Viewer/NimbleRichTextViewer.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/RichText/Viewer/NimbleRichTextViewer.razor
@@ -1,5 +1,6 @@
 ﻿@namespace NimbleBlazor
 <nimble-rich-text-viewer
+    @onblur="HandleBlur"
     markdown="@Markdown"
     @attributes="AdditionalAttributes">
     @ChildContent

--- a/packages/blazor-workspace/NimbleBlazor/Source/RichText/Viewer/NimbleRichTextViewer.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/RichText/Viewer/NimbleRichTextViewer.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -21,4 +22,12 @@ public partial class NimbleRichTextViewer : ComponentBase
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Step/NimbleStep.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Step/NimbleStep.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-step
+    @onblur="HandleBlur"
     severity="@Severity.ToAttributeValue()"
     disabled="@Disabled"
     readonly="@ReadOnly"

--- a/packages/blazor-workspace/NimbleBlazor/Source/Step/NimbleStep.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Step/NimbleStep.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -39,4 +40,12 @@ public partial class NimbleStep : ComponentBase
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Stepper/NimbleStepper.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Stepper/NimbleStepper.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-stepper
+    @onblur="HandleBlur"
     orientation="@Orientation.ToAttributeValue()"
     @attributes="AdditionalAttributes">
     @ChildContent

--- a/packages/blazor-workspace/NimbleBlazor/Source/Stepper/NimbleStepper.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Stepper/NimbleStepper.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -21,4 +22,12 @@ public partial class NimbleStepper : ComponentBase
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Switch/NimbleSwitch.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Switch/NimbleSwitch.razor
@@ -1,6 +1,7 @@
 @namespace NimbleBlazor
 @inherits NimbleInputBase<bool>
 <nimble-switch
+    @onblur="HandleBlur"
     disabled="@Disabled"
     current-checked="@BindConverter.FormatValue(CurrentValue)"
     @onnimblecheckedchange="(__value) => CurrentValue = __value.Checked"

--- a/packages/blazor-workspace/NimbleBlazor/Source/Switch/NimbleSwitch.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Switch/NimbleSwitch.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -16,5 +17,13 @@ public partial class NimbleSwitch : NimbleInputBase<bool>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
     protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out bool result, [NotNullWhen(false)] out string? validationErrorMessage) => throw new NotSupportedException($"This component does not parse string inputs. Bind to the '{nameof(CurrentValue)}' property, not '{nameof(CurrentValueAsString)}'.");
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Tab/NimbleTab.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Tab/NimbleTab.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-tab
+    @onblur="HandleBlur"
     disabled="@Disabled"
     @attributes="AdditionalAttributes">
     @ChildContent

--- a/packages/blazor-workspace/NimbleBlazor/Source/Tab/NimbleTab.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Tab/NimbleTab.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -12,4 +13,12 @@ public partial class NimbleTab : ComponentBase
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/TabPanel/NimbleTabPanel.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/TabPanel/NimbleTabPanel.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-tab-panel
+    @onblur="HandleBlur"
     @attributes="AdditionalAttributes">
     @ChildContent
 </nimble-tab-panel>

--- a/packages/blazor-workspace/NimbleBlazor/Source/TabPanel/NimbleTabPanel.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/TabPanel/NimbleTabPanel.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -9,4 +10,12 @@ public partial class NimbleTabPanel : ComponentBase
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Table/NimbleTable.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Table/NimbleTable.razor
@@ -1,6 +1,7 @@
 ﻿@namespace NimbleBlazor
 @typeparam TData
 <nimble-table
+    @onblur="HandleBlur"
     @ref="_table"
     id-field-name="@IdFieldName"
     parent-id-field-name="@ParentIdFieldName"

--- a/packages/blazor-workspace/NimbleBlazor/Source/Table/NimbleTable.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Table/NimbleTable.razor.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 
 namespace NimbleBlazor;
@@ -41,6 +42,9 @@ public partial class NimbleTable<TData> : ComponentBase
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
 
     /// <summary>
     /// Sets the data in the table.
@@ -166,5 +170,10 @@ public partial class NimbleTable<TData> : ComponentBase
     protected async void HandleRowExpandToggle(TableRowExpandToggleEventArgs eventArgs)
     {
         await RowExpandToggle.InvokeAsync(eventArgs);
+    }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
     }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Tabs/NimbleTabs.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Tabs/NimbleTabs.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-tabs
+    @onblur="HandleBlur"
     activeid="@BindConverter.FormatValue(ActiveId)"
     @onnimbletabsactiveidchange="(__value) => UpdateActiveId(__value?.ActiveId)"
     @attributes="AdditionalAttributes">

--- a/packages/blazor-workspace/NimbleBlazor/Source/Tabs/NimbleTabs.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Tabs/NimbleTabs.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -26,4 +27,12 @@ public partial class NimbleTabs : ComponentBase
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/TabsToolbar/NimbleTabsToolbar.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/TabsToolbar/NimbleTabsToolbar.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-tabs-toolbar
+    @onblur="HandleBlur"
     @attributes="AdditionalAttributes">
     @ChildContent
 </nimble-tabs-toolbar>

--- a/packages/blazor-workspace/NimbleBlazor/Source/TabsToolbar/NimbleTabsToolbar.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/TabsToolbar/NimbleTabsToolbar.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -9,4 +10,12 @@ public partial class NimbleTabsToolbar : ComponentBase
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/TextArea/NimbleTextArea.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/TextArea/NimbleTextArea.razor
@@ -1,6 +1,7 @@
 @namespace NimbleBlazor
 @inherits NimbleInputBase<string?>
 <nimble-text-area
+    @onblur="HandleBlur"
     autofocus="@AutoFocus"
     appearance="@Appearance.ToAttributeValue()"
     current-value="@BindConverter.FormatValue(CurrentValue)"

--- a/packages/blazor-workspace/NimbleBlazor/Source/TextArea/NimbleTextArea.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/TextArea/NimbleTextArea.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -107,10 +108,18 @@ public partial class NimbleTextArea : NimbleInputBase<string?>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
     protected override bool TryParseValueFromString(string? value, out string? result, [NotNullWhen(false)] out string? validationErrorMessage)
     {
         result = value;
         validationErrorMessage = null;
         return true;
+    }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
     }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/TextField/NimbleTextField.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/TextField/NimbleTextField.razor
@@ -1,6 +1,7 @@
 @namespace NimbleBlazor
 @inherits NimbleInputBase<string?>
 <nimble-text-field
+    @onblur="HandleBlur"
     autofocus="@AutoFocus"
     appearance="@Appearance.ToAttributeValue()"
     current-value="@BindConverter.FormatValue(CurrentValue)"

--- a/packages/blazor-workspace/NimbleBlazor/Source/TextField/NimbleTextField.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/TextField/NimbleTextField.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -68,10 +69,18 @@ public partial class NimbleTextField : NimbleInputBase<string?>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
     protected override bool TryParseValueFromString(string? value, out string? result, [NotNullWhen(false)] out string? validationErrorMessage)
     {
         result = value;
         validationErrorMessage = null;
         return true;
+    }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
     }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/ToggleButton/NimbleToggleButton.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/ToggleButton/NimbleToggleButton.razor
@@ -1,6 +1,7 @@
 @namespace NimbleBlazor
 @inherits NimbleInputBase<bool>
 <nimble-toggle-button
+    @onblur="HandleBlur"
     current-checked="@BindConverter.FormatValue(CurrentValue)"
     @onnimblecheckedchange="(__value) => CurrentValue = __value.Checked"
     appearance="@Appearance.ToAttributeValue()"

--- a/packages/blazor-workspace/NimbleBlazor/Source/ToggleButton/NimbleToggleButton.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/ToggleButton/NimbleToggleButton.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -22,5 +23,13 @@ public partial class NimbleToggleButton : NimbleInputBase<bool>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
     protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out bool result, [NotNullWhen(false)] out string? validationErrorMessage) => throw new NotSupportedException($"This component does not parse string inputs. Bind to the '{nameof(CurrentValue)}' property, not '{nameof(CurrentValueAsString)}'.");
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Toolbar/NimbleToolbar.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Toolbar/NimbleToolbar.razor
@@ -1,5 +1,6 @@
 ﻿@namespace NimbleBlazor
 <nimble-toolbar
+    @onblur="HandleBlur"
     @attributes="AdditionalAttributes">
     @ChildContent
 </nimble-toolbar>

--- a/packages/blazor-workspace/NimbleBlazor/Source/Toolbar/NimbleToolbar.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Toolbar/NimbleToolbar.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -12,4 +13,12 @@ public partial class NimbleToolbar
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/Tooltip/NimbleTooltip.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Tooltip/NimbleTooltip.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-tooltip
+    @onblur="HandleBlur"
     anchor="@Anchor"
     delay="@Delay"
     severity="@Severity.ToAttributeValue()"

--- a/packages/blazor-workspace/NimbleBlazor/Source/Tooltip/NimbleTooltip.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Tooltip/NimbleTooltip.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -21,4 +22,12 @@ public partial class NimbleTooltip : ComponentBase
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/TreeItem/NimbleTreeItem.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/TreeItem/NimbleTreeItem.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-tree-item
+    @onblur="HandleBlur"
     disabled="@Disabled"
     selected="@Selected"
     expanded="@Expanded"

--- a/packages/blazor-workspace/NimbleBlazor/Source/TreeItem/NimbleTreeItem.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/TreeItem/NimbleTreeItem.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -18,4 +19,12 @@ public partial class NimbleTreeItem : ComponentBase
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/TreeView/NimbleTreeView.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/TreeView/NimbleTreeView.razor
@@ -1,5 +1,6 @@
 @namespace NimbleBlazor
 <nimble-tree-view
+    @onblur="HandleBlur"
     render-collapsed-nodes="@RenderCollapsedNodes"
     selection-mode="@SelectionMode.ToAttributeValue()"
     @attributes="AdditionalAttributes">

--- a/packages/blazor-workspace/NimbleBlazor/Source/TreeView/NimbleTreeView.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/TreeView/NimbleTreeView.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace NimbleBlazor;
 
@@ -15,4 +16,12 @@ public partial class NimbleTreeView : ComponentBase
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
+    }
 }

--- a/packages/blazor-workspace/NimbleBlazor/Source/WaferMap/NimbleWaferMap.razor
+++ b/packages/blazor-workspace/NimbleBlazor/Source/WaferMap/NimbleWaferMap.razor
@@ -1,6 +1,7 @@
 ﻿@using System.Globalization
 @namespace NimbleBlazor
 <nimble-wafer-map
+    @onblur="HandleBlur"
     @ref="_waferMap"
     origin-location="@OriginLocation.ToAttributeValue()"
     grid-min-x="@GridMinX?.ToString(CultureInfo.InvariantCulture)"

--- a/packages/blazor-workspace/NimbleBlazor/Source/WaferMap/NimbleWaferMap.razor.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/WaferMap/NimbleWaferMap.razor.cs
@@ -2,6 +2,7 @@
 using Apache.Arrow;
 using Apache.Arrow.Ipc;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 
 namespace NimbleBlazor;
@@ -177,5 +178,13 @@ public partial class NimbleWaferMap : ComponentBase
             await JSRuntime!.InvokeVoidAsync(SetWaferMapHighlightedTagsMethodName, _waferMap, JsonSerializer.Serialize(HighlightedTags, _options));
         }
         _highlightedTagsUpdated = false;
+    }
+
+    [Parameter]
+    public EventCallback<FocusEventArgs> Blur { get; set; }
+
+    protected async void HandleBlur(FocusEventArgs e)
+    {
+        await Blur.InvokeAsync(e);
     }
 }


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Following the pattern from #3035, I am adding the `Blur` event to interactive elements in Nimble Blazor. 

## 👩‍💻 Implementation

Followed existing patterns.

Components explicitly not updated:
- Theme provider
- Label provider
- Table columns
- Unit components
- Icons
- Spinner
- List option group

## 🧪 Testing

None - followed existing pattern

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [ ] I have updated the project documentation to reflect my changes or determined no changes are needed.
