### PR TITLE
Add compact mode for ok-fv-summary-panel

### DIFF
--- a/change/@ni-ok-angular-9f7c8d31-1d92-4ea1-9b20-6f4b5a8d0c63.json
+++ b/change/@ni-ok-angular-9f7c8d31-1d92-4ea1-9b20-6f4b5a8d0c63.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Expose compact FV summary panel sizing through the Angular wrappers",
+  "packageName": "@ni/ok-angular",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-ok-components-2f07bb8e-4e7b-4f0f-9b4f-5c9ddf7d7e44.json
+++ b/change/@ni-ok-components-2f07bb8e-4e7b-4f0f-9b4f-5c9ddf7d7e44.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add compact sizing and horizontal scrolling to the FV summary panel",
+  "packageName": "@ni/ok-components",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-ok-react-f1b3a2c4-6d7e-48f0-9a1b-2c3d4e5f6071.json
+++ b/change/@ni-ok-react-f1b3a2c4-6d7e-48f0-9a1b-2c3d4e5f6071.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Expose compact FV summary panel sizing through the React wrappers",
+  "packageName": "@ni/ok-react",
+  "email": "1458528+fredvisser@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/angular-workspace/ok-angular/fv/summary-panel-tile/ok-fv-summary-panel-tile.directive.ts
+++ b/packages/angular-workspace/ok-angular/fv/summary-panel-tile/ok-fv-summary-panel-tile.directive.ts
@@ -2,11 +2,13 @@ import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
 import type { FvSummaryPanelTile } from '@ni/ok-components/dist/esm/fv/summary-panel-tile';
 import { fvSummaryPanelTileTag } from '@ni/ok-components/dist/esm/fv/summary-panel-tile';
 import { FvSummaryPanelTileTextPosition } from '@ni/ok-components/dist/esm/fv/summary-panel-tile/types';
+import { FvSummaryPanelSize } from '@ni/ok-components/dist/esm/fv/summary-panel/types';
 import { type BooleanValueOrAttribute, toBooleanProperty } from '@ni/nimble-angular/internal-utilities';
 
 export type { FvSummaryPanelTile };
 export { fvSummaryPanelTileTag };
 export { FvSummaryPanelTileTextPosition };
+export { FvSummaryPanelSize };
 
 /**
  * Directive to provide Angular integration for the summary panel tile.
@@ -41,6 +43,15 @@ export class OkFvSummaryPanelTileDirective {
     @Input('legacy-style')
     public set legacyStyle(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'legacyStyle', toBooleanProperty(value));
+    }
+
+    public get size(): FvSummaryPanelSize {
+        return this.elementRef.nativeElement.size;
+    }
+
+    @Input()
+    public set size(value: FvSummaryPanelSize) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'size', value);
     }
 
     public get selected(): boolean {

--- a/packages/angular-workspace/ok-angular/fv/summary-panel-tile/tests/ok-fv-summary-panel-tile.directive.spec.ts
+++ b/packages/angular-workspace/ok-angular/fv/summary-panel-tile/tests/ok-fv-summary-panel-tile.directive.spec.ts
@@ -1,6 +1,12 @@
 import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { type FvSummaryPanelTile, FvSummaryPanelTileTextPosition, OkFvSummaryPanelTileDirective } from '../ok-fv-summary-panel-tile.directive';
+import {
+    FvSummaryPanelSize,
+    type FvSummaryPanelTile,
+    FvSummaryPanelTileTextPosition,
+    OkFvSummaryPanelTileDirective
+} from '../ok-fv-summary-panel-tile.directive';
+import type { FvSummaryPanelSize as FvSummaryPanelSizeType } from '@ni/ok-components/dist/esm/fv/summary-panel/types';
 import { OkFvSummaryPanelTileModule } from '../ok-fv-summary-panel-tile.module';
 
 describe('Ok fv summary panel tile', () => {
@@ -59,6 +65,11 @@ describe('Ok fv summary panel tile', () => {
             expect(nativeElement.legacyStyle).toBe(false);
         });
 
+        it('has expected defaults for size', () => {
+            expect(directive.size).toBe(FvSummaryPanelSize.default);
+            expect(nativeElement.size).toBe(FvSummaryPanelSize.default);
+        });
+
         it('has expected defaults for selected', () => {
             expect(directive.selected).toBe(false);
             expect(nativeElement.selected).toBe(false);
@@ -77,6 +88,7 @@ describe('Ok fv summary panel tile', () => {
                     count="7"
                     label="open items"
                     legacy-style
+                    size="compact"
                     selected
                     text-position="under">
                 </ok-fv-summary-panel-tile>
@@ -119,6 +131,11 @@ describe('Ok fv summary panel tile', () => {
             expect(nativeElement.legacyStyle).toBeTrue();
         });
 
+        it('will use template string values for size', () => {
+            expect(directive.size).toBe(FvSummaryPanelSize.compact);
+            expect(nativeElement.size).toBe(FvSummaryPanelSize.compact);
+        });
+
         it('will use template string values for selected', () => {
             expect(directive.selected).toBeTrue();
             expect(nativeElement.selected).toBeTrue();
@@ -137,6 +154,7 @@ describe('Ok fv summary panel tile', () => {
                     [count]="count"
                     [label]="label"
                     [legacy-style]="legacyStyle"
+                    [size]="size"
                     [selected]="selected"
                     [text-position]="textPosition">
                 </ok-fv-summary-panel-tile>
@@ -149,6 +167,7 @@ describe('Ok fv summary panel tile', () => {
             public count = '7';
             public label = 'open items';
             public legacyStyle = false;
+            public size: FvSummaryPanelSizeType = FvSummaryPanelSize.default;
             public selected = false;
             public textPosition: FvSummaryPanelTileTextPosition = FvSummaryPanelTileTextPosition.beside;
         }
@@ -200,6 +219,17 @@ describe('Ok fv summary panel tile', () => {
 
             expect(directive.legacyStyle).toBeTrue();
             expect(nativeElement.legacyStyle).toBeTrue();
+        });
+
+        it('can be configured with property binding for size', () => {
+            expect(directive.size).toBe(FvSummaryPanelSize.default);
+            expect(nativeElement.size).toBe(FvSummaryPanelSize.default);
+
+            fixture.componentInstance.size = FvSummaryPanelSize.compact;
+            fixture.detectChanges();
+
+            expect(directive.size).toBe(FvSummaryPanelSize.compact);
+            expect(nativeElement.size).toBe(FvSummaryPanelSize.compact);
         });
 
         it('can be configured with property binding for selected', () => {

--- a/packages/angular-workspace/ok-angular/fv/summary-panel-tile/tests/ok-fv-summary-panel-tile.directive.spec.ts
+++ b/packages/angular-workspace/ok-angular/fv/summary-panel-tile/tests/ok-fv-summary-panel-tile.directive.spec.ts
@@ -1,12 +1,12 @@
 import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { FvSummaryPanelSize as FvSummaryPanelSizeType } from '@ni/ok-components/dist/esm/fv/summary-panel/types';
 import {
     FvSummaryPanelSize,
     type FvSummaryPanelTile,
     FvSummaryPanelTileTextPosition,
     OkFvSummaryPanelTileDirective
 } from '../ok-fv-summary-panel-tile.directive';
-import type { FvSummaryPanelSize as FvSummaryPanelSizeType } from '@ni/ok-components/dist/esm/fv/summary-panel/types';
 import { OkFvSummaryPanelTileModule } from '../ok-fv-summary-panel-tile.module';
 
 describe('Ok fv summary panel tile', () => {

--- a/packages/angular-workspace/ok-angular/fv/summary-panel/ok-fv-summary-panel.directive.ts
+++ b/packages/angular-workspace/ok-angular/fv/summary-panel/ok-fv-summary-panel.directive.ts
@@ -1,10 +1,12 @@
 import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
 import type { FvSummaryPanel } from '@ni/ok-components/dist/esm/fv/summary-panel';
 import { fvSummaryPanelTag } from '@ni/ok-components/dist/esm/fv/summary-panel';
+import { FvSummaryPanelSize } from '@ni/ok-components/dist/esm/fv/summary-panel/types';
 import { type BooleanValueOrAttribute, toBooleanProperty } from '@ni/nimble-angular/internal-utilities';
 
 export type { FvSummaryPanel };
 export { fvSummaryPanelTag };
+export { FvSummaryPanelSize };
 
 /**
  * Directive to provide Angular integration for the summary panel.
@@ -30,6 +32,15 @@ export class OkFvSummaryPanelDirective {
     @Input('legacy-style')
     public set legacyStyle(value: BooleanValueOrAttribute) {
         this.renderer.setProperty(this.elementRef.nativeElement, 'legacyStyle', toBooleanProperty(value));
+    }
+
+    public get size(): FvSummaryPanelSize {
+        return this.elementRef.nativeElement.size;
+    }
+
+    @Input()
+    public set size(value: FvSummaryPanelSize) {
+        this.renderer.setProperty(this.elementRef.nativeElement, 'size', value);
     }
 
     public get editItemsButtonLabel(): string {

--- a/packages/angular-workspace/ok-angular/fv/summary-panel/tests/ok-fv-summary-panel.directive.spec.ts
+++ b/packages/angular-workspace/ok-angular/fv/summary-panel/tests/ok-fv-summary-panel.directive.spec.ts
@@ -1,6 +1,7 @@
 import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { type FvSummaryPanel, OkFvSummaryPanelDirective } from '../ok-fv-summary-panel.directive';
+import { FvSummaryPanelSize, type FvSummaryPanel, OkFvSummaryPanelDirective } from '../ok-fv-summary-panel.directive';
+import type { FvSummaryPanelSize as FvSummaryPanelSizeType } from '@ni/ok-components/dist/esm/fv/summary-panel/types';
 import { OkFvSummaryPanelModule } from '../ok-fv-summary-panel.module';
 
 describe('Ok fv summary panel', () => {
@@ -54,6 +55,11 @@ describe('Ok fv summary panel', () => {
             expect(nativeElement.legacyStyle).toBe(false);
         });
 
+        it('has expected defaults for size', () => {
+            expect(directive.size).toBe(FvSummaryPanelSize.default);
+            expect(nativeElement.size).toBe(FvSummaryPanelSize.default);
+        });
+
         it('has expected defaults for editItemsButtonLabel', () => {
             expect(directive.editItemsButtonLabel).toBe('Configure');
             expect(nativeElement.editItemsButtonLabel).toBe('Configure');
@@ -66,6 +72,7 @@ describe('Ok fv summary panel', () => {
                 <ok-fv-summary-panel #summaryPanel
                     show-edit-items-button
                     legacy-style
+                    size="compact"
                     edit-items-button-label="Customize summary">
                 </ok-fv-summary-panel>
             `,
@@ -102,6 +109,11 @@ describe('Ok fv summary panel', () => {
             expect(nativeElement.legacyStyle).toBeTrue();
         });
 
+        it('will use template string values for size', () => {
+            expect(directive.size).toBe(FvSummaryPanelSize.compact);
+            expect(nativeElement.size).toBe(FvSummaryPanelSize.compact);
+        });
+
         it('will use template string values for editItemsButtonLabel', () => {
             expect(directive.editItemsButtonLabel).toBe('Customize summary');
             expect(nativeElement.editItemsButtonLabel).toBe('Customize summary');
@@ -114,6 +126,7 @@ describe('Ok fv summary panel', () => {
                 <ok-fv-summary-panel #summaryPanel
                     [show-edit-items-button]="showEditItemsButton"
                     [legacy-style]="legacyStyle"
+                    [size]="size"
                     [edit-items-button-label]="editItemsButtonLabel">
                 </ok-fv-summary-panel>
             `,
@@ -124,6 +137,7 @@ describe('Ok fv summary panel', () => {
             @ViewChild('summaryPanel', { read: ElementRef }) public elementRef: ElementRef<FvSummaryPanel>;
             public showEditItemsButton = false;
             public legacyStyle = false;
+            public size: FvSummaryPanelSizeType = FvSummaryPanelSize.default;
             public editItemsButtonLabel = 'Configure tiles';
         }
 
@@ -163,6 +177,17 @@ describe('Ok fv summary panel', () => {
 
             expect(directive.legacyStyle).toBeTrue();
             expect(nativeElement.legacyStyle).toBeTrue();
+        });
+
+        it('can be configured with property binding for size', () => {
+            expect(directive.size).toBe(FvSummaryPanelSize.default);
+            expect(nativeElement.size).toBe(FvSummaryPanelSize.default);
+
+            fixture.componentInstance.size = FvSummaryPanelSize.compact;
+            fixture.detectChanges();
+
+            expect(directive.size).toBe(FvSummaryPanelSize.compact);
+            expect(nativeElement.size).toBe(FvSummaryPanelSize.compact);
         });
 
         it('can be configured with property binding for editItemsButtonLabel', () => {

--- a/packages/angular-workspace/ok-angular/fv/summary-panel/tests/ok-fv-summary-panel.directive.spec.ts
+++ b/packages/angular-workspace/ok-angular/fv/summary-panel/tests/ok-fv-summary-panel.directive.spec.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FvSummaryPanelSize, type FvSummaryPanel, OkFvSummaryPanelDirective } from '../ok-fv-summary-panel.directive';
 import type { FvSummaryPanelSize as FvSummaryPanelSizeType } from '@ni/ok-components/dist/esm/fv/summary-panel/types';
+import { FvSummaryPanelSize, type FvSummaryPanel, OkFvSummaryPanelDirective } from '../ok-fv-summary-panel.directive';
 import { OkFvSummaryPanelModule } from '../ok-fv-summary-panel.module';
 
 describe('Ok fv summary panel', () => {

--- a/packages/ok-components/src/fv/summary-panel-tile/index.ts
+++ b/packages/ok-components/src/fv/summary-panel-tile/index.ts
@@ -2,6 +2,7 @@ import { attr } from '@ni/fast-element';
 import { DesignSystem, FoundationElement } from '@ni/fast-foundation';
 import { styles } from './styles';
 import { template } from './template';
+import { FvSummaryPanelSize, type FvSummaryPanelSize as FvSummaryPanelSizeType } from '../summary-panel/types';
 import {
     FvSummaryPanelTileTextPosition,
     type FvSummaryPanelTileTextPosition as FvSummaryPanelTileTextPositionType
@@ -25,6 +26,9 @@ export class FvSummaryPanelTile extends FoundationElement {
 
     @attr({ attribute: 'legacy-style', mode: 'boolean' })
     public legacyStyle = false;
+
+    @attr
+    public size: FvSummaryPanelSizeType = FvSummaryPanelSize.default;
 
     @attr({ mode: 'boolean' })
     public selected = false;

--- a/packages/ok-components/src/fv/summary-panel-tile/styles.ts
+++ b/packages/ok-components/src/fv/summary-panel-tile/styles.ts
@@ -89,6 +89,24 @@ export const styles = css`
             text-transform: uppercase;
             white-space: nowrap;
         }
+
+        :host([size='compact']) .summary-panel-tile-content {
+            gap: 6px;
+            margin: 10px 14px;
+        }
+
+        :host([size='compact']) .count {
+            font-size: 24px;
+            line-height: normal;
+        }
+
+        :host([size='compact']) .summary-panel-tile-content.beside .count {
+            padding-right: 0;
+        }
+
+        :host([size='compact']) .label {
+            font-size: 11px;
+        }
     }
 
     @layer hover {

--- a/packages/ok-components/src/fv/summary-panel/index.ts
+++ b/packages/ok-components/src/fv/summary-panel/index.ts
@@ -1,9 +1,12 @@
-import { attr } from '@ni/fast-element';
+import { attr, observable } from '@ni/fast-element';
 import { DesignSystem, FoundationElement } from '@ni/fast-foundation';
 import '@ni/nimble-components/dist/esm/button';
 import '@ni/nimble-components/dist/esm/icons/cog';
 import { styles } from './styles';
 import { template } from './template';
+import { FvSummaryPanelSize, type FvSummaryPanelSize as FvSummaryPanelSizeType } from './types';
+
+export { FvSummaryPanelSize } from './types';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -21,19 +24,52 @@ export class FvSummaryPanel extends FoundationElement {
     @attr({ attribute: 'legacy-style', mode: 'boolean' })
     public legacyStyle = false;
 
+    @attr
+    public size: FvSummaryPanelSizeType = FvSummaryPanelSize.default;
+
+    /** @internal */
+    @observable
+    public hasOverflow = false;
+
+    /** @internal */
+    public readonly summaryItems!: HTMLElement;
+
     @attr({ attribute: 'edit-items-button-label' })
     public editItemsButtonLabel = 'Configure';
+
+    private readonly summaryItemsResizeObserver: ResizeObserver;
+
+    public constructor() {
+        super();
+        this.summaryItemsResizeObserver = new ResizeObserver(() => this.updateOverflow());
+    }
 
     /** @internal */
     public override connectedCallback(): void {
         super.connectedCallback();
-        this.syncTileLegacyStyle();
+        this.syncTileAttributes();
+        this.observeSummaryItems();
+    }
+
+    /** @internal */
+    public override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this.summaryItemsResizeObserver.disconnect();
     }
 
     /** @internal */
     public legacyStyleChanged(): void {
         if (this.$fastController.isConnected) {
-            this.syncTileLegacyStyle();
+            this.syncTileAttributes();
+            this.updateOverflow();
+        }
+    }
+
+    /** @internal */
+    public sizeChanged(): void {
+        if (this.$fastController.isConnected) {
+            this.syncTileAttributes();
+            this.updateOverflow();
         }
     }
 
@@ -47,10 +83,26 @@ export class FvSummaryPanel extends FoundationElement {
 
     /** @internal */
     public handleItemsSlotChange(): void {
-        this.syncTileLegacyStyle();
+        this.syncTileAttributes();
+        this.observeSummaryItems();
     }
 
-    private syncTileLegacyStyle(): void {
+    private observeSummaryItems(): void {
+        this.summaryItemsResizeObserver.disconnect();
+        this.summaryItemsResizeObserver.observe(this.summaryItems);
+        for (const element of this.shadowRoot?.querySelector('slot')?.assignedElements({ flatten: true }) ?? []) {
+            this.summaryItemsResizeObserver.observe(element);
+        }
+        this.updateOverflow();
+    }
+
+    private updateOverflow(): void {
+        this.hasOverflow = this.size === FvSummaryPanelSize.compact
+            && this.summaryItems.scrollWidth > this.summaryItems.clientWidth;
+        this.summaryItems.classList.toggle('has-overflow', this.hasOverflow);
+    }
+
+    private syncTileAttributes(): void {
         for (const element of this.shadowRoot?.querySelector('slot')?.assignedElements({ flatten: true }) ?? []) {
             if (element.localName !== 'ok-fv-summary-panel-tile') {
                 continue;
@@ -60,6 +112,12 @@ export class FvSummaryPanel extends FoundationElement {
                 element.setAttribute('legacy-style', '');
             } else {
                 element.removeAttribute('legacy-style');
+            }
+
+            if (this.size === FvSummaryPanelSize.compact) {
+                element.setAttribute('size', FvSummaryPanelSize.compact);
+            } else {
+                element.removeAttribute('size');
             }
         }
     }

--- a/packages/ok-components/src/fv/summary-panel/index.ts
+++ b/packages/ok-components/src/fv/summary-panel/index.ts
@@ -87,6 +87,11 @@ export class FvSummaryPanel extends FoundationElement {
         this.observeSummaryItems();
     }
 
+    /** @internal */
+    public handleItemsScroll(): void {
+        this.updateOverflow();
+    }
+
     private observeSummaryItems(): void {
         this.summaryItemsResizeObserver.disconnect();
         this.summaryItemsResizeObserver.observe(this.summaryItems);
@@ -97,8 +102,12 @@ export class FvSummaryPanel extends FoundationElement {
     }
 
     private updateOverflow(): void {
+        const maxScrollDistance = this.summaryItems.scrollWidth - this.summaryItems.clientWidth;
+        const scrollPosition = getComputedStyle(this.summaryItems).direction === 'rtl'
+            ? Math.abs(this.summaryItems.scrollLeft)
+            : this.summaryItems.scrollLeft;
         this.hasOverflow = this.size === FvSummaryPanelSize.compact
-            && this.summaryItems.scrollWidth > this.summaryItems.clientWidth;
+            && maxScrollDistance - scrollPosition > 0;
         this.summaryItems.classList.toggle('has-overflow', this.hasOverflow);
     }
 

--- a/packages/ok-components/src/fv/summary-panel/styles.ts
+++ b/packages/ok-components/src/fv/summary-panel/styles.ts
@@ -1,5 +1,9 @@
 import { css } from '@ni/fast-element';
-import { standardPadding } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
+import {
+    mediumPadding,
+    smallPadding,
+    standardPadding
+} from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
 import { display } from '../../utilities/style/display';
 
 export const styles = css`
@@ -24,6 +28,25 @@ export const styles = css`
         }
 
         .summary-item-container:empty {
+            display: none;
+        }
+
+        :host([size='compact']) .summary-item-container {
+            flex-wrap: nowrap;
+            box-sizing: border-box;
+            overflow-x: auto;
+            overflow-y: hidden;
+            gap: ${mediumPadding};
+            padding: calc(${standardPadding} - ${smallPadding});
+            scrollbar-width: none;
+        }
+
+        :host([size='compact']) .summary-item-container.has-overflow {
+            -webkit-mask-image: linear-gradient(to right, black calc(100% - 48px), transparent);
+            mask-image: linear-gradient(to right, black calc(100% - 48px), transparent);
+        }
+
+        :host([size='compact']) .summary-item-container::-webkit-scrollbar {
             display: none;
         }
 

--- a/packages/ok-components/src/fv/summary-panel/template.ts
+++ b/packages/ok-components/src/fv/summary-panel/template.ts
@@ -1,4 +1,4 @@
-import { html, when } from '@ni/fast-element';
+import { html, ref, when } from '@ni/fast-element';
 import { buttonTag } from '@ni/nimble-components/dist/esm/button';
 import { ButtonAppearance } from '@ni/nimble-components/dist/esm/button/types';
 import { iconCogTag } from '@ni/nimble-components/dist/esm/icons/cog';
@@ -6,7 +6,7 @@ import type { FvSummaryPanel } from '.';
 
 export const template = html<FvSummaryPanel>`
     <section class="summary-panel" part="panel">
-        <div class="summary-item-container" part="items">
+        <div ${ref('summaryItems')} class="summary-item-container" part="items">
             <slot @slotchange="${x => x.handleItemsSlotChange()}"></slot>
         </div>
         ${when(x => x.showEditItemsButton, html<FvSummaryPanel>`

--- a/packages/ok-components/src/fv/summary-panel/template.ts
+++ b/packages/ok-components/src/fv/summary-panel/template.ts
@@ -6,7 +6,12 @@ import type { FvSummaryPanel } from '.';
 
 export const template = html<FvSummaryPanel>`
     <section class="summary-panel" part="panel">
-        <div ${ref('summaryItems')} class="summary-item-container" part="items">
+        <div
+            ${ref('summaryItems')}
+            class="summary-item-container"
+            part="items"
+            @scroll="${x => x.handleItemsScroll()}"
+        >
             <slot @slotchange="${x => x.handleItemsSlotChange()}"></slot>
         </div>
         ${when(x => x.showEditItemsButton, html<FvSummaryPanel>`

--- a/packages/ok-components/src/fv/summary-panel/tests/summary-panel.spec.ts
+++ b/packages/ok-components/src/fv/summary-panel/tests/summary-panel.spec.ts
@@ -125,4 +125,23 @@ describe('FvSummaryPanel', () => {
         expect(overflowingContainer?.scrollWidth).toBeGreaterThan(overflowingContainer?.clientWidth ?? 0);
         expect(getComputedStyle(overflowingContainer!).overflowX).toBe('auto');
     });
+
+    it('removes the compact overflow fade after scrolling to the end', async () => {
+        ({ element, connect, disconnect } = await setupWithTiles());
+        element.style.width = '200px';
+        element.size = FvSummaryPanelSize.compact;
+        await connect();
+        await waitForUpdatesAsync();
+        await waitAnimationFrame();
+
+        const container = element.shadowRoot?.querySelector('.summary-item-container');
+        expect(container?.classList.contains('has-overflow')).toBeTrue();
+
+        if (container) {
+            container.scrollLeft = container.scrollWidth;
+            container.dispatchEvent(new Event('scroll'));
+        }
+
+        expect(container?.classList.contains('has-overflow')).toBeFalse();
+    });
 });

--- a/packages/ok-components/src/fv/summary-panel/tests/summary-panel.spec.ts
+++ b/packages/ok-components/src/fv/summary-panel/tests/summary-panel.spec.ts
@@ -1,7 +1,9 @@
 import { html } from '@ni/fast-element';
 import { waitForUpdatesAsync } from '@ni/nimble-components/dist/esm/testing/async-helpers';
+import { waitAnimationFrame } from '@ni/nimble-components/dist/esm/utilities/testing/component';
 import { fixture, type Fixture } from '../../../utilities/tests/fixture';
 import { FvSummaryPanel, fvSummaryPanelTag } from '..';
+import { FvSummaryPanelSize } from '../types';
 import { fvSummaryPanelTileTag } from '../../summary-panel-tile';
 
 async function setup(): Promise<Fixture<FvSummaryPanel>> {
@@ -18,6 +20,10 @@ async function setupWithTiles(): Promise<Fixture<FvSummaryPanel>> {
         <${fvSummaryPanelTag}>
             <${fvSummaryPanelTileTag} count="852" label="files"></${fvSummaryPanelTileTag}>
             <${fvSummaryPanelTileTag} count="1234" label="test results"></${fvSummaryPanelTileTag}>
+            <${fvSummaryPanelTileTag} count="42" label="systems"></${fvSummaryPanelTileTag}>
+            <${fvSummaryPanelTileTag} count="17" label="assets"></${fvSummaryPanelTileTag}>
+            <${fvSummaryPanelTileTag} count="8" label="alarms"></${fvSummaryPanelTileTag}>
+            <${fvSummaryPanelTileTag} count="3" label="users"></${fvSummaryPanelTileTag}>
         </${fvSummaryPanelTag}>
     `);
 }
@@ -78,5 +84,45 @@ describe('FvSummaryPanel', () => {
         await waitForUpdatesAsync();
 
         expect(tile?.hasAttribute('legacy-style')).toBeFalse();
+    });
+
+    it('propagates compact sizing to slotted summary panel tiles', async () => {
+        ({ element, connect, disconnect } = await setupWithTiles());
+        element.size = FvSummaryPanelSize.compact;
+        await connect();
+        await waitForUpdatesAsync();
+
+        const tile = element.querySelector(fvSummaryPanelTileTag);
+        expect(tile?.getAttribute('size')).toBe(FvSummaryPanelSize.compact);
+
+        element.size = FvSummaryPanelSize.default;
+        await waitForUpdatesAsync();
+
+        expect(tile?.hasAttribute('size')).toBeFalse();
+    });
+
+    it('only applies the compact overflow fade when items overflow', async () => {
+        ({ element, connect, disconnect } = await setupWithTiles());
+        element.style.width = '1000px';
+        element.size = FvSummaryPanelSize.compact;
+        await connect();
+        await waitForUpdatesAsync();
+        await waitAnimationFrame();
+
+        const container = element.shadowRoot?.querySelector('.summary-item-container');
+        expect(container?.classList.contains('has-overflow')).toBeFalse();
+
+        await disconnect?.();
+        ({ element, connect, disconnect } = await setupWithTiles());
+        element.style.width = '200px';
+        element.size = FvSummaryPanelSize.compact;
+        await connect();
+        await waitForUpdatesAsync();
+        await waitAnimationFrame();
+
+        const overflowingContainer = element.shadowRoot?.querySelector('.summary-item-container');
+        expect(overflowingContainer?.classList.contains('has-overflow')).toBeTrue();
+        expect(overflowingContainer?.scrollWidth).toBeGreaterThan(overflowingContainer?.clientWidth ?? 0);
+        expect(getComputedStyle(overflowingContainer!).overflowX).toBe('auto');
     });
 });

--- a/packages/ok-components/src/fv/summary-panel/types.ts
+++ b/packages/ok-components/src/fv/summary-panel/types.ts
@@ -1,0 +1,6 @@
+export const FvSummaryPanelSize = {
+    default: 'default',
+    compact: 'compact'
+} as const;
+
+export type FvSummaryPanelSize = (typeof FvSummaryPanelSize)[keyof typeof FvSummaryPanelSize];

--- a/packages/react-workspace/ok-react/src/fv/summary-panel-tile/index.ts
+++ b/packages/react-workspace/ok-react/src/fv/summary-panel-tile/index.ts
@@ -5,8 +5,9 @@ import {
     fvSummaryPanelTileTag
 } from '@ni/ok-components/dist/esm/fv/summary-panel-tile';
 import { FvSummaryPanelTileTextPosition } from '@ni/ok-components/dist/esm/fv/summary-panel-tile/types';
+import { FvSummaryPanelSize } from '@ni/ok-components/dist/esm/fv/summary-panel/types';
 import { wrap } from '../../utilities/react-wrapper';
 
 export { fvSummaryPanelTileTag };
-export { type FvSummaryPanelTile, FvSummaryPanelTileTextPosition };
+export { type FvSummaryPanelTile, FvSummaryPanelTileTextPosition, FvSummaryPanelSize };
 export const OkFvSummaryPanelTile = wrap(FvSummaryPanelTile);

--- a/packages/react-workspace/ok-react/src/fv/summary-panel/index.ts
+++ b/packages/react-workspace/ok-react/src/fv/summary-panel/index.ts
@@ -1,10 +1,10 @@
 'use client';
 
-import { FvSummaryPanel, fvSummaryPanelTag } from '@ni/ok-components/dist/esm/fv/summary-panel';
+import { FvSummaryPanel, FvSummaryPanelSize, fvSummaryPanelTag } from '@ni/ok-components/dist/esm/fv/summary-panel';
 import { wrap, type EventName } from '../../utilities/react-wrapper';
 
 export { fvSummaryPanelTag };
-export { type FvSummaryPanel };
+export { type FvSummaryPanel, FvSummaryPanelSize };
 export const OkFvSummaryPanel = wrap(FvSummaryPanel, {
     events: {
         onEditItems: 'edit-items' as EventName<FvSummaryPanelEditItemsEvent>,

--- a/packages/storybook/src/ok/fv/summary-panel/fv-summary-panel-matrix.stories.ts
+++ b/packages/storybook/src/ok/fv/summary-panel/fv-summary-panel-matrix.stories.ts
@@ -26,3 +26,16 @@ export const themeMatrix: StoryFn = createMatrixThemeStory(html`
         </${fvSummaryPanelTag}>
     </div>
 `);
+
+export const compact: StoryFn = createMatrixThemeStory(html`
+    <div style="display: inline-flex; width: 390px;">
+        <${fvSummaryPanelTag} size="compact">
+            <${fvSummaryPanelTileTag} count="234" label="systems" selected></${fvSummaryPanelTileTag}>
+            <${fvSummaryPanelTileTag} count="207" label="connected"></${fvSummaryPanelTileTag}>
+            <${fvSummaryPanelTileTag} count="28" label="disconnected"></${fvSummaryPanelTileTag}>
+            <${fvSummaryPanelTileTag} count="1" label="pending"></${fvSummaryPanelTileTag}>
+            <${fvSummaryPanelTileTag} count="12" label="warnings"></${fvSummaryPanelTileTag}>
+            <${fvSummaryPanelTileTag} count="3" label="critical"></${fvSummaryPanelTileTag}>
+        </${fvSummaryPanelTag}>
+    </div>
+`);

--- a/packages/storybook/src/ok/fv/summary-panel/fv-summary-panel.mdx
+++ b/packages/storybook/src/ok/fv/summary-panel/fv-summary-panel.mdx
@@ -7,6 +7,8 @@ import * as summaryPanelStories from './fv-summary-panel.stories';
 
 A layout container for summary tiles with an optional edit-items action.
 
+Use `size="compact"` when the summary needs a denser presentation. Compact panels keep tiles on one line and allow horizontal scrolling when the tiles do not fit. The scrollbar is hidden and a trailing fade indicates additional content. `default` is the standard size.
+
 <Canvas of={summaryPanelStories.fvSummaryPanel} />
 
 ## API

--- a/packages/storybook/src/ok/fv/summary-panel/fv-summary-panel.stories.ts
+++ b/packages/storybook/src/ok/fv/summary-panel/fv-summary-panel.stories.ts
@@ -1,6 +1,7 @@
 import { html } from '@ni/fast-element';
 import type { Meta, StoryObj } from '@storybook/html-vite';
-import { fvSummaryPanelTag } from '@ni/ok-components/dist/esm/fv/summary-panel';
+import { FvSummaryPanelSize, fvSummaryPanelTag } from '@ni/ok-components/dist/esm/fv/summary-panel';
+import type { FvSummaryPanelSize as FvSummaryPanelSizeType } from '@ni/ok-components/dist/esm/fv/summary-panel/types';
 import { fvSummaryPanelTileTag } from '@ni/ok-components/dist/esm/fv/summary-panel-tile';
 import {
     apiCategory,
@@ -12,6 +13,7 @@ interface FvSummaryPanelArgs {
     showEditItemsButton: boolean;
     editItemsButtonLabel: string;
     legacyStyle: boolean;
+    size: FvSummaryPanelSizeType;
     tileTextPosition: 'beside' | 'under';
     click?: (e: Event) => void;
     editItems?: (e: Event) => void;
@@ -37,6 +39,7 @@ const metadata: Meta<FvSummaryPanelArgs> = {
             ?show-edit-items-button="${x => x.showEditItemsButton}"
             edit-items-button-label="${x => x.editItemsButtonLabel}"
             ?legacy-style="${x => x.legacyStyle}"
+            size="${x => x.size}"
         >
             ${summaryItems}
         </${fvSummaryPanelTag}>
@@ -48,6 +51,12 @@ const metadata: Meta<FvSummaryPanelArgs> = {
         },
         editItemsButtonLabel: {
             name: 'edit-items-button-label',
+            table: { category: apiCategory.attributes }
+        },
+        size: {
+            name: 'size',
+            options: Object.values(FvSummaryPanelSize),
+            control: { type: 'radio' },
             table: { category: apiCategory.attributes }
         },
         legacyStyle: {
@@ -76,6 +85,7 @@ const metadata: Meta<FvSummaryPanelArgs> = {
         showEditItemsButton: true,
         editItemsButtonLabel: 'Configure tiles',
         legacyStyle: false,
+        size: FvSummaryPanelSize.default,
         tileTextPosition: 'beside'
     }
 };


### PR DESCRIPTION
## 🤨 Rationale

Adding a compact mode for the `ok-fv-summary-panel` so it uses less vertical space for web apps that don't need the summary panel to have such a central role. Also, the overflow behavior is to scroll horizontally, so could also be swapped out on mobile widths.

## 👩‍💻 Implementation

- Adds shared size types and styles for summary panels and tiles.
- Updates the Angular and React wrappers to expose the same behavior.
- Adds focused tests, refreshed Storybook examples, and a summary panel matrix.

## 🧪 Testing

- Adds or updates unit tests for summary panel and tile behavior.
- Adds Storybook coverage for supported panel combinations.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.