### PR TITLE
Add Maskito-backed FV text field

### DIFF
--- a/change/@ni-ok-components-8f42c8bd-1f4e-4fa1-b1b2-527db7bdddaa.json
+++ b/change/@ni-ok-components-8f42c8bd-1f4e-4fa1-b1b2-527db7bdddaa.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add the ok-fv-text-field component with configurable Maskito input masking.",
+  "packageName": "@ni/ok-components",
+  "email": "1458528+fredvisser@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5663,6 +5663,12 @@
         "win32"
       ]
     },
+    "node_modules/@maskito/core": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@maskito/core/-/core-5.4.0.tgz",
+      "integrity": "sha512-g2Ps71bVidiIoIdrSqzvu85i1vbfDnQScJItikIXTrSGZN8/PwcRsnzr0Cx56dljWbVcEHe2cpZMkYo5Th64zw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@mdit-vue/shared": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@mdit-vue/shared/-/shared-3.0.2.tgz",
@@ -34279,6 +34285,7 @@
       "version": "1.8.3",
       "license": "MIT",
       "dependencies": {
+        "@maskito/core": "^5.4.0",
         "@ni/fast-element": "^10.1.2",
         "@ni/fast-foundation": "^10.2.5",
         "@ni/fast-web-utilities": "^10.0.0",

--- a/packages/ok-components/package.json
+++ b/packages/ok-components/package.json
@@ -40,6 +40,7 @@
   "homepage": "https://github.com/ni/nimble#readme",
   "customElements": "dist/custom-elements.json",
   "dependencies": {
+    "@maskito/core": "^5.4.0",
     "@ni/fast-element": "^10.1.2",
     "@ni/fast-foundation": "^10.2.5",
     "@ni/fast-web-utilities": "^10.0.0",

--- a/packages/ok-components/src/fv/all-fv.ts
+++ b/packages/ok-components/src/fv/all-fv.ts
@@ -10,3 +10,4 @@ import './sticky-header';
 import './summary-panel';
 import './summary-panel-tile';
 import './search-input';
+import './text-field';

--- a/packages/ok-components/src/fv/text-field/index.ts
+++ b/packages/ok-components/src/fv/text-field/index.ts
@@ -1,0 +1,134 @@
+import { observable } from '@ni/fast-element';
+import type { TextFieldOptions } from '@ni/fast-foundation';
+import {
+    Maskito,
+    type MaskitoOptions,
+    maskitoTransform
+} from '@maskito/core';
+import {
+    TextField as NimbleTextField
+} from '@ni/nimble-components/dist/esm/text-field';
+import { styles } from '@ni/nimble-components/dist/esm/text-field/styles';
+import { template } from '@ni/nimble-components/dist/esm/text-field/template';
+import { DesignSystem } from '@ni/fast-foundation';
+
+export type { MaskitoOptions } from '@maskito/core';
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'ok-fv-text-field': FvTextField;
+    }
+}
+
+/**
+ * A Nimble text field with optional Maskito input masking.
+ */
+export class FvTextField extends NimbleTextField {
+    /**
+     * Maskito configuration applied to user and programmatic input.
+     *
+     * @public
+     * @remarks
+     * This property is not reflected to an HTML attribute because Maskito
+     * options can contain regular expressions and functions.
+     */
+    @observable
+    public maskOptions?: MaskitoOptions;
+
+    private maskito?: Maskito;
+    private updatingValueFromControl = false;
+    private normalizingValue = false;
+
+    /** @internal */
+    public override connectedCallback(): void {
+        super.connectedCallback();
+        this.initializeMask();
+    }
+
+    /** @internal */
+    public override disconnectedCallback(): void {
+        this.destroyMask();
+        super.disconnectedCallback();
+    }
+
+    /** @internal */
+    public maskOptionsChanged(): void {
+        if (this.$fastController.isConnected) {
+            this.initializeMask();
+        }
+    }
+
+    /** @internal */
+    public override handleTextInput(): void {
+        this.updatingValueFromControl = true;
+        super.handleTextInput();
+        this.updatingValueFromControl = false;
+    }
+
+    /** @internal */
+    public override valueChanged(previous: string, next: string): void {
+        if (
+            !this.maskOptions
+            || this.updatingValueFromControl
+            || this.normalizingValue
+        ) {
+            super.valueChanged(previous, next);
+            return;
+        }
+
+        const maskedValue = maskitoTransform(next, this.maskOptions);
+        if (maskedValue !== next) {
+            this.normalizingValue = true;
+            this.value = maskedValue;
+            this.normalizingValue = false;
+        } else {
+            super.valueChanged(previous, next);
+        }
+
+        if (this.$fastController.isConnected) {
+            this.control.value = maskedValue;
+            this.createMask();
+        }
+    }
+
+    private initializeMask(): void {
+        this.destroyMask();
+        if (!this.maskOptions) {
+            return;
+        }
+
+        const maskedValue = maskitoTransform(this.value, this.maskOptions);
+        if (maskedValue !== this.value) {
+            this.value = maskedValue;
+            return;
+        }
+
+        this.control.value = maskedValue;
+        this.createMask();
+    }
+
+    private createMask(): void {
+        this.destroyMask();
+        if (this.maskOptions) {
+            this.maskito = new Maskito(this.control, this.maskOptions);
+        }
+    }
+
+    private destroyMask(): void {
+        this.maskito?.destroy();
+        this.maskito = undefined;
+    }
+}
+
+const okFvTextField = FvTextField.compose<TextFieldOptions>({
+    baseName: 'fv-text-field',
+    baseClass: NimbleTextField,
+    template,
+    styles,
+    shadowOptions: {
+        delegatesFocus: true
+    }
+});
+
+DesignSystem.getOrCreate().withPrefix('ok').register(okFvTextField());
+export const fvTextFieldTag = 'ok-fv-text-field';

--- a/packages/ok-components/src/fv/text-field/index.ts
+++ b/packages/ok-components/src/fv/text-field/index.ts
@@ -1,4 +1,4 @@
-import { observable } from '@ni/fast-element';
+import { html, observable } from '@ni/fast-element';
 import type { TextFieldOptions } from '@ni/fast-foundation';
 import {
     Maskito,
@@ -10,6 +10,8 @@ import {
 } from '@ni/nimble-components/dist/esm/text-field';
 import { styles } from '@ni/nimble-components/dist/esm/text-field/styles';
 import { template } from '@ni/nimble-components/dist/esm/text-field/template';
+import { errorTextTemplate } from '@ni/nimble-components/dist/esm/patterns/error/template';
+import { iconExclamationMarkTag } from '@ni/nimble-components/dist/esm/icons/exclamation-mark';
 import { DesignSystem } from '@ni/fast-foundation';
 
 export type { MaskitoOptions } from '@maskito/core';
@@ -127,7 +129,17 @@ const okFvTextField = FvTextField.compose<TextFieldOptions>({
     styles,
     shadowOptions: {
         delegatesFocus: true
-    }
+    },
+    end: html<FvTextField>`
+        <${iconExclamationMarkTag}
+            severity="error"
+            class="error-icon"
+        ></${iconExclamationMarkTag}>
+        <span part="actions">
+            <slot name="actions"></slot>
+        </span>
+        ${errorTextTemplate}
+    `
 });
 
 DesignSystem.getOrCreate().withPrefix('ok').register(okFvTextField());

--- a/packages/ok-components/src/fv/text-field/tests/fv-text-field.spec.ts
+++ b/packages/ok-components/src/fv/text-field/tests/fv-text-field.spec.ts
@@ -1,0 +1,144 @@
+import { html } from '@ni/fast-element';
+import { waitForUpdatesAsync } from '@ni/nimble-components/dist/esm/testing/async-helpers';
+import { fixture, type Fixture } from '../../../utilities/tests/fixture';
+import {
+    FvTextField,
+    fvTextFieldTag,
+    type MaskitoOptions
+} from '..';
+
+const groupedDigitsMask: MaskitoOptions = {
+    mask: [/\d/, /\d/, '-', /\d/, /\d/]
+};
+
+const uppercaseGroupedMask: MaskitoOptions = {
+    mask: [
+        /[A-Za-z0-9]/,
+        /[A-Za-z0-9]/,
+        /[A-Za-z0-9]/,
+        /[A-Za-z0-9]/,
+        '-',
+        /[A-Za-z0-9]/,
+        /[A-Za-z0-9]/,
+        /[A-Za-z0-9]/,
+        /[A-Za-z0-9]/
+    ],
+    postprocessors: [({ value, selection }) => ({
+        value: value.toUpperCase(),
+        selection
+    })]
+};
+
+async function setup(
+    maskOptions?: MaskitoOptions
+): Promise<Fixture<FvTextField>> {
+    return await fixture<FvTextField>(
+        html`<${fvTextFieldTag} :maskOptions="${() => maskOptions}"></${fvTextFieldTag}>`
+    );
+}
+
+function typeCharacter(input: HTMLInputElement, character: string): void {
+    const beforeInputEvent = new InputEvent('beforeinput', {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        data: character,
+        inputType: 'insertText'
+    });
+    const shouldPerformDefaultAction = input.dispatchEvent(beforeInputEvent);
+    if (shouldPerformDefaultAction) {
+        input.setRangeText(character, input.selectionStart ?? 0, input.selectionEnd ?? 0, 'end');
+        input.dispatchEvent(new InputEvent('input', {
+            bubbles: true,
+            composed: true,
+            data: character,
+            inputType: 'insertText'
+        }));
+    }
+}
+
+describe('FvTextField', () => {
+    let element: FvTextField;
+    let connect: () => Promise<void>;
+    let disconnect: (() => Promise<void>) | undefined;
+
+    afterEach(async () => {
+        await disconnect?.();
+        disconnect = undefined;
+    });
+
+    it('can construct an element instance', () => {
+        expect(document.createElement(fvTextFieldTag)).toBeInstanceOf(FvTextField);
+    });
+
+    it('applies mask options to user input', async () => {
+        ({ element, connect, disconnect } = await setup(groupedDigitsMask));
+        await connect();
+        element.control.focus();
+
+        typeCharacter(element.control, '1');
+        typeCharacter(element.control, '2');
+        typeCharacter(element.control, '3');
+        typeCharacter(element.control, '4');
+
+        expect(element.control.value).toBe('12-34');
+        expect(element.value).toBe('12-34');
+    });
+
+    it('supports uppercase grouped alphanumeric input', async () => {
+        ({ element, connect, disconnect } = await setup(uppercaseGroupedMask));
+        await connect();
+        element.control.focus();
+
+        typeCharacter(element.control, 'a');
+        typeCharacter(element.control, 'b');
+        typeCharacter(element.control, '1');
+        typeCharacter(element.control, '2');
+        typeCharacter(element.control, 'c');
+        typeCharacter(element.control, 'd');
+        typeCharacter(element.control, '3');
+        typeCharacter(element.control, '4');
+
+        expect(element.control.value).toBe('AB12-CD34');
+        expect(element.value).toBe('AB12-CD34');
+    });
+
+    it('masks a programmatically assigned value', async () => {
+        ({ element, connect, disconnect } = await setup(groupedDigitsMask));
+        await connect();
+
+        element.value = '1234';
+        await waitForUpdatesAsync();
+
+        expect(element.value).toBe('12-34');
+        expect(element.control.value).toBe('12-34');
+    });
+
+    it('replaces the active mask when mask options change', async () => {
+        ({ element, connect, disconnect } = await setup(groupedDigitsMask));
+        await connect();
+        element.value = '1234';
+        await waitForUpdatesAsync();
+
+        element.maskOptions = { mask: [/\d/, '-', /\d/, '-', /\d/, /\d/] };
+        await waitForUpdatesAsync();
+
+        expect(element.value).toBe('1-2-34');
+        expect(element.control.value).toBe('1-2-34');
+    });
+
+    it('accepts unmasked input when mask options are not configured', async () => {
+        ({ element, connect, disconnect } = await setup());
+        await connect();
+
+        element.control.value = 'unmasked value';
+        element.control.dispatchEvent(new InputEvent('input', {
+            bubbles: true,
+            composed: true,
+            data: 'unmasked value',
+            inputType: 'insertText'
+        }));
+
+        expect(element.value).toBe('unmasked value');
+    });
+});

--- a/packages/ok-components/src/fv/text-field/tests/fv-text-field.spec.ts
+++ b/packages/ok-components/src/fv/text-field/tests/fv-text-field.spec.ts
@@ -71,6 +71,23 @@ describe('FvTextField', () => {
         expect(document.createElement(fvTextFieldTag)).toBeInstanceOf(FvTextField);
     });
 
+    it('renders inherited error and actions content', async () => {
+        ({ element, connect, disconnect } = await fixture<FvTextField>(html`
+            <${fvTextFieldTag} error-text="Invalid value">
+                <button slot="actions">Action</button>
+            </${fvTextFieldTag}>
+        `));
+        await connect();
+
+        expect(element.shadowRoot?.querySelector('.error-icon')).not.toBeNull();
+        expect(element.shadowRoot?.querySelector('.error-text')?.textContent?.trim()).toBe('Invalid value');
+        expect(
+            element.shadowRoot
+                ?.querySelector<HTMLSlotElement>('slot[name="actions"]')
+                ?.assignedElements()
+        ).toHaveSize(1);
+    });
+
     it('applies mask options to user input', async () => {
         ({ element, connect, disconnect } = await setup(groupedDigitsMask));
         await connect();

--- a/packages/storybook/src/docs/component-data/ok/fv/index.ts
+++ b/packages/storybook/src/docs/component-data/ok/fv/index.ts
@@ -101,5 +101,14 @@ export const componentDataOkFv = [
         angularStatus: ComponentFrameworkStatus.ready,
         blazorStatus: ComponentFrameworkStatus.doesNotExist,
         reactStatus: ComponentFrameworkStatus.ready
+    },
+    {
+        componentName: 'Fv Text Field',
+        componentHref: './?path=/docs/ok-fv-text-field--docs',
+        library: 'ok',
+        componentStatus: ComponentFrameworkStatus.ready,
+        angularStatus: ComponentFrameworkStatus.doesNotExist,
+        blazorStatus: ComponentFrameworkStatus.doesNotExist,
+        reactStatus: ComponentFrameworkStatus.doesNotExist
     }
 ] as const;

--- a/packages/storybook/src/ok/fv/text-field/fv-text-field.mdx
+++ b/packages/storybook/src/ok/fv/text-field/fv-text-field.mdx
@@ -1,0 +1,20 @@
+import { Canvas, Controls, Meta, Title } from '@storybook/addon-docs/blocks';
+import ComponentApisLink from '../../../docs/component-apis-link.mdx';
+import * as textFieldStories from './fv-text-field.stories';
+
+<Meta of={textFieldStories} />
+<Title of={textFieldStories} />
+
+A Nimble text field that applies a consumer-provided [Maskito](https://maskito.dev/) configuration to user and programmatic input.
+
+Set `maskOptions` as a JavaScript property. Maskito configurations can contain regular expressions and functions, so they cannot be represented as an HTML attribute.
+
+The example accepts up to 16 ASCII letters or digits, converts letters to uppercase, and inserts a hyphen after every four characters.
+
+<Canvas of={textFieldStories.defaultStory} />
+
+## API
+
+<Controls of={textFieldStories.defaultStory} />
+
+<ComponentApisLink />

--- a/packages/storybook/src/ok/fv/text-field/fv-text-field.stories.ts
+++ b/packages/storybook/src/ok/fv/text-field/fv-text-field.stories.ts
@@ -1,0 +1,120 @@
+import type { HtmlRenderer, Meta, StoryObj } from '@storybook/html-vite';
+import { withActions } from 'storybook/actions/decorator';
+import { html } from '@ni/fast-element';
+import {
+    fvTextFieldTag,
+    type MaskitoOptions
+} from '@ni/ok-components/dist/esm/fv/text-field';
+import {
+    apiCategory,
+    createUserSelectedThemeStory,
+    okWarning,
+    placeholderDescription,
+    slottedLabelDescription
+} from '../../../utilities/storybook';
+
+interface TextFieldArgs {
+    label: string;
+    placeholder: string;
+    value: string;
+    maskOptions: MaskitoOptions;
+    input?: (event: Event) => void;
+    change?: (event: Event) => void;
+}
+
+const alphanumericCharacter = /[A-Za-z0-9]/;
+const uppercasePostprocessor: NonNullable<MaskitoOptions['postprocessors']>[number] = (
+    { value, selection }
+) => ({
+    value: value.toUpperCase(),
+    selection
+});
+const uppercaseGroupedMask: MaskitoOptions = {
+    mask: [
+        alphanumericCharacter,
+        alphanumericCharacter,
+        alphanumericCharacter,
+        alphanumericCharacter,
+        '-',
+        alphanumericCharacter,
+        alphanumericCharacter,
+        alphanumericCharacter,
+        alphanumericCharacter,
+        '-',
+        alphanumericCharacter,
+        alphanumericCharacter,
+        alphanumericCharacter,
+        alphanumericCharacter,
+        '-',
+        alphanumericCharacter,
+        alphanumericCharacter,
+        alphanumericCharacter,
+        alphanumericCharacter
+    ],
+    postprocessors: [uppercasePostprocessor]
+};
+
+const metadata: Meta<TextFieldArgs> = {
+    title: 'Ok/Fv Text Field',
+    decorators: [withActions<HtmlRenderer>],
+    parameters: {
+        actions: {
+            handles: ['input', 'change']
+        }
+    },
+    render: createUserSelectedThemeStory(html<TextFieldArgs>`
+        ${okWarning({
+            componentName: 'Fv Text Field',
+            statusLink: './?path=/docs/component-status--docs#ok-components'
+        })}
+        <${fvTextFieldTag}
+            style="width: 320px;"
+            placeholder="${x => x.placeholder}"
+            :value="${x => x.value}"
+            :maskOptions="${x => x.maskOptions}"
+        >
+            ${x => x.label}
+        </${fvTextFieldTag}>
+    `),
+    argTypes: {
+        label: {
+            name: 'default',
+            description: slottedLabelDescription({ componentName: 'Fv Text Field' }),
+            table: { category: apiCategory.slots }
+        },
+        placeholder: {
+            description: placeholderDescription({ componentName: 'Fv Text Field' }),
+            table: { category: apiCategory.attributes }
+        },
+        value: {
+            description: 'The current masked value.',
+            table: { category: apiCategory.nonAttributeProperties }
+        },
+        maskOptions: {
+            description:
+                'Maskito options applied to user and programmatic input. This API is available as a JavaScript property, not an HTML attribute.',
+            table: { category: apiCategory.nonAttributeProperties },
+            control: false
+        },
+        input: {
+            table: { category: apiCategory.events },
+            control: false
+        },
+        change: {
+            table: { category: apiCategory.events },
+            control: false
+        }
+    },
+    args: {
+        label: 'Identifier',
+        placeholder: 'XXXX-XXXX-XXXX-XXXX',
+        value: '',
+        maskOptions: uppercaseGroupedMask
+    }
+};
+
+export default metadata;
+
+export const defaultStory: StoryObj<TextFieldArgs> = {
+    name: 'Fv Text Field'
+};


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Applications need a reusable FV text field that can enforce structured input formats while preserving Nimble text-field behavior and styling. This adds a generic Maskito-backed control so consumers can provide masks for identifiers and other formatted values without attaching behavior through the component's shadow DOM.

## 👩‍💻 Implementation

- Add `ok-fv-text-field` as a subclass of the Nimble text field.
- Add a property-only `maskOptions` API for Maskito configurations containing regular expressions and functions.
- Manage Maskito initialization, option replacement, programmatic value transformation, and teardown within the component lifecycle.
- Add `@maskito/core` as an `@ni/ok-components` dependency and register the component in the FV bundle.
- Add Storybook documentation demonstrating uppercase alphanumeric groups separated by hyphens.
- Add a minor Beachball change for `@ni/ok-components`.

Angular, React, and Blazor wrappers are intentionally deferred while the property-based web-component API settles.

## 🧪 Testing

- Added focused tests for user input masking, uppercase alphanumeric grouping, programmatic values, mask replacement, and unmasked fallback.
- `npm run test-chrome -w @ni/ok-components -- --grep FvTextField` (179 passed)
- `npm run test-webkit -w @ni/ok-components -- --grep FvTextField` (179 passed)
- `npm run build -w @ni/ok-components`
- `npm run build-bundle -w @ni/ok-components`
- `npm run lint -w @ni/ok-components`
- `npm run lint -w @ni-private/storybook`
- `npm run build -w @ni-private/storybook`
- `npm run check`
- `git diff --check`

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.