### PR TITLE
Simplify tabs examples

### DIFF
--- a/packages/angular-workspace/example-client-app/src/app/customapp/anchor-tabs-section.component.ts
+++ b/packages/angular-workspace/example-client-app/src/app/customapp/anchor-tabs-section.component.ts
@@ -5,7 +5,7 @@ import { Component } from '@angular/core';
     selector: 'example-anchor-tabs-section',
     template: `
         <example-sub-container label="Tabs - Anchor">
-            <nimble-anchor-tabs [activeid]="activeAnchorTabId">
+            <nimble-anchor-tabs activeid="a-tab-1">
                 <nimble-anchor-tab id="a-tab-1" href="https://nimble.ni.dev">Tab 1</nimble-anchor-tab>
                 <nimble-anchor-tab id="a-tab-2" href="https://ni.com">Tab 2</nimble-anchor-tab>
                 <nimble-anchor-tab disabled id="a-tab-3" href="https://google.com">Tab 3 (Disabled)</nimble-anchor-tab>
@@ -13,21 +13,11 @@ import { Component } from '@angular/core';
                     <nimble-button (click)="onTabToolbarButtonClick()">Toolbar button</nimble-button>
                 </nimble-tabs-toolbar>
             </nimble-anchor-tabs>
-            <label id="activeAnchorTabLabel">
-                Active tab:
-            </label>
-            <nimble-select [(ngModel)]="activeAnchorTabId" aria-labelledby="activeAnchorTabLabel">
-                <nimble-list-option value="a-tab-1">Tab 1</nimble-list-option>
-                <nimble-list-option value="a-tab-2">Tab 2</nimble-list-option>
-                <nimble-list-option value="a-tab-3">Tab 3</nimble-list-option>
-            </nimble-select>
         </example-sub-container>
     `,
     standalone: false
 })
 export class AnchorTabsSectionComponent {
-    public activeAnchorTabId = 'a-tab-2';
-
     public onTabToolbarButtonClick(): void {
         alert('Tab toolbar button clicked');
     }

--- a/packages/angular-workspace/example-client-app/src/app/customapp/tabs-section.component.ts
+++ b/packages/angular-workspace/example-client-app/src/app/customapp/tabs-section.component.ts
@@ -5,7 +5,7 @@ import { Component } from '@angular/core';
     selector: 'example-tabs-section',
     template: `
         <example-sub-container label="Tabs">
-            <nimble-tabs [(activeid)]="activeTabId">
+            <nimble-tabs activeid="tab-1">
                 <nimble-tab id="tab-1">Tab 1</nimble-tab>
                 <nimble-tab id="tab-2">Tab 2</nimble-tab>
                 <nimble-tab id="tab-3" disabled>Tab 3 (Disabled)</nimble-tab>
@@ -22,14 +22,6 @@ import { Component } from '@angular/core';
                     <div class="container-label">Tab 3 content</div>
                 </nimble-tab-panel>
             </nimble-tabs>
-            <label id="activeTabLabel">
-                Active tab:
-            </label>
-            <nimble-select [(ngModel)]="activeTabId" aria-labelledby="activeTabLabel">
-                <nimble-list-option value="tab-1">Tab 1</nimble-list-option>
-                <nimble-list-option value="tab-2">Tab 2</nimble-list-option>
-                <nimble-list-option value="tab-3">Tab 3</nimble-list-option>
-            </nimble-select>
         </example-sub-container>
     `,
     styles: [`
@@ -43,8 +35,6 @@ import { Component } from '@angular/core';
     standalone: false
 })
 export class TabsSectionComponent {
-    public activeTabId = 'tab-1';
-
     public onTabToolbarButtonClick(): void {
         alert('Tab toolbar button clicked');
     }

--- a/packages/blazor-workspace/Examples/Demo.Shared/Pages/Sections/AnchorTabsSection.razor
+++ b/packages/blazor-workspace/Examples/Demo.Shared/Pages/Sections/AnchorTabsSection.razor
@@ -2,7 +2,7 @@
 
 <div>
     <SubContainer Label="Tabs - Anchor">
-        <NimbleAnchorTabs ActiveId="@ActiveAnchorTabId">
+        <NimbleAnchorTabs ActiveId="a-tab-1">
             <NimbleAnchorTab id="a-tab-1" href="https://nimble.ni.dev">Tab 1</NimbleAnchorTab>
             <NimbleAnchorTab id="a-tab-2" href="https://ni.com">Tab 2</NimbleAnchorTab>
             <NimbleAnchorTab id="a-tab-3" Disabled="true">Tab 3 (Disabled)</NimbleAnchorTab>
@@ -10,17 +10,5 @@
                 <NimbleButton>Toolbar Button</NimbleButton>
             </NimbleTabsToolbar>
         </NimbleAnchorTabs>
-        <label id="activeAnchorTab">
-            Active tab:
-        </label>
-        <NimbleSelect @bind-Value="@ActiveAnchorTabId" aria-labelledby="activeAnchorTab">
-            <NimbleListOption Value="a-tab-1">Tab 1</NimbleListOption>
-            <NimbleListOption Value="a-tab-2">Tab 2</NimbleListOption>
-            <NimbleListOption Value="a-tab-3">Tab 3</NimbleListOption>
-        </NimbleSelect>
     </SubContainer>
 </div>
-
-@code {
-    private string? ActiveAnchorTabId { get; set; } = "a-tab-1";
-}

--- a/packages/blazor-workspace/Examples/Demo.Shared/Pages/Sections/TabsSection.razor
+++ b/packages/blazor-workspace/Examples/Demo.Shared/Pages/Sections/TabsSection.razor
@@ -2,7 +2,7 @@
 
 <div>
     <SubContainer Label="Tabs">
-        <NimbleTabs @bind-ActiveId="@ActiveTabId">
+        <NimbleTabs ActiveId="tab-1">
             <NimbleTab id="tab-1">Tab 1</NimbleTab>
             <NimbleTab id="tab-2">Tab 2</NimbleTab>
             <NimbleTab id="tab-3" Disabled="true">Tab 3 (Disabled)</NimbleTab>
@@ -20,17 +20,5 @@
                 <div class="container-label">Tab 3 content</div>
             </NimbleTabPanel>
         </NimbleTabs>
-        <label id="activeTab">
-            Active tab:
-        </label>
-        <NimbleSelect @bind-Value="@ActiveTabId" aria-labelledby="activeTab">
-            <NimbleListOption Value="tab-1">Tab 1</NimbleListOption>
-            <NimbleListOption Value="tab-2">Tab 2</NimbleListOption>
-            <NimbleListOption Value="tab-3">Tab 3</NimbleListOption>
-        </NimbleSelect>
     </SubContainer>
 </div>
-
-@code {
-    private string? ActiveTabId { get; set; }
-}

--- a/packages/react-workspace/react-client-app/src/components/AnchorTabsSection.tsx
+++ b/packages/react-workspace/react-client-app/src/components/AnchorTabsSection.tsx
@@ -1,24 +1,17 @@
-import { useState } from 'react';
 import { NimbleButton } from '@ni/nimble-react/button';
 import { NimbleAnchorTabs } from '@ni/nimble-react/anchor-tabs';
 import { NimbleAnchorTab } from '@ni/nimble-react/anchor-tab';
 import { NimbleTabsToolbar } from '@ni/nimble-react/tabs-toolbar';
-import { NimbleSelect } from '@ni/nimble-react/select';
-import { NimbleListOption } from '@ni/nimble-react/list-option';
 import { SubContainer } from './SubContainer';
 
 export function AnchorTabsSection(): React.JSX.Element {
-    const [activeAnchorTabId, setActiveAnchorTabId] = useState('a-tab-2');
-
     function onTabToolbarButtonClick(): void {
         alert('Tab toolbar button clicked');
     }
 
     return (
         <SubContainer label="Tabs - Anchor">
-            <NimbleAnchorTabs
-                activeid={activeAnchorTabId}
-            >
+            <NimbleAnchorTabs activeid="a-tab-1">
                 <NimbleAnchorTab id="a-tab-1" href="https://nimble.ni.dev">Tab 1</NimbleAnchorTab>
                 <NimbleAnchorTab id="a-tab-2" href="https://ni.com">Tab 2</NimbleAnchorTab>
                 <NimbleAnchorTab disabled id="a-tab-3" href="https://google.com">Tab 3 (Disabled)</NimbleAnchorTab>
@@ -28,17 +21,6 @@ export function AnchorTabsSection(): React.JSX.Element {
                     >Toolbar button</NimbleButton>
                 </NimbleTabsToolbar>
             </NimbleAnchorTabs>
-            <label id="activeAnchorTabLabel">
-                Active tab:
-            </label>
-            <NimbleSelect
-                value={activeAnchorTabId}
-                onChange={e => setActiveAnchorTabId(e.target.value)}
-                aria-labelledby="activeAnchorTabLabel">
-                <NimbleListOption value="a-tab-1">Tab 1</NimbleListOption>
-                <NimbleListOption value="a-tab-2">Tab 2</NimbleListOption>
-                <NimbleListOption value="a-tab-3">Tab 3</NimbleListOption>
-            </NimbleSelect>
         </SubContainer>
     );
 }

--- a/packages/react-workspace/react-client-app/src/components/TabsSection.tsx
+++ b/packages/react-workspace/react-client-app/src/components/TabsSection.tsx
@@ -1,26 +1,18 @@
-import { useState } from 'react';
 import { NimbleButton } from '@ni/nimble-react/button';
 import { NimbleTabs } from '@ni/nimble-react/tabs';
 import { NimbleTab } from '@ni/nimble-react/tab';
 import { NimbleTabsToolbar } from '@ni/nimble-react/tabs-toolbar';
 import { NimbleTabPanel } from '@ni/nimble-react/tab-panel';
-import { NimbleSelect } from '@ni/nimble-react/select';
-import { NimbleListOption } from '@ni/nimble-react/list-option';
 import { SubContainer } from './SubContainer';
 
 export function TabsSection(): React.JSX.Element {
-    const [activeTabId, setActiveTabId] = useState('tab-1');
-
     function onTabToolbarButtonClick(): void {
         alert('Tab toolbar button clicked');
     }
 
     return (
         <SubContainer label="Tabs">
-            <NimbleTabs
-                activeid={activeTabId}
-                onChange={e => setActiveTabId(e.target.activeid)}
-            >
+            <NimbleTabs activeid="tab-1">
                 <NimbleTab id="tab-1">Tab 1</NimbleTab>
                 <NimbleTab id="tab-2">Tab 2</NimbleTab>
                 <NimbleTab id="tab-3" disabled>Tab 3 (Disabled)</NimbleTab>
@@ -39,17 +31,6 @@ export function TabsSection(): React.JSX.Element {
                     <div className="container-label">Tab 3 content</div>
                 </NimbleTabPanel>
             </NimbleTabs>
-            <label id="activeTabLabel">
-                Active tab:
-            </label>
-            <NimbleSelect
-                value={activeTabId}
-                onChange={e => setActiveTabId(e.target.value)}
-                aria-labelledby="activeTabLabel">
-                <NimbleListOption value="tab-1">Tab 1</NimbleListOption>
-                <NimbleListOption value="tab-2">Tab 2</NimbleListOption>
-                <NimbleListOption value="tab-3">Tab 3</NimbleListOption>
-            </NimbleSelect>
         </SubContainer>
     );
 }

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -103,5 +103,5 @@ configureActions({
     depth: 1
 });
 
-// Update the GUID on this line to trigger a turbosnap full rebuild: 4F8A9E2B-1C7D-4A3E-B5F6-9D8C7E6A5B4C
+// Update the GUID on this line to trigger a turbosnap full rebuild: 4F8A9E2B-1C7D-4A3E-B5F6-9D8C7E6A5B4D
 // See https://www.chromatic.com/docs/turbosnap/#full-rebuilds


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

As part of #2461 simplified the example apps for tab and anchor tab sections to prevent the page from scrolling down to tabs on load. A mitigation until the `scrollIntoView` option `container: nearest` is available to fully address the issue. 

## 👩‍💻 Implementation

- Removed the activetab selector and label
- Found that I needed to initialize `activeid` in each of the apps to prevent scrolling to the default tab on page load.

## 🧪 Testing

Manually verified none of the apps scroll on load.

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
