### PR TITLE
Force Storybook build publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,6 +108,7 @@ jobs:
           storybookBaseDir: ./packages/storybook
           exitOnceUploaded: true # Do not wait for test results
           exitZeroOnChanges: true # Option to prevent the workflow from failing
+          forceRebuild: true # Always publish build so example app only changes are pushed
 
       # Validate (Lint and Test)
       - run: npm run validate

--- a/packages/react-workspace/react-client-app/src/components/OverviewSection.tsx
+++ b/packages/react-workspace/react-client-app/src/components/OverviewSection.tsx
@@ -3,7 +3,7 @@ import { SubContainer } from './SubContainer';
 
 export function OverviewSection(): React.JSX.Element {
     return (
-        <SubContainer label="Overview">
+        <SubContainer>
             Explore the components below to see the Nimble components in action.
             See the <NimbleAnchor href="https://nimble.ni.dev/storybook/">Nimble component docs</NimbleAnchor> for additional usage details.
             Navigate to the <NimbleAnchor href="../index.html">parent page</NimbleAnchor>.

--- a/packages/react-workspace/react-client-app/src/components/SubContainer.tsx
+++ b/packages/react-workspace/react-client-app/src/components/SubContainer.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 
 interface SubContainerProp {
-    label: string;
+    label?: string;
     children?: ReactNode;
 }
 
@@ -9,7 +9,7 @@ export function SubContainer({ label, children }: SubContainerProp): React.JSX.E
     return (
         <>
             <div className="sub-container">
-                <div className="container-label">{label}</div>
+                {label && <div className="container-label">{label}</div>}
                 <div>{children}</div>
             </div>
         </>


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

It was found that storybook had a behavior change where if turbosnap is enabled and no turbosnap changes are found then chromatic skipped publishing the new storybook build altogether, see example log that only had changes to example apps:

```
13:50:14.325 Chromatic CLI v18.7.1
             https://www.chromatic.com/docs/cli
13:50:14.326 Authenticating with Chromatic
13:50:14.326     → Connecting to https://index.chromatic.com/
13:50:14.492 Authenticated with Chromatic
13:50:14.492     → Using project token '********e1a6'
13:50:14.493 Retrieving git information
13:50:16.315 Found 22 changed files:
               change/@ni-ok-angular-9f7c8d31-1d92-4ea1-9b20-6f4b5a8d0c63.json
               change/@ni-ok-components-2f07bb8e-4e7b-4f0f-9b4f-5c9ddf7d7e44.json
               change/@ni-ok-react-f1b3a2c4-6d7e-48f0-9a1b-2c3d4e5f6071.json
               package-lock.json
               packages/angular-workspace/example-client-app/src/app/customapp/anchor-tabs-section.component.ts
               packages/angular-workspace/example-client-app/src/app/customapp/tabs-section.component.ts
               packages/angular-workspace/ok-angular/CHANGELOG.json
               packages/angular-workspace/ok-angular/CHANGELOG.md
               packages/angular-workspace/ok-angular/package.json
               packages/blazor-workspace/Examples/Demo.Shared/Pages/Sections/AnchorTabsSection.razor
               packages/blazor-workspace/Examples/Demo.Shared/Pages/Sections/TabsSection.razor
               packages/blazor-workspace/OkBlazor/CHANGELOG.json
               packages/blazor-workspace/OkBlazor/CHANGELOG.md
               packages/blazor-workspace/OkBlazor/package.json
               packages/ok-components/CHANGELOG.json
               packages/ok-components/CHANGELOG.md
               packages/ok-components/package.json
               packages/react-workspace/ok-react/CHANGELOG.json
               packages/react-workspace/ok-react/CHANGELOG.md
               packages/react-workspace/ok-react/package.json
               packages/react-workspace/react-client-app/src/components/AnchorTabsSection.tsx
               packages/react-workspace/react-client-app/src/components/TabsSection.tsx
13:50:16.318 Retrieved git information
13:50:16.319     → Commit '64d9738' on branch 'selects-example-apps'; found 1 parent build and 22 changed files
13:50:16.319 Collecting Storybook metadata
13:50:16.374 No viewlayer package listed in dependencies. Checking transitive dependencies.
13:50:16.377 Collected Storybook metadata
13:50:16.378     → Build metadata gathered
13:50:16.378 Initializing build
13:50:17.590 Initialized build
13:50:17.590     → Build 14673 initialized
13:50:17.590 Building your Storybook
13:50:17.591 Build Storybook [skipped]
13:50:17.591     → Using prebuilt Storybook at ./packages/site/dist/storybook
13:50:17.592 Prepare your built Storybook
13:50:17.592     → Validating Storybook files
13:50:17.605     → Traversing dependencies for 22 files that changed since the last build
13:50:20.415 Found 6 changed dependencies:
               @ni/ok-components
               @ni/ok-react
               @ni-private/storybook
               @ni-private/react-client-app
               @ni-private/blazor-workspace
               @ni-private/angular-workspace
13:50:20.477 Found affected story files:
             
13:50:20.478     → Found 0 story files affected by recent changes
13:50:20.478     → Calculating file hashes
13:50:20.566 Preparation complete
13:50:20.567     → Storybook files validated and prepared for upload
13:50:20.567 Publishing your built Storybook
13:50:20.567     → Starting publish
13:50:21.923 ✔ TurboSnap enabled
             Bypassed 1101 snapshots because no frontend files were changed.
13:50:21.924 ✔ This build was skipped and will not be displayed in Chromatic.
             The passed status will be carried over from the most recent ancestor build.
             ℹ View ancestor build details at https://www.chromatic.com/build?appId=60e89457a987cf003efc0a5b&number=14655
             
13:50:21.924 Publishing your built Storybook
```

See PR [discussion where behavior was noted](https://github.com/ni/nimble/pull/3037#discussion_r3866626694) and see [discussion that first attempted to address the behavior](https://github.com/ni/nimble/pull/3037#discussion_r3866602883).

## 👩‍💻 Implementation

- Enable the [forceRebuild flag](https://www.chromatic.com/docs/configure/#forcerebuild)
- Made a minor example app alignment change to exercise workflow

## 🧪 Testing

- Pushed one commit that was example app only changes
- Pushed a commit that enabled force rebuild and verified turbosnaps still utilized

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
