### PR TITLE
Fix OK FV summary panel spacing

### DIFF
--- a/change/@ni-ok-components-4c3d0f2a-6b7e-4f81-9a20-5d6c8e7f104b.json
+++ b/change/@ni-ok-components-4c3d0f2a-6b7e-4f81-9a20-5d6c8e7f104b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix FV summary panel spacing and preserve compact tile hover styling",
+  "packageName": "@ni/ok-components",
+  "email": "1458528+fredvisser@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/ok-components/src/fv/summary-panel-tile/styles.ts
+++ b/packages/ok-components/src/fv/summary-panel-tile/styles.ts
@@ -65,6 +65,7 @@ export const styles = css`
             flex-direction: column;
             align-items: center;
             gap: ${smallPadding};
+            margin-top: calc(${largePadding} - ${smallPadding});
             text-align: center;
         }
 
@@ -93,6 +94,10 @@ export const styles = css`
         :host([size='compact']) .summary-panel-tile-content {
             gap: 6px;
             margin: 10px 14px;
+        }
+
+        :host([size='compact']) .summary-panel-tile-content.under {
+            margin-top: ${mediumPadding};
         }
 
         :host([size='compact']) .count {

--- a/packages/ok-components/src/fv/summary-panel-tile/tests/summary-panel-tile.spec.ts
+++ b/packages/ok-components/src/fv/summary-panel-tile/tests/summary-panel-tile.spec.ts
@@ -1,6 +1,7 @@
 import { html } from '@ni/fast-element';
 import { fixture, type Fixture } from '../../../utilities/tests/fixture';
 import { FvSummaryPanelTile, fvSummaryPanelTileTag } from '..';
+import { FvSummaryPanelSize } from '../../summary-panel/types';
 
 async function setup(): Promise<Fixture<FvSummaryPanelTile>> {
     return await fixture<FvSummaryPanelTile>(html`
@@ -52,7 +53,20 @@ describe('FvSummaryPanelTile', () => {
         element.textPosition = 'under';
         await connect();
 
-        expect(element.shadowRoot?.querySelector('.summary-panel-tile-content')?.classList.contains('under')).toBeTrue();
+        const content = element.shadowRoot?.querySelector('.summary-panel-tile-content');
+        expect(content?.classList.contains('under')).toBeTrue();
+        expect(getComputedStyle(content!).marginTop).toBe('20px');
+    });
+
+    it('uses an 8px top margin for compact under text positioning', async () => {
+        ({ element, connect, disconnect } = await setup());
+        element.setAttribute('size', FvSummaryPanelSize.compact);
+        element.textPosition = 'under';
+        await connect();
+
+        const content = element.shadowRoot?.querySelector('.summary-panel-tile-content');
+        expect(content?.classList.contains('under')).toBeTrue();
+        expect(getComputedStyle(content!).marginTop).toBe('8px');
     });
 
     it('supports the legacy-style attribute', async () => {

--- a/packages/ok-components/src/fv/summary-panel/styles.ts
+++ b/packages/ok-components/src/fv/summary-panel/styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@ni/fast-element';
 import {
-    mediumPadding,
+    borderWidth,
     smallPadding,
     standardPadding
 } from '@ni/nimble-components/dist/esm/theme-provider/design-tokens';
@@ -36,8 +36,7 @@ export const styles = css`
             box-sizing: border-box;
             overflow-x: auto;
             overflow-y: hidden;
-            gap: ${mediumPadding};
-            padding: calc(${standardPadding} - ${smallPadding});
+            gap: ${smallPadding};
             scrollbar-width: none;
         }
 
@@ -57,6 +56,10 @@ export const styles = css`
 
         ::slotted(*) {
             flex: 0 0 auto;
+        }
+
+        :host([size='compact']) ::slotted(ok-fv-summary-panel-tile) {
+            margin: calc(2 * ${borderWidth});
         }
     }
 

--- a/packages/ok-components/src/fv/summary-panel/tests/summary-panel.spec.ts
+++ b/packages/ok-components/src/fv/summary-panel/tests/summary-panel.spec.ts
@@ -101,6 +101,28 @@ describe('FvSummaryPanel', () => {
         expect(tile?.hasAttribute('size')).toBeFalse();
     });
 
+    it('leaves room for compact tile hover styling without padding the scroll container', async () => {
+        ({ element, connect, disconnect } = await setupWithTiles());
+        element.size = FvSummaryPanelSize.compact;
+        await connect();
+        await waitForUpdatesAsync();
+
+        const container = element.shadowRoot?.querySelector('.summary-item-container');
+        const tile = element.querySelector(fvSummaryPanelTileTag);
+
+        if (!container || !tile) {
+            throw new Error('Expected compact summary panel elements to be rendered');
+        }
+
+        const containerRect = container.getBoundingClientRect();
+        const tileRect = tile.getBoundingClientRect();
+
+        expect(getComputedStyle(container).padding).toBe('0px');
+        expect(getComputedStyle(tile).margin).toBe('2px');
+        expect(tileRect.top).toBe(containerRect.top + 2);
+        expect(tileRect.bottom).toBe(containerRect.bottom - 2);
+    });
+
     it('only applies the compact overflow fade when items overflow', async () => {
         ({ element, connect, disconnect } = await setupWithTiles());
         element.style.width = '1000px';

--- a/packages/storybook/src/ok/fv/summary-panel/fv-summary-panel-matrix.stories.ts
+++ b/packages/storybook/src/ok/fv/summary-panel/fv-summary-panel-matrix.stories.ts
@@ -36,7 +36,7 @@ const summaryPanel = (
 ): ViewTemplate => {
     const isCompact = size === 'compact';
     return html`
-        <div style="display: ${isCompact ? 'inline-flex' : 'flex'}; flex-direction: column; width: ${isCompact ? '390px' : '460px'}; margin: 0 16px 16px 0;">
+        <div style="display: ${isCompact ? 'inline-flex' : 'flex'}; flex-direction: column; width: ${isCompact ? '390px' : '960px'}; margin: 0 16px 16px 0;">
             <div style="font-size: 12px; color: #0076d6; text-align: center; min-height: 16px;">
                 ${() => `${legacyStyleName} ${textPositionName}`}
             </div>

--- a/packages/storybook/src/ok/fv/summary-panel/fv-summary-panel-matrix.stories.ts
+++ b/packages/storybook/src/ok/fv/summary-panel/fv-summary-panel-matrix.stories.ts
@@ -1,11 +1,24 @@
 import type { Meta, StoryFn } from '@storybook/html-vite';
-import { html } from '@ni/fast-element';
+import { html, type ViewTemplate } from '@ni/fast-element';
 import { fvSummaryPanelTag } from '@ni/ok-components/dist/esm/fv/summary-panel';
 import { fvSummaryPanelTileTag } from '@ni/ok-components/dist/esm/fv/summary-panel-tile';
 import {
+    createMatrix,
     createMatrixThemeStory,
     sharedMatrixParameters
 } from '../../../utilities/matrix';
+
+const legacyStyleStates = [
+    ['Modern', false],
+    ['Legacy', true]
+] as const;
+type LegacyStyleState = (typeof legacyStyleStates)[number];
+
+const textPositionStates = [
+    ['Beside', 'beside'],
+    ['Under', 'under']
+] as const;
+type TextPositionState = (typeof textPositionStates)[number];
 
 const metadata: Meta = {
     title: 'Tests Ok/Fv Summary Panel',
@@ -16,26 +29,45 @@ const metadata: Meta = {
 
 export default metadata;
 
-export const themeMatrix: StoryFn = createMatrixThemeStory(html`
-    <div style="display: inline-flex; width: 960px; padding: 16px;">
-        <${fvSummaryPanelTag} show-edit-items-button legacy-style>
-            <${fvSummaryPanelTileTag} count="234" label="systems" text-position="under" selected></${fvSummaryPanelTileTag}>
-            <${fvSummaryPanelTileTag} count="207" label="connected" text-position="under"></${fvSummaryPanelTileTag}>
-            <${fvSummaryPanelTileTag} count="28" label="disconnected" text-position="under"></${fvSummaryPanelTileTag}>
-            <${fvSummaryPanelTileTag} count="1" label="pending" text-position="under"></${fvSummaryPanelTileTag}>
-        </${fvSummaryPanelTag}>
-    </div>
-`);
+const summaryPanel = (
+    [legacyStyleName, legacyStyle]: LegacyStyleState,
+    [textPositionName, textPosition]: TextPositionState,
+    size: 'default' | 'compact'
+): ViewTemplate => {
+    const isCompact = size === 'compact';
+    return html`
+        <div style="display: inline-flex; flex-direction: column; width: ${isCompact ? '390px' : '460px'}; margin: 0 16px 16px 0;">
+            <div style="font-size: 12px; color: #0076d6; text-align: center; min-height: 16px;">
+                ${() => `${legacyStyleName} ${textPositionName}`}
+            </div>
+            <${fvSummaryPanelTag}
+                ?show-edit-items-button="${() => !isCompact}"
+                ?legacy-style="${() => legacyStyle}"
+                size="${() => size}"
+            >
+                <${fvSummaryPanelTileTag} count="234" label="systems" text-position="${() => textPosition}" selected></${fvSummaryPanelTileTag}>
+                <${fvSummaryPanelTileTag} count="207" label="connected" text-position="${() => textPosition}"></${fvSummaryPanelTileTag}>
+                <${fvSummaryPanelTileTag} count="28" label="disconnected" text-position="${() => textPosition}"></${fvSummaryPanelTileTag}>
+                <${fvSummaryPanelTileTag} count="1" label="pending" text-position="${() => textPosition}"></${fvSummaryPanelTileTag}>
+                ${isCompact ? html`
+                    <${fvSummaryPanelTileTag} count="12" label="warnings" text-position="${() => textPosition}"></${fvSummaryPanelTileTag}>
+                    <${fvSummaryPanelTileTag} count="3" label="critical" text-position="${() => textPosition}"></${fvSummaryPanelTileTag}>
+                ` : ''}
+            </${fvSummaryPanelTag}>
+        </div>
+    `;
+};
 
-export const compact: StoryFn = createMatrixThemeStory(html`
-    <div style="display: inline-flex; width: 390px;">
-        <${fvSummaryPanelTag} size="compact" legacy-style>
-            <${fvSummaryPanelTileTag} count="234" label="systems" text-position="under" selected></${fvSummaryPanelTileTag}>
-            <${fvSummaryPanelTileTag} count="207" label="connected" text-position="under"></${fvSummaryPanelTileTag}>
-            <${fvSummaryPanelTileTag} count="28" label="disconnected" text-position="under"></${fvSummaryPanelTileTag}>
-            <${fvSummaryPanelTileTag} count="1" label="pending" text-position="under"></${fvSummaryPanelTileTag}>
-            <${fvSummaryPanelTileTag} count="12" label="warnings" text-position="under"></${fvSummaryPanelTileTag}>
-            <${fvSummaryPanelTileTag} count="3" label="critical" text-position="under"></${fvSummaryPanelTileTag}>
-        </${fvSummaryPanelTag}>
-    </div>
-`);
+export const themeMatrix: StoryFn = createMatrixThemeStory(
+    createMatrix(
+        (legacyStyle, textPosition) => summaryPanel(legacyStyle, textPosition, 'default'),
+        [legacyStyleStates, textPositionStates]
+    )
+);
+
+export const compact: StoryFn = createMatrixThemeStory(
+    createMatrix(
+        (legacyStyle, textPosition) => summaryPanel(legacyStyle, textPosition, 'compact'),
+        [legacyStyleStates, textPositionStates]
+    )
+);

--- a/packages/storybook/src/ok/fv/summary-panel/fv-summary-panel-matrix.stories.ts
+++ b/packages/storybook/src/ok/fv/summary-panel/fv-summary-panel-matrix.stories.ts
@@ -18,24 +18,24 @@ export default metadata;
 
 export const themeMatrix: StoryFn = createMatrixThemeStory(html`
     <div style="display: inline-flex; width: 960px; padding: 16px;">
-        <${fvSummaryPanelTag} show-edit-items-button>
-            <${fvSummaryPanelTileTag} count="234" label="systems" selected></${fvSummaryPanelTileTag}>
-            <${fvSummaryPanelTileTag} count="207" label="connected"></${fvSummaryPanelTileTag}>
-            <${fvSummaryPanelTileTag} count="28" label="disconnected"></${fvSummaryPanelTileTag}>
-            <${fvSummaryPanelTileTag} count="1" label="pending"></${fvSummaryPanelTileTag}>
+        <${fvSummaryPanelTag} show-edit-items-button legacy-style>
+            <${fvSummaryPanelTileTag} count="234" label="systems" text-position="under" selected></${fvSummaryPanelTileTag}>
+            <${fvSummaryPanelTileTag} count="207" label="connected" text-position="under"></${fvSummaryPanelTileTag}>
+            <${fvSummaryPanelTileTag} count="28" label="disconnected" text-position="under"></${fvSummaryPanelTileTag}>
+            <${fvSummaryPanelTileTag} count="1" label="pending" text-position="under"></${fvSummaryPanelTileTag}>
         </${fvSummaryPanelTag}>
     </div>
 `);
 
 export const compact: StoryFn = createMatrixThemeStory(html`
     <div style="display: inline-flex; width: 390px;">
-        <${fvSummaryPanelTag} size="compact">
-            <${fvSummaryPanelTileTag} count="234" label="systems" selected></${fvSummaryPanelTileTag}>
-            <${fvSummaryPanelTileTag} count="207" label="connected"></${fvSummaryPanelTileTag}>
-            <${fvSummaryPanelTileTag} count="28" label="disconnected"></${fvSummaryPanelTileTag}>
-            <${fvSummaryPanelTileTag} count="1" label="pending"></${fvSummaryPanelTileTag}>
-            <${fvSummaryPanelTileTag} count="12" label="warnings"></${fvSummaryPanelTileTag}>
-            <${fvSummaryPanelTileTag} count="3" label="critical"></${fvSummaryPanelTileTag}>
+        <${fvSummaryPanelTag} size="compact" legacy-style>
+            <${fvSummaryPanelTileTag} count="234" label="systems" text-position="under" selected></${fvSummaryPanelTileTag}>
+            <${fvSummaryPanelTileTag} count="207" label="connected" text-position="under"></${fvSummaryPanelTileTag}>
+            <${fvSummaryPanelTileTag} count="28" label="disconnected" text-position="under"></${fvSummaryPanelTileTag}>
+            <${fvSummaryPanelTileTag} count="1" label="pending" text-position="under"></${fvSummaryPanelTileTag}>
+            <${fvSummaryPanelTileTag} count="12" label="warnings" text-position="under"></${fvSummaryPanelTileTag}>
+            <${fvSummaryPanelTileTag} count="3" label="critical" text-position="under"></${fvSummaryPanelTileTag}>
         </${fvSummaryPanelTag}>
     </div>
 `);

--- a/packages/storybook/src/ok/fv/summary-panel/fv-summary-panel-matrix.stories.ts
+++ b/packages/storybook/src/ok/fv/summary-panel/fv-summary-panel-matrix.stories.ts
@@ -36,7 +36,7 @@ const summaryPanel = (
 ): ViewTemplate => {
     const isCompact = size === 'compact';
     return html`
-        <div style="display: inline-flex; flex-direction: column; width: ${isCompact ? '390px' : '460px'}; margin: 0 16px 16px 0;">
+        <div style="display: ${isCompact ? 'inline-flex' : 'flex'}; flex-direction: column; width: ${isCompact ? '390px' : '460px'}; margin: 0 16px 16px 0;">
             <div style="font-size: 12px; color: #0076d6; text-align: center; min-height: 16px;">
                 ${() => `${legacyStyleName} ${textPositionName}`}
             </div>


### PR DESCRIPTION
## Rationale

Correct the minor spacing issues in the FV summary panel. Compact panels should not add unnecessary container padding, while tile hover styling must remain visible. Under-positioned tiles also need the intended top margins in default and compact layouts.

## Changes

- Remove compact summary-panel container padding.
- Preserve compact tile hover clearance with token-based margins while retaining the intended visible gap.
- Set under-positioned tile top margins to 20px in default mode and 8px in compact mode.
- Expand both summary-panel testing theme matrices into a full option matrix covering `legacy-style` true and false crossed with `text-position="beside"` and `text-position="under"`.
- Keep each non-compact matrix panel on its own 960px-wide row so all tiles fit without wrapping at the Storybook view width.
- Add focused regression coverage for compact geometry, hover clearance, and both margin values.
- Add the required `@ni/ok-components` patch change file.

## Validation

- `npm run test-webkit -w @ni/ok-components` (173 tests passed)
- `npm run lint -w @ni/ok-components`
- `npm run lint -w @ni-private/storybook`
- `npm run build:ts -w @ni-private/storybook`
- Browser-checked all four matrix combinations in both the default and compact Storybook stories across the available themes.
- Browser-checked that the four non-compact panels render on separate rows with all tiles on one row.
- `git diff --check`