### PR TITLE
Remove Snyk configuration (.snyk)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,6 @@
 specs @rajsite @jattasNI @mollykreis
 
 # Security scanning configuration files
-/.snyk @ni/security-scanning-owners
 /.wiz @ni/security-scanning-owners
 
 # Change files don't need explicit reviewers

--- a/.snyk
+++ b/.snyk
@@ -1,7 +1,0 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-exclude:
-  global:
-    - '**/node_modules/**'
-version: v1.25.1
-ignore: {}
-patch: {}


### PR DESCRIPTION
Removes the `.snyk` configuration file as part of the Snyk -> Wiz migration.

Snyk scanning has been replaced by Wiz, so the repo-level `.snyk` policy /
ignore file is no longer used.

Work item: [AB#3893372](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3893372)