### PR TITLE
NimbleBlazor: Fix behavior when a NimbleNumberField's value is cleared

### DIFF
--- a/change/@ni-nimble-blazor-442fb16c-d7ea-496f-ba82-a5948b16eac2.json
+++ b/change/@ni-nimble-blazor-442fb16c-d7ea-496f-ba82-a5948b16eac2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix NimbleNumberField behavior when value is cleared",
+  "packageName": "@ni/nimble-blazor",
+  "email": "20709258+msmithNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/blazor-workspace/NimbleBlazor/Source/Patterns/NimbleInputBase.cs
+++ b/packages/blazor-workspace/NimbleBlazor/Source/Patterns/NimbleInputBase.cs
@@ -10,7 +10,7 @@ public abstract class NimbleInputBase<TValue> : ComponentBase, IDisposable
     private readonly EventHandler<ValidationStateChangedEventArgs> _validationStateChangedHandler;
     private bool _previousParsingAttemptFailed;
     private ValidationMessageStore? _parsingValidationMessages;
-    private Type? _nullableUnderlyingType;
+    private readonly Type? _nullableUnderlyingType;
 
     [CascadingParameter] private EditContext? CascadedEditContext { get; set; }
 
@@ -129,6 +129,7 @@ public abstract class NimbleInputBase<TValue> : ComponentBase, IDisposable
     /// </summary>
     protected NimbleInputBase()
     {
+        _nullableUnderlyingType = Nullable.GetUnderlyingType(typeof(TValue));
         _validationStateChangedHandler = OnValidateStateChanged;
     }
 
@@ -199,8 +200,6 @@ public abstract class NimbleInputBase<TValue> : ComponentBase, IDisposable
                 EditContext = CascadedEditContext;
                 EditContext.OnValidationStateChanged += _validationStateChangedHandler;
             }
-
-            _nullableUnderlyingType = Nullable.GetUnderlyingType(typeof(TValue));
         }
         else if (CascadedEditContext != EditContext)
         {

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests.Acceptance/Pages.InteractiveServer/NumberFieldClearValue.razor
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests.Acceptance/Pages.InteractiveServer/NumberFieldClearValue.razor
@@ -1,0 +1,11 @@
+﻿@page "/InteractiveServer/NumberFieldClearValue"
+@namespace NimbleBlazor.Tests.Acceptance.Pages
+@inherits LayoutComponentBase
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
+
+<NimbleNumberField id="number1" @bind-Value="_value"></NimbleNumberField>
+<NimbleNumberField id="number2" Value="_value"></NimbleNumberField>
+
+@code {
+    private double? _value = 123;
+}

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests.Acceptance/Tests.InteractiveServer/NumberFieldClearValueTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests.Acceptance/Tests.InteractiveServer/NumberFieldClearValueTests.cs
@@ -1,0 +1,35 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace NimbleBlazor.Tests.Acceptance.InteractiveServer;
+
+public partial class NumberFieldClearValueTests : NimbleInteractiveAcceptanceTestsBase
+{
+    public NumberFieldClearValueTests(NimbleBlazorWebHostServerFixture blazorServerClassFixture)
+        : base(blazorServerClassFixture)
+    {
+    }
+
+    [Fact]
+    public async Task NumberField_ClearingValueUpdatesControlAndBoundValue()
+    {
+        await using (var pageWrapper = await NewPageForRouteAsync("InteractiveServer/NumberFieldClearValue"))
+        {
+            var page = pageWrapper.Page;
+            var numberField1 = page.Locator("#number1");
+            var numberField2 = page.Locator("#number2");
+            await Expect(numberField1).ToHaveAttributeAsync("current-value", "123");
+            await Expect(numberField2).ToHaveAttributeAsync("current-value", "123");
+
+            var number1Input = numberField1.Locator("input");
+            await number1Input.ClearAsync();
+            await number1Input.BlurAsync();
+
+            await Expect(numberField1).Not.ToHaveAttributeAsync("current-value", AnyValueRegex());
+            await Expect(numberField2).Not.ToHaveAttributeAsync("current-value", AnyValueRegex());
+        }
+    }
+
+    [GeneratedRegex(".*")]
+    private static partial Regex AnyValueRegex();
+}

--- a/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleNumberFieldTests.cs
+++ b/packages/blazor-workspace/Tests/NimbleBlazor.Tests/Unit/Components/NimbleNumberFieldTests.cs
@@ -36,6 +36,18 @@ public class NimbleNumberFieldTests : BunitTestBase
     }
 
     [Fact]
+    public void Render_ClearValue_ValueUpdated()
+    {
+        var field = Render<NimbleNumberField>();
+        field.Find(NumberFieldMarkup).Change("123");
+
+        field.Find(NumberFieldMarkup).Change(string.Empty);
+
+        Assert.Null(field.Instance.Value);
+        field.AssertAttribute("current-value", null);
+    }
+
+    [Fact]
     public void NimbleNumberField_SupportsAdditionalAttributes()
     {
         var exception = Record.Exception(() => Render<NimbleNumberField>(parameters => parameters.AddUnmatched("class", "foo")));


### PR DESCRIPTION
# Pull Request

## 🤨 Rationale

Resolves #3060 

## 👩‍💻 Implementation

Fix logic in `NimbleInputBase` when `EditContext` is unset, such that we go through the right code path to handle null/empty value updates.

## 🧪 Testing

- Added unit and acceptance test (both fail before change)
- Tested new package in ConfigUI

## ✅ Checklist

<!--- Review the list and put an x in the boxes that apply or ~~strike through~~ around items that don't (along with an explanation). -->

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.
